### PR TITLE
Interupt the thread on job cancel

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/InternalJob.java
@@ -200,7 +200,10 @@ public abstract class InternalJob extends PlatformObject implements Comparable<I
 	}
 
 	protected void canceling() {
-		//default implementation does nothing
+		Thread t = getThread();
+		if (t != null) {
+			t.interrupt();
+		}
 	}
 
 	@Override

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/Job.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/Job.java
@@ -301,6 +301,7 @@ public abstract class Job extends InternalJob {
 	@Override
 	protected void canceling() {
 		//default implementation does nothing
+		super.canceling();
 	}
 
 	/**


### PR DESCRIPTION
currently the default impl of (Internal)Job#canceling do nothing, but this could mean that jobs possibly hang forever (and even prevent Eclipse from shutting down) if a Job is hung for example in an I/O operation or a wait condition.

This performs Thread cancelation if not overriden by an implementor.