### PR TITLE
Port team.ui away of deprecated ResourceSorter

### DIFF
--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.9.500.qualifier
+Bundle-Version: 3.9.600.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/plugin.xml
+++ b/team/bundles/org.eclipse.team.ui/plugin.xml
@@ -584,7 +584,7 @@
             </enablement>
          </actionProvider>
          <commonSorter
-            class="org.eclipse.team.internal.ui.mapping.ResourceModelSorter"
+            class="org.eclipse.team.internal.ui.mapping.ResourceModelComparator"
             id="org.eclipse.team.ui.resourceSorter"/>
        </navigatorContent>
    </extension>

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ResourceModelComparator.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ResourceModelComparator.java
@@ -17,14 +17,14 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.team.internal.ui.IPreferenceIds;
 import org.eclipse.team.internal.ui.TeamUIPlugin;
-import org.eclipse.ui.views.navigator.ResourceSorter;
+import org.eclipse.ui.views.navigator.ResourceComparator;
 
 /**
  * Sorter for use by Common Navigator
  */
-public class ResourceModelSorter extends ResourceSorter {
+public class ResourceModelComparator extends ResourceComparator {
 
-	public ResourceModelSorter() {
+	public ResourceModelComparator() {
 		super(NAME);
 	}
 
@@ -33,7 +33,7 @@ public class ResourceModelSorter extends ResourceSorter {
 		if (getLayout().equals(IPreferenceIds.COMPRESSED_LAYOUT)
 				&& r1 instanceof IFolder
 				&& r2 instanceof IFolder) {
-			return collator.compare(r1.getProjectRelativePath().toString(), r2.getProjectRelativePath().toString());
+			return getComparator().compare(r1.getProjectRelativePath().toString(), r2.getProjectRelativePath().toString());
 		}
 		return super.compareNames(r1, r2);
 	}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ChangeSetModelComparator.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ChangeSetModelComparator.java
@@ -16,7 +16,7 @@ package org.eclipse.team.internal.ui.synchronize;
 import java.util.Date;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.internal.core.subscribers.ActiveChangeSet;
 import org.eclipse.team.internal.core.subscribers.ChangeSet;
 import org.eclipse.team.internal.core.subscribers.CheckedInChangeSet;
@@ -27,7 +27,7 @@ import org.eclipse.team.ui.synchronize.ISynchronizeModelElement;
  *
  * @since 3.0
  */
-public class ChangeSetModelSorter extends ViewerSorter {
+public class ChangeSetModelComparator extends ViewerComparator {
 
 	private int commentCriteria;
 	private ChangeSetModelProvider provider;
@@ -37,7 +37,7 @@ public class ChangeSetModelSorter extends ViewerSorter {
 	public final static int COMMENT = 2;
 	public final static int USER = 3;
 
-	public ChangeSetModelSorter(ChangeSetModelProvider provider, int commentCriteria) {
+	public ChangeSetModelComparator(ChangeSetModelProvider provider, int commentCriteria) {
 		this.provider = provider;
 		this.commentCriteria = commentCriteria;
 	}
@@ -105,7 +105,7 @@ public class ChangeSetModelSorter extends ViewerSorter {
 		}
 
 		if (o1 instanceof ISynchronizeModelElement && o2 instanceof ISynchronizeModelElement) {
-			ViewerSorter embeddedSorter = provider.getEmbeddedSorter();
+			ViewerComparator embeddedSorter = provider.getEmbeddedComparator();
 			if (embeddedSorter != null) {
 				return embeddedSorter.compare(viewer, o1, o2);
 			} else {

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ChangeSetModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ChangeSetModelProvider.java
@@ -20,7 +20,7 @@ import org.eclipse.compare.structuremergeviewer.IDiffElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.ISyncInfoTreeChangeEvent;
 import org.eclipse.team.core.synchronize.SyncInfo;
 import org.eclipse.team.core.synchronize.SyncInfoSet;
@@ -42,14 +42,14 @@ import org.eclipse.team.ui.synchronize.SynchronizePageActionGroup;
  */
 public class ChangeSetModelProvider extends CompositeModelProvider {
 
-	private ViewerSorter viewerSorter;
+	private ViewerComparator viewerComparator;
 
 	// The id of the sub-provider
 	private final String subProvierId;
 
 	private Map<ISynchronizeModelElement, ISynchronizeModelProvider> rootToProvider = new HashMap<>();
 
-	private ViewerSorter embeddedSorter;
+	private ViewerComparator embeddedSorter;
 
 	private SyncInfoSetChangeSetCollector checkedInCollector;
 
@@ -214,18 +214,18 @@ public class ChangeSetModelProvider extends CompositeModelProvider {
 	}
 
 	@Override
-	public ViewerSorter getViewerSorter() {
-		if (viewerSorter == null) {
-			viewerSorter = new ChangeSetModelSorter(this, ChangeSetActionGroup.getSortCriteria(getConfiguration()));
+	public ViewerComparator getViewerComparator() {
+		if (viewerComparator == null) {
+			viewerComparator = new ChangeSetModelComparator(this, ChangeSetActionGroup.getSortCriteria(getConfiguration()));
 		}
-		return viewerSorter;
+		return viewerComparator;
 	}
 
 	/*
 	 * Method to allow ChangeSetActionGroup to set the viewer sorter of this provider.
 	 */
-	public void setViewerSorter(ViewerSorter viewerSorter) {
-		this.viewerSorter = viewerSorter;
+	public void setViewerComparator(ViewerComparator viewerSorter) {
+		this.viewerComparator = viewerSorter;
 		firePropertyChange(ISynchronizeModelProvider.P_VIEWER_SORTER, null, null);
 	}
 
@@ -263,7 +263,7 @@ public class ChangeSetModelProvider extends CompositeModelProvider {
 	 * Return the sorter associated with the sub-provider being used.
 	 * @return the sorter associated with the sub-provider being used
 	 */
-	public ViewerSorter getEmbeddedSorter() {
+	public ViewerComparator getEmbeddedComparator() {
 		return embeddedSorter;
 	}
 
@@ -294,7 +294,7 @@ public class ChangeSetModelProvider extends CompositeModelProvider {
 			tree = new SyncInfoTree();
 		}
 		final ISynchronizeModelProvider provider = createProviderRootedAt(getModelRoot(), tree);
-		embeddedSorter = provider.getViewerSorter();
+		embeddedSorter = provider.getViewerComparator();
 		if (provider instanceof AbstractSynchronizeModelProvider) {
 			SynchronizePageActionGroup actionGroup = ((AbstractSynchronizeModelProvider)provider).getActionGroup();
 			if (actionGroup != null) {
@@ -302,7 +302,7 @@ public class ChangeSetModelProvider extends CompositeModelProvider {
 				getConfiguration().addActionContribution(actionGroup);
 				provider.addPropertyChangeListener(event -> {
 					if (event.getProperty().equals(P_VIEWER_SORTER)) {
-						embeddedSorter = provider.getViewerSorter();
+						embeddedSorter = provider.getViewerComparator();
 						ChangeSetModelProvider.this.firePropertyChange(P_VIEWER_SORTER, null, null);
 					}
 				});

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/CompressedFoldersModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/CompressedFoldersModelProvider.java
@@ -27,7 +27,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.ISyncInfoTreeChangeEvent;
 import org.eclipse.team.core.synchronize.SyncInfo;
 import org.eclipse.team.core.synchronize.SyncInfoSet;
@@ -111,12 +111,12 @@ public class CompressedFoldersModelProvider extends HierarchicalModelProvider {
 	}
 
 	@Override
-	public ViewerSorter getViewerSorter() {
-		return new SynchronizeModelElementSorter() {
+	public ViewerComparator getViewerComparator() {
+		return new SynchronizeModelElementComparator() {
 			@Override
 			protected int compareNames(IResource resource1, IResource resource2) {
 				if (resource1.getType() == IResource.FOLDER && resource2.getType() == IResource.FOLDER) {
-					return collator.compare(resource1.getProjectRelativePath().toString(), resource2.getProjectRelativePath().toString());
+					return getComparator().compare(resource1.getProjectRelativePath().toString(), resource2.getProjectRelativePath().toString());
 				}
 				return super.compareNames(resource1, resource2);
 			}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/FlatModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/FlatModelProvider.java
@@ -25,7 +25,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.ISyncInfoTreeChangeEvent;
 import org.eclipse.team.core.synchronize.SyncInfo;
 import org.eclipse.team.core.synchronize.SyncInfoSet;
@@ -61,7 +61,7 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 
 	private static final String P_LAST_RESOURCESORT = TeamUIPlugin.ID + ".P_LAST_RESOURCE_SORT"; //$NON-NLS-1$
 
-	private int sortCriteria = FlatSorter.PATH;
+	private int sortCriteria = FlatComparator.PATH;
 
 	/* *****************************************************************************
 	 * Model element for the resources in this layout. They are displayed with filename and path
@@ -82,7 +82,7 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 	 * Sorter that sorts flat path elements using the criteria specified
 	 * when the sorter is created
 	 */
-	public class FlatSorter extends ViewerSorter {
+	public class FlatComparator extends ViewerComparator {
 
 		private int resourceCriteria;
 
@@ -91,7 +91,7 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 		public final static int PATH = 2;
 		public final static int PARENT_NAME = 3;
 
-		public FlatSorter(int resourceCriteria) {
+		public FlatComparator(int resourceCriteria) {
 			this.resourceCriteria = resourceCriteria;
 		}
 
@@ -107,7 +107,7 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 		}
 
 		protected int compareNames(String s1, String s2) {
-			return collator.compare(s1, s2);
+			return getComparator().compare(s1, s2);
 		}
 
 		@Override
@@ -188,9 +188,9 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 			// Ensure that the sort criteria of the provider is properly initialized
 			FlatModelProvider.this.initialize(configuration);
 
-			sortByResource.add( new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_8, FlatSorter.PATH));
-			sortByResource.add(new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_7, FlatSorter.NAME));
-			sortByResource.add(new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_9, FlatSorter.PARENT_NAME));
+			sortByResource.add( new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_8, FlatComparator.PATH));
+			sortByResource.add(new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_7, FlatComparator.NAME));
+			sortByResource.add(new ToggleSortOrderAction(TeamUIMessages.FlatModelProvider_9, FlatComparator.PARENT_NAME));
 		}
 
 		@Override
@@ -221,12 +221,12 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 			// ignore and use the defaults.
 		}
 		switch (sortCriteria) {
-		case FlatSorter.PATH:
-		case FlatSorter.NAME:
-		case FlatSorter.PARENT_NAME:
+		case FlatComparator.PATH:
+		case FlatComparator.NAME:
+		case FlatComparator.PARENT_NAME:
 			break;
 		default:
-			sortCriteria = FlatSorter.PATH;
+			sortCriteria = FlatComparator.PATH;
 			break;
 		}
 	}
@@ -237,8 +237,8 @@ public class FlatModelProvider extends SynchronizeModelProvider {
 	}
 
 	@Override
-	public ViewerSorter getViewerSorter() {
-		return new FlatSorter(sortCriteria);
+	public ViewerComparator getViewerComparator() {
+		return new FlatComparator(sortCriteria);
 	}
 
 	@Override

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/HierarchicalModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/HierarchicalModelProvider.java
@@ -21,7 +21,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.ISyncInfoTreeChangeEvent;
 import org.eclipse.team.core.synchronize.SyncInfo;
 import org.eclipse.team.core.synchronize.SyncInfoSet;
@@ -94,9 +94,8 @@ public class HierarchicalModelProvider extends SynchronizeModelProvider {
 		return hierarchicalDescriptor;
 	}
 
-	@Override
-	public ViewerSorter getViewerSorter() {
-		return new SynchronizeModelElementSorter();
+	public ViewerComparator getViewerComparator() {
+		return new SynchronizeModelElementComparator();
 	}
 
 	protected SyncInfoTree getSyncInfoTree() {

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ISynchronizeModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ISynchronizeModelProvider.java
@@ -16,7 +16,7 @@ package org.eclipse.team.internal.ui.synchronize;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.viewers.StructuredViewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.SyncInfoSet;
 import org.eclipse.team.internal.ui.TeamUIPlugin;
 import org.eclipse.team.ui.synchronize.ISynchronizeModelElement;
@@ -76,10 +76,10 @@ public interface ISynchronizeModelProvider {
 	public abstract ISynchronizeModelElement getModelRoot();
 
 	/**
-	 * Returns the sorter for this model.
-	 * @return the sorter for this model.
+	 * Returns the comparator for this model.
+	 * @return the comparator for this model.
 	 */
-	public abstract ViewerSorter getViewerSorter();
+	public abstract ViewerComparator getViewerComparator();
 
 	/**
 	 * Allows the provider to save state. Is usually called before provider is disposed and it

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelElementComparator.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelElementComparator.java
@@ -16,16 +16,16 @@ package org.eclipse.team.internal.ui.synchronize;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.team.internal.ui.Utils;
-import org.eclipse.ui.views.navigator.ResourceSorter;
+import org.eclipse.ui.views.navigator.ResourceComparator;
 
 /**
  * This class sorts <code>SyncInfoModelElement</code> instances.
  * It is not thread safe so it should not be reused between views.
  */
-public class SynchronizeModelElementSorter extends ResourceSorter {
+public class SynchronizeModelElementComparator extends ResourceComparator {
 
-	public SynchronizeModelElementSorter() {
-		super(ResourceSorter.NAME);
+	public SynchronizeModelElementComparator() {
+		super(ResourceComparator.NAME);
 	}
 
 	@Override

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelProvider.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.team.core.synchronize.ISyncInfoSetChangeListener;
 import org.eclipse.team.core.synchronize.ISyncInfoTreeChangeEvent;
 import org.eclipse.team.core.synchronize.SyncInfo;
@@ -79,7 +79,7 @@ public abstract class SynchronizeModelProvider extends AbstractSynchronizeModelP
 	 * @return the sorter for this model provider.
 	 */
 	@Override
-	public abstract ViewerSorter getViewerSorter();
+	public abstract ViewerComparator getViewerComparator();
 
 	/**
 	 * Return the model object (i.e. an instance of <code>SyncInfoModelElement</code>

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/TreeViewerAdvisor.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/TreeViewerAdvisor.java
@@ -24,7 +24,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.OpenEvent;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSourceEvent;
@@ -237,19 +237,19 @@ public class TreeViewerAdvisor extends AbstractTreeViewerAdvisor {
 		modelRoot.addCompareInputChangeListener(source -> getActionGroup().modelChanged(modelRoot));
 		final StructuredViewer viewer = getViewer();
 		if (viewer != null) {
-			viewer.setSorter(modelProvider.getViewerSorter());
+			viewer.setComparator(modelProvider.getViewerComparator());
 			viewer.setInput(modelRoot);
 			modelProvider.addPropertyChangeListener(event -> {
 				if (event.getProperty() == ISynchronizeModelProvider.P_VIEWER_SORTER) {
 					if (viewer != null && !viewer.getControl().isDisposed()) {
 						viewer.getControl().getDisplay().syncExec(() -> {
 							if (viewer != null && !viewer.getControl().isDisposed()) {
-								ViewerSorter newSorter = modelProvider.getViewerSorter();
-								ViewerSorter oldSorter = viewer.getSorter();
+								ViewerComparator newSorter = modelProvider.getViewerComparator();
+								ViewerComparator oldSorter = viewer.getComparator();
 								if (newSorter == oldSorter) {
 									viewer.refresh();
 								} else {
-									viewer.setSorter(newSorter);
+									viewer.setComparator(newSorter);
 								}
 							}
 						});

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/actions/ChangeSetActionGroup.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/actions/ChangeSetActionGroup.java
@@ -35,7 +35,7 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.team.core.diff.IDiff;
@@ -49,8 +49,8 @@ import org.eclipse.team.internal.core.subscribers.ChangeSet;
 import org.eclipse.team.internal.ui.TeamUIMessages;
 import org.eclipse.team.internal.ui.TeamUIPlugin;
 import org.eclipse.team.internal.ui.synchronize.ChangeSetCapability;
+import org.eclipse.team.internal.ui.synchronize.ChangeSetModelComparator;
 import org.eclipse.team.internal.ui.synchronize.ChangeSetModelProvider;
-import org.eclipse.team.internal.ui.synchronize.ChangeSetModelSorter;
 import org.eclipse.team.ui.synchronize.ISynchronizePageConfiguration;
 import org.eclipse.team.ui.synchronize.SubscriberParticipant;
 import org.eclipse.team.ui.synchronize.SynchronizeModelAction;
@@ -259,7 +259,7 @@ public class ChangeSetActionGroup extends SynchronizePageActionGroup {
 					pageSettings.put(key, criteria);
 				}
 				update();
-				provider.setViewerSorter(getViewerSorter());
+				provider.setViewerComparator(getViewerComparator());
 			}
 		}
 
@@ -292,10 +292,10 @@ public class ChangeSetActionGroup extends SynchronizePageActionGroup {
 	/*
 	 * The currently chosen sort criteria
 	 */
-	private int sortCriteria = ChangeSetModelSorter.DATE;
+	private int sortCriteria = ChangeSetModelComparator.DATE;
 
 	public static int getSortCriteria(ISynchronizePageConfiguration configuration) {
-		int sortCriteria = ChangeSetModelSorter.DATE;
+		int sortCriteria = ChangeSetModelComparator.DATE;
 		try {
 			IDialogSettings pageSettings = configuration.getSite().getPageSettings();
 			if(pageSettings != null) {
@@ -305,12 +305,12 @@ public class ChangeSetActionGroup extends SynchronizePageActionGroup {
 			// ignore and use the defaults.
 		}
 		switch (sortCriteria) {
-		case ChangeSetModelSorter.COMMENT:
-		case ChangeSetModelSorter.DATE:
-		case ChangeSetModelSorter.USER:
+		case ChangeSetModelComparator.COMMENT:
+		case ChangeSetModelComparator.DATE:
+		case ChangeSetModelComparator.USER:
 			break;
 		default:
-			sortCriteria = ChangeSetModelSorter.DATE;
+			sortCriteria = ChangeSetModelComparator.DATE;
 			break;
 		}
 		return sortCriteria;
@@ -327,9 +327,9 @@ public class ChangeSetActionGroup extends SynchronizePageActionGroup {
 		if (getChangeSetCapability().supportsCheckedInChangeSets()) {
 			sortCriteria = getSortCriteria(configuration);
 			sortByComment = new MenuManager(TeamUIMessages.ChangeLogModelProvider_0a);
-			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_1a, ChangeSetModelSorter.COMMENT));
-			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_2a, ChangeSetModelSorter.DATE));
-			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_3a, ChangeSetModelSorter.USER));
+			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_1a, ChangeSetModelComparator.COMMENT));
+			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_2a, ChangeSetModelComparator.DATE));
+			sortByComment.add(new ToggleSortOrderAction(TeamUIMessages.ChangeLogModelProvider_3a, ChangeSetModelComparator.USER));
 		}
 
 		if (getChangeSetCapability().supportsActiveChangeSets()) {
@@ -449,12 +449,12 @@ public class ChangeSetActionGroup extends SynchronizePageActionGroup {
 	}
 
 	/**
-	 * Return a viewer sorter that utilizes the sort criteria
+	 * Return a viewer comparator that utilizes the sort criteria
 	 * selected by the user.
 	 * @return a sorter
 	 */
-	public ViewerSorter getViewerSorter() {
-		return new ChangeSetModelSorter(provider, sortCriteria);
+	public ViewerComparator getViewerComparator() {
+		return new ChangeSetModelComparator(provider, sortCriteria);
 	}
 
 	private ActiveChangeSet createChangeSet(IDiff[] diffs) {


### PR DESCRIPTION
It has been announced for removal in 2019 and notification period ended in 2021 so it's high time to get rid of it in 2023. In order to do it proper a good number of places had to be modified from deprecated ViewerSorter to ViewerComparator
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953 for actual deprecation.