### PR TITLE
Improve tests for calling LockListener in JobManager #399

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestJob.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestJob.java
@@ -26,6 +26,7 @@ public class TestJob extends Job {
 	private int ticks;
 	private long tickLength;
 	private int runCount = 0;
+	private volatile boolean terminateOnNextTick = false;
 
 	/**
 	 * A job that runs for one second in 100 millisecond increments.
@@ -61,7 +62,7 @@ public class TestJob extends Job {
 		//must have positive work
 		monitor.beginTask(getName(), ticks <= 0 ? 1 : ticks);
 		try {
-			for (int i = 0; i < ticks; i++) {
+			for (int i = 0; i < ticks && !terminateOnNextTick; i++) {
 				monitor.subTask("Tick: " + i);
 				if (monitor.isCanceled()) {
 					return Status.CANCEL_STATUS;
@@ -85,4 +86,12 @@ public class TestJob extends Job {
 	private synchronized void setRunCount(int count) {
 		runCount = count;
 	}
+
+	/**
+	 * Terminates this test job when executing the next tick with status OK.
+	 */
+	public void terminate() {
+		terminateOnNextTick = true;
+	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -1054,17 +1054,19 @@ public class JobTest extends AbstractJobTest {
 	 * See bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=195839.
 	 */
 	public void testJoinLockListener() {
-		Job testJob = new TestJob("testJoinLockListener", 5, 500);
-		TestLockListener lockListener = new TestLockListener();
+		TestJob longRunningTestJob = new TestJob("testJoinLockListener", 100000, 10);
+		longRunningTestJob.schedule();
+		TestLockListener lockListener = new TestLockListener(() -> longRunningTestJob.terminate());
 		try {
 			Job.getJobManager().setLockListener(lockListener);
-			testJob.join();
+			longRunningTestJob.join();
 		} catch (OperationCanceledException | InterruptedException e) {
-			fail("4.99", e);
+			fail("Exception occurred when joining job", e);
 		} finally {
 			Job.getJobManager().setLockListener(null);
 		}
-		lockListener.assertNotWaiting("1.0");
+		lockListener.assertHasBeenWaiting("JobManager has not been waiting for lock");
+		lockListener.assertNotWaiting("JobManager has not finished waiting for lock");
 	}
 
 	/**


### PR DESCRIPTION
The tests for calls of the `LockListener` from a `JobManager` only validate whether the JobManager is not waiting for a lock in the end. They do not validate whether it has been waiting for a lock at all. The jobs may not be running anymore when `JobManager.join` is called, such that no lock will be acquired at all.

The proposed changes do the following:
- Add possibility to explicitly define when a `TestJob` should end rather than trusting in proper timing behavior with a defined Job run time
- Improve tests for calling LockListener when joining on JobManager

The former improvement will also be useful for properly fixing #397 .

Public APIs of the two test bundles are affected, but version has already been bumped for the move to Java 17.

Fixes #399.