### PR TITLE
fix random failing NPE Thread.interrupt()

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -1359,7 +1359,10 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 			assertEquals(1, familyJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
-			job.getThread().interrupt();
+			Thread thread = job.getThread();
+			if (thread != null) {
+				thread.interrupt();
+			}
 			// re-throw since the test failed
 			throw e;
 		} finally {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -913,7 +913,10 @@ public class JobGroupTest extends AbstractJobTest {
 			assertEquals(1, groupJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
-			job.getThread().interrupt();
+			Thread thread = job.getThread();
+			if (thread != null) {
+				thread.interrupt();
+			}
 			// re-throw since the test failed
 			throw e;
 		} finally {
@@ -985,7 +988,10 @@ public class JobGroupTest extends AbstractJobTest {
 			assertEquals(1, groupJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
-			job.getThread().interrupt();
+			Thread thread = job.getThread();
+			if (thread != null) {
+				thread.interrupt();
+			}
 			// re-throw since the test failed
 			throw e;
 		} finally {
@@ -1053,7 +1059,10 @@ public class JobGroupTest extends AbstractJobTest {
 			assertEquals(0, groupJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
-			job.getThread().interrupt();
+			Thread thread = job.getThread();
+			if (thread != null) {
+				thread.interrupt();
+			}
 			// re-throw since the test failed
 			throw e;
 		} finally {


### PR DESCRIPTION
happened in IJobManagerTest.testJobFamilyJoinWhenSuspended_2