### PR TITLE
LocalFileNativesManager initialisation is not flexible enough #416

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
@@ -21,17 +21,19 @@ import org.eclipse.core.filesystem.provider.FileInfo;
 import org.eclipse.core.internal.filesystem.local.nio.*;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileNatives;
+import org.eclipse.osgi.service.environment.Constants;
 
 /**
- * Dispatches methods backed by native code to the appropriate platform specific
+ * <p>Dispatches methods backed by native code to the appropriate platform specific
  * implementation depending on a library provided by a fragment. Failing this it tries
- * to use Java 7 NIO/2 API's.
- * <p>
- * Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false to VM
- * arguments.
- * <p>
- * Please notice that the native implementation is significantly faster than the non-native one.
- * The BenchFileStore test runs 3.1 times faster on Linux with the native code than without it.
+ * to use Java 7 NIO/2 API's.</p>
+ * 
+ * <p>Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false 
+ * to VM arguments.<p>
+ * 
+ * <p>Please notice that the native implementation is significantly faster than the non-native
+ * one. The BenchFileStore test runs 3.1 times faster on Linux with the native code than 
+ * without it.</p>
  */
 public class LocalFileNativesManager {
 	public static final boolean PROPERTY_USE_NATIVE_DEFAULT = true;
@@ -55,10 +57,12 @@ public class LocalFileNativesManager {
 	 */
 	public static boolean setUsingNative(boolean useNatives) {
 		boolean nativesAreUsed;
-		if (useNatives && UnixFileNatives.isUsingNatives()) {
+		boolean isWindowsOS = Constants.OS_WIN32.equals(LocalFileSystem.getOS());
+
+		if (useNatives && !isWindowsOS && UnixFileNatives.isUsingNatives()) {
 			HANDLER = new UnixFileHandler();
 			nativesAreUsed = true;
-		} else if (useNatives && LocalFileNatives.isUsingNatives()) {
+		} else if (useNatives && isWindowsOS && LocalFileNatives.isUsingNatives()) {
 			HANDLER = new LocalFileHandler();
 			nativesAreUsed = true;
 		} else {


### PR DESCRIPTION
An update to LocalFileNativesManager such that on Windows OS there will be no attempt to perform a system load of a library (which will not exist) called "_unixfile_1_0_0.dll_".

For historical detail & discussions, please see the previous PR: https://github.com/eclipse-platform/eclipse.platform/pull/418
The previous PR linked above has code change identical to this one, the new PR was created to attempt to get the ECA pipeline job to rerun against my correct email address.