### PR TITLE
Ensure that workspace directory is clean after each test run #406

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -50,6 +50,7 @@ public class FileStoreTest extends LocalStoreTest {
 			store.delete(EFS.NONE, null);
 		}
 		store.mkdir(EFS.NONE, null);
+		deleteOnTearDown(store);
 		IFileInfo info = store.fetchInfo();
 		assertTrue("createDir.1", info.exists());
 		assertTrue("createDir.1", info.isDirectory());
@@ -89,6 +90,7 @@ public class FileStoreTest extends LocalStoreTest {
 	private IFileStore getDirFileStore(String path) throws CoreException {
 		IFileStore store = EFS.getFileSystem(EFS.SCHEME_FILE).getStore(new Path(path));
 		store.mkdir(EFS.NONE, null);
+		deleteOnTearDown(store);
 		return store;
 	}
 
@@ -169,15 +171,13 @@ public class FileStoreTest extends LocalStoreTest {
 		target.copy(destination, EFS.NONE, null);
 		assertTrue("6.2", verifyTree(getTree(destination)));
 		destination.delete(EFS.NONE, null);
-
-		/* remove trash */
-		target.delete(EFS.NONE, null);
 	}
 
 	public void testCopyDirectory() throws Throwable {
 		/* build scenario */
 		IFileStore temp = EFS.getFileSystem(EFS.SCHEME_FILE)
 				.getStore(getWorkspace().getRoot().getLocation().append("temp"));
+		deleteOnTearDown(temp);
 		temp.mkdir(EFS.NONE, null);
 		assertTrue("1.1", temp.fetchInfo().isDirectory());
 		// create tree
@@ -189,10 +189,6 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore copyOfTarget = temp.getChild("copy of target");
 		target.copy(copyOfTarget, EFS.NONE, null);
 		assertTrue("2.1", verifyTree(getTree(copyOfTarget)));
-
-		/* remove trash */
-		target.delete(EFS.NONE, null);
-		copyOfTarget.delete(EFS.NONE, null);
 	}
 
 	public void testCopyDirectoryParentMissing() throws Throwable {
@@ -246,9 +242,6 @@ public class FileStoreTest extends LocalStoreTest {
 			String message = NLS.bind(Messages.couldNotMove, fileWithSmallName.toString());
 			assertEquals(message, e.getMessage());
 		}
-
-		/* take out the trash */
-		temp.delete(EFS.NONE, null);
 	}
 
 	public void testCopyFile() throws Throwable {
@@ -300,9 +293,6 @@ public class FileStoreTest extends LocalStoreTest {
 		bigFile.copy(destination, EFS.NONE, monitor);
 		assertTrue("7.3", compareContent(getContents(sb.toString()), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
-
-		/* take out the trash */
-		temp.delete(EFS.NONE, null);
 	}
 
 	/**
@@ -367,36 +357,27 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("6.2", ok);
 		assertTrue("6.3", destination.fetchInfo().isDirectory());
 		destination.delete(EFS.NONE, null);
-
-		/* remove trash */
-		target.delete(EFS.NONE, null);
 	}
 
 	public void testGetLength() throws Exception {
 		// evaluate test environment
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
 		IFileStore temp = createDir(root.toString(), true);
-		try {
-			// create common objects
-			IFileStore target = temp.getChild("target");
+		// create common objects
+		IFileStore target = temp.getChild("target");
 
-			// test non-existent file
-			assertEquals("1.0", EFS.NONE, target.fetchInfo().getLength());
+		// test non-existent file
+		assertEquals("1.0", EFS.NONE, target.fetchInfo().getLength());
 
-			// create empty file
-			target.openOutputStream(EFS.NONE, null).close();
-			assertEquals("1.0", 0, target.fetchInfo().getLength());
+		// create empty file
+		target.openOutputStream(EFS.NONE, null).close();
+		assertEquals("1.0", 0, target.fetchInfo().getLength());
 
-			try ( // add a byte
-					OutputStream out = target.openOutputStream(EFS.NONE, null)) {
-				out.write(5);
-			}
-			assertEquals("1.0", 1, target.fetchInfo().getLength());
-		} finally {
-			/* remove trash */
-			temp.delete(EFS.NONE, null);
+		try ( // add a byte
+				OutputStream out = target.openOutputStream(EFS.NONE, null)) {
+			out.write(5);
 		}
-
+		assertEquals("1.0", 1, target.fetchInfo().getLength());
 	}
 
 	public void testGetStat() throws CoreException {
@@ -416,9 +397,6 @@ public class FileStoreTest extends LocalStoreTest {
 		createDir(target, true);
 		stat = target.fetchInfo().getLastModified();
 		assertTrue("2.0", EFS.NONE != stat);
-
-		/* remove trash */
-		temp.delete(EFS.NONE, null);
 	}
 
 	public void testMove() throws Throwable {
@@ -477,10 +455,6 @@ public class FileStoreTest extends LocalStoreTest {
 		destination.move(tree, EFS.NONE, null);
 		assertTrue("6.3", verifyTree(getTree(tree)));
 		assertTrue("6.4", !destination.fetchInfo().exists());
-
-		/* remove trash */
-		target.delete(EFS.NONE, null);
-		tree.delete(EFS.NONE, null);
 	}
 
 	public void testMoveAcrossVolumes() throws Throwable {
@@ -524,10 +498,6 @@ public class FileStoreTest extends LocalStoreTest {
 		destination.move(tree, EFS.NONE, null);
 		assertTrue("9.3", verifyTree(getTree(tree)));
 		assertTrue("9.4", !destination.fetchInfo().exists());
-
-		/* remove trash */
-		target.delete(EFS.NONE, null);
-		tree.delete(EFS.NONE, null);
 	}
 
 	public void testMoveDirectoryParentMissing() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -316,6 +316,7 @@ public class BasicAliasTest extends ResourceTest {
 	private void replaceProject(IProject project, URI newLocation) throws CoreException {
 		IProjectDescription projectDesc = project.getDescription();
 		projectDesc.setLocationURI(newLocation);
+		deleteOnTearDown(project.getLocation()); // Ensure that project contents are removed from file system
 		project.move(projectDesc, IResource.REPLACE, null);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -70,7 +70,6 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 	@Override
 	protected void tearDown() throws Exception {
 		Job.getJobManager().removeJobChangeListener(jobChangeListener);
-		project.delete(true, null);
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -55,15 +55,6 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		setupProject(project1);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
-		// Delete resources
-		project0.delete(true, null);
-		project1.delete(true, null);
-	}
-
 	/**
 	 * Helper method to configure a project with a build command and several buildConfigs.
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -133,16 +133,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	}
 
 	/**
-	 * Tears down the fixture, for example, close a network connection.
-	 * This method is called after a test is executed.
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		getWorkspace().getRoot().delete(true, getMonitor());
-	}
-
-	/**
 	 * Tests that the builder is receiving an appropriate delta
 	 * @see SortBuilderPlugin
 	 * @see SortBuilder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -50,7 +50,6 @@ public class BuilderTest extends AbstractBuilderTest {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		getWorkspace().getRoot().delete(true, null);
 		TestBuilder builder = SortBuilder.getInstance();
 		if (builder != null) {
 			builder.reset();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -102,15 +102,6 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 		ensureExistsInWorkspace(resources, true);
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		getWorkspace().getRoot().delete(true, getMonitor());
-	}
-
 	/**
 	 * In this test, only project1 has a builder, but it is interested in deltas from the other projects.
 	 * We vary the set of projects that are changed, and the set of projects we request deltas for.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -60,7 +60,6 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		getWorkspace().getRoot().delete(true, null);
 		TestBuilder builder = DeltaVerifierBuilder.getInstance();
 		if (builder != null) {
 			builder.reset();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -169,13 +169,9 @@ public abstract class LocalStoreTest extends ResourceTest {
 				projects[i] = getWorkspace().getRoot().getProject(projectNames[i]);
 				projects[i].create(null);
 				projects[i].open(null);
+				deleteOnTearDown(projects[i].getLocation());
 			}
 		}, null);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -105,14 +105,6 @@ public class MoveTest extends LocalStoreTest {
 		} catch (CoreException e) {
 			fail("5.3", e);
 		}
-
-		// remove garbage
-		try {
-			source.delete(true, true, getMonitor());
-			destination.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
 	}
 
 	/**
@@ -237,14 +229,6 @@ public class MoveTest extends LocalStoreTest {
 			}
 		} catch (CoreException e) {
 			fail("5.3", e);
-		}
-
-		// remove garbage
-		try {
-			source.delete(true, true, getMonitor());
-			destination.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("6.0", e);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -255,7 +255,9 @@ public class UnifiedTreeTest extends LocalStoreTest {
 		File file = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile(), "link");
 		file.mkdir();
 
-		link.createLink(EFS.getLocalFileSystem().fromLocalFile(file).toURI(), IResource.NONE, null);
+		IFileStore fileStore = EFS.getLocalFileSystem().fromLocalFile(file);
+		link.createLink(fileStore.toURI(), IResource.NONE, null);
+		deleteOnTearDown(fileStore);
 
 		IFile rf = link.getFile("fileTest342968.txt");
 		rf.create(new ByteArrayInputStream("test342968".getBytes()), false, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
@@ -43,12 +43,6 @@ public class FilePropertyTesterTest extends ResourceTest {
 		tester = new FilePropertyTester();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		project.delete(true, monitor);
-		super.tearDown();
-	}
-
 	public void testNonExistingTextFile() throws Throwable {
 		String expected = "org.eclipse.core.runtime.text";
 		IFile target = project.getFile("tmp.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -42,12 +42,6 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		defaultVariant = new BuildConfiguration(project, IBuildConfiguration.DEFAULT_CONFIG_NAME);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		project.delete(true, null);
-	}
-
 	public void testBasics() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		String[] configs = new String[] {variantId0, variantId1};

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -58,9 +58,6 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		DynamicReferenceProvider.clear();
-		project0.delete(true, null);
-		project1.delete(true, null);
-		project2.delete(true, null);
 	}
 
 	public void testReferencedProjects() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -259,7 +259,6 @@ public class IFileTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -20,7 +20,6 @@ public class IFolderTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -731,12 +731,6 @@ public class IPathVariableTest extends ResourceTest {
 		}
 	}
 
-	@Override
-	protected void cleanup() throws CoreException {
-		project.delete(true, getMonitor());
-		super.cleanup();
-	}
-
 	/**
 	 * Regression for Bug 308975 - Can't recover from 'invalid' path variable
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -444,7 +444,7 @@ public class IProjectTest extends ResourceTest {
 		assertFalse("3.1", target.isOpen());
 
 		monitor.prepare();
-		target.delete(true, monitor);
+		target.delete(true, true, monitor);
 		monitor.assertUsedUp();
 		assertFalse("4.1", target.exists());
 	}
@@ -2065,13 +2065,13 @@ public class IProjectTest extends ResourceTest {
 		assertTrue("5.3", getWorkspace().validateProjectLocation(null, root.append("%20foo")).isOK());
 
 		monitor.prepare();
-		project1.delete(true, monitor);
+		project1.delete(true, true, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		project2.delete(true, monitor);
+		project2.delete(true, true, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		project3.delete(true, monitor);
+		project3.delete(true, true, monitor);
 		monitor.assertUsedUp();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -68,16 +68,6 @@ public class IResourceChangeEventTest extends ResourceTest {
 	}
 
 	/**
-	 * Tears down the fixture, for example, close a network connection.
-	 * This method is called after a test is executed.
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-	}
-
-	/**
 	 * Tests the IResourceChangeEvent#findMarkerDeltas method.
 	 */
 	public void testFindMarkerDeltas() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -103,6 +103,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			IProjectDescription description = getWorkspace().newProjectDescription(project.getName());
 			IPath root = getWorkspace().getRoot().getLocation();
 			IPath contents = root.append("temp/testing");
+			deleteOnTearDown(root.append("temp"));
 			description.setLocation(contents);
 			project.create(description, getMonitor());
 			project.open(getMonitor());
@@ -250,7 +251,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	protected void tearDown() throws Exception {
 		getWorkspace().removeResourceChangeListener(verifier);
 		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 	}
 
 	/*

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -63,16 +63,6 @@ public class IResourceDeltaTest extends ResourceTest {
 	}
 
 	/**
-	 * Tears down the fixture, for example, close a network connection.
-	 * This method is called after a test is executed.
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-	}
-
-	/**
 	 * Tests the IResourceDelta#findMember method.
 	 */
 	public void testFindMember() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -568,7 +568,6 @@ public class IResourceTest extends ResourceTest {
 			getWorkspace().removeResourceChangeListener(verifier);
 		}
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		interestingPaths = null;
 		interestingResources = null;
 		setAutoBuild(storedAutoBuildValue);
@@ -1023,6 +1022,10 @@ public class IResourceTest extends ResourceTest {
 					fussy.prepare();
 				}
 				try {
+					if (resource.exists()) {
+						deleteOnTearDown(resource.getLocation()); // Ensure that resource contents are removed from file
+																	// system
+					}
 					resource.delete(force.booleanValue(), monitor);
 				} catch (OperationCanceledException e) {
 					return CANCELED;
@@ -1356,7 +1359,7 @@ public class IResourceTest extends ResourceTest {
 
 		/* remove trash */
 		try {
-			project.delete(true, getMonitor());
+			project.delete(true, true, getMonitor());
 		} catch (CoreException e) {
 			fail("7.0", e);
 		}
@@ -1564,7 +1567,7 @@ public class IResourceTest extends ResourceTest {
 	public void testGetModificationStamp() {
 		// cleanup auto-created resources
 		try {
-			getWorkspace().getRoot().delete(true, getMonitor());
+			getWorkspace().getRoot().delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
 		} catch (CoreException e) {
 			fail("0.0", e);
 		}
@@ -2293,7 +2296,7 @@ public class IResourceTest extends ResourceTest {
 
 		/* remove trash */
 		try {
-			project.delete(true, getMonitor());
+			project.delete(true, true, getMonitor());
 		} catch (CoreException e) {
 			fail("3.0", e);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -496,7 +496,9 @@ public class ISynchronizerTest extends ResourceTest {
 		}
 
 		// write out the data
-		File file = Platform.getLocation().append(".testsyncinfo").toFile();
+		IPath syncInfoPath = Platform.getLocation().append(".testsyncinfo");
+		File file = syncInfoPath.toFile();
+		deleteOnTearDown(syncInfoPath);
 		OutputStream fileOutput = null;
 		DataOutputStream o1 = null;
 		try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -26,13 +26,6 @@ import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
 
 public class IWorkspaceRootTest extends ResourceTest {
 
-	@Override
-	protected void tearDown() throws Exception {
-		IProject[] projects = getWorkspace().getRoot().getProjects();
-		getWorkspace().delete(projects, true, null);
-		super.tearDown();
-	}
-
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -47,7 +47,6 @@ public class IWorkspaceTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -53,11 +53,6 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		doCleanup();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 	public void internalMovedAndCopyTest(IResource resource, int copyMoveFlag, boolean copyMoveSucceeds) {
 		//		try {
 		//			resource.copy(otherExistingProject.getFullPath().append(resource.getProjectRelativePath()), copyMoveFlag, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -89,7 +89,7 @@ public class LinkedResourceTest extends ResourceTest {
 	protected void doCleanup() throws Exception {
 		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject}, true);
 		closedProject.close(getMonitor());
-		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
+		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
 		ensureDoesNotExistInFileSystem(resolve(nonExistingLocation).toFile());
 		resolve(localFolder).toFile().mkdirs();
 		createFileInFileSystem(resolve(localFile), getRandomContents());
@@ -145,7 +145,9 @@ public class LinkedResourceTest extends ResourceTest {
 			IProjectDescription desc = getWorkspace().newProjectDescription(existingProjectInSubDirectory.getName());
 			File dir = existingProject.getLocation().toFile();
 			dir = dir.getParentFile();
-			dir = new File(dir + File.separator + "sub" + File.separator + "dir" + File.separator + "more" + File.separator + "proj");
+			dir = new File(dir + File.separator + "sub");
+			deleteOnTearDown(Path.fromOSString(dir.getAbsolutePath()));
+			dir = new File(dir + File.separator + "dir" + File.separator + "more" + File.separator + "proj");
 			dir.mkdirs();
 			desc.setLocation(Path.fromOSString(dir.getAbsolutePath()));
 			existingProjectInSubDirectory.create(desc, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -453,11 +453,6 @@ public class MarkerTest extends ResourceTest {
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
 		super.tearDown();
-		try {
-			getWorkspace().getRoot().delete(true, null);
-		} catch (CoreException e) {
-			fail("#tearDown", e);
-		}
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -74,9 +74,8 @@ public class NatureTest extends ResourceTest {
 		project.delete(true, null);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, PreferenceInitializer.PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
-		super.tearDown();
 		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+		super.tearDown();
 	}
 
 	@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -254,6 +254,8 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFileSystem system = getBogusFileSystem();
 		IFileStore store = system.getStore(Path.ROOT.append(name));
 		try {
+			deleteOnTearDown(
+					Path.fromOSString(system.getStore(Path.ROOT).toLocalFile(EFS.NONE, getMonitor()).getPath()));
 			store.mkdir(EFS.NONE, getMonitor());
 		} catch (CoreException e) {
 			fail("createFolderStore", e);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -40,7 +40,7 @@ public class ProjectEncodingTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		if (project != null) {
-			project.delete(true, null);
+			project.delete(true, true, null);
 		}
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(
 				ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -50,11 +50,6 @@ public class ProjectSnapshotTest extends ResourceTest {
 		ensureExistsInWorkspace(projects, true);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 	private void populateProject(IProject project) {
 		// add files and folders to project
 		IFile file = project.getFile("file");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -41,11 +41,6 @@ public class VirtualFolderTest extends ResourceTest {
 		doCleanup();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 	/**
 	 * Tests creating a virtual folder
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -30,20 +30,6 @@ import org.eclipse.core.tests.harness.FussyProgressMonitor;
  */
 public class WorkspaceTest extends ResourceTest {
 	/**
-	 * All of the WorkspaceTests build on each other. This test must
-	 * be run last of all to clean up from all previous tests in this class.
-	 */
-	public void doCleanup() throws Exception {
-		IPath location = getWorkspace().getRoot().getLocation().append("testProject");
-		deleteOnTearDown(location);
-		IPath location2 = getWorkspace().getRoot().getLocation().append("testProject2");
-		deleteOnTearDown(location2);
-		cleanup();
-		assertTrue(location.toOSString() + " has not been deleted", !location.toFile().exists());
-		assertTrue(location2.toOSString() + " has not been deleted", !location2.toFile().exists());
-	}
-
-	/**
 	 * Returns a collection of string paths describing the standard
 	 * resource hierarchy for this test.  In the string forms, folders are
 	 * represented as having trailing separators ('/').  All other resources
@@ -53,12 +39,6 @@ public class WorkspaceTest extends ResourceTest {
 	@Override
 	public String[] defineHierarchy() {
 		return new String[] {"/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2", "/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5"};
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		doCleanup();
 	}
 
 	protected IProject getTestProject() {
@@ -287,7 +267,7 @@ public class WorkspaceTest extends ResourceTest {
 		monitor.assertUsedUp();
 		assertTrue(!target.isOpen());
 		monitor.prepare();
-		target.delete(true, monitor);
+		target.delete(true, true, monitor);
 		monitor.assertUsedUp();
 		assertTrue(!target.exists());
 	}
@@ -374,7 +354,7 @@ public class WorkspaceTest extends ResourceTest {
 		assertTrue(target.getReferencingProjects().length == 1);
 
 		monitor.prepare();
-		target.delete(true, monitor);
+		target.delete(true, true, monitor);
 		monitor.assertUsedUp();
 		assertTrue(!target.exists());
 	}
@@ -382,25 +362,16 @@ public class WorkspaceTest extends ResourceTest {
 	public void testDanglingReferences() throws Throwable {
 		IProject p1 = null;
 		IProject p2 = null;
-		try {
-			p2 = getWorkspace().getRoot().getProject("p2");
-			p2.create(new NullProgressMonitor());
-			p1 = getWorkspace().getRoot().getProject("p1");
-			IProjectDescription description = getWorkspace().newProjectDescription("p1");
-			description.setReferencedProjects(new IProject[] { p2 });
-			p1.create(description, new NullProgressMonitor());
-			p1.open(new NullProgressMonitor());
-			assertFalse(getWorkspace().getDanglingReferences().containsKey(p1));
-			p2.delete(true, new NullProgressMonitor());
-			assertArrayEquals(new IProject[] { p2 }, getWorkspace().getDanglingReferences().get(p1));
-		} finally {
-			if (p1 != null && p1.exists()) {
-				p1.delete(true, new NullProgressMonitor());
-			}
-			if (p2 != null && p2.exists()) {
-				p2.delete(true, new NullProgressMonitor());
-			}
-		}
+		p2 = getWorkspace().getRoot().getProject("p2");
+		p2.create(new NullProgressMonitor());
+		p1 = getWorkspace().getRoot().getProject("p1");
+		IProjectDescription description = getWorkspace().newProjectDescription("p1");
+		description.setReferencedProjects(new IProject[] { p2 });
+		p1.create(description, new NullProgressMonitor());
+		p1.open(new NullProgressMonitor());
+		assertFalse(getWorkspace().getDanglingReferences().containsKey(p1));
+		p2.delete(true, true, new NullProgressMonitor());
+		assertArrayEquals(new IProject[] { p2 }, getWorkspace().getDanglingReferences().get(p1));
 	}
 
 	public void testSetContents() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -127,15 +127,6 @@ public class BenchWorkspace extends ResourceTest {
 		}
 	}
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		project.delete(true, true, null);
-	}
-
 	public void testCountResources() {
 		final Workspace workspace = (Workspace) getWorkspace();
 		final IWorkspaceRoot root = workspace.getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
@@ -101,12 +101,4 @@ public class MarkerPerformanceTest extends ResourceTest {
 		markers = createdMarkers;
 	}
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		project.delete(true, true, null);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -259,6 +259,7 @@ public class Bug_032076 extends ResourceTest {
 			}
 
 			try {
+				deleteOnTearDown(sourceProject.getLocation()); // Ensure project location is moved after test
 				sourceProject.move(destinationProject.getFullPath(), IResource.FORCE, getMonitor());
 				fail("2.0");
 			} catch (CoreException ce) {
@@ -294,13 +295,6 @@ public class Bug_032076 extends ResourceTest {
 				}
 			} catch (IOException e) {
 				fail("6.0", e);
-			} finally {
-				if (sourceProject != null) {
-					ensureDoesNotExistInFileSystem(sourceProject);
-				}
-				if (destinationProject != null) {
-					ensureDoesNotExistInFileSystem(destinationProject);
-				}
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
@@ -45,15 +45,6 @@ public class Bug_530868 extends ResourceTest {
 
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		try {
-			testProject.delete(true, getMonitor());
-		} finally {
-			super.tearDown();
-		}
-	}
-
 	/**
 	 * Create a file several times and check that we see different modification
 	 * timestamps.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -26,12 +26,6 @@ public class IResourceTest extends ResourceTest {
 
 	private final boolean DISABLED = true;
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		getWorkspace().getRoot().delete(true, null);
-	}
-
 	/**
 	 * 1G9RBH5: ITPCORE:WIN98 - IFile.appendContents might lose data
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -20,12 +20,6 @@ import org.eclipse.core.tests.resources.ResourceTest;
 
 public class IWorkspaceTest extends ResourceTest {
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		getWorkspace().getRoot().delete(true, null);
-	}
-
 	/**
 	 * 1GDKIHD: ITPCORE:WINNT - API - IWorkspace.move needs to keep history
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -60,6 +60,7 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 	public void test_1G65KR1() {
 		/* evaluate test environment */
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
+		deleteOnTearDown(root);
 		File temp = root.toFile();
 		temp.mkdirs();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
@@ -57,7 +57,6 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
 		getWorkspace().removeResourceChangeListener(verifier);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
@@ -20,12 +20,6 @@ import org.eclipse.core.tests.resources.ResourceTest;
 
 public class PR_1GH2B0N_Test extends ResourceTest {
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-	}
-
 	public void test_1GH2B0N() {
 		IPath path = getTempDir().append("1GH2B0N");
 		IProject project = getWorkspace().getRoot().getProject("MyProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
@@ -18,15 +18,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 public class PR_1GHOM0N_Test extends ResourceTest {
-	/**
-	 * Tears down the fixture, for example, close a network connection.
-	 * This method is called after a test is executed.
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-	}
 
 	/*
 	 * Ensure that we get ADDED and OPEN in the delta when we create and open

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
@@ -35,7 +35,7 @@ public class HistoryStorePerformanceTest extends ResourceTest {
 	protected void tearDown() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		project.clearHistory(getMonitor());
-		project.delete(true, true, getMonitor());
+		super.tearDown();
 	}
 
 	public void testPerformance() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
@@ -233,7 +233,7 @@ public class IProjectTest extends IResourceTest {
 
 		// Delete the project
 		try {
-			proj.delete(false, monitor);
+			proj.delete(true, true, monitor);
 		} catch (CoreException e) {
 			fail("20.0", e);
 		}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
@@ -57,8 +57,6 @@ public class ScopeTests extends TeamTest {
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		this.manager.dispose();
-		project1.delete(true, null);
-		project2.delete(true, null);
 		IWorkingSetManager manager = PlatformUI.getWorkbench().getWorkingSetManager();
 		manager.removeWorkingSet(workingSet);
 	}


### PR DESCRIPTION
* Ensure that all files that may be created in the workspace directory without being present in the workspace for cleanup at the end of the test run are removed
* Ensure that files from additional files stores are properly removed
* Add assertion for having a clean workspace directory after executing a test
* Remove redundant test cleanup functionality

Contributes to #406.
Fixes #107. Fixes #210. Fixes #217. 