### PR TITLE
#178 do not show Get Contents for current-state local file revisions

### DIFF
--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.9.400.qualifier
+Bundle-Version: 3.9.500.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
@@ -567,8 +567,19 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 					if (sel instanceof IStructuredSelection) {
 						IStructuredSelection tempSelection = (IStructuredSelection) sel;
 						if (tempSelection.size() == 1) {
-							manager.add(new Separator("getContents")); //$NON-NLS-1$
-							manager.add(getContentsAction);
+							boolean showGetContentsAction = true;
+							// Issue 178 avoid presenting this action against the current
+							// revision which would result in an undesired truncation
+							if (tempSelection.getFirstElement() instanceof LocalFileRevision) {
+								LocalFileRevision lfr = (LocalFileRevision) tempSelection.getFirstElement();
+								if (lfr.isCurrentState()) {
+									showGetContentsAction = false;
+								}
+							}
+							if (showGetContentsAction) {
+								manager.add(new Separator("getContents")); //$NON-NLS-1$
+								manager.add(getContentsAction);
+							}
 						}
 					}
 				}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
@@ -562,11 +562,9 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 			}
 			if (compareAction != null)
 				manager.add(compareAction);
-			if (getContentsAction != null) {
-				if (showGetContentsAction(treeViewer.getStructuredSelection())) {
-					manager.add(new Separator("getContents")); //$NON-NLS-1$
-					manager.add(getContentsAction);
-				}
+			if (getContentsAction != null && showGetContentsAction(treeViewer.getStructuredSelection())) {
+				manager.add(new Separator("getContents")); //$NON-NLS-1$
+				manager.add(getContentsAction);
 			}
 		}
 	}


### PR DESCRIPTION
Issue 178, do not show Get Contents when the selected revision represent a local, current state