### PR TITLE
Improve timing behavior of IJobManagerTest for slow servers #397

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -1202,7 +1202,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		final int[] familyJobsCount = new int[] {-1};
 		final TestBarrier2 barrier = new TestBarrier2();
 		final Job waiting = new FamilyTestJob("waiting job", 1000000, 10, TestJobFamily.TYPE_ONE);
-		final Job running = new FamilyTestJob("running job", 2, 1, TestJobFamily.TYPE_ONE);
+		final Job running = new FamilyTestJob("running job", 2, 100, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
@@ -1292,7 +1292,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		final int[] familyJobsCount = new int[] {-1};
 		final TestBarrier2 barrier = new TestBarrier2();
 		final Job waiting = new FamilyTestJob("waiting job", 1000000, 10, TestJobFamily.TYPE_ONE);
-		final Job running = new FamilyTestJob("running job", 2, 1, TestJobFamily.TYPE_ONE);
+		final Job running = new FamilyTestJob("running job", 2, 100, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
@@ -1381,8 +1381,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	public void testJobFamilyJoinWhenSuspended_3() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final TestBarrier2 barrier = new TestBarrier2();
-		final Job waiting = new FamilyTestJob("waiting job", 4, 1, TestJobFamily.TYPE_ONE);
-		final Job running = new FamilyTestJob("running job", 2, 1, TestJobFamily.TYPE_ONE);
+		final Job waiting = new FamilyTestJob("waiting job", 4, 100, TestJobFamily.TYPE_ONE);
+		final Job running = new FamilyTestJob("running job", 2, 100, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
@@ -1717,7 +1717,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	public void testOrder() {
 		//ensure jobs are run in order from lowest to highest sleep time.
 		final Queue<Job> done = new ConcurrentLinkedQueue<>();
-		int[] sleepTimes = new int[] { 5, 100, 200, 300 };
+		int[] sleepTimes = new int[] { 5, 200, 400, 600 };
 		Job[] jobs = new Job[sleepTimes.length];
 		for (int i = 0; i < sleepTimes.length; i++) {
 			jobs[i] = new Job("testOrder(" + i + ")") {
@@ -1878,7 +1878,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	}
 
 	public void testSleep() {
-		TestJob job = new TestJob("ParentJob", 10, 10);
+		TestJob job = new TestJob("ParentJob", 10, 50);
 		//sleeping a job that isn't scheduled should have no effect
 		assertEquals("1.0", Job.NONE, job.getState());
 		assertTrue("1.1", job.sleep());


### PR DESCRIPTION
On a slow server some of the `IJobManagerTest` test cases (`testSleep`, `testOrder`, `testJobFamilyJoinWhenSuspended_1`/`2`/`3`) may fail because the main thread is executed so slowly that the jobs are already finished while the main thread still assumes them running. 

Increasing the according values for the time until termination will reduce the chance for random failures of these test cases. However, this should be a temporary solution to be replaced by properly checking a condition as mentioned in https://github.com/eclipse-platform/eclipse.platform/pull/398#issuecomment-1496940439.

Contributes to #397 as a temporary improvement, but does not resolve it.