### PR TITLE
Synchronize IJobChangeListener with Job State change #193

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
@@ -161,7 +160,7 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	 * Used to synchronize Job listener notification
 	 */
 	final Queue<JobChangeEvent> eventQueue = new ConcurrentLinkedQueue<>();
-	final Lock eventQueueLock = new ReentrantLock();
+	final ReentrantLock eventQueueLock = new ReentrantLock();
 	final AtomicReference<Thread> eventQueueThread = new AtomicReference<>();
 
 	private static synchronized int getNextJobNumber() {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import java.io.*;
 import junit.framework.TestCase;
+import org.eclipse.core.internal.jobs.JobListeners;
 import org.eclipse.core.internal.jobs.JobManager;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -133,5 +134,24 @@ public class AbstractJobTest extends TestCase {
 
 	public static long now() {
 		return ((JobManager) (Job.getJobManager())).now();
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		assertNoTimeoutOccured();
+		super.setUp();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		assertNoTimeoutOccured();
+		super.tearDown();
+	}
+
+	public static void assertNoTimeoutOccured() throws Exception {
+		int jobListenerTimeout = JobListeners.getJobListenerTimeout();
+		JobListeners.resetJobListenerTimeout();
+		int defaultTimeout = JobListeners.getJobListenerTimeout();
+		assertEquals("See logfile for TimeoutException to get details.", defaultTimeout, jobListenerTimeout);
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
@@ -391,10 +391,7 @@ public class JobEventTest {
 
 	@Test
 	public void testNoTimeoutOccured() throws Exception {
-		int jobListenerTimeout = JobListeners.getJobListenerTimeout();
-		JobListeners.resetJobListenerTimeout();
-		int defaultTimeout = JobListeners.getJobListenerTimeout();
-		assertEquals(defaultTimeout, jobListenerTimeout);
+		AbstractJobTest.assertNoTimeoutOccured();
 	}
 
 	@Test

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -603,6 +603,12 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	public void testCancelAboutToScheduleLegacy() {
+		JobListeners.setJobListenerTimeout(0);
+		testCancelAboutToSchedule();
+		JobListeners.resetJobListenerTimeout();
+	}
+
 	public void testCancelAboutToSchedule() {
 		final boolean[] failure = new boolean[1];
 		final Job j = new Job("testCancelAboutToSchedule") {


### PR DESCRIPTION
Possible deadlock in IJobChangeListener
---------------------------------------

Attention: The JobManager implementation was changed! The old JobMangager implementation notified IJobChangeListener about various IJobChangeEvent without strict order in various Threads. For example scheduled() was called in a Thread that did call schedule() on a Job while done() was normally called within a Worker Thread. In case of a repeated schedule() both Notifications could run in parallel. That was a race condition. The Listener could not deterministically know if the Job was still scheduled or already done. As a consequence a join() could have returned too early or the Progress View did not show Jobs that did still run. And probably many other things went wrong totally unnoticed.
Even multiple notifications could have happened in parallel in various Worker Threads, as there is no guarantee that the next execution is done in the same Worker.

To fix this indeterministic behavior all notifications for a Job will now be done one after the other. It is still not defined in which Thread the notification happens, but the new implementation will not call any IJobChangeListener until all pending events for the jobs are processed by all registered IJobChangeListener. The new implementation will also wait with any job state change until all calls to IJobChangeListener for that job returned.

The IJobChangeListener javadoc clearly specifies "whether the state change occurs before, during, or after listeners are notified is unspecified." - and the implementation changed within that broad specification. Unfortunately some IJobChangeListener around rely on the old implementation. They may now deadlock. For example the following snippet can now deadlock:

```
 job.schedule(); // may result in done();
 synchronized (lock){
  boolean schedule = ...; // lock needed for reasons
  if (schedule ) job.schedule(); // schedule() will notify scheduled()
  // - which may not return before previous Notifications return!
 }

 public void done(IJobChangeEvent event) {
  // can not enter while other Thread holds lock:
  synchronized (lock) {// possible deadlock
  }
 }
```

Instead use:

```
 job.schedule();
 boolean schedule;
 synchronized (lock) {
  schedule=...; // lock needed for reasons
 }
 if (schedule) job.schedule();

 public void done(IJobChangeEvent event) {
  synchronized (lock) {// OK
  }
 }
```

The same problem may occur on all IJobChangeListener methods and all methods that result in IJobChangeEvent being sent: Job.schedule(), cancel(), wakeUp(), sleep() and JobManager shutdown. Make sure all IJobChangeListener implementations do not block and return promptly.

Due to the extreme risk the new Implementation tries to identify non-conforming IJobChangeListener and do a fall back: When a IJobChangeEvent is not handled within 3 seconds a Timeout error is logged with stacktraces of the competing Threads and the JobManager will no longer wait - until JVM is restarted. Further calls to IJobChangeListener may occur in random order and join(family) can return too soon! However there may also be some deadlocks in Clients code due to the changed JobManager implementation that may be undetected by JobManager. **So better check your IJobChangeListener!**