### PR TITLE
SaveManager: Use custom ForkJoinWorkerThreadFactory

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.18.100.qualifier
+Bundle-Version: 3.18.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
In case a SecurityManager is installed, using the
defaultForkJoinWorkerThreadFactory would result in worker threads with no permissions, which could prevent the workspace from being saved [1].

Use a custom ForkJoinWorkerThreadFactory implementation to work around this.

Fixes #294.