### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/ant/org.eclipse.ant.core/pom.xml
+++ b/ant/org.eclipse.ant.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/ant/org.eclipse.ant.launching/pom.xml
+++ b/ant/org.eclipse.ant.launching/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/ant/org.eclipse.ant.tests.core/pom.xml
+++ b/ant/org.eclipse.ant.tests.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/ant/org.eclipse.ant.tests.ui/pom.xml
+++ b/ant/org.eclipse.ant.tests.ui/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/ant/org.eclipse.ant.ui/pom.xml
+++ b/ant/org.eclipse.ant.ui/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/platform/org.eclipse.platform/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.platform/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-ClassPath: platform.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/platform/org.eclipse.platform/pom.xml
+++ b/platform/org.eclipse.platform/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform</groupId>

--- a/platform/org.eclipse.sdk/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.sdk;singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",

--- a/platform/org.eclipse.sdk/pom.xml
+++ b/platform/org.eclipse.sdk/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/update/org.eclipse.update.configurator.tests/pom.xml
+++ b/update/org.eclipse.update.configurator.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.update</groupId>

--- a/update/org.eclipse.update.configurator/pom.xml
+++ b/update/org.eclipse.update.configurator/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform</artifactId>
     <groupId>eclipse.platform</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.update</groupId>


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release