### PR TITLE
Enable the teams examples

### DIFF
--- a/team/pom.xml
+++ b/team/pom.xml
@@ -37,11 +37,9 @@
     <module>bundles/org.eclipse.team.ui</module>
     <module>bundles/org.eclipse.team.genericeditor.diff.extension</module>
     <module>bundles/org.eclipse.ui.net</module>
-    <!-- Examples, currently deactivated due to warnings in the code 
     <module>examples/org.eclipse.compare.examples</module>
     <module>examples/org.eclipse.compare.examples.xml</module>
     <module>examples/org.eclipse.team.examples.filesystem</module>
-    -->
 
     <!-- fragments -->
     <module>bundles/org.eclipse.core.net.linux</module>


### PR DESCRIPTION
FYI @akurtakov @vogella @iloveeclipse 

Actually here are some warnings disabled (I used that from the original team pom xml) but the build still complains if I urn this locally: https://github.com/eclipse-platform/eclipse.platform/blob/564174870d375d2dc773d31b68bf40c04602dc97/team/pom.xml#L22

