### PR TITLE
Set explicit project encoding to UTF-8

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime.releng/.settings/org.eclipse.core.resources.prefs
+++ b/runtime/bundles/org.eclipse.core.runtime.releng/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Avoid the new warning in 2022-06