### PR TITLE
WIP Semaphore release check.

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.jobs; singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.jobs;x-internal:=true,

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/Semaphore.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/Semaphore.java
@@ -31,6 +31,12 @@ public class Semaphore {
 	 * and false otherwise.
 	 */
 	public synchronized boolean acquire(long delay) throws InterruptedException {
+		if (notifications == 0) {
+			// constructor already acquires Semaphore
+			// has to be released before requiring again or gets stuck in wait.
+			System.err.println("Semaphore already acquired"); //$NON-NLS-1$
+			throw new IllegalStateException("Semaphore already acquired"); //$NON-NLS-1$
+		}
 		if (Thread.interrupted())
 			throw new InterruptedException();
 		long start = System.nanoTime();
@@ -76,6 +82,11 @@ public class Semaphore {
 	}
 
 	public synchronized void release() {
+		if (notifications > 0) {
+			System.err.println("Semaphore already released"); //$NON-NLS-1$
+			throw new IllegalStateException("Semaphore already released"); //$NON-NLS-1$
+			// TODO just do not increment any further?
+		}
 		notifications++;
 		notifyAll();
 	}


### PR DESCRIPTION
Semaphore may wait endlessly in acquire() when released multiple times