### PR TITLE
Fix Job Notification order to fix JobManager.join() #167

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -155,7 +155,7 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	/**
 	 * This signal is used to synchronize Job listener notification
 	 */
-	volatile boolean waitForNotificationFinsished;
+	volatile boolean waitForNotificationFinished;
 
 	private static synchronized int getNextJobNumber() {
 		return nextJobNumber++;

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -701,7 +701,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 		final boolean scheduled;
 		try {
 			// do not restart job before notification finished:
-			job.waitForNotificationFinsished = true;
+			job.waitForNotificationFinished = true;
 			synchronized (lock) {
 				//if the job is finishing asynchronously, there is nothing more to do for now
 				if (result == Job.ASYNC_FINISH)
@@ -734,7 +734,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 			}
 		} finally {
 			// now job may be restartet eventually in other thread:
-			job.waitForNotificationFinsished = false;
+			job.waitForNotificationFinished = false;
 		}
 		//log result if it is warning or error. When the job belongs to a job group defer the logging
 		//until the whole group is completed (see JobManager#updateJobGroup).
@@ -1202,7 +1202,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 					Assert.isTrue(job.next() == null);
 					Assert.isTrue(job.previous() == null);
 					blocker.addLast(job);
-				} else if (job.waitForNotificationFinsished) {
+				} else if (job.waitForNotificationFinished) {
 					// do not start this job yet!
 				} else if (jobGroup == null || jobGroup.getMaxThreads() == 0 || (jobGroup.getState() != JobGroup.CANCELING && jobGroup.getRunningJobsCount() < jobGroup.getMaxThreads())) {
 					break;
@@ -1350,6 +1350,12 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 
 	protected void schedule(InternalJob job, long delay, boolean reschedule) {
 		if (scheduleInternal(job, delay, reschedule)) {
+			while (job.waitForNotificationFinished) {
+				// Do not notify next schedule until notification finished delivered.
+				// Which will happen very soon as the job is already finished and only waiting
+				// for the listeners
+				Thread.onSpinWait();
+			}
 			scheduleNotify(job, delay, reschedule);
 		}
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
@@ -26,6 +26,7 @@ import org.junit.runners.Suite;
 		BeginEndRuleTest.class, JobTest.class, DeadlockDetectionTest.class, Bug_129551.class, Bug_211799.class,
 		Bug_307282.class, Bug_307391.class, MultiRuleTest.class, Bug_311756.class, Bug_311863.class, Bug_316839.class,
 		Bug_320329.class, Bug_478634.class, Bug_550738.class, Bug_574883.class, Bug_412138.class,
+		Bug_574883Join.class,
 		WorkerPoolTest.class
 })
 public class AllTests {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883Join.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883Join.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Joerg Kubitz and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joerg Kubitz - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.runtime.jobs;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicInteger;
+import junit.framework.TestCase;
+import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.jobs.Job;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+/**
+ * Test for bug https://github.com/eclipse-platform/eclipse.platform/issues/160
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class Bug_574883Join extends TestCase {
+
+	static class SerialExecutor extends Job {
+
+		private final Object myFamily;
+		final Runnable action;
+		AtomicInteger executions = new AtomicInteger();
+
+		/**
+		 * @param jobName descriptive job name
+		 * @param family  non null object to control this job execution
+		 **/
+		public SerialExecutor(String jobName, Object family, Runnable action) {
+			super(jobName);
+			Assert.isNotNull(family);
+			this.myFamily = family;
+			setSystem(true);
+			setPriority(Job.INTERACTIVE);
+			this.action = action;
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return myFamily == family;
+		}
+
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			action.run();
+			executions.incrementAndGet();
+			return Status.OK_STATUS;
+		}
+
+		@Override
+		public String toString() {
+			return " executions=" + executions.get() + " run " + run;
+		}
+
+	}
+
+	final int RUNS = 100_000;
+	static volatile int run;
+
+	/**
+	 * starts many jobs that should run three times but sometimes only run exactly
+	 * once (with reschedules=0 or 1) and rarely twice (reschedules=1)
+	 */
+	@Test
+	public void testJoinLambdaQuick() throws InterruptedException {
+		String firstMessage = null;
+		int joinFails = 0;
+		int scheduleFails = 0;
+		for (run = 0; run < RUNS; run++) {
+			AtomicInteger executions = new AtomicInteger();
+			int EXPECTED_RUNS = 2;
+			Reference<SerialExecutor> jobReference = createAndRunJobTwice(executions);
+
+			Job.getJobManager().join(this, null);
+			int executionsAfterJoin = executions.get();
+			if (executionsAfterJoin != EXPECTED_RUNS) {
+				int waits = 0;
+				while (executions.get() != EXPECTED_RUNS) {
+					waits++;
+					if (waits < 10) {
+						Thread.yield(); // give the job a chance to finish
+					} else {
+						System.gc();
+						System.runFinalization(); // indirectly wait till job finished
+						SerialExecutor job = jobReference.get();
+						if (job == null) {
+							// when job == null it can not be running anymore
+							break;
+						}
+					}
+				}
+				int executionsCured = executions.get();
+				String message = "after " + run + " tries: executionsAfterJoin: " + executionsAfterJoin + "/"
+						+ EXPECTED_RUNS;
+				if (executionsCured == EXPECTED_RUNS) {
+					// join() bug
+					if (joinFails == 0) {
+						System.out.println(message + " but did finish with " + executionsCured);
+						firstMessage = message;
+					}
+					joinFails++;
+					// assertEquals("Job was not joined " + message, 0, joinFails);
+				} else {
+					// schedule bug
+					if (scheduleFails == 0) {
+						System.out.println(message);
+						firstMessage = message;
+					}
+					scheduleFails++;
+					// assertEquals("Job was not (re)scheduled " + message, 0, scheduleFails);
+				}
+			}
+		}
+		assertEquals("Job was not (re)scheduled " + scheduleFails + "/" + run + " times. example: " + firstMessage, 0,
+				scheduleFails);
+		assertEquals("Job was not joined " + joinFails + "/" + run + " times. example: " + firstMessage, 0, joinFails);
+	}
+
+	/** do not inline - so that SerialExecutor can be garbage collected **/
+	private Reference<SerialExecutor> createAndRunJobTwice(AtomicInteger executions) {
+		SerialExecutor serialExecutor = new SerialExecutor("test", this, () -> executions.incrementAndGet());
+		serialExecutor.schedule();
+		while (executions.get() == 0) {
+			Thread.onSpinWait();
+		}
+		// according to contract the schedule() should run the Job at least once more.
+		serialExecutor.schedule(); // this sometimes does not work when job is already scheduled (i.e may be
+		// waiting/running)
+		return new WeakReference<>(serialExecutor);
+	}
+
+}


### PR DESCRIPTION
Fixes left over part from
Bug 574883 - Job.getJobManager().join(family) doesn't wait for a re-scheduled job

Previously it could happen that a Job was scheduled and then executed but did not yet notify that it was finished. Then it could be scheduled again in another thread which would notify the scheduling before the done() event was handled. A join() would see the Job as running but would receive an obsolete done() event which terminates the join() even though the current job execution was not done yet.