### PR TITLE
The auto-builder shouldn't be interrupted by its own workspace changes.

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.18.100.qualifier
+Bundle-Version: 3.18.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2015 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -201,8 +201,7 @@ class AutoBuildJob extends Job implements Preferences.IPropertyChangeListener {
 				setInterrupted(!sleep());
 				break;
 			case RUNNING :
-				//make sure autobuild doesn't interrupt itself
-				if (Job.getJobManager().currentJob() == this)
+				if (!shouldInterrupt())
 					return;
 				setInterrupted(true);
 				break;
@@ -296,6 +295,18 @@ class AutoBuildJob extends Job implements Preferences.IPropertyChangeListener {
 			//regardless of the result, clear the build flags for next time
 			forceBuild = avoidBuild = buildNeeded = false;
 		}
+	}
+
+	/**
+	 * Returns {@code true}, if the auto-build job should be interrupted. The job
+	 * should always be interrupted, unless this method is called by a job within
+	 * the {@link ResourcesPlugin#FAMILY_AUTO_BUILD} family.
+	 */
+	private synchronized boolean shouldInterrupt() {
+		Job currentJob = Job.getJobManager().currentJob();
+
+		// make sure autobuild doesn't interrupt itself
+		return currentJob == null || !currentJob.belongsTo(ResourcesPlugin.FAMILY_AUTO_BUILD);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.10.2000.qualifier
+Bundle-Version: 3.10.3000.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/plugin.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/plugin.xml
@@ -647,4 +647,15 @@
        </dynamicReference>
     </builder>
  </extension>
+ <extension
+       id="interruptingBuilder"
+       name="Interrupting Builder"
+       point="org.eclipse.core.resources.builders">
+    <builder
+          callOnEmptyDelta="true">
+       <run
+             class="org.eclipse.core.tests.internal.builders.InterruptingBuilder">
+       </run>
+    </builder>
+ </extension>
 </plugin>

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.27.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.10.2000-SNAPSHOT</version>
+  <version>3.10.3000-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuildderTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuildderTests.java
@@ -22,7 +22,8 @@ import org.junit.runners.Suite;
 		RebuildTest.class,
 		BuildDeltaVerificationTest.class, CustomBuildTriggerTest.class, EmptyDeltaTest.class,
 		MultiProjectBuildTest.class, RelaxedSchedRuleBuilderTest.class, BuildConfigurationsTest.class,
-		BuildContextTest.class, ParallelBuildChainTest.class, ComputeProjectOrderTest.class })
+		BuildContextTest.class, ParallelBuildChainTest.class, ComputeProjectOrderTest.class,
+		InterruptingBuilderTest.class })
 public class AllBuildderTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilder.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.builders;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
