### PR TITLE
Close project when failing to restore metadata in SaveManager (#377)

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -910,10 +910,13 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		}
 		project.internalSetDescription(description, false);
 		if (failure != null) {
-			// write the project tree ...
-			writeTree(project, IResource.DEPTH_INFINITE);
-			// ... and close the project
-			project.internalClose(monitor);
+			try {
+				// write the project tree ...
+				writeTree(project, IResource.DEPTH_INFINITE);
+			} finally {
+				// ... and close the project
+				project.internalClose(monitor);
+			}
 			throw failure;
 		}
 		if (Policy.DEBUG_RESTORE_METAINFO)


### PR DESCRIPTION
As explained in #377, the `SaveManager` does not properly close a project when failing to restore the workspace with inconsistent metadata (e.g. after a process kill). The randomly failing test case `TestBug294854.testDelete` revealed that behavior.

The proposed changes ensure that a project is properly closed in such a case (as intended by the existing code). In addition, the changes fix the indeterministic behavior of `TestBug294854.testDelete` by splitting it up into the cases which randomly occurred before and of which only one was only successful:
1. Kill the process before metadata has been stored in the snapshot job
2. Kill the process after metadata has been stored in the snapshot job

In addition, I propose to replace the `sleep` calls, which try to wait for the snapshot job to be finished, with an according utility that properly waits for it.

Fixes #377 