### PR TITLE
Race condition in AutoBuildJob.build() (#158)

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.18.100.qualifier
+Bundle-Version: 3.18.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuildderTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuildderTests.java
@@ -22,7 +22,7 @@ import org.junit.runners.Suite;
 		RebuildTest.class,
 		BuildDeltaVerificationTest.class, CustomBuildTriggerTest.class, EmptyDeltaTest.class,
 		MultiProjectBuildTest.class, RelaxedSchedRuleBuilderTest.class, BuildConfigurationsTest.class,
-		BuildContextTest.class, ParallelBuildChainTest.class, ComputeProjectOrderTest.class })
+		BuildContextTest.class, ParallelBuildChainTest.class, ComputeProjectOrderTest.class, AutoBuildJobTest.class })
 public class AllBuildderTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.builders;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.core.internal.events.BuildManager;
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.internal.utils.Policy;
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.tests.internal.builders.TestBuilder.BuilderRuleCallback;
+
+/**
+ * Test for various AutoBuildJob scheduling use cases
+ */
+public class AutoBuildJobTest extends AbstractBuilderTest {
+
+	private IProject project;
+	private AtomicLong running;
+	private AtomicLong scheduled;
+
+	public AutoBuildJobTest(String name) {
+		super(name);
+	}
+
+	IJobChangeListener jobChangeListener = new JobChangeAdapter() {
+
+		@Override
+		public void scheduled(IJobChangeEvent event) {
+			if (event.getJob().belongsTo(ResourcesPlugin.FAMILY_AUTO_BUILD)) {
+				scheduled.incrementAndGet();
+			}
+		}
+
+		@Override
+		public void running(IJobChangeEvent event) {
+			if (event.getJob().belongsTo(ResourcesPlugin.FAMILY_AUTO_BUILD)) {
+				running.incrementAndGet();
+			}
+		}
+	};
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		setAutoBuilding(true);
+		scheduled = new AtomicLong(0);
+		running = new AtomicLong(0);
+		setupProjectWithOurBuilder();
+
+		// Setup above will trigger autobuild
+		waitForBuild();
+		Job.getJobManager().addJobChangeListener(jobChangeListener);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		Job.getJobManager().removeJobChangeListener(jobChangeListener);
+		project.delete(true, null);
+		super.tearDown();
+	}
+
+	private void setupProjectWithOurBuilder() throws CoreException {
+		project = getWorkspace().getRoot().getProject(getName());
+		project.create(getMonitor());
+		project.open(getMonitor());
+		IProjectDescription desc = project.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, getName()) });
+		project.setDescription(desc, getMonitor());
+	}
+
+	private void requestAutoBuildJobExecution() {
+		// Simulates autobuild job triggering from build thread
+		// basically same as autoBuildJob.build(true);
+		BuildManager buildManager = ((Workspace) project.getWorkspace()).getBuildManager();
+		buildManager.endTopLevel(true);
+	}
+
+	public void testNoBuildIfBuildRequestedFromSameThread() throws Exception {
+		triggerAutobuildAndCheckNoExtraBuild(false);
+	}
+
+	public void testNoBuildIfBuildRequestedFromSameThreadAfterCancel() throws Exception {
+		triggerAutobuildAndCheckNoExtraBuild(true);
+	}
+
+	private void triggerAutobuildAndCheckNoExtraBuild(boolean cancel) throws Exception {
+		AtomicBoolean cancelled = new AtomicBoolean();
+		EmptyDeltaBuilder.getInstance().setRuleCallback(new BuilderRuleCallback() {
+			@Override
+			public IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
+				if (cancel) {
+					monitor.setCanceled(true);
+					cancelled.set(true);
+				}
+				// should be ignored
+				requestAutoBuildJobExecution();
+				return new IProject[0];
+			}
+		});
+
+		// triggers autobuild
+		project.touch(getMonitor());
+
+		Thread.sleep(Policy.MAX_BUILD_DELAY);
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+		assertEquals("Should see one scheduled() call", 1, scheduled.get());
+		assertEquals("Should see one running() call", 1, running.get());
+
+		if (cancel) {
+			assertEquals(true, cancelled.get());
+		}
+	}
+
+	public void testExtraBuildIfBuildRequestedFromOtherThreadDuringRun() throws Exception {
+		EmptyDeltaBuilder.getInstance().setRuleCallback(new BuilderRuleCallback() {
+			@Override
+			public IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
+				// Simulate someone requests autobuild in parallel to already running autobuild.
+				// That shouldn't be ignored, otherwise no build may happen
+				Job job = Job.createSystem("", (ICoreRunnable) m -> requestAutoBuildJobExecution());
+				job.schedule();
+				try {
+					job.join();
+				} catch (InterruptedException e) {
+					//
+				}
+				return new IProject[0];
+			}
+		});
+
+		// triggers autobuild
+		project.touch(getMonitor());
+		Thread.sleep(Policy.MAX_BUILD_DELAY);
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+		assertEquals("Should see two scheduled() calls", 2, scheduled.get());
+		assertEquals("Should see two running() calls", 2, running.get());
+	}
+}


### PR DESCRIPTION
It can happen that the AutoBuildJob's buildNeeded flag is true, but the
AutoBuildJob is not scheduled and not executed until the next workspace
change.

The race condition happens when the AutoBuildJob in doBuild() method
reaches last line which releases the workspace lock, but the job is
still in RUNNING state.

At same time client code calls AutoBuildJob.build(true), the buildNeeded
flag is set to true and then the method checks the state of the
AutoBuildJob and finds that it is currently (still) in the RUNNING
state, so it does *not* schedule it again (it falls through the
switch(state).

In this situation, the AutoBuild is not scheduled even though it is
marked as being in need of a build, so until the next workspace change
triggering a build, this situation won't change and the AutoBuildJob
will not be executed.

- Let build() reschedule the AutoBuildJob even if it is currently
running.
- Remove additional reset of buildNeeded flag in doBuild(), so it does
not interfere with other threads concurrently requesting a build.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/158