### PR TITLE
Make ResourceTest restore workspace description #406

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.core.tests.internal.builders;
 
 import java.util.Map;
-import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -24,9 +23,6 @@ import org.eclipse.core.tests.resources.ResourceTest;
  * This class does not define any tests, just convenience methods for other builder tests.
  */
 public abstract class AbstractBuilderTest extends ResourceTest {
-
-	private boolean autoBuilding;
-	private int simultaneousBuilds;
 
 	public AbstractBuilderTest(String name) {
 		super(name);
@@ -69,69 +65,4 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 		file.setContents(getRandomContents(), true, true, getMonitor());
 	}
 
-	/**
-	 * Sets the workspace autobuilding to the desired value.
-	 */
-	protected void setAutoBuilding(boolean value) throws CoreException {
-		changeAutoBuilding(value);
-		if (!value) {
-			((Workspace) getWorkspace()).getBuildManager().waitForAutoBuild();
-		}
-	}
-
-	private void changeAutoBuilding(boolean value) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		if (workspace.isAutoBuilding() == value) {
-			return;
-		}
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setAutoBuilding(value);
-		workspace.setDescription(desc);
-	}
-
-	/**
-	 * Sets the workspace build order to just contain the given project.
-	 */
-	protected void setBuildOrder(IProject project) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setBuildOrder(new String[] {project.getName()});
-		workspace.setDescription(desc);
-	}
-
-	/**
-	 * Sets the workspace build order to contain the two given projects
-	 */
-	protected void setBuildOrder(IProject project1, IProject project2) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setBuildOrder(new String[] {project1.getName(), project2.getName()});
-		workspace.setDescription(desc);
-	}
-
-	/**
-	 * Saves the current auto-build flag value so it can be restored later.
-	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		autoBuilding = getWorkspace().isAutoBuilding();
-		simultaneousBuilds = getWorkspace().getDescription().getMaxConcurrentBuilds();
-	}
-
-	/**
-	 * Restores the auto-build flag to its original value.
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		//revert to default build order
-		IWorkspace workspace = getWorkspace();
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setBuildOrder(null);
-		desc.setMaxConcurrentBuilds(simultaneousBuilds);
-		workspace.setDescription(desc);
-		waitForBuild();
-		setAutoBuilding(autoBuilding);
-		super.tearDown();
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -57,13 +57,10 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		setAutoBuilding(true);
 		scheduled = new AtomicLong(0);
 		running = new AtomicLong(0);
 		setupProjectWithOurBuilder();
-
-		// Setup above will trigger autobuild
-		waitForBuild();
+		setAutoBuilding(true);
 		Job.getJobManager().addJobChangeListener(jobChangeListener);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -36,10 +36,8 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		ensureExistsInWorkspace(new IResource[] {project, before1, before2, after1, after2}, true);
 
 		try {
-			IWorkspaceDescription description = getWorkspace().getDescription();
-			description.setBuildOrder(new String[] {before1.getName(), before2.getName(), project.getName(), after1.getName(), after2.getName()});
-			description.setAutoBuilding(false);
-			getWorkspace().setDescription(description);
+			setBuildOrder(before1, before2, project, after1, after2);
+			setAutoBuilding(false);
 		} catch (CoreException e) {
 			fail("1.0", e);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -412,7 +412,6 @@ public class BuilderTest extends AbstractBuilderTest {
 			notified[0] = false;
 			//now turn on autobuild and see if the listener is notified again
 			setAutoBuilding(true);
-			waitForBuild();
 			assertTrue("1.0", !notified[0]);
 		} catch (CoreException e) {
 			fail("2.99", e);
@@ -739,6 +738,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		} catch (CoreException e) {
 			fail("3.99", e);
 		}
+		waitForEncodingRelatedJobs();
 		waitForBuild();
 		SortBuilder builder = SortBuilder.getInstance();
 		assertEquals("4.0", proj2, builder.getProject());
@@ -864,7 +864,6 @@ public class BuilderTest extends AbstractBuilderTest {
 		//Cause a build by enabling autobuild
 		try {
 			setAutoBuilding(true);
-			waitForBuild();
 			verifier = SortBuilder.getInstance();
 			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
@@ -173,7 +173,11 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		desc.setBuildSpec(new ICommand[] {command});
 		project.setDescription(desc, getMonitor());
 		command = project.getDescription().getBuildSpec()[0];
-		setAutoBuilding(true);
+
+		// Turn on autobuild without waiting for build to be finished
+		IWorkspaceDescription description = workspace.getDescription();
+		description.setAutoBuilding(true);
+		workspace.setDescription(description);
 
 		// do an initial workspace build to get the builder instance
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
@@ -554,7 +558,6 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		// turn auto-building on
 		setAutoBuilding(true);
-		waitForBuild();
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("1.0", builder);
 		assertEquals("1.1", 0, builder.triggerForLastBuild);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
@@ -35,15 +35,13 @@ public class BuildProjectFromMultipleJobsTest extends ResourceTest {
 	private static final String TEST_PROJECT_NAME = "ProjectForBuildCommandTest";
 
 	private final ErrorLogListener logListener = new ErrorLogListener();
-	private boolean wasAutoBuildOn;
 
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
 		// auto-build makes reproducing the problem harder,
 		// since it may build before we trigger parallel builds from the test
-		wasAutoBuildOn = setWorkspaceAutoBuild(false);
-
+		setAutoBuilding(false);
 		Platform.addLogListener(logListener);
 	}
 
@@ -60,7 +58,6 @@ public class BuildProjectFromMultipleJobsTest extends ResourceTest {
 				testProject.delete(true, null);
 			}
 		} finally {
-			setWorkspaceAutoBuild(wasAutoBuildOn);
 		}
 
 		super.tearDown();
@@ -151,17 +148,6 @@ public class BuildProjectFromMultipleJobsTest extends ResourceTest {
 		IWorkspaceRoot workspaceRoot = getWorkspace().getRoot();
 		IProject project = workspaceRoot.getProject(TEST_PROJECT_NAME);
 		return project;
-	}
-
-	private static boolean setWorkspaceAutoBuild(boolean autobuildOn) throws CoreException {
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		final IWorkspaceDescription description = workspace.getDescription();
-		boolean oldAutoBuildingState = description.isAutoBuilding();
-		if (oldAutoBuildingState != autobuildOn) {
-			description.setAutoBuilding(autobuildOn);
-			workspace.setDescription(description);
-		}
-		return oldAutoBuildingState;
 	}
 
 	private static class ErrorLogListener implements ILogListener {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -90,8 +90,6 @@ public class HistoryStoreTest extends ResourceTest {
 		}
 	}
 
-	private IWorkspaceDescription original;
-
 	public static void assertEquals(String tag, IFileState expected, IFileState actual) {
 		assertEquals(tag + " path differs", expected.getFullPath(), actual.getFullPath());
 		assertEquals(tag + " timestamp differs", expected.getModificationTime(), actual.getModificationTime());
@@ -140,14 +138,7 @@ public class HistoryStoreTest extends ResourceTest {
 	}
 
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		original = getWorkspace().getDescription();
-	}
-
-	@Override
 	protected void tearDown() throws Exception {
-		getWorkspace().setDescription(original);
 		super.tearDown();
 		wipeHistoryStore(getMonitor());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -187,23 +187,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	/**
-	 * Sets the workspace autobuilding to the desired value.
-	 */
-	protected void setAutoBuilding(boolean value) {
-		IWorkspace workspace = getWorkspace();
-		if (workspace.isAutoBuilding() == value) {
-			return;
-		}
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setAutoBuilding(value);
-		try {
-			workspace.setDescription(desc);
-		} catch (CoreException e) {
-			fail("failed to set workspace description", e);
-		}
-	}
-
-	/**
 	 * Sets up the fixture, for example, open a network connection. This method
 	 * is called before a test is executed.
 	 */
