### PR TITLE
fix JobGroupTest.testGetActiveJobs() in IDE #134

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -412,7 +412,7 @@ public class JobGroupTest extends AbstractJobTest {
 		allJobs = manager.find(null);
 		for (int i = 0; i < allJobs.length; i++) {
 			// Verify that no jobs that we know about are found (they should have all been removed)
-			assertTrue(allJobs[i].toString(), testJobs.remove(allJobs[i]));
+			assertFalse(allJobs[i].toString(), testJobs.remove(allJobs[i]));
 		}
 		assertEquals("15.0", NUM_JOBS, testJobs.size());
 		testJobs.clear();


### PR DESCRIPTION
AllJobs should be empty at that time. If not it has to be a job that the test does NOT know about. i.e. it can NOT be removed from testJobs.