### PR TITLE
fix random failing OrderedLockTest

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.20.300.qualifier
+Bundle-Version: 3.20.400.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -412,7 +412,7 @@ public class JobGroupTest extends AbstractJobTest {
 		allJobs = manager.find(null);
 		for (int i = 0; i < allJobs.length; i++) {
 			// Verify that no jobs that we know about are found (they should have all been removed)
-			assertTrue(testJobs.remove(allJobs[i]));
+			assertTrue(allJobs[i].toString(), testJobs.remove(allJobs[i]));
 		}
 		assertEquals("15.0", NUM_JOBS, testJobs.size());
 		testJobs.clear();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/LockAcquiringRunnable.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/LockAcquiringRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2015 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,62 +13,102 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import java.util.Random;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.core.runtime.jobs.ILock;
 
 public class LockAcquiringRunnable implements Runnable {
-	private ILock[] locks;
-	private Random random = new Random();
-	private boolean alive;
-	private boolean done;
+	static class RandomOrder {
+		private final Queue<LockAcquiringRunnable> randomRunnables = new ConcurrentLinkedQueue<>();
+		private final int workerCount;
+		private final AtomicInteger waiting = new AtomicInteger();
+		private final AtomicInteger busy = new AtomicInteger();
+
+		RandomOrder(ArrayList<LockAcquiringRunnable> allRunnables, int maxRounds) {
+			workerCount = allRunnables.size();
+			// create a random order in which the threads should do their operations:
+			List<LockAcquiringRunnable> randomOrder = new ArrayList<>();
+			for (LockAcquiringRunnable l : allRunnables) {
+				for (int i = 1; i < maxRounds * (1 + l.locks.length); i++) {
+					randomOrder.add(l);
+				}
+			}
+			Collections.shuffle(randomOrder);
+			this.randomRunnables.addAll(randomOrder);
+		}
+
+		/**
+		 * wait "random time" till thread is the next in the random order
+		 **/
+		public boolean randomWait(LockAcquiringRunnable me) {
+			int waitingCount = waiting.incrementAndGet();
+			try {
+				while (randomRunnables.peek() != me) {
+					if (randomRunnables.isEmpty()) {
+						return false; // no more work
+					}
+					if (waitingCount >= workerCount - busy.get()) {
+						// the head thread is not progressing (waiting in
+						// acquire), so stop waiting
+						LockAcquiringRunnable head = randomRunnables.poll();
+						if (head != null) {
+							randomRunnables.add(head);
+							return true;
+						}
+					}
+					Thread.yield();
+				}
+				// fast path - do not wait any fixed time
+				randomRunnables.remove();
+				return true;
+			} finally {
+				waiting.decrementAndGet();
+			}
+		}
+
+		public void waitForEnd() {
+			while (!randomRunnables.isEmpty()) {
+				Thread.yield();
+			}
+		}
+
+		public void busy(Runnable runner) {
+			busy.incrementAndGet();
+			try {
+				runner.run();
+			} finally {
+				busy.decrementAndGet();
+			}
+		}
+	}
+
+	private final ILock[] locks;
+	private volatile RandomOrder rnd;
 
 	/**
-	 * This runnable will randomly acquire the given lock for
-	 * random periods of time, in the given order
+	 * This runnable will randomly acquire the given lock for random periods of
+	 * time, in the given order
 	 */
 	public LockAcquiringRunnable(ILock[] locks) {
 		this.locks = locks;
-		this.alive = true;
-		done = false;
-	}
-
-	public void kill() {
-		alive = false;
 	}
 
 	@Override
 	public void run() {
-		while (alive) {
-			try {
-				Thread.sleep(random.nextInt(500));
-			} catch (InterruptedException e) {
-				//ignore
-			}
+		while (rnd.randomWait(this)) {
 			for (ILock lock : locks) {
-				lock.acquire();
-				try {
-					Thread.sleep(random.nextInt(500));
-				} catch (InterruptedException e1) {
-					//ignore
-				}
+				rnd.busy(lock::acquire);
+				rnd.randomWait(this);
 			}
-			//release all locks
+			// release all locks
 			for (int i = locks.length; --i >= 0;) {
 				locks[i].release();
 			}
 		}
-		done = true;
 	}
 
-	public void isDone() {
-		while (!done) {
-			try {
-				Thread.yield();
-				Thread.sleep(100);
-				Thread.yield();
-			} catch (InterruptedException e) {
-				//ignore
-			}
-		}
+	public void setRandomOrder(RandomOrder rnd) {
+		this.rnd = rnd;
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2015 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,13 +15,16 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 import org.eclipse.core.internal.jobs.LockManager;
 import org.eclipse.core.internal.jobs.OrderedLock;
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.LockListener;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.eclipse.core.tests.runtime.jobs.LockAcquiringRunnable.RandomOrder;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -29,6 +32,8 @@ import org.junit.Test;
  */
 @SuppressWarnings("restriction")
 public class OrderedLockTest {
+	@Rule
+	public RetryTestRule retry = new RetryTestRule(10); // executes all tests in the Class multiple times
 
 	/**
 	 * Creates n runnables on the given lock and adds them to the given list.
@@ -36,12 +41,6 @@ public class OrderedLockTest {
 	private void createRunnables(ILock[] locks, int n, ArrayList<LockAcquiringRunnable> allRunnables) {
 		for (int i = 0; i < n; i++) {
 			allRunnables.add(new LockAcquiringRunnable(locks));
-		}
-	}
-
-	private void kill(ArrayList<LockAcquiringRunnable> allRunnables) {
-		for (LockAcquiringRunnable lockAcquiringRunnable : allRunnables) {
-			lockAcquiringRunnable.kill();
 		}
 	}
 
@@ -56,15 +55,7 @@ public class OrderedLockTest {
 		createRunnables(new ILock[] {lock3, lock2, lock1}, 5, allRunnables);
 		createRunnables(new ILock[] {lock1, lock3, lock2}, 5, allRunnables);
 		createRunnables(new ILock[] {lock2, lock3, lock1}, 5, allRunnables);
-		start(allRunnables);
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException e) {
-		}
-		kill(allRunnables);
-		for (LockAcquiringRunnable runnable : allRunnables) {
-			runnable.isDone();
-		}
+		execute(allRunnables);
 		//the underlying array has to be empty
 		assertTrue("Locks not removed from graph.", manager.isEmpty());
 	}
@@ -78,15 +69,7 @@ public class OrderedLockTest {
 		OrderedLock lock3 = manager.newLock();
 		createRunnables(new ILock[] {lock1, lock2, lock3}, 1, allRunnables);
 		createRunnables(new ILock[] {lock3, lock2, lock1}, 1, allRunnables);
-		start(allRunnables);
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException e) {
-		}
-		kill(allRunnables);
-		for (LockAcquiringRunnable runnable : allRunnables) {
-			runnable.isDone();
-		}
+		execute(allRunnables);
 		//the underlying array has to be empty
 		assertTrue("Locks not removed from graph.", manager.isEmpty());
 	}
@@ -116,7 +99,7 @@ public class OrderedLockTest {
 		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 		//make sure thread is blocked
 		barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
-		Thread.sleep(500);
+		Thread.yield();
 		t.interrupt();
 		lock.release();
 		t.join();
@@ -133,34 +116,31 @@ public class OrderedLockTest {
 		final LockManager manager = new LockManager();
 		final OrderedLock lock = manager.newLock();
 		//status array for communicating between threads
-		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_START });
+		final TestBarrier2 status = new TestBarrier2(TestBarrier2.STATUS_START);
 		//array to end a runnable after it is no longer needed
 		final boolean[] alive = {true};
 
 		//first runnable which is going to hold the created lock
 		Runnable getLock = () -> {
 			lock.acquire();
-			status.set(0, TestBarrier2.STATUS_RUNNING);
+			status.upgradeTo(TestBarrier2.STATUS_RUNNING);
 			while (alive[0]) {
-				try {
-					Thread.sleep(100);
-				} catch (InterruptedException e) {
-				}
+				Thread.yield();
 			}
 			lock.release();
-			status.set(0, TestBarrier2.STATUS_DONE);
+			status.upgradeTo(TestBarrier2.STATUS_DONE);
 		};
 
 		//second runnable which is going to try and acquire the given lock and then time out
 		Runnable tryForLock = () -> {
 			boolean success = false;
 			try {
-				success = lock.acquire(100);
+				success = lock.acquire(0);
 			} catch (InterruptedException e) {
 			}
 			assertTrue("1.0", !success);
 			assertTrue("1.1", !manager.isLockOwner());
-			status.set(0, TestBarrier2.STATUS_WAIT_FOR_DONE);
+			status.upgradeTo(TestBarrier2.STATUS_WAIT_FOR_DONE);
 		};
 
 		Thread first = new Thread(getLock);
@@ -168,13 +148,13 @@ public class OrderedLockTest {
 
 		//start the first thread and wait for it to acquire the lock
 		first.start();
-		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_RUNNING);
+		status.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		//start the second thread, make sure the assertion passes
 		second.start();
-		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_WAIT_FOR_DONE);
+		status.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 		//let the first thread die
 		alive[0] = false;
-		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
+		status.waitForStatus(TestBarrier2.STATUS_DONE);
 		//the underlying array has to be empty
 		assertTrue("Locks not removed from graph.", manager.isEmpty());
 	}
@@ -185,44 +165,69 @@ public class OrderedLockTest {
 	 */
 	@Test
 	public void testLockRequestDisappearence() {
-		//create a new lock manager and 1 lock
+		// create a new lock manager and 1 lock
 		final LockManager manager = new LockManager();
 		final OrderedLock lock = manager.newLock();
-		//status array for communicating between threads
-		final AtomicIntegerArray status = new AtomicIntegerArray(
-				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
+		// communicating between threads:
+		final TestBarrier2 status0main = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
+		final TestBarrier2 status1getLock = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
+		final TestBarrier2 status2waitForLock = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
+		final TestBarrier2 status3forceGetLock = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
+		Collection<Throwable> errors = new ConcurrentLinkedQueue<>();
 
-		//first runnable which is going to hold the created lock
-		Runnable getLock = () -> {
-			lock.acquire();
-			status.set(0, TestBarrier2.STATUS_START);
-			TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
-			lock.release();
-			status.set(0, TestBarrier2.STATUS_DONE);
+		// first runnable which is going to hold the created lock
+		Thread thread1getLock = new Thread("thread1getLock") {
+			@Override
+			public void run() {
+				try {
+					lock.acquire();
+					status1getLock.upgradeTo(TestBarrier2.STATUS_START);
+					status0main.waitForStatus(TestBarrier2.STATUS_RUNNING);
+					lock.release();
+					status1getLock.upgradeTo(TestBarrier2.STATUS_DONE);
+				} catch (Throwable t) {
+					errors.add(t);
+				}
+			}
 		};
 
-		//second runnable which is going to submit a request for this lock and wait until it is available
-		Runnable waitForLock = () -> {
-			status.set(1, TestBarrier2.STATUS_START);
-			lock.acquire(); // has to be in waiting state before manager.setLockListener(listener) should
-							// happen
-			assertTrue("1.0", manager.isLockOwner()); // XXX fails silently in other thread and test times out.
-			status.set(1, TestBarrier2.STATUS_WAIT_FOR_DONE);
-			lock.release();
-			status.set(1, TestBarrier2.STATUS_DONE);
-
+		// second runnable which is going to submit a request for this lock and wait
+		// until it is available
+		Thread thread2waitForLock = new Thread("thread2waitForLock") {
+			@Override
+			public void run() {
+				try {
+					status2waitForLock.upgradeTo(TestBarrier2.STATUS_START);
+					lock.acquire(); // has to be in waiting state before manager.setLockListener(listener) should
+									// happen
+					assertTrue("1.0", manager.isLockOwner());
+					// status2waitForLock.upgrade(TestBarrier2.STATUS_WAIT_FOR_DONE);// done in
+					// waitListener
+					lock.release();
+					status2waitForLock.upgradeTo(TestBarrier2.STATUS_DONE);
+				} catch (Throwable t) {
+					errors.add(t);
+				}
+			}
 		};
 
-		//third runnable which is going to submit a request for this lock but not wait
-		//because the hook is going to force it to be given the lock (implicitly)
-		Runnable forceGetLock = () -> {
-			lock.acquire();
-			lock.release();
-			status.set(0, TestBarrier2.STATUS_WAIT_FOR_DONE);
+		// third runnable which is going to submit a request for this lock but not wait
+		// because the hook is going to force it to be given the lock (implicitly)
+		Thread thread3forceGetLock = new Thread("thread3forceGetLock") {
+			@Override
+			public void run() {
+				try {
+					lock.acquire();
+					lock.release();
+					status3forceGetLock.upgradeTo(TestBarrier2.STATUS_DONE);
+				} catch (Throwable t) {
+					errors.add(t);
+				}
+			}
 		};
 
-
-		//a locklistener to force lock manager to give the lock to the third runnable (implicitly)
+		// a LockListener to force lock manager to give the lock to the third runnable
+		// (implicitly)
 		LockListener listener = new LockListener() {
 			@Override
 			public boolean aboutToWait(Thread lockOwner) {
@@ -230,50 +235,69 @@ public class OrderedLockTest {
 			}
 		};
 
-		//assign each runnable to a separate thread
-		Thread first = new Thread(getLock);
-		Thread second = new Thread(waitForLock);
-		Thread third = new Thread(forceGetLock);
-
 		LockListener waitListener = new LockListener() {
 			@Override
 			public boolean aboutToWait(Thread lockOwner) {
-				if (Thread.currentThread() == second) {
-					status.set(1, TestBarrier2.STATUS_WAIT_FOR_DONE);
+				if (Thread.currentThread() == thread2waitForLock) {
+					status0main.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
+					status2waitForLock.upgradeTo(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				}
 				return false;
 			}
 		};
-		//start the first thread and wait for it to acquire the lock
-		first.start();
-		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		// start the first thread and wait for it to acquire the lock
+		thread1getLock.start();
 		manager.setLockListener(waitListener);
-		//start the second thread, make sure it is added to the lock wait queue
-		second.start();
-		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
+		status1getLock.waitForStatus(TestBarrier2.STATUS_START);
+		// start the second thread, make sure it is added to the lock wait queue
+		thread2waitForLock.start();
+		status2waitForLock.waitForStatus(TestBarrier2.STATUS_START);
+		status0main.upgradeTo(TestBarrier2.STATUS_WAIT_FOR_RUN);
 		// wait till waitForLock's "lock.acquire()" has been progressed enough:
-		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_DONE);
+		status2waitForLock.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 
-		//assign our listener to the manager
+		// assign our listener to the manager
 		manager.setLockListener(listener);
-		//start the third thread
-		third.start();
-		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_DONE);
+		// start the third thread
+		thread3forceGetLock.start();
+		status3forceGetLock.waitForStatus(TestBarrier2.STATUS_DONE);
 
-		//let the first runnable complete
-		status.set(0, TestBarrier2.STATUS_RUNNING);
-		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
+		// let the first runnable complete
+		status0main.upgradeTo(TestBarrier2.STATUS_RUNNING);
+		status1getLock.waitForStatus(TestBarrier2.STATUS_DONE);
 
-		//now wait for the second runnable to get the lock, and have the assertion pass
-		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
+		// now wait for the second runnable to get the lock, and have the assertion pass
+		status2waitForLock.waitForStatus(TestBarrier2.STATUS_DONE);
 
-		//the underlying array has to be empty
+		// the underlying array has to be empty
 		assertTrue("Locks not removed from graph.", manager.isEmpty());
+		errors.forEach(e -> e.printStackTrace());
+		assertTrue("Error happend: " + errors.stream().map(e -> "" + e).collect(Collectors.joining(", ")),
+				errors.isEmpty());
 	}
 
-	private void start(ArrayList<LockAcquiringRunnable> allRunnables) {
+	private void execute(ArrayList<LockAcquiringRunnable> allRunnables) {
+		RandomOrder randomOrder = new RandomOrder(allRunnables, 2);
 		for (LockAcquiringRunnable lockAcquiringRunnable : allRunnables) {
-			new Thread(lockAcquiringRunnable).start();
+			lockAcquiringRunnable.setRandomOrder(randomOrder);
+		}
+		List<Thread> threads = new ArrayList<>();
+		for (LockAcquiringRunnable lockAcquiringRunnable : allRunnables) {
+			Thread thread = new Thread(lockAcquiringRunnable);
+			threads.add(thread);
+			thread.start();
+		}
+		randomOrder.waitForEnd();
+		for (Thread thread : threads) {
+			try {
+				thread.join(500);
+				if (thread.isAlive()) {
+					throw new IllegalStateException("thread did not end");
+
+				}
+			} catch (InterruptedException e) {
+				throw new IllegalStateException("interrupted");
+			}
 		}
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/RetryTestRule.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/RetryTestRule.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Joerg Kubitz and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.runtime.jobs;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/** runs the test class multiple times **/
+public class RetryTestRule implements TestRule {
+
+	private final int retryCount;
+
+	public RetryTestRule(int retryCount) {
+		this.retryCount = retryCount;
+	}
+
+	@Override
+	public Statement apply(final Statement base, final Description description) {
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				Throwable caughtThrowable = null;
+				int failuresCount = 0;
+				for (int i = 0; i < retryCount; i++) {
+					try {
+						base.evaluate();
+					} catch (Throwable t) {
+						caughtThrowable = t;
+						System.err.println(description.getDisplayName() + ": run " + (i + 1) + " failed:");
+						t.printStackTrace();
+						++failuresCount;
+					}
+				}
+				if (caughtThrowable == null) {
+					return;
+				}
+				throw new AssertionError(description.getDisplayName() + ": failures " + failuresCount + " out of "
+						+ retryCount + " tries. Last cause:" + caughtThrowable, caughtThrowable);
+			}
+		};
+	}
+}


### PR DESCRIPTION
* do not wait random time but use random order (faster)
* log thread dump on timeout (better diagnosis)
* execute test multiple times for (easier finding random failings)
* fixed waiting conditions.