### PR TITLE
IEclipseContext.TOPIC_DISPOSE should carry the disposed context.

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.core.contexts
-Bundle-Version: 1.10.100.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IEclipseContext.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IEclipseContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * Copyright (c) 2009, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - Issue #215
  *******************************************************************************/
 
 package org.eclipse.e4.core.contexts;
@@ -54,6 +55,14 @@ public interface IEclipseContext {
 	 * @since 1.6
 	 */
 	String TOPIC_DISPOSE = "org/eclipse/e4/core/contexts/IEclipseContext/DISPOSE"; //$NON-NLS-1$
+
+	/**
+	 * Property that is used for the event on {@link #TOPIC_DISPOSE} and contains
+	 * the {@link IEclipseContext} that is about to be disposed.
+	 *
+	 * @since 1.11
+	 */
+	String PROPERTY_CONTEXT = "org.eclipse.e4.core.contexts.IEclipseContext"; //$NON-NLS-1$
 
 	/**
 	 * Returns whether this context or a parent has a value stored for the given

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/EclipseContext.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/EclipseContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * Copyright (c) 2009, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Daniel Kruegler <daniel.kruegler@gmail.com> - Bug 487417
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 492963
+ *     Christoph Läubrich - Issue #215
  *******************************************************************************/
 package org.eclipse.e4.core.internal.contexts;
 
@@ -212,8 +213,9 @@ public class EclipseContext implements IEclipseContext {
 			// ExtendedObjectSupplier implementations
 			EventAdmin admin = parent.get(EventAdmin.class);
 			if (admin != null) {
-				Event osgiEvent = new Event(IEclipseContext.TOPIC_DISPOSE, (Map<String, ?>) null);
-				admin.postEvent(osgiEvent);
+				Event osgiEvent = new Event(IEclipseContext.TOPIC_DISPOSE,
+						Map.of(IEclipseContext.PROPERTY_CONTEXT, this));
+				admin.sendEvent(osgiEvent);
 			}
 		}
 


### PR DESCRIPTION
Currently there is an event published for every disposal of an
IEclipseContext to IEclipseContext.TOPIC_DISPOSE
but because the properties are completely empty one needs to guess if
the context one was using is actually affected. Even worse, it is not
actually possible to know if a context is/was disposed or not.

The event now contain the disposed IEclipseContext so it is more generic
e.g. if one want to dispose resources from a context function.

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/215