### PR TITLE
Improve OSGi metadata about dependency to javax.inject/annotations

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.e4.core.di
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.inject;version="1.0.0",
+Import-Package: javax.inject;version="[1.0.0,2.0.0)",
  org.osgi.framework;version="[1.5.0,2.0.0)",
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Export-Package: org.eclipse.e4.core.contexts;version="1.7.0",

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.e4.core.di.annotations
 Bundle-Version: 1.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.annotations;version="1.6.0"
-Import-Package: javax.inject;version="1.0.0"
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.e4.core.di.annotations

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions.supplier/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions.supplier/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 0.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.extender;
   filter:="(&(osgi.extender=osgi.component)(version>=1.3)(!(version>=2.0)))"
-Import-Package: javax.annotation;version="1.3.5",
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  org.eclipse.core.runtime.preferences;version="3.3.0",
  org.eclipse.e4.core.contexts;version="1.6.0",
  org.eclipse.e4.core.di,

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.extensions;version="0.16.0"
 Bundle-Localization: fragment
-Import-Package: javax.inject;version="1.0.0"
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.e4.core.di.extensions

--- a/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Export-Package: org.eclipse.e4.core.di;version="1.7.0",
  org.eclipse.e4.core.internal.di;x-friends:="org.eclipse.e4.core.contexts",
  org.eclipse.e4.core.internal.di.osgi;x-internal:=true,
  org.eclipse.e4.core.internal.di.shared;x-friends:="org.eclipse.e4.core.contexts,org.eclipse.e4.core.di.extensions.supplier"
-Require-Bundle: org.eclipse.e4.core.di.annotations;bundle-version="[1.4.0,2.0.0)";visibility:=reexport,
- javax.annotation;bundle-version="[1.3.5,2.0.0)"
-Import-Package: javax.inject;version="1.0.0",
+Require-Bundle: org.eclipse.e4.core.di.annotations;bundle-version="[1.4.0,2.0.0)";visibility:=reexport
+Import-Package: javax.annotation;version="[1.3.5,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.framework.log;version="1.1.0",
  org.osgi.framework;version="[1.8.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.1,2.0.0)"

--- a/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Localization: plugin
 Bundle-Version: 2.4.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation;version="1.3.5",
- javax.inject;version="1.0.0",
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.debug;version="1.1.0",
  org.eclipse.osgi.service.localization;version="1.1.0",
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",


### PR DESCRIPTION
- Only use Import-Package to for javax.annotation and javax.inject
- Always use closed version ranges [1.X,2) with a minor lower bound

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056