### PR TITLE
Perform minor version bump due to method addition

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
@@ -2,11 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Harness
 Bundle-SymbolicName: org.eclipse.core.tests.harness;singleton:=true
-Bundle-Version: 3.12.300.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: Eclipse.org
-Export-Package: org.eclipse.core.tests.harness,
- org.eclipse.core.tests.session,
- org.eclipse.core.tests.session.samples
+Export-Package: org.eclipse.core.tests.harness;version="1.0",
+ org.eclipse.core.tests.session;version="1.1"
 Require-Bundle: org.junit,
  org.eclipse.test.performance,
  org.eclipse.core.runtime,


### PR DESCRIPTION
The method additions in https://github.com/eclipse-platform/eclipse.platform/pull/54 make a version bump is necessary so that it can be specified as lower bound and P2/Tycho are forced to use the new version.