### PR TITLE
Fix random failing IProjectTest.*OutOfSync #422

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -1372,6 +1372,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
+		waitForRefresh();
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1623,6 +1624,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project, true);
+		waitForRefresh();
 		ensureExistsInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1923,6 +1925,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
+		waitForRefresh();
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();


### PR DESCRIPTION
The `*OutOfSync` tests in `IProjectTest` create files in the file system and assume them to be unsynchronized with the workspace. A concurrent execution of the background refresh job can, however, lead to a synchronized state of the resources in the workspace. With this change, the out-of-sync state for the according resources is enforced. 

With this change, a potentially pending refresh is processed before creating the file in the file system, such that its state may not concurrently change.

Fixes #422.