### PR TITLE
Mark Message#contributorURI for deletion

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Message.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Message.java
@@ -154,7 +154,7 @@ public @interface Message {
 	/**
 	 * @deprecated Use contributionURI instead
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "4.26")
 	String contributorURI() default "";
 
 	/**


### PR DESCRIPTION
Deprecated shortly after its creation in 2014, its time to mark it for
deletion in + 2 years.