@@ -511,7 +494,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			workspace.removeResourceChangeListener(preBuild);
 			workspace.removeResourceChangeListener(postBuild);
 			workspace.removeResourceChangeListener(postChange);
-			setAutoBuilding(true);
 		}
 	}
 
@@ -537,8 +519,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		final IWorkspace workspace = getWorkspace();
 		try {
 			setAutoBuilding(false);
-			// make sure the events do not get fired from autobuild:
-			((Workspace) getWorkspace()).getBuildManager().waitForAutoBuild();
 
 			workspace.addResourceChangeListener(preBuild, IResourceChangeEvent.PRE_BUILD);
 			workspace.addResourceChangeListener(postBuild, IResourceChangeEvent.POST_BUILD);
@@ -554,7 +534,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			assertEquals("Should see workspace root on PRE_BUILD event", workspace, preBuild.source);
 			assertEquals("Should see workspace root on POST_BUILD event", workspace, postBuild.source);
 		} finally {
-			setAutoBuilding(true);
 			workspace.removeResourceChangeListener(preBuild);
 			workspace.removeResourceChangeListener(postBuild);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -43,7 +43,6 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceFilterDescription;
 import org.eclipse.core.resources.IResourceProxyVisitor;
 import org.eclipse.core.resources.IResourceVisitor;
-import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -114,8 +113,6 @@ public class IResourceTest extends ResourceTest {
 
 	/* the delta verifier */
 	ResourceDeltaVerifier verifier;
-
-	private boolean storedAutoBuildValue;
 
 	/**
 	 * Get all files and directories in given directory recursive.
@@ -404,7 +401,7 @@ public class IResourceTest extends ResourceTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		storedAutoBuildValue = setAutoBuild(false);
+		setAutoBuilding(false);
 
 		try {
 			// open project
@@ -570,25 +567,7 @@ public class IResourceTest extends ResourceTest {
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
 		interestingPaths = null;
 		interestingResources = null;
-		setAutoBuild(storedAutoBuildValue);
 		super.tearDown();
-	}
-
-	private boolean setAutoBuild(boolean enabled) throws CoreException {
-		IWorkspaceDescription description = getWorkspace().getDescription();
-		boolean wasAutoBuildEnabled = description.isAutoBuilding();
-		if (wasAutoBuildEnabled == enabled) {
-			return wasAutoBuildEnabled;
-		}
-		if (wasAutoBuildEnabled) {
-			waitForBuild();
-		}
-		description.setAutoBuilding(enabled);
-		getWorkspace().setDescription(description);
-		if (enabled) {
-			waitForBuild();
-		}
-		return wasAutoBuildEnabled;
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -29,8 +29,6 @@ import org.eclipse.core.tests.resources.ResourceTest;
  */
 public class LocalHistoryPerformanceTest extends ResourceTest {
 
-	private IWorkspaceDescription original;
-
 	void cleanHistory() {
 		((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore().clean(getMonitor());
 	}
@@ -81,14 +79,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	}
 
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		original = getWorkspace().getDescription();
-	}
-
-	@Override
 	protected void tearDown() throws Exception {
-		getWorkspace().setDescription(original);
 		super.tearDown();
 		HistoryStoreTest.wipeHistoryStore(getMonitor());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -72,7 +72,6 @@ public class Bug_147232 extends AbstractBuilderTest implements IResourceChangeLi
 			project.open(getMonitor());
 			addBuilder(project, ClearMarkersBuilder.BUILDER_NAME);
 			setAutoBuilding(true);
-			waitForBuild();
 		} catch (CoreException e) {
 			fail("0.99", e);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -56,11 +56,7 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 			//give unsorted files some initial content
 			unsortedFile1.setContents(new ByteArrayInputStream(new byte[] {1, 4, 3}), true, true, null);
 
-			//turn off autobuild
-			IWorkspace workspace = getWorkspace();
-			IWorkspaceDescription desc = workspace.getDescription();
-			desc.setAutoBuilding(false);
-			workspace.setDescription(desc);
+			setAutoBuilding(false);
 
 			//configure builder for project1
 			IProjectDescription description = project1.getDescription();
@@ -68,7 +64,7 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 			project1.setDescription(description, getMonitor());
 
 			//initial build -- created sortedFile1
-			workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 
 			getWorkspace().save(true, getMonitor());
 		} catch (CoreException e) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -36,10 +36,7 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 		IProject project = workspace.getRoot().getProject("Project1");
 		ensureExistsInWorkspace(project, true);
 		try {
-			//turn off autobuild
-			IWorkspaceDescription desc = workspace.getDescription();
-			desc.setAutoBuilding(false);
-			workspace.setDescription(desc);
+			setAutoBuilding(false);
 
 			//create a project and configure builder
 			IProjectDescription description = project.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -34,16 +34,9 @@ public class TestBug6995 extends WorkspaceSessionTest {
 	/**
 	 * Create a project and configure a builder for it.
 	 */
-	public void test1() {
-		//turn off autobuild
+	public void test1() throws CoreException {
 		IWorkspace workspace = getWorkspace();
-		try {
-			IWorkspaceDescription desc = workspace.getDescription();
-			desc.setAutoBuilding(false);
-			workspace.setDescription(desc);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		setAutoBuilding(false);
 
 		//create a project and configure builder
 		IProject project = workspace.getRoot().getProject("Project");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -60,11 +60,8 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 			unsortedFile1.setContents(new ByteArrayInputStream(new byte[] {1, 4, 3}), true, true, null);
 			unsortedFile2.setContents(new ByteArrayInputStream(new byte[] {1, 4, 3}), true, true, null);
 
-			//turn off autobuild
-			IWorkspaceDescription desc = workspace.getDescription();
-			desc.setAutoBuilding(false);
-			desc.setBuildOrder(new String[] {project1.getName(), project2.getName()});
-			workspace.setDescription(desc);
+			setBuildOrder(project1, project2);
+			setAutoBuilding(false);
 
 			//configure builder for project1
 			IProjectDescription description = project1.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -41,19 +41,6 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 	private IFile file3;
 	private IFile file4;
 
-	/**
-	 * Sets the workspace autobuilding to the desired value.
-	 */
-	protected void setAutoBuilding(boolean value) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		if (workspace.isAutoBuilding() == value) {
-			return;
-		}
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setAutoBuilding(value);
-		workspace.setDescription(desc);
-	}
-
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
@@ -75,11 +62,7 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		IResource[] resources = {project1, project2, project3, project4, file1, file2, file3, file4};
 		ensureExistsInWorkspace(resources, true);
 		try {
-			//turn off autobuild
-			IWorkspace workspace = getWorkspace();
-			IWorkspaceDescription desc = workspace.getDescription();
-			desc.setAutoBuilding(false);
-			workspace.setDescription(desc);
+			setAutoBuilding(false);
 
 			//create a project and configure builder
 			IProjectDescription description = project1.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -52,19 +52,6 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	}
 
 	/**
-	 * Sets the workspace autobuilding to the desired value.
-	 */
-	protected void setAutoBuilding(boolean value) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		if (workspace.isAutoBuilding() == value) {
-			return;
-		}
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setAutoBuilding(value);
-		workspace.setDescription(desc);
-	}
-
-	/**
 	 * Setup.  Create a project that has a disabled builder due to
 	 * missing nature prerequisite.
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
@@ -49,9 +49,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 		IWorkspaceDescription original = getWorkspace().getDescription();
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		try {
-			IWorkspaceDescription description = getWorkspace().getDescription();
-			description.setAutoBuilding(true);
-			getWorkspace().setDescription(description);
+			setAutoBuilding(true);
 			IProjectDescription prjDescription = getWorkspace().newProjectDescription("MyProject");
 			ICommand command = prjDescription.newCommand();
 			command.setBuilderName(SignaledBuilder.BUILDER_ID);


### PR DESCRIPTION
Several realizations of a `ResourceTest` perform changes to the workspace description, e.g., in terms of changing the auto-build settings, without resetting them afterwards. And even if they do, the functionality is redundantly present at different places within the source code.
This induces dependencies between test executions, as the behavior of a subsequent test case execution depends on the modifications of the workspace description by previous ones.

The proposed changes do the following: 
- Store the workspace description before executing a `ResourceTest` and restore it during teardown
- Provide only one central method enabling and disabling autobuild and setting the build order and remove all redundant methods or in-place realizations
- Remove manual restorations of autobuild settings after test execution, as this is subsumed by `ResourceTest` performing `setup` and `teardown`
- Properly wait for background jobs completion in `BuilderTest` to avoid race conditions because of changed runtime behavior due to resetting workspace description after executing other test cases

I am not sure whether the missing restoration of the workspace settings after a test run leads to build failures right now (might be a cause for some of the random failures). But locally executing certain extracts of available tests, such as a single class or package, can currently lead to failures due to missing test isolation.

Contributes to #406.
Fixes #408.