### PR TITLE
extension mechanism for ignore white space action of the compare view

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/IIgnoreWhitespaceContributor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/IIgnoreWhitespaceContributor.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2023 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.compare.contentmergeviewer;
+
+/**
+ * @since 3.9
+ */
+public interface IIgnoreWhitespaceContributor {
+	/**
+	 * Method is called when a whitespace is detected in the "ignore whitespace"
+	 * action run in the compare view. Implementors of this method can specify if
+	 * whitespace can be ignored or not (e.g. whitespace in literals should never be
+	 * ignored and always shown as diff).
+	 *
+	 * @param lineNumber   line number in source code starting at number zero
+	 * @param columnNumber column number of current line starting at number zero
+	 * @return boolean
+	 */
+	public boolean isIgnoredWhitespace(int lineNumber, int columnNumber);
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -1528,6 +1528,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 			public ITokenComparator createTokenComparator(String line) {
 				return TextMergeViewer.this.createTokenComparator(line);
 			}
+
+			@Override
+			public Optional<IIgnoreWhitespaceContributor> createIgnoreWhitespaceContributor(IDocument document) {
+				return TextMergeViewer.this.createIgnoreWhitespaceContributor(document);
+			}
+
 			@Override
 			public CompareConfiguration getCompareConfiguration() {
 				return TextMergeViewer.this.getCompareConfiguration();
@@ -1863,6 +1869,22 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 	 */
 	protected ITokenComparator createTokenComparator(String line) {
 		return new TokenComparator(line);
+	}
+
+	/**
+	 * Creates an <code>IIgnoreWhitespaceContributor</code> which allows to hook
+	 * into the ignore whitespace logic in the compare viewer. Tool specific
+	 * implementations can overrule which whitespaces can be ignored and which not
+	 * (e.g. whitespaces in literals).
+	 *
+	 * @param document
+	 * @return a IIgnoreWhitespaceContributor which allows to overrule the platform
+	 *         based whitespace ignore logic in the compare view. Default
+	 *         implementation doesn't supply a contributor.
+	 * @since 3.9
+	 */
+	protected Optional<IIgnoreWhitespaceContributor> createIgnoreWhitespaceContributor(IDocument document) {
+		return Optional.empty();
 	}
 
 	/**

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/DocumentMerger.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/DocumentMerger.java
@@ -19,9 +19,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.ICompareFilter;
+import org.eclipse.compare.contentmergeviewer.IIgnoreWhitespaceContributor;
 import org.eclipse.compare.contentmergeviewer.ITokenComparator;
 import org.eclipse.compare.internal.CompareContentViewerSwitchingPane;
 import org.eclipse.compare.internal.CompareMessages;
@@ -88,6 +90,8 @@ public class DocumentMerger {
 		CompareConfiguration getCompareConfiguration();
 
 		ITokenComparator createTokenComparator(String s);
+
+		Optional<IIgnoreWhitespaceContributor> createIgnoreWhitespaceContributor(IDocument document);
 
 		boolean isHunkOnLeft();
 
@@ -378,15 +382,15 @@ public class DocumentMerger {
 
 		DocLineComparator sright = new DocLineComparator(rDoc,
 				toRegion(rRegion), ignoreWhiteSpace, compareFilters,
-				MergeViewerContentProvider.RIGHT_CONTRIBUTOR);
+				MergeViewerContentProvider.RIGHT_CONTRIBUTOR, createIgnoreWhitespaceContributor(rDoc));
 		DocLineComparator sleft = new DocLineComparator(lDoc,
 				toRegion(lRegion), ignoreWhiteSpace, compareFilters,
-				MergeViewerContentProvider.LEFT_CONTRIBUTOR);
+				MergeViewerContentProvider.LEFT_CONTRIBUTOR, createIgnoreWhitespaceContributor(lDoc));
 		DocLineComparator sancestor = null;
 		if (aDoc != null) {
 			sancestor = new DocLineComparator(aDoc, toRegion(aRegion),
 					ignoreWhiteSpace, compareFilters,
-					MergeViewerContentProvider.ANCESTOR_CONTRIBUTOR);
+					MergeViewerContentProvider.ANCESTOR_CONTRIBUTOR, createIgnoreWhitespaceContributor(aDoc));
 			/*if (isPatchHunk()) {
 				if (isHunkOnLeft()) {
 					sright= new DocLineComparator(aDoc, toRegion(aRegion), ignoreWhiteSpace);
@@ -551,11 +555,14 @@ public class DocumentMerger {
 		boolean ignoreWhiteSpace= isIgnoreWhitespace();
 		ICompareFilter[] compareFilters = getCompareFilters();
 
-		DocLineComparator sright= new DocLineComparator(rDoc, toRegion(rRegion), ignoreWhiteSpace, compareFilters, MergeViewerContentProvider.RIGHT_CONTRIBUTOR);
-		DocLineComparator sleft= new DocLineComparator(lDoc, toRegion(lRegion), ignoreWhiteSpace, compareFilters, MergeViewerContentProvider.LEFT_CONTRIBUTOR);
+		DocLineComparator sright = new DocLineComparator(rDoc, toRegion(rRegion), ignoreWhiteSpace, compareFilters,
+				MergeViewerContentProvider.RIGHT_CONTRIBUTOR, createIgnoreWhitespaceContributor(rDoc));
+		DocLineComparator sleft = new DocLineComparator(lDoc, toRegion(lRegion), ignoreWhiteSpace, compareFilters,
+				MergeViewerContentProvider.LEFT_CONTRIBUTOR, createIgnoreWhitespaceContributor(lDoc));
 		DocLineComparator sancestor= null;
 		if (aDoc != null)
-			sancestor= new DocLineComparator(aDoc, toRegion(aRegion), ignoreWhiteSpace, compareFilters, MergeViewerContentProvider.ANCESTOR_CONTRIBUTOR);
+			sancestor = new DocLineComparator(aDoc, toRegion(aRegion), ignoreWhiteSpace, compareFilters,
+					MergeViewerContentProvider.ANCESTOR_CONTRIBUTOR, createIgnoreWhitespaceContributor(aDoc));
 
 		final Object[] result= new Object[1];
 		final DocLineComparator sa= sancestor, sl= sleft, sr= sright;
@@ -896,6 +903,10 @@ public class DocumentMerger {
 
 	private ITokenComparator createTokenComparator(String s) {
 		return fInput.createTokenComparator(s);
+	}
+
+	private Optional<IIgnoreWhitespaceContributor> createIgnoreWhitespaceContributor(IDocument document) {
+		return fInput.createIgnoreWhitespaceContributor(document);
 	}
 
 	private static int maxWork(IRangeComparator a, IRangeComparator l, IRangeComparator r) {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/SimpleIgnoreWhitespaceContributor.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/SimpleIgnoreWhitespaceContributor.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2023 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.compare.tests;
+
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.eclipse.compare.contentmergeviewer.IIgnoreWhitespaceContributor;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.junit.Assert;
+
+public class SimpleIgnoreWhitespaceContributor implements IIgnoreWhitespaceContributor {
+
+	private final IDocument document;
+	private TreeMap<Integer /* start offset */, Integer /* end offset */> literalsByOffset = new TreeMap<>();
+
+	public SimpleIgnoreWhitespaceContributor(IDocument document) {
+		this.document = document;
+		scanAndCreateLiteralsByOffset();
+	}
+
+	private void scanAndCreateLiteralsByOffset() {
+		String s = document.get();
+		boolean inStringLiteral = false;
+		int start = 0, end = 0;
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			if (c == '\\' && inStringLiteral) {
+				i++;
+			} else if (c == '"') {
+				inStringLiteral = !inStringLiteral;
+				if (inStringLiteral) {
+					start = i;
+				} else {
+					end = i;
+					literalsByOffset.put(start, end);
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean isIgnoredWhitespace(int lineNumber, int columnNumber) {
+		try {
+			int offset = document.getLineOffset(lineNumber) + columnNumber;
+			Entry<Integer, Integer> entry = literalsByOffset.floorEntry(offset);
+			if (entry != null) {
+				int start = entry.getKey();
+				int end = entry.getValue();
+				if (offset >= start && offset <= end) {
+					return false; // part of literal - whitespace cannot be ignored
+				}
+			}
+		} catch (BadLocationException e) {
+			Assert.fail("BadLocationException not expected");
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
The "Ignore White Space" context menu action in the eclipse compare view is ignoring all whitespaces in the source code, including the significant ones. Whitespace differences in string literals in programming languages like Java or ABAP for example are quite important and should not simply be ignored. We got at least this feedback from our users of the ABAP Development Tools here at SAP. 

The changes in this pull request allow tool implementers to hook into the ignore whitespace algorithm by providing an implementation of interface IIgnoreWhitespaceContributor; similar to TextMergeViewer#createTokenComparator, a new method TextMergeViewer#createIgnoreWhitespaceContributor is introduced which can be overriden when creating the TextMergeViewer in the IViewerCreator#createViewer extension. 

IIgnoreWhitespaceContributor#isIgnoredWhitespace is called in the "Ignore White Space" action run for each found whitespace and the implementer can decide whether the whitespace can be really ignored or not if it is part of a string literal.

The "Text Compare" IViewerCreator implementation will ignore all whitespaces because it cannot have any knowledge about the programming language. Language specific IViewerCreator implementations like "Java Compare" or "ABAP Compare" can now influence the ignore whitespace behavior and include all programming language relevant whitespaces inside string literals or elsewhere.

I worked on this pull request as part of the "Contributing to Eclipse" Hackathon here at SAP and it would be great if you could take a look and review it? Feedback is very welcome. 