### PR TITLE
Compare: asyncExec propertyChange() to avoid Deadlock #282

### DIFF
--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.9.100.qualifier
+Bundle-Version: 3.9.200.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -178,11 +178,7 @@ public class Utilities {
 				SafeRunner.run(() -> listener.propertyChange(event));
 			}
 		};
-		if (Display.getCurrent() == null) {
-			Display.getDefault().syncExec(runnable);
-		} else {
-			runnable.run();
-		}
+		Display.getDefault().execute(runnable);
 	}
 
 	public static boolean okToUse(Widget widget) {


### PR DESCRIPTION
SynchronizableDocument holds a lock that is used by IPropertyChangeListener.  This deadlocked if the document was updated in background thread as the lock is only reentrant inside a thread.