### PR TITLE
[win] ignore "Problem occurred in auto-refresh native code: 5." #124

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Monitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Monitor.java
@@ -608,7 +608,9 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 			// we ran into a problem
 			int error = Win32Natives.GetLastError();
 			if (error != Win32Natives.ERROR_INVALID_HANDLE && error != Win32Natives.ERROR_SUCCESS) {
-				addException(NLS.bind(Messages.WM_nativeErr, Integer.toString(error)));
+				if (error != Win32Natives.ERROR_ACCESS_DENIED) {
+					addException(NLS.bind(Messages.WM_nativeErr, Integer.toString(error)));
+				}
 				refreshResult.monitorFailed(this, null);
 			}
 			return;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
@@ -34,6 +34,9 @@ public class Win32Natives {
 	 * invalid.
 	 */
 	public static final int ERROR_INVALID_HANDLE;
+
+	/** Access is denied. */
+	public static final int ERROR_ACCESS_DENIED = 5;
 	/**
 	 * The combination of all of the error constants.
 	 */


### PR DESCRIPTION
WaitForMultipleObjects -> WAIT_FAILED -> GetLastError can return 5
(ERROR_ACCESS_DENIED) as described in:
https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects
https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-

Happens sometimes and can flood log without giving any value.