### PR TITLE
Add no-argument Platform.getContextLog()

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -512,6 +512,8 @@ public final class Platform {
 		SYSTEM_CHARSET = result;
 	}
 
+	private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+
 	/**
 	 * Private constructor to block instance creation.
 	 */
@@ -930,13 +932,33 @@ public final class Platform {
 	 * is created.
 	 *
 	 * @param clazz the class in a bundle whose log is returned
-	 * @return the log for the bundle to which the bundle belongs
+	 * @return the log for the bundle to which the class belongs
 	 *
 	 * @since 3.16
 	 */
 	public static ILog getLog(Class<?> clazz) {
 		Bundle bundle = FrameworkUtil.getBundle(clazz);
 		return InternalPlatform.getDefault().getLog(bundle);
+	}
+
+	/**
+	 * Returns the log for the bundle of the calling class. If no such log exists,
+	 * one is created.
+	 * <p>
+	 * There may be a small performance penalty when using this method that
+	 * automatically determines the calling class by using {@link StackWalker}. For
+	 * performance critical code consider to use {@link #getLog(Class)} or
+	 * ultimately {@link #getLog(Bundle)} and pass the calling class respectively
+	 * its bundle directly.
+	 * </p>
+	 *
+	 * @return the log for the bundle to which the caller belongs
+	 *
+	 * @since 3.26
+	 */
+	public static ILog getContextLog() {
+		Class<?> callerClass = STACK_WALKER.getCallerClass();
+		return getLog(callerClass);
 	}
 
 	/**

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
@@ -275,6 +275,15 @@ public class PlatformTest extends RuntimeTest {
 		}
 	}
 
+	@Test
+	public void testGetLog_noArgument() {
+		ILog staticLog = RuntimeTestsPlugin.getPlugin().getLog();
+		assertNotNull(staticLog);
+		ILog log = Platform.getContextLog();
+		assertSame(staticLog, log);
+		assertSame(Platform.getLog(PlatformTest.class), log);
+	}
+
 	/**
 	 * Test for method {@link Platform#getBundles(String, String)}.
 	 * <p>


### PR DESCRIPTION
This PR adds the convince `Platform.getLog()` method that returns an `ILog` for the bundle of the caller-class and uses a stack-walker to obtain the latter.

Calling `Platform.getLog(ThisClass.class)` to obtain a log is a very common pattern. Providing `Platform.getLog()` is not only convenient, it also avoids copy-past-errors were one accidentally passes a class from another bundle and consequently uses those bundles log.

Unfortunately this comes with a little performance penalty because the `StackWalker.getCallerClass()` is not for free. I added a corresponding note in the java-doc.

This was originally created in https://github.com/eclipse-platform/eclipse.platform.runtime/pull/58 and is recreated here due to the merge of the `eclipse.platform.runtime` repo.