### PR TITLE
ExpressionTestsPluginUnloading force start of com.ibm.icu

### DIFF
--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
@@ -46,14 +46,14 @@ public class ExpressionTestsPluginUnloading {
 	@Test
 	public void test01PluginStopping() throws Exception {
 		Bundle bundle= getBundle("com.ibm.icu");
-
+		bundle.start();
 		int state = bundle.getState();
-		if (state != Bundle.RESOLVED && state != Bundle.STARTING && state != Bundle.ACTIVE) {
+		if (state != Bundle.ACTIVE) {
 			fail("Unexpected bundle state: " + stateToString(state) + " for bundle " + bundle);
 		}
 
 		doTestInstanceofICUDecimalFormat(bundle);
-		assertEquals(Bundle.ACTIVE, bundle.getState());
+		assertEquals("Instanceof with bundle-local class should load extra bundle", state, bundle.getState());
 
 		bundle.stop();
 		assertEquals(Bundle.RESOLVED, bundle.getState());


### PR DESCRIPTION
This test seems to expect that com.ibm.icu bundle is always started when
running. This may not be always true, so we explicitly start the
com.ibm.icu bundle to get in the state expected by the tests.