### PR TITLE
Use 'pom.model.packaging' to declare test-plugins

### DIFF
--- a/ant/org.eclipse.ant.tests.core/build.properties
+++ b/ant/org.eclipse.ant.tests.core/build.properties
@@ -33,7 +33,7 @@ output.anttestscore.jar = bin/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 tycho.pomless.parent = ../../
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
-tycho.pomless.testbundle = true
+pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.ant.tests.core.AutomatedSuite
 pom.model.property.tycho.surefire.testClassesDirectory = target/anttestscore.jar-classes
 pom.model.property.tycho.surefire.useUIHarness = true

--- a/ant/org.eclipse.ant.tests.ui/build.properties
+++ b/ant/org.eclipse.ant.tests.ui/build.properties
@@ -35,7 +35,7 @@ output.anttestsui.jar = bin/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 tycho.pomless.parent = ../../
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
-tycho.pomless.testbundle = true
+pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.ant.tests.ui.testplugin.AntUITests
 pom.model.property.tycho.surefire.testClassesDirectory = target/anttestsui.jar-classes
 pom.model.property.tycho.surefire.useUIHarness = true

--- a/runtime/tests/org.eclipse.core.contenttype.tests/build.properties
+++ b/runtime/tests/org.eclipse.core.contenttype.tests/build.properties
@@ -21,7 +21,7 @@ src.includes = about.html
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
-tycho.pomless.testbundle = true
+pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.core.internal.contenttype.tests.AllTests
 pom.model.property.tycho.surefire.useUIHarness = false
 pom.model.property.tycho.surefire.useUIThread = false

--- a/runtime/tests/org.eclipse.core.tests.runtime/build.properties
+++ b/runtime/tests/org.eclipse.core.tests.runtime/build.properties
@@ -26,6 +26,6 @@ javacWarnings..=-unchecked,-raw
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
-tycho.pomless.testbundle = true
+pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.core.tests.runtime.AutomatedTests
 pom.model.property.defaultSigning-excludeInnerJars = true


### PR DESCRIPTION
Use 'pom.model.packaging = eclipse-test-plugin' instead of
'tycho.pomless.testbundle = true', which is planned to be removed with
Tycho 3.0, for test-plugins whose name do not comply with the
test-plugin naming-convention (i.e. don't end with ".test(s)")