### PR TITLE
Fix random failing JobTest.* tests #402

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestBarrier2.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestBarrier2.java
@@ -153,7 +153,7 @@ public class TestBarrier2 {
 	 * value Times out after a predefined period to avoid hanging tests
 	 */
 	public static void waitForStatus(AtomicIntegerArray location, int index, int status) {
-		doWaitForStatus(location, index, status, 5000);
+		doWaitForStatus(location, index, status, 10000);
 	}
 
 	/**


### PR DESCRIPTION
Several test cases in `JobTest` fail because of relying on non-deterministic timing behavior.
- Increase too low `TestBarrier2` timeout while waiting for status change to fix `testAsynchJobConflict`
- Add proper barrier in `testJoinWithTimeout`
- Make `testJoinInterruptNonUIThread` validate execution time in proper thread

Fixes #402.