### PR TITLE
fix TestWorkspaceEncodingExistingWorkspace.testExpectedEncoding1() #128

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import junit.framework.Test;
@@ -50,8 +51,8 @@ public class TestWorkspaceEncodingExistingWorkspace extends WorkspaceSessionTest
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		// Should be system default
-		assertEquals(defaultValue, ResourcesPlugin.getEncoding());
-		assertEquals(defaultValue, workspace.getRoot().getDefaultCharset(true));
+		assertEquals(Charset.forName(defaultValue), Charset.forName(ResourcesPlugin.getEncoding()));
+		assertEquals(Charset.forName(defaultValue), Charset.forName(workspace.getRoot().getDefaultCharset(true)));
 
 		// and not defined in workspace
 		String charset = workspace.getRoot().getDefaultCharset(false);


### PR DESCRIPTION
expected:<[Cp]1252> but was:<[windows-]1252>
The Charset is the same, but not it's ambigous name.