### PR TITLE
Marker not found logged without stack trace on launch

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Marker.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Marker.java
@@ -60,7 +60,7 @@ public class Marker extends PlatformObject implements IMarker {
 	private void checkInfo(MarkerInfo info) throws CoreException {
 		if (info == null) {
 			String message = NLS.bind(Messages.resources_markerNotFound, Long.toString(id));
-			throw new ResourceException(new ResourceStatus(IResourceStatus.MARKER_NOT_FOUND, resource.getFullPath(), message));
+			throw new ResourceException(new ResourceStatus(IResourceStatus.MARKER_NOT_FOUND, resource.getFullPath(), message, new IllegalStateException()));
 		}
 	}
 


### PR DESCRIPTION
Add an exception to the ResourceException status created in Marker.checkInfo(), to have more context in the logged error.

Related to: #383