### PR TITLE
Fix missing workspace cleanups after executing tests in oe.core.tests.resources

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.0.qualifier
+Bundle-Version: 3.11.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.28.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.0-SNAPSHOT</version>
+  <version>3.11.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,13 +16,16 @@ package org.eclipse.core.tests.internal.resources;
 
 import java.util.*;
 import junit.framework.ComparisonFailure;
+import junit.framework.Test;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.resources.WorkspacePreferences;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.AutomatedResourceTests;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
+import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
-public class WorkspacePreferencesTest extends ResourceTest {
+public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 	private IWorkspace workspace;
 	private Preferences preferences;
 
@@ -300,4 +303,9 @@ public class WorkspacePreferencesTest extends ResourceTest {
 		assertEquals(message + " - 9", description1.getMaxBuildIterations(), description2.getMaxBuildIterations());
 		assertEquals(message + " -10", description1.isKeepDerivedState(), description2.isKeepDerivedState());
 	}
+
+	public static Test suite() {
+		return new WorkspaceSessionTestSuite(AutomatedResourceTests.PI_RESOURCES_TESTS, WorkspacePreferencesTest.class);
+	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2022 IBM Corporation and others.
+ *  Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -108,6 +108,8 @@ public class IResourceTest extends ResourceTest {
 
 	/* the delta verifier */
 	ResourceDeltaVerifier verifier;
+
+	private boolean storedAutoBuildValue;
 
 	/**
 	 * Get all files and directories in given directory recursive.
@@ -396,9 +398,7 @@ public class IResourceTest extends ResourceTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		IWorkspaceDescription description = getWorkspace().getDescription();
-		description.setAutoBuilding(false);
-		getWorkspace().setDescription(description);
+		storedAutoBuildValue = setAutoBuild(false);
 
 		try {
 			// open project
@@ -565,7 +565,25 @@ public class IResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		interestingPaths = null;
 		interestingResources = null;
+		setAutoBuild(storedAutoBuildValue);
 		super.tearDown();
+	}
+
+	private boolean setAutoBuild(boolean enabled) throws CoreException {
+		IWorkspaceDescription description = getWorkspace().getDescription();
+		boolean wasAutoBuildEnabled = description.isAutoBuilding();
+		if (wasAutoBuildEnabled == enabled) {
+			return wasAutoBuildEnabled;
+		}
+		if (wasAutoBuildEnabled) {
+			waitForBuild();
+		}
+		description.setAutoBuilding(enabled);
+		getWorkspace().setDescription(description);
+		if (enabled) {
+			waitForBuild();
+		}
+		return wasAutoBuildEnabled;
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	protected void tearDown() throws Exception {
 		IProject[] projects = getWorkspace().getRoot().getProjects();
 		getWorkspace().delete(projects, true, null);
+		super.tearDown();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -62,10 +62,6 @@ public class ResourceURLTest extends ResourceTest {
 		return new String[] {"/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2", "/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5"};
 	}
 
-	public void doCleanup() throws CoreException {
-		getWorkspace().getRoot().delete(true, true, null);
-	}
-
 	protected IProject getTestProject() {
 		return getWorkspace().getRoot().getProject("testProject");
 	}
@@ -80,11 +76,6 @@ public class ResourceURLTest extends ResourceTest {
 
 	private URL getURL(IResource resource) throws Throwable {
 		return getURL(resource.getFullPath());
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		// overwrite the superclass and do nothing since our test methods build on each other
 	}
 
 	public void testBasicURLs() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_134364.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_134364.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources.regression;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.tests.resources.ResourceTest;
 import org.junit.Test;
 
 /**
@@ -27,7 +28,7 @@ import org.junit.Test;
  * malformed state.  The fix was to synchronize the routine that collapses
  * unused trees in ElementTree.
  */
-public class Bug_134364 {
+public class Bug_134364 extends ResourceTest {
 	/**
 	 * Creates a project with a builder attached
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class Bug_226264 extends ResourceTest {
 		};
 
 		// the listener will schedule another project delete
-		workspace.addResourceChangeListener(event -> {
+		IResourceChangeListener projectDeletingChangeListener = event -> {
 			if (event.getResource() == project1) {
 				// because notification is run in a protected block,
 				// this job will start after the notification
@@ -49,15 +49,17 @@ public class Bug_226264 extends ResourceTest {
 					//ignore
 				}
 			}
-		}, IResourceChangeEvent.PRE_DELETE);
-
-		// delete project
-		project1.delete(true, null);
+		};
+		workspace.addResourceChangeListener(projectDeletingChangeListener, IResourceChangeEvent.PRE_DELETE);
 
 		try {
+			// delete project
+			project1.delete(true, null);
 			job.join();
 		} catch (InterruptedException e) {
 			fail("1.0", e);
+		} finally {
+			workspace.removeResourceChangeListener(projectDeletingChangeListener);
 		}
 
 		assertTrue("2.0: " + job.getResult(), job.getResult().isOK());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class Bug_231301 extends ResourceTest {
 		};
 
 		// the listener will schedule another project close
-		workspace.addResourceChangeListener(event -> {
+		IResourceChangeListener projectClosingChangeListener = event -> {
 			if (event.getResource() == project1) {
 				// because notification is run in a protected block,
 				// this job will start after the notification
@@ -49,15 +49,17 @@ public class Bug_231301 extends ResourceTest {
 					//ignore
 				}
 			}
-		}, IResourceChangeEvent.PRE_CLOSE);
-
-		// close project
-		project1.close(getMonitor());
+		};
+		workspace.addResourceChangeListener(projectClosingChangeListener, IResourceChangeEvent.PRE_CLOSE);
 
 		try {
+			// close project
+			project1.close(getMonitor());
 			job.join();
 		} catch (InterruptedException e) {
 			fail("1.0", e);
+		} finally {
+			workspace.removeResourceChangeListener(projectClosingChangeListener);
 		}
 
 		assertTrue("2.0: " + job.getResult(), job.getResult().isOK());


### PR DESCRIPTION
Several test cases/classes in `org.eclipse.core.tests.resources` do not perform a proper cleanup after their execution. In consequence, the workspace is not in a clean state afterwards, e.g., in terms of remaining projects/files, changed workspace settings, and still registered or missing listeners.
This can lead to failures of subsequent test executions that assume a clean workspace state, depending on the execution order of tests. This particularly occurs when executing a bunch of test classes within Eclipse in a single run, but may also affect the Maven build.

Since tests should be isolated to be executable in any order without affecting other tests, I propose the following changes to cleanup several places I found when investigating test failures:
* Add missing removal of workspace listeners 
* Properly reset workspace properties such as the `autobuild` property in `teardown`
* Add missing calls to `teardown` because of unnecessarily overwritten methods, missing calls to the super method or missing extensions of an according test class ensuring cleanup (i.e. `ResourceTest`)
* Add removal of all files places in the workspace directory but not contained in projects

This missing isolation of test executions may also be a reason for the randomly occuring `Verifier has not yet been given a resource delta` test failures, such as #99 and #319. At least during local execution I had random occurrences of that failure because of interfering workspace listeners still registered from previously executed tests.