### PR TITLE
Improve JobManager IJobChangeListener Notification #193

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ImplicitJobs.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ImplicitJobs.java
@@ -116,7 +116,7 @@ class ImplicitJobs {
 		if (threadJob == null)
 			Assert.isLegal(rule == null, "endRule without matching beginRule: " + rule); //$NON-NLS-1$
 		else if (threadJob.pop(rule)) {
-			endThreadJob(threadJob, resume);
+			endThreadJob(threadJob, resume, false);
 		}
 	}
 
@@ -138,7 +138,7 @@ class ImplicitJobs {
 			String msg = "Worker thread ended job: " + lastJob + ", but still holds rule: " + threadJob; //$NON-NLS-1$ //$NON-NLS-2$
 			error = new Status(IStatus.ERROR, JobManager.PI_JOBS, 1, msg, new IllegalStateException(msg));
 			//end the thread job
-			endThreadJob(threadJob, false);
+			endThreadJob(threadJob, false, true);
 		}
 		try {
 			RuntimeLog.log(error);
@@ -151,7 +151,7 @@ class ImplicitJobs {
 	/**
 	 * @GuardedBy("this")
 	 */
-	private void endThreadJob(ThreadJob threadJob, boolean resume) {
+	private void endThreadJob(ThreadJob threadJob, boolean resume, boolean worker) {
 		Thread currentThread = Thread.currentThread();
 		//clean up when last rule scope exits
 		threadJobs.remove(currentThread);
@@ -166,7 +166,7 @@ class ImplicitJobs {
 		}
 		//if the job was started, we need to notify job manager to end it
 		if (threadJob.isRunning())
-			manager.endJob(threadJob, Status.OK_STATUS, false);
+			manager.endJob(threadJob, Status.OK_STATUS, false, worker);
 		recycle(threadJob);
 	}
 

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -20,6 +20,9 @@ package org.eclipse.core.internal.jobs;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
 
@@ -158,6 +161,8 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	 * Used to synchronize Job listener notification
 	 */
 	final Queue<JobChangeEvent> eventQueue = new ConcurrentLinkedQueue<>();
+	final Lock eventQueueLock = new ReentrantLock();
+	final AtomicReference<Thread> eventQueueThread = new AtomicReference<>();
 
 	private static synchronized int getNextJobNumber() {
 		return nextJobNumber++;
@@ -205,7 +210,7 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	}
 
 	protected void done(IStatus endResult) {
-		manager.endJob(this, endResult, true);
+		manager.endJob(this, endResult, true, false);
 	}
 
 	/**

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJobGroup.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJobGroup.java
@@ -40,7 +40,7 @@ public class InternalJobGroup {
 	 *
 	 * @GuardedBy("itself")
 	 */
-	private final Object jobGroupStateLock = new Object();
+	final Object jobGroupStateLock = new Object();
 
 	private static final JobManager manager = JobManager.getInstance();
 

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/WorkerPool.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/WorkerPool.java
@@ -114,7 +114,7 @@ class WorkerPool {
 				//remove any locks this thread may be owning on that rule
 				manager.getLockManager().removeLockCompletely(Thread.currentThread(), job.getRule());
 			}
-			manager.endJob(job, result, true);
+			manager.endJob(job, result, true, false);
 			//ensure this thread no longer owns any scheduling rules
 			manager.implicitJobs.endJob(job);
 		} finally {

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/IJobChangeListener.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/IJobChangeListener.java
@@ -26,6 +26,8 @@ package org.eclipse.core.runtime.jobs;
  * all job state changes, but whether the state change occurs before, during, or
  * after listeners are notified is unspecified.
  * </p><p>
+ * It is undefined in which Thread the notification occurs.
+ * </p><p>
  * Clients may implement this interface.
  * </p>
  * @see JobChangeAdapter
@@ -38,51 +40,81 @@ package org.eclipse.core.runtime.jobs;
  */
 public interface IJobChangeListener {
 	/**
-	 * Notification that a job is about to be run. Listeners are allowed to sleep, cancel,
-	 * or change the priority of the job before it is started (and as a result may prevent
-	 * the run from actually occurring).
+	 * <p>
+	 * Notification that a job is about to be run. Listeners are allowed to sleep,
+	 * cancel, or change the priority of the job before it is started (and as a
+	 * result may prevent the run from actually occurring).
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details
 	 */
 	void aboutToRun(IJobChangeEvent event);
 
 	/**
+	 * <p>
 	 * Notification that a job was previously sleeping and has now been rescheduled
 	 * to run.
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details
 	 */
 	void awake(IJobChangeEvent event);
 
 	/**
-	 * Notification that a job has completed execution, either due to cancelation, successful
-	 * completion, or failure.  The event status object indicates how the job finished,
-	 * and the reason for failure, if applicable.
+	 * <p>
+	 * Notification that a job has completed execution, either due to cancelation,
+	 * successful completion, or failure. The event status object indicates how the
+	 * job finished, and the reason for failure, if applicable.
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details
 	 */
 	void done(IJobChangeEvent event);
 
 	/**
+	 * <p>
 	 * Notification that a job has started running.
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details
 	 */
 	void running(IJobChangeEvent event);
 
 	/**
-	 * Notification that a job is being added to the queue of scheduled jobs.
-	 * The event details includes the scheduling delay before the job should start
+	 * <p>
+	 * Notification that a job is being added to the queue of scheduled jobs. The
+	 * event details includes the scheduling delay before the job should start
 	 * running.
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details, including the job instance and the scheduling
-	 * delay
+	 *              delay
 	 */
 	void scheduled(IJobChangeEvent event);
 
 	/**
+	 * <p>
 	 * Notification that a job was waiting to run and has now been put in the
 	 * sleeping state.
+	 * </p>
+	 * <p>
+	 * Implementations should not block and return promptly.
+	 * </p>
 	 *
 	 * @param event the event details
 	 */

--- a/runtime/tests/org.eclipse.core.tests.runtime/All Runtime Tests.launch
+++ b/runtime/tests/org.eclipse.core.tests.runtime/All Runtime Tests.launch
@@ -14,6 +14,7 @@
     <booleanAttribute key="includeFragments" value="false"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-test-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/AutomatedRuntimeTests.java"/>
     </listAttribute>
@@ -28,10 +29,13 @@
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.core.tests.runtime.AutomatedRuntimeTests"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.core.tests.runtime"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -1269,7 +1269,10 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 			assertEquals(1, familyJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
-			job.getThread().interrupt();
+			Thread thread = job.getThread();
+			if (thread != null) {
+				thread.interrupt();
+			}
 			// re-throw since the test failed
 			throw e;
 		} finally {


### PR DESCRIPTION
* Fall back to asynchronous events if IJobChangeListener timeout detected (possible deadlock).

* Make sure all IJobChangeListener calls returned before a state change happens to avoid stale Events to happen after the state change.

* Fix order of scheduled() and done() in case of reschedule: Some IJobChangeListener like ProgressManager.createChangeListener() expect a scheduled() to happen after done() even if a rescheduling schedule() was called before done() happened.

* Fix cancel of InternalJobGroup (did synchronize wrong lock during cancel events)

* avoid nested "synchronized (lock)"

https://github.com/eclipse-platform/eclipse.platform/issues/193