### PR TITLE
LocalFileNativesManager initialisation is not flexible enough #416

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
@@ -21,17 +21,18 @@ import org.eclipse.core.filesystem.provider.FileInfo;
 import org.eclipse.core.internal.filesystem.local.nio.*;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileNatives;
+import org.eclipse.osgi.service.environment.Constants;
 
 /**
- * Dispatches methods backed by native code to the appropriate platform specific
+ * <p>Dispatches methods backed by native code to the appropriate platform specific
  * implementation depending on a library provided by a fragment. Failing this it tries
- * to use Java 7 NIO/2 API's.
- * <p>
- * Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false to VM
- * arguments.
- * <p>
- * Please notice that the native implementation is significantly faster than the non-native one.
- * The BenchFileStore test runs 3.1 times faster on Linux with the native code than without it.
+ * to use Java 7 NIO/2 API's.</p>
+ * 
+ * <p>Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false 
+ * to VM arguments.<p>
+ * 
+ * <p>Please notice that the native implementation is significantly faster than the non-native one.
+ * The BenchFileStore test runs 3.1 times faster on Linux with the native code than without it.</p>
  */
 public class LocalFileNativesManager {
 	public static final boolean PROPERTY_USE_NATIVE_DEFAULT = true;
@@ -55,10 +56,12 @@ public class LocalFileNativesManager {
 	 */
 	public static boolean setUsingNative(boolean useNatives) {
 		boolean nativesAreUsed;
-		if (useNatives && UnixFileNatives.isUsingNatives()) {
+		boolean isWindowsOS = Constants.OS_WIN32.equals(LocalFileSystem.getOS());
+
+		if (useNatives && !isWindowsOS && UnixFileNatives.isUsingNatives()) {
 			HANDLER = new UnixFileHandler();
 			nativesAreUsed = true;
-		} else if (useNatives && LocalFileNatives.isUsingNatives()) {
+		} else if (useNatives && isWindowsOS && LocalFileNatives.isUsingNatives()) {
 			HANDLER = new LocalFileHandler();
 			nativesAreUsed = true;
 		} else {


### PR DESCRIPTION
LocalFileNativesManager initialisation is not flexible enough to avoid DLL Hijacking #416

If the use of native libraries is enabled (ie. the default), the default priority order for the loading of associated JNI library is Unix followed by Windows. With this proposed change, this order can be reversed to give priority to attempt to load Windows library first by use of the system property _-Declipse.filesystem.favourWindowsNative=true_

This avoids the potential for DLL Hijack type attack on the (non-existent) file named "_unixfile_1_0_0.dll_" on Windows systems.

See Issue #416 for further detail.