### PR TITLE
Fix for "ObjectNotFoundException: Tree element '/' not found"

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DeltaDataTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DeltaDataTree.java
@@ -994,6 +994,9 @@ public class DeltaDataTree extends AbstractDataTree {
 	@Override
 	public String toString() {
 		DeltaDataTree root = getParent();
+		if (root == null && isEmptyDelta()) {
+			return this.getClass().getSimpleName() + " -> rootNode=" + rootNode.toShortString(); //$NON-NLS-1$
+		}
 		int depth = root == null ? 0 : 1;
 		while (root != null && root.getParent() != null) {
 			root = root.getParent();


### PR DESCRIPTION
Don't try to compute delta for projects neither existing in the workspace nor in any of the build trees.
ResourceDeltaFactory.computeDelta() can't deal with that and will fail with ObjectNotFoundException, breaking build.

Application use case: importing an Xtext based project that references another (not yet imported) project via .project file. Xtext builder reports it is interested in the project that isn't there (but is referenced in the .project file).

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/243