### PR TITLE
Wait for pending background refresh before executing ResourceTest #417

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -1068,6 +1068,8 @@ public abstract class ResourceTest extends CoreTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
+		// Wait for any pending refresh operation, in particular from startup
+		waitForRefresh();
 		TestUtil.log(IStatus.INFO, getName(), "setUp");
 		FreezeMonitor.expectCompletionInAMinute();
 		assertNotNull("Workspace was not setup", getWorkspace());


### PR DESCRIPTION
There were some tests randomly failing, for which the root cause was a concurrent execution of the background refresh job. To ensure that no refresh operation potentially triggered by a previous test run is still scheduled or running, this change ensures that any pending refresh is processed before running a test case.

See for example #417.