### PR TITLE
Fix random failing LinkedResourceTest.* #210

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -87,6 +87,7 @@ public class LinkedResourceTest extends ResourceTest {
 	protected IProject otherExistingProject;
 
 	protected void doCleanup() throws Exception {
+		waitForRefresh();
 		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject}, true);
 		closedProject.close(getMonitor());
 		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });


### PR DESCRIPTION
The `LinkedResourceTest` and `LinkedResourceWithPathVariableTest` use the `TestPerformer` for executing parameterized tests. The cleanup between two test iterations restores the test workspace. However, the background refresh job can concurrently update the workspace such that resources existing in the file system but not in the workspace appear and the test fails due to an unexpected state.

With this change, every test iteration waits for the refresh job to be finished to avoid that it concurrently modifies the workspace state.

Fixes #210.