### PR TITLE
Avoid concurrent builds during teardown #437

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -416,6 +416,8 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	protected void cleanup() throws CoreException {
+		// Wait for any build job that may still be executed
+		waitForBuild();
 		final IFileStore[] toDelete = storesToDelete.toArray(new IFileStore[0]);
 		storesToDelete.clear();
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
@@ -426,7 +428,7 @@ public abstract class ResourceTest extends CoreTest {
 			}
 		}, null);
 		getWorkspace().save(true, null);
-		//don't leak builder jobs, since they may affect subsequent tests
+		// don't leak builder jobs, since they may affect subsequent tests
 		waitForBuild();
 		assertWorkspaceFolderEmpty();
 	}


### PR DESCRIPTION
It can happen that build operations are still running when the `cleanup` of `ResourceTests` tries to empty the workspace. This is particularly the case if auto build settings were changed within the executed test.

This change fixes two problems related to build operations executed during `teardown`:
1. It ensures that `cleanup` in `ResourceTest` waits for builds to be executed before deleting contents of the workspace
2. It ensures that `ParallelBuildChainTest.testWorkspaceParrallelBuildCurrentProject` properly waits for a build-triggering job to be running before joining it

I hope these changes fix #437, but I have to admit that I am not completely sure about that, since I do not fully understand the reasons for the failure.
The [test log](https://download.eclipse.org/eclipse/downloads/drops4/I20230504-1800/testresults/ep428I-unit-mac64-java17_macosx.cocoa.x86_64_17/org.eclipse.core.tests.resources.AutomatedResourceTests.txt) looks as if the test may have run into a timeout (> 5 seconds between setUp and tearDown while having a timeout of 5 seconds for the join operation in the test). This is why this PR also increases the timeout, as the actual value is only relevant in case of regression to ensure that the test still terminates. However, the assertion checking the timeout did not fail.
Since the build-triggering job is still running, when the test is aborted, `join` can only have been successful when the job was not yet running when `join` was called. Waiting for the job to be actually running instead of only being scheuled is currently missing in the test.

Remark: The additional `waitForBuild` call during cleanup has no impact on the overall execution time during my test executions.