### PR TITLE
synchronize Job Notification to fix join() (fixes #148)

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.jobs; singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.jobs;x-internal:=true,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
@@ -105,12 +105,46 @@ public class Bug_574883 extends AbstractJobManagerTest {
 					length);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
-			// TODO: print the fail only, as long as bug 574883 is not fixed yet
-			t.printStackTrace(System.out);
-			t.printStackTrace(System.err);
 			Job.getJobManager().cancel(this);
 			Thread.sleep(1000);
 			Job.getJobManager().join(this, null);
+			throw t;
+		}
+	}
+
+	/**
+	 * same as testReschedulingLambda but repeated with more joins to be more likely
+	 * to fail
+	 */
+	@Test
+	public void testJoinLambdaOften() throws InterruptedException {
+		for (int l = 0; l < RUNS; l++) {
+			// Executor has to execute every task. Even when they are scheduled fast
+			// and execute fast
+			SerialExecutor serialExecutor = new SerialExecutor("test", this);
+			AtomicInteger executions = new AtomicInteger();
+			int INNER_RUNS = 10;
+			for (int i = 0; i < INNER_RUNS; i++) {
+				serialExecutor.schedule(() -> executions.incrementAndGet());
+			}
+			Job.getJobManager().join(this, null);
+			Job[] jobs = Job.getJobManager().find(this);
+			int length = jobs.length;
+			int firstState = executions.get();
+			try {
+				if (executions.get() != INNER_RUNS) {
+					System.out.println("error");
+				}
+				assertEquals("after " + l + " tries: Job still running after join, executed: " + firstState
+						+ ", cpu: " + processors, 0,
+						length);
+				assertEquals("after " + l + " tries", INNER_RUNS, executions.get());
+			} catch (Throwable t) {
+				Job.getJobManager().cancel(this);
+				Thread.sleep(1000);
+				Job.getJobManager().join(this, null);
+				throw t;
+			}
 		}
 	}
 
@@ -140,12 +174,10 @@ public class Bug_574883 extends AbstractJobManagerTest {
 					length);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
-			// TODO: print the fail only, as long as bug 574883 is not fixed yet
-			t.printStackTrace(System.out);
-			t.printStackTrace(System.err);
 			Job.getJobManager().cancel(this);
 			Thread.sleep(1000);
 			Job.getJobManager().join(this, null);
+			throw t;
 		}
 	}
 
@@ -185,12 +217,10 @@ public class Bug_574883 extends AbstractJobManagerTest {
 					length);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
-			// TODO: print the fail only, as long as bug 574883 is not fixed yet
-			t.printStackTrace(System.out);
-			t.printStackTrace(System.err);
 			Job.getJobManager().cancel(this);
 			Thread.sleep(1000);
 			Job.getJobManager().join(this, null);
+			throw t;
 		}
 	}
 


### PR DESCRIPTION
Bug 574883 - Job.getJobManager().join(family) doesn't wait for a
re-scheduled job

* Add and use a Job specific lock to make sure the notification that a
job stopped is send before the job is reported to be started again
(in another thread).

* JobManager.schedule() - when called from endJob() - is called within
the synchronized(lock)) instead of using a second (non atomic)
synchronized(lock) afterwards. The notification is still send outside
that synchronized(lock).

Previously it was possible that the Job notifications was send and
processed in different threads and - since not synchronized - in
arbitrary order. Especially a job
could restart in another worker thread before the notification was
processed that previous job execution was done.
Still the events are processed in different threads, but the
notification order is fixed.

=> The same Job will not start again before all listeners noticed that
the Job was finished. That is also wanted for other Listeneres then the
join() Listener since the Listeners should be able to decide if the Job
should start again (see JobTest.testCancelFromAboutToRun())

The benefit is proven by JUnit Test Bug_574883.testJoinLambdaOften().
Basic functionality is tested by JobTest.
