### PR TITLE
Avoid background refresh while ensuring file is out of sync #96

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -1052,7 +1052,6 @@ public class IFileTest extends ResourceTest {
 		new TestPerformer("IFileTest.testSetContents1") {
 			@Override
 			public void cleanUp(Object[] args, int count) {
-				waitForRefresh();
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -687,6 +687,7 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public void ensureOutOfSync(final IFile file) {
 		modifyInFileSystem(file);
+		waitForRefresh();
 		touchInFilesystem(file);
 		assertTrue("File not out of sync: " + file.getLocation().toOSString(), file.getLocation().toFile().lastModified() != file.getLocalTimeStamp());
 	}


### PR DESCRIPTION
The functionality in ResourceTest for ensuring that a file is out of sync may fail randomly if a refresh task is still running in background and finishes right after the method has made the file out of sync with the workspace. This at least affects `IFileTest.testCreate`. Waiting for a potential refresh to finish before making the file out of sync should avoid this situation deterministically.

Fixes #96.