### PR TITLE
Full deterministic JobEvent order.

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -18,6 +18,8 @@
 package org.eclipse.core.internal.jobs;
 
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
 
@@ -153,9 +155,9 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	final Object jobStateLock = new Object();
 
 	/**
-	 * This signal is used to synchronize Job listener notification
+	 * Used to synchronize Job listener notification
 	 */
-	volatile Thread notifyPendingThread;
+	final Queue<JobChangeEvent> eventQueue = new ConcurrentLinkedQueue<>();
 
 	private static synchronized int getNextJobNumber() {
 		return nextJobNumber++;
@@ -567,4 +569,5 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	long getWaitQueueStamp() {
 		return waitQueueStamp;
 	}
+
 }

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobChangeEvent.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobChangeEvent.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.internal.jobs;
 
+import org.eclipse.core.internal.jobs.JobListeners.IListenerDoit;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
@@ -22,27 +23,59 @@ public class JobChangeEvent implements IJobChangeEvent {
 	/**
 	 * The job on which this event occurred.
 	 */
-	Job job = null;
+	final Job job;
 	/**
 	 * The result returned by the job's run method, or <code>null</code> if
 	 * not applicable.
 	 */
-	IStatus result = null;
+	final IStatus result;
 	/**
 	 * The result returned by the job's job group, if this event signals
 	 * completion of the last job in a group, or <code>null</code> if not
 	 * applicable.
 	 */
-	IStatus jobGroupResult = null;
+	IStatus jobGroupResult;
 	/**
 	 * The amount of time to wait after scheduling the job before it should be run,
 	 * or <code>-1</code> if not applicable for this type of event.
 	 */
-	long delay = -1;
+	final long delay;
 	/**
 	 * Whether this job is being immediately rescheduled.
 	 */
-	boolean reschedule = false;
+	final boolean reschedule;
+
+	final IListenerDoit doit;
+
+	JobChangeEvent(IListenerDoit doit, Job job) {
+		this.doit = doit;
+		this.job = job;
+
+		this.result = null;
+		this.jobGroupResult = null;
+		this.reschedule = false;
+		this.delay = -1;
+	}
+
+	JobChangeEvent(IListenerDoit doit, Job job, IStatus result, boolean reschedule) {
+		this.doit = doit;
+		this.job = job;
+		this.result = result;
+
+		this.jobGroupResult = null;
+		this.reschedule = reschedule;
+		this.delay = -1;
+	}
+
+	JobChangeEvent(IListenerDoit doit, Job job, long delay, boolean reschedule) {
+		this.doit = doit;
+		this.job = job;
+		this.delay = delay;
+
+		this.result = null;
+		this.jobGroupResult = null;
+		this.reschedule = reschedule;
+	}
 
 	@Override
 	public long getDelay() {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllTests.java
@@ -26,7 +26,7 @@ import org.junit.runners.Suite;
 		BeginEndRuleTest.class, JobTest.class, DeadlockDetectionTest.class, Bug_129551.class, Bug_211799.class,
 		Bug_307282.class, Bug_307391.class, MultiRuleTest.class, Bug_311756.class, Bug_311863.class, Bug_316839.class,
 		Bug_320329.class, Bug_478634.class, Bug_550738.class, Bug_574883.class, Bug_412138.class,
-		Bug_574883Join.class,
+		Bug_574883Join.class, GithubBug_193.class,
 		WorkerPoolTest.class
 })
 public class AllTests {


### PR DESCRIPTION
Events are queued inside the synchronize(JobManager.lock) blocks and send in the queued order after the block.
There is however no guarantee in which Thread the event is delivered - only the order is guaranteed to be the same order as the events happened.
Events will never be delivered in parallel - for the same job, but can be delivered in parallel for distinct jobs.