### PR TITLE
Parent pom for runtime is now eclipse.platform

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -13,10 +13,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.eclipse</groupId>
-    <artifactId>eclipse-platform-parent</artifactId>
+    <groupId>eclipse.platform</groupId>
+    <artifactId>eclipse.platform</artifactId>
     <version>4.25.0-SNAPSHOT</version>
-    <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 
   <groupId>eclipse.platform</groupId>


### PR DESCRIPTION
Instead of pointing to the main aggregator repo, the runtime pom should
point to the eclipse.platform repo