+
+/**
+ * This class delegates "performance-heavy" computation to a worker thread.
+ */
+public class InterruptingBuilder extends IncrementalProjectBuilder {
+
+	public static final String BUILDER_NAME = "org.eclipse.core.tests.resources.interruptingBuilder";
+	private static CountDownLatch LATCH = new CountDownLatch(1);
+	private static Job AUTO_BUILD_JOB;
+
+	public static void reset() {
+		LATCH = new CountDownLatch(1);
+		AUTO_BUILD_JOB = null;
+	}
+
+	public static boolean waitForStart() {
+		try {
+			return LATCH.await(15, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			return false;
+		}
+	}
+
+	public static boolean waitForEnd() {
+		Objects.requireNonNull(AUTO_BUILD_JOB);
+
+		try {
+			return AUTO_BUILD_JOB.join(15000, new NullProgressMonitor());
+		} catch (InterruptedException e) {
+			return false;
+		}
+	}
+
+	@Override
+	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
+		AUTO_BUILD_JOB = Job.getJobManager().currentJob();
+		LATCH.countDown();
+
+		Job worker = new WorkerJob();
+		worker.setPriority(Job.LONG);
+		worker.setRule(new WorkerSchedulingRule());
+		worker.schedule();
+
+		try {
+			worker.join();
+		} catch (InterruptedException e) {
+			// ignored
+		}
+
+		// Simulate a job cancellation
+		throw new OperationCanceledException();
+	}
+
+	private class WorkerJob extends Job {
+
+		public WorkerJob() {
+			super("Worker");
+		}
+
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			try {
+				// Raises the interrupt flag of the auto-builder
+				getProject().getFile(".project").touch(monitor);
+			} catch (CoreException e) {
+				return Status.error(e.getMessage(), e);
+			}
+
+			return Status.OK_STATUS;
+		}
+	}
+
+	private static class WorkerSchedulingRule implements ISchedulingRule {
+
+		private final ISchedulingRule buildRule;
+
+		public WorkerSchedulingRule() {
+			buildRule = ResourcesPlugin.getWorkspace().getRuleFactory().buildRule();
+		}
+
+		@Override
+		public boolean contains(ISchedulingRule rule) {
+			return rule == this || buildRule.contains(rule);
+		}
+
+		@Override
+		public boolean isConflicting(ISchedulingRule rule) {
+			return rule == this || buildRule.isConflicting(rule);
+		}
+	}
+
+}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilder.java
@@ -91,6 +91,11 @@ public class InterruptingBuilder extends IncrementalProjectBuilder {
 
 			return Status.OK_STATUS;
 		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return ResourcesPlugin.FAMILY_AUTO_BUILD.equals(family);
+		}
 	}
 
 	private static class WorkerSchedulingRule implements ISchedulingRule {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilderTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.builders;
+
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+/**
+ * Tests that the AutoBuild job doesn't raise its interrupt flag when doing
+ * workspace modifications.
+ */
+public class InterruptingBuilderTest extends AbstractBuilderTest {
+
+	private static final String TEST_PROJECT_NAME = "WorkerProject";
+	private static final String TEST_FILE_NAME = "test.txt";
+	private IProject project;
+	private IFile file;
+
+	public InterruptingBuilderTest() {
+		super("Interrupting Builder");
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		setAutoBuilding(false);
+		project = setUpProject();
+		file = setUpFile(project);
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+		project.delete(true, new NullProgressMonitor());
+		setAutoBuilding(true);
+	}
+
+	private IProject setUpProject() throws CoreException {
+		IWorkspaceRoot workspaceRoot = getWorkspace().getRoot();
+		IProject result = workspaceRoot.getProject(TEST_PROJECT_NAME);
+		result.create(new NullProgressMonitor());
+		result.open(new NullProgressMonitor());
+		return result;
+	}
+
+	private IFile setUpFile(IProject project) throws CoreException {
+		IFile result = project.getFile(TEST_FILE_NAME);
+		result.create(getRandomContents(), true, new NullProgressMonitor());
+		return result;
+	}
+
+	/**
+	 * This test case checks whether the interrupt flag of the auto-builder is set
+	 * upon workspace modifications. This interrupt flag is set when another thread
+	 * performs such modifications, while the auto-builder is running.
+	 *
+	 * This interruption then causes the auto-builder to reschedule itself, if the
+	 * current job has been canceled by the user. If this thread has been created
+	 * from within the auto-builder it is therefore no longer possible to gracefully
+	 * cancel the auto-build, given that this interrupt flag is set by its own
+	 * thread.
+	 *
+	 * @throws CoreException
+	 *             If one of the initial workspace modifications failed for
+	 *             unexpected reasons.
+	 */
+	public void testBuildProject() throws CoreException {
+		addBuilder(project, InterruptingBuilder.BUILDER_NAME);
+
+		try {
+			setAutoBuilding(true);
+
+			dirty(file);
+
+			assertTrue("The auto-builder didn't start in time...", InterruptingBuilder.waitForStart());
+
+			assertTrue("The auto-builder didn't finish in time...", InterruptingBuilder.waitForEnd());
+
+			assertFalse("The auto-builder should be idle!", isBuildPending());
+		} finally {
+			// Otherwise the auto-builder gets stuck in an infinite loop
+			setAutoBuilding(false);
+		}
+	}
+
+	private boolean isBuildPending() {
+		return ((Workspace) getWorkspace()).getBuildManager().isAutobuildBuildPending();
+	}
+}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/InterruptingBuilderTest.java
@@ -37,6 +37,7 @@ public class InterruptingBuilderTest extends AbstractBuilderTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		setAutoBuilding(false);
+		waitForBuild();
 		project = setUpProject();
 		file = setUpFile(project);
 	}


### PR DESCRIPTION
If a worker job is created from within the auto-build job, performing
workspace changes, it is no longer possible to gracefully cancel the
job.

Those changes cause the auto-builder to reschedule itself over and over
again, until the build finished successfully or the auto-builder is
disabled.

This unit-test should illustrate the problem described above.

**Expectation**:

The auto-builder should start due to the workspace modification, respond to the user cancellation and then switch into an idle state.

**Result**:

The auto-builder re-schedules itself indefinitely, resulting in an infinite loop until the automatic build is deactivatied.