### PR TITLE
Implement removeFileSpec for pattern style content types

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/IContentTypeManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/IContentTypeManagerTest.java
@@ -970,8 +970,14 @@ public class IContentTypeManagerTest extends ContentTypeTest {
 		assertNull("File pattern unknown at that point", single);
 
 		textContentType.addFileSpec("*Text*", IContentType.FILE_PATTERN_SPEC);
+		try {
+			single = finder.findContentTypeFor(getInputStream("Just a test"), "someText.unknown");
+			assertEquals("Text content should now match *Text* files", textContentType, single);
+		} finally {
+			textContentType.removeFileSpec("*Text*", IContentType.FILE_PATTERN_SPEC);
+		}
 		single = finder.findContentTypeFor(getInputStream("Just a test"), "someText.unknown");
-		assertEquals("Text content should now match *Text* files", textContentType, single);
+		assertNull("File pattern unknown at that point", single);
 	}
 
 	@Test

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeCatalog.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeCatalog.java
@@ -277,12 +277,22 @@ public final class ContentTypeCatalog {
 	}
 
 	synchronized void dissociate(ContentType contentType, String text, int type) {
-		Map<String, Set<ContentType>> fileSpecMap = ((type & IContentType.FILE_NAME_SPEC) != 0) ? fileNames : fileExtensions;
-		String mappingKey = FileSpec.getMappingKeyFor(text);
-		Set<ContentType> existing = fileSpecMap.get(mappingKey);
-		if (existing == null)
-			return;
-		existing.remove(contentType);
+		Map<String, Set<ContentType>> fileSpecMap = null;
+		if ((type & IContentType.FILE_NAME_SPEC) != 0) {
+			fileSpecMap = fileNames;
+		} else if ((type & IContentType.FILE_EXTENSION_SPEC) != 0) {
+			fileSpecMap = fileExtensions;
+		}
+		if (fileSpecMap != null) {
+			String mappingKey = FileSpec.getMappingKeyFor(text);
+			Set<ContentType> existing = fileSpecMap.get(mappingKey);
+			if (existing == null)
+				return;
+			existing.remove(contentType);
+		} else if ((type & IContentType.FILE_PATTERN_SPEC) != 0) {
+			Pattern pattern = compiledRegexps.get(text);
+			fileRegexps.get(pattern).remove(contentType);
+		}
 	}
 
 	/**

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/IContentTypeSettings.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/IContentTypeSettings.java
@@ -104,7 +104,8 @@ public interface IContentTypeSettings {
 	 * @param fileSpec the file specification
 	 * @param type the type of the file specification. One of
 	 * <code>FILE_NAME_SPEC</code>,
-	 * <code>FILE_EXTENSION_SPEC</code>.
+	 * <code>FILE_EXTENSION_SPEC</code>,
+	 * <code>FILE_PATTERN_SPEC</code>.
 	 * @throws IllegalArgumentException if the type bit mask is
 	 * incorrect
 	 * @throws CoreException if this method fails. Reasons include:
@@ -113,6 +114,7 @@ public interface IContentTypeSettings {
 	 * </ul>
 	 * @see #FILE_NAME_SPEC
 	 * @see #FILE_EXTENSION_SPEC
+	 * @see #FILE_PATTERN_SPEC
 	 */
 	void removeFileSpec(String fileSpec, int type) throws CoreException;
 


### PR DESCRIPTION
Commit 85b23928b9d76e3b2ed9aeca2df0c520a79040ca for Bug 263316 introduced filename patterns for content type selection, but at the time the remove wasn't implemented.

This patch adds the implementation for removeFileSpec. The test was extended to remove the new content type and verify that the findContentTypeFor returns to the initial state.