### PR TITLE
CVS support is still listed in the Preferences->General->Capabilities->Team

### DIFF
--- a/platform/org.eclipse.sdk/plugin.properties
+++ b/platform/org.eclipse.sdk/plugin.properties
@@ -33,8 +33,6 @@ activity.plugin=Plug-in Development
 activity.plugin.desc=Develop plug-ins, fragments, and features for Eclipse.
 activity.ant=Ant Development
 activity.ant.desc=Create and use Ant build scripts
-activity.team.cvs=CVS Support
-activity.team.cvs.desc=Use the Concurrent Versions System (CVS) to manage resources.
 activity.team=Core Team Support
 activity.team.desc=Share projects using configuration management systems.
 

--- a/platform/org.eclipse.sdk/plugin.xml
+++ b/platform/org.eclipse.sdk/plugin.xml
@@ -92,14 +92,7 @@
             id="org.eclipse.debugSupport"
             name="%activity.debug">
       </activity>
-      
-  
-      <activity
-            name="%activity.team.cvs"
-            description="%activity.team.cvs.desc"
-            id="org.eclipse.team.cvs">
-      </activity> 
-      
+
       <activity
             name="%activity.team"
             description="%activity.team.desc"


### PR DESCRIPTION
Preferences->General->Capabilities->Team

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/116