### PR TITLE
Do not upload windows tests results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         clean verify
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
+      if: ${{ matrix.os != 'windows-latest'}} # currently disabled because of https://github.com/actions/upload-artifact/issues/240
       with:
         name: test-results-${{ matrix.os }}
         if-no-files-found: error


### PR DESCRIPTION
Fails due to https://github.com/actions/upload-artifact/issues/240 .
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/278