### PR TITLE
EclipseContext: allow GC for undisposed contexts #375

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/WeakGroupedListenerList.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/WeakGroupedListenerList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,14 +14,15 @@
 
 package org.eclipse.e4.core.internal.contexts;
 
-import java.lang.ref.WeakReference;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
  * Listeners are held wrapped in weak references and are removed if no other [strong] reference
@@ -29,121 +30,66 @@ import java.util.Set;
  */
 public class WeakGroupedListenerList {
 
-	public static class WeakComputationReference extends WeakReference<Computation> {
+	private final Map<String, Set<Computation>> listeners = new HashMap<>();
 
-		final private int hashCode;
+	public synchronized void add(String groupName, Computation computation) {
+		Objects.requireNonNull(computation);
+		listeners.computeIfAbsent(groupName,
+						k -> Collections.newSetFromMap(new WeakHashMap<Computation, Boolean>()))
+				.add(computation);
+	}
 
-		public WeakComputationReference(Computation computation) {
-			super(computation);
-			hashCode = computation.hashCode();
-		}
-
-		@Override
-		public int hashCode() {
-			return hashCode;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (obj == null)
-				return false;
-			if (!WeakComputationReference.class.equals(obj.getClass()))
-				return super.equals(obj);
-			Computation computation = get();
-			Computation otherComputation = ((WeakComputationReference) obj).get();
-			if (computation == null && otherComputation == null)
-				return true;
-			if (computation == null || otherComputation == null)
-				return false;
-			return computation.equals(otherComputation);
+	public synchronized void remove(Computation computation) {
+		Collection<Set<Computation>> allListeners = listeners.values();
+		for (Set<Computation> group : allListeners) {
+			group.remove(computation);
 		}
 	}
 
-	private Map<String, HashSet<WeakComputationReference>> listeners = new HashMap<>(10, 0.8f);
-
-	synchronized public void add(String groupName, Computation computation) {
-		HashSet<WeakComputationReference> nameListeners = listeners.get(groupName);
-		if (nameListeners == null) {
-			nameListeners = new HashSet<>(30, 0.75f);
-			nameListeners.add(new WeakComputationReference(computation));
-			listeners.put(groupName, nameListeners);
-		}
-		nameListeners.add(new WeakComputationReference(computation));
-	}
-
-	synchronized public void remove(Computation computation) {
-		WeakComputationReference ref = new WeakComputationReference(computation);
-		Collection<HashSet<WeakComputationReference>> allListeners = listeners.values();
-		for (HashSet<WeakComputationReference> group : allListeners) {
-			group.remove(ref);
-		}
-	}
-
-	synchronized public Set<String> getNames() {
-		Set<String> tmp = listeners.keySet(); // clone internal name list
-		Set<String> usedNames = new HashSet<>(tmp.size());
-		usedNames.addAll(tmp);
+	public synchronized Set<String> getNames() {
+		Set<String> groupNames = listeners.keySet(); // clone internal name list
+		Set<String> usedNames = new HashSet<>(groupNames.size());
+		usedNames.addAll(groupNames);
 		return usedNames;
 	}
 
-	synchronized public void clear() {
+	public synchronized void clear() {
 		listeners.clear();
 	}
 
-	synchronized public Set<Computation> getListeners() {
-		Collection<HashSet<WeakComputationReference>> collection = listeners.values();
+	public synchronized Set<Computation> getListeners() {
+		Collection<Set<Computation>> groups = listeners.values();
 		Set<Computation> result = new HashSet<>();
-		for (HashSet<WeakComputationReference> set : collection) {
-			for (Iterator<WeakComputationReference> i = set.iterator(); i.hasNext();) {
-				WeakComputationReference ref = i.next();
-				Computation computation = ref.get();
-				if (computation == null || !computation.isValid()) {
-					i.remove(); // do a clean-up while we are here
-				} else
+		for (Set<Computation> computations : groups) {
+			for (Computation computation : computations) {
+				if (computation.isValid()) {
 					result.add(computation);
+				}
 			}
 		}
 		return result;
 	}
 
-	synchronized public Set<Computation> getListeners(String groupName) {
-		HashSet<WeakComputationReference> tmp = listeners.get(groupName);
-		if (tmp == null)
+	public synchronized Set<Computation> getListeners(String groupName) {
+		Set<Computation> computations = listeners.get(groupName);
+		if (computations == null)
 			return null;
-		Set<Computation> result = new HashSet<>(tmp.size());
-
-		for (Iterator<WeakComputationReference> i = tmp.iterator(); i.hasNext();) {
-			WeakComputationReference ref = i.next();
-			Computation computation = ref.get();
-			if (computation == null || !computation.isValid()) {
-				i.remove(); // do a clean-up while we are here
-			} else
+		Set<Computation> result = new HashSet<>(computations.size());
+		for (Computation computation : computations) {
+			if (computation.isValid()) {
 				result.add(computation);
+			}
 		}
 		return result;
 	}
 
-	synchronized public void cleanup() {
-		boolean cleanGroups = false;
-		for (HashSet<WeakComputationReference> set : listeners.values()) {
-			for (Iterator<WeakComputationReference> i = set.iterator(); i.hasNext();) {
-				WeakComputationReference ref = i.next();
-				Computation computation = ref.get();
-				if (computation == null || !computation.isValid())
-					i.remove();
-			}
-			if (set.isEmpty())
-				cleanGroups = true;
-		}
-		if (cleanGroups) {
-			Set<Entry<String, HashSet<WeakComputationReference>>> entries = listeners.entrySet();
-			for (Iterator<Entry<String, HashSet<WeakComputationReference>>> i = entries.iterator(); i.hasNext();) {
-				Entry<String, HashSet<WeakComputationReference>> entry = i.next();
-				HashSet<WeakComputationReference> value = entry.getValue();
-				if (value == null || value.isEmpty())
-					i.remove();
-			}
-		}
+	public synchronized void cleanup() {
+		Set<Entry<String, Set<Computation>>> entries = listeners.entrySet();
+		entries.removeIf(entry -> {
+			Set<Computation> computations = entry.getValue();
+			computations.removeIf(computation -> !computation.isValid());
+			return computations.isEmpty();
+		});
 	}
 
 }


### PR DESCRIPTION
* WeakGroupedListenerList: Use JDK's WeakHashMap (with a cleaner) to not leak WeakComputationReference

* InjectorImpl: Use WeakHashMap to avoid strong references to injected Contexts to avoid leaked EclipseContext in the key of InjectorImpl.injectedObjects

* Fix modifiers and their order

Fixes Eclipse-IDE process stuck in EclipseContext.cleanup during shutdown. Happened if EclipseContext could be garbage collected but is not explicitly disposed.