### PR TITLE
Reduce unnecessary worker threads #163

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -389,7 +389,7 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 
 	protected void schedule(long delay) {
 		if (shouldSchedule())
-			manager.schedule(this, delay, false);
+			manager.schedule(this, delay);
 	}
 
 	/**


### PR DESCRIPTION
No need to spawn a new Thread during job end if a job is rescheduled... the current thread can run it again.