### PR TITLE
Fix deadlock when reschedule from the JobChangeAdapter done()

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -155,7 +155,7 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	/**
 	 * This signal is used to synchronize Job listener notification
 	 */
-	volatile boolean waitForNotificationFinished;
+	volatile Thread notifyPendingThread;
 
 	private static synchronized int getNextJobNumber() {
 		return nextJobNumber++;

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -701,7 +701,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 		final boolean scheduled;
 		try {
 			// do not restart job before notification finished:
-			job.waitForNotificationFinished = true;
+			job.notifyPendingThread = Thread.currentThread();
 			synchronized (lock) {
 				//if the job is finishing asynchronously, there is nothing more to do for now
 				if (result == Job.ASYNC_FINISH)
@@ -734,7 +734,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 			}
 		} finally {
 			// now job may be restartet eventually in other thread:
-			job.waitForNotificationFinished = false;
+			job.notifyPendingThread = null;
 		}
 		//log result if it is warning or error. When the job belongs to a job group defer the logging
 		//until the whole group is completed (see JobManager#updateJobGroup).
@@ -1202,7 +1202,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 					Assert.isTrue(job.next() == null);
 					Assert.isTrue(job.previous() == null);
 					blocker.addLast(job);
-				} else if (job.waitForNotificationFinished) {
+				} else if (job.notifyPendingThread != null) {
 					// do not start this job yet!
 				} else if (jobGroup == null || jobGroup.getMaxThreads() == 0 || (jobGroup.getState() != JobGroup.CANCELING && jobGroup.getRunningJobsCount() < jobGroup.getMaxThreads())) {
 					break;
@@ -1350,7 +1350,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 
 	protected void schedule(InternalJob job, long delay, boolean reschedule) {
 		if (scheduleInternal(job, delay, reschedule)) {
-			while (job.waitForNotificationFinished) {
+			while (job.notifyPendingThread != null && job.notifyPendingThread != Thread.currentThread()) {
 				// Do not notify next schedule until notification finished delivered.
 				// Which will happen very soon as the job is already finished and only waiting
 				// for the listeners


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/122

It is however not recommended to reschedule from done() but better from within the job as it is undefined what other JobChangeAdapter will see and thus if a join() would wait for the rescheduled job or not.