### PR TITLE
Add test for #160:  Job.schedule() randomly sometimes not rescheduling

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
@@ -26,6 +26,7 @@ import org.junit.runners.Suite;
 		BeginEndRuleTest.class, JobTest.class, DeadlockDetectionTest.class, Bug_129551.class, Bug_211799.class,
 		Bug_307282.class, Bug_307391.class, MultiRuleTest.class, Bug_311756.class, Bug_311863.class, Bug_316839.class,
 		Bug_320329.class, Bug_478634.class, Bug_550738.class, Bug_574883.class, Bug_412138.class,
+		Bug_574884Schedule.class,
 		WorkerPoolTest.class
 })
 public class AllTests {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
@@ -26,7 +26,7 @@ import org.junit.runners.Suite;
 		BeginEndRuleTest.class, JobTest.class, DeadlockDetectionTest.class, Bug_129551.class, Bug_211799.class,
 		Bug_307282.class, Bug_307391.class, MultiRuleTest.class, Bug_311756.class, Bug_311863.class, Bug_316839.class,
 		Bug_320329.class, Bug_478634.class, Bug_550738.class, Bug_574883.class, Bug_412138.class,
-		Bug_574884Schedule.class,
+		Bug_574883Schedule.class,
 		WorkerPoolTest.class
 })
 public class AllTests {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883Schedule.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883Schedule.java
@@ -26,7 +26,7 @@ import org.junit.runners.MethodSorters;
  * Test for bug https://github.com/eclipse-platform/eclipse.platform/issues/160
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class Bug_574884Schedule extends AbstractJobManagerTest {
+public class Bug_574883Schedule extends AbstractJobManagerTest {
 
 	static class SerialExecutor extends Job {
 
@@ -80,7 +80,7 @@ public class Bug_574884Schedule extends AbstractJobManagerTest {
 		}
 	}
 
-	final int RUNS = 10_000_000;
+	final int RUNS = 1_000_000;
 
 
 	/**

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574884Schedule.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574884Schedule.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Joerg Kubitz and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joerg Kubitz - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.runtime.jobs;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.jobs.Job;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+/**
+ * Test for bug https://github.com/eclipse-platform/eclipse.platform/issues/160
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class Bug_574884Schedule extends AbstractJobManagerTest {
+
+	static class SerialExecutor extends Job {
+
+		private final Queue<Runnable> queue;
+		private final Object myFamily;
+
+		/**
+		 * @param jobName descriptive job name
+		 * @param family  non null object to control this job execution
+		 **/
+		public SerialExecutor(String jobName, Object family) {
+			super(jobName);
+			Assert.isNotNull(family);
+			this.myFamily = family;
+			this.queue = new ConcurrentLinkedQueue<>();
+			setSystem(true);
+			setPriority(Job.INTERACTIVE);
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return myFamily == family;
+		}
+
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			Runnable action = queue.poll();
+			try {
+				if (action != null && !monitor.isCanceled()) {
+					action.run();
+				}
+			} finally {
+				if (!queue.isEmpty() && !monitor.isCanceled()) {
+					schedule(); // this sometimes does not work?
+				}
+			}
+			return Status.OK_STATUS;
+		}
+
+		/**
+		 * Enqueue an action asynchronously.
+		 */
+		public void schedule(Runnable action) {
+			queue.offer(action);
+			schedule(); // or this sometimes does not work?
+		}
+	}
+
+	final int RUNS = 1_000_000;
+
+
+	/**
+	 * starts many jobs that should run three times but sometimes only run exactly
+	 * once (i have never seen running twice)
+	 */
+	@Test
+	public void testJoinLambdaQuick() throws InterruptedException {
+		String firstMessage = null;
+		int fails = 0;
+		for (int l = 0; l < RUNS; l++) {
+			// Executor has to execute every task. Even when they are scheduled fast
+			// and execute fast
+			SerialExecutor serialExecutor = new SerialExecutor("test", this);
+			AtomicInteger executions = new AtomicInteger();
+			int INNER_RUNS = 3;
+			for (int i = 0; i < INNER_RUNS; i++) {
+				serialExecutor.schedule(() -> executions.incrementAndGet());
+			}
+			Job.getJobManager().join(this, null);
+			int executionsAfterJoin = executions.get();
+			String message = "after " + l + " tries: executionsAfterJoin: " + executionsAfterJoin + "/" + INNER_RUNS;
+			if (executionsAfterJoin != INNER_RUNS) {
+				System.out.println(message);
+				Thread.sleep(1000); // wait till the Job did finish (no way such a simple job can still be running)
+				int executionsCured = executions.get();
+				if (executionsCured != INNER_RUNS) {
+					System.out.println("but did finish"); // would be a join() bug
+				} else {
+					fails++;
+					if (firstMessage == null) {
+						firstMessage = message;
+					}
+				}
+			}
+		}
+		assertEquals("Job was not (re)scheduled " + fails + "/" + RUNS + " times. example: " + firstMessage, 0, fails);
+	}
+}


### PR DESCRIPTION
Example output:
after 179536 tries: executionsAfterJoin: 1/3
after 542737 tries: executionsAfterJoin: 1/3
after 896829 tries: executionsAfterJoin: 1/3