### PR TITLE
Partial revert of "Use more Tycho-pomless: Simplify poms and delete (now) trivial poms"

### DIFF
--- a/platform/org.eclipse.platform/build.properties
+++ b/platform/org.eclipse.platform/build.properties
@@ -48,7 +48,3 @@ bin.includes = about.html,\
                700E4F39BC05364B.asc
 src.includes = about.html
 source.platform.jar = src-intro/
-
-# Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
-tycho.pomless.parent = ../../
-pom.model.property.tycho.buildqualifier.format = 'v${buildTimestamp}'

--- a/platform/org.eclipse.platform/pom.xml
+++ b/platform/org.eclipse.platform/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2012, 2017 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+ 
+  Contributors:
+     Igor Fedorenko - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.platform</artifactId>
+    <groupId>eclipse.platform</groupId>
+    <version>4.25.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <groupId>org.eclipse.platform</groupId>
+  <artifactId>org.eclipse.platform</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <format>'v${buildTimestamp}'</format>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/platform/org.eclipse.sdk/build.properties
+++ b/platform/org.eclipse.sdk/build.properties
@@ -41,6 +41,3 @@ bin.includes = about.html,\
                eclipse512.png,\
                org.eclipse.ui.intro.universal.solstice/
 
-# Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
-tycho.pomless.parent = ../../
-pom.model.property.tycho.buildqualifier.format = 'v${buildTimestamp}'

--- a/platform/org.eclipse.sdk/pom.xml
+++ b/platform/org.eclipse.sdk/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2012, 2017 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+ 
+  Contributors:
+     Igor Fedorenko - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.platform</artifactId>
+    <groupId>eclipse.platform</groupId>
+    <version>4.25.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <groupId>org.eclipse.sdk</groupId>
+  <artifactId>org.eclipse.sdk</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <format>'v${buildTimestamp}'</format>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This reverts commit 0a954de3c69870625b1b33c605c35bb036f9b326 for
platform/org.eclipse.sdk and platform/org.eclipse.platform modules.

See https://github.com/eclipse-platform/eclipse.platform/issues/59