### PR TITLE
Avoid random failure in JobTest.testJoinWithTimeout

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -922,8 +922,6 @@ public class JobTest extends AbstractJobTest {
 		// Verify that join call is blocked for at least the duration of given timeout
 		String durationAndTimoutMessage = "duration: " + duration[0] + " timeout: " + timeout;
 		assertTrue("Join did not run into timeout; " + durationAndTimoutMessage, duration[0] >= timeout);
-		assertTrue("Join took significantly longer than timeout; " + durationAndTimoutMessage,
-				duration[0] <= 1.5 * timeout);
 
 		// Finally cancel the job
 		longJob.cancel();


### PR DESCRIPTION
The test expected a measurement of a Job.join call to not exceed its timeout value by a specific factor. The thread executing the call may, however, not be executed for an indefinite amount of time, which can then lead to a test failure.
The actual timing behavior is irrelevant for the test as long as the timeout is interpreted at all. If this is not the case, the test will fail while waiting for a status change on the barrier anyway. Thus, this change deletes the risky assertion, which aligns it with the behavior of `JobGroupTest.testJoinWithTimeout` (see https://github.com/eclipse-platform/eclipse.platform/pull/412#discussion_r1170893556).
