### PR TITLE
Use "assume" instead of "return" in several tests #434

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -39,10 +39,15 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.internal.localstore.LocalStoreTest;
 import org.eclipse.osgi.util.NLS;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Basic tests for the IFileStore API
  */
+@RunWith(JUnit4.class)
 public class FileStoreTest extends LocalStoreTest {
 	private IFileStore createDir(IFileStore store, boolean clear) throws CoreException {
 		if (clear && store.fetchInfo().exists()) {
@@ -64,6 +69,7 @@ public class FileStoreTest extends LocalStoreTest {
 	 * Tests behavior of IFileStore#fetchInfo when underlying file system throws
 	 * exceptions.
 	 */
+	@Test
 	public void testBrokenFetchInfo() {
 		IFileStore broken = null;
 		try {
@@ -121,14 +127,14 @@ public class FileStoreTest extends LocalStoreTest {
 	/**
 	 * Basically this is a test for the Windows Platform.
 	 */
+
+	@Test
 	public void testCopyAcrossVolumes() throws Throwable {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		if (tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null);
 
 		/* build scenario */
 		// create source root folder
@@ -181,6 +187,7 @@ public class FileStoreTest extends LocalStoreTest {
 		destination.delete(EFS.NONE, null);
 	}
 
+	@Test
 	public void testCopyDirectory() throws Throwable {
 		/* build scenario */
 		IFileStore temp = EFS.getFileSystem(EFS.SCHEME_FILE)
@@ -199,6 +206,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("2.1", verifyTree(getTree(copyOfTarget)));
 	}
 
+	@Test
 	public void testCopyDirectoryParentMissing() throws Throwable {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
@@ -215,13 +223,12 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("1.1", !child.fetchInfo().exists());
 	}
 
+	@Test
 	public void testCaseInsensitive() throws Throwable {
 		IFileStore temp = createDir(getWorkspace().getRoot().getLocation().append("temp").toString(), true);
 		boolean isCaseSensitive = temp.getFileSystem().isCaseSensitive();
-		if (isCaseSensitive) {
-			System.out.println("Skipping copy test on caseSensitive System");
-			return;
-		}
+		Assume.assumeFalse("Skipping copy test on caseSensitive System", isCaseSensitive);
+
 		// create a file
 		String content = "this is just a simple content \n to a simple file \n to test a 'simple' copy";
 		IFileStore fileWithSmallName = temp.getChild("filename");
@@ -252,6 +259,7 @@ public class FileStoreTest extends LocalStoreTest {
 		}
 	}
 
+	@Test
 	public void testCopyFile() throws Throwable {
 		/* build scenario */
 		IFileStore temp = createDir(getWorkspace().getRoot().getLocation().append("temp").toString(), true);
@@ -306,14 +314,13 @@ public class FileStoreTest extends LocalStoreTest {
 	/**
 	 * Basically this is a test for the Windows Platform.
 	 */
+	@Test
 	public void testCopyFileAcrossVolumes() throws Throwable {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		if (tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null);
 
 		/* build scenario */
 		/* get the source folder */
@@ -374,6 +381,7 @@ public class FileStoreTest extends LocalStoreTest {
 		destination.delete(EFS.NONE, null);
 	}
 
+	@Test
 	public void testGetLength() throws Exception {
 		// evaluate test environment
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
@@ -395,6 +403,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertEquals("1.0", 1, target.fetchInfo().getLength());
 	}
 
+	@Test
 	public void testGetStat() throws CoreException {
 		/* evaluate test environment */
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
@@ -414,6 +423,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("2.0", EFS.NONE != stat);
 	}
 
+	@Test
 	public void testMove() throws Throwable {
 		/* build scenario */
 		IFileStore tempC = createDir(getWorkspace().getRoot().getLocation().append("temp").toString(), true);
@@ -472,14 +482,13 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("6.4", !destination.fetchInfo().exists());
 	}
 
+	@Test
 	public void testMoveAcrossVolumes() throws Throwable {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		if (tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null);
 
 		/* build scenario */
 		/* get the source folder */
@@ -520,6 +529,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("9.4", !destination.fetchInfo().exists());
 	}
 
+	@Test
 	public void testMoveDirectoryParentMissing() throws Throwable {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
@@ -540,6 +550,7 @@ public class FileStoreTest extends LocalStoreTest {
 	 * Tests public API method
 	 * {@link IFileStore#putInfo(IFileInfo, int, IProgressMonitor)}.
 	 */
+	@Test
 	public void testPutInfo() {
 		IFileStore nonExisting = getTempStore();
 
@@ -562,10 +573,12 @@ public class FileStoreTest extends LocalStoreTest {
 		}
 	}
 
+	@Test
 	public void testReadOnly() throws CoreException {
 		testAttribute(EFS.ATTRIBUTE_READ_ONLY);
 	}
 
+	@Test
 	public void testPermissionsEnabled() {
 		String os = Platform.getOS();
 		if (Platform.OS_LINUX.equals(os) || Platform.OS_MACOSX.equals(os)) {
@@ -591,6 +604,7 @@ public class FileStoreTest extends LocalStoreTest {
 		}
 	}
 
+	@Test
 	public void testPermissions() throws CoreException {
 		testAttribute(EFS.ATTRIBUTE_OWNER_READ);
 		testAttribute(EFS.ATTRIBUTE_OWNER_WRITE);
@@ -604,9 +618,7 @@ public class FileStoreTest extends LocalStoreTest {
 	}
 
 	private void testAttribute(int attribute) throws CoreException {
-		if (!isAttributeSupported(attribute)) {
-			return;
-		}
+		Assume.assumeTrue(isAttributeSupported(attribute));
 
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
 		IFileStore targetFolder = createDir(root.toString(), true);
@@ -634,6 +646,7 @@ public class FileStoreTest extends LocalStoreTest {
 		}
 	}
 
+	@Test
 	public void testGetFileStore() throws Exception {
 		// create files
 		File file = getTempDir().append("test.txt").toFile();
@@ -675,6 +688,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("11.0", info.exists());
 	}
 
+	@Test
 	public void testSortOrder() {
 		IFileSystem nullfs = NullFileSystem.getInstance();
 		if (nullfs == null) {
@@ -701,6 +715,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertEquals("4.1", 1, nabc.compareTo(null));
 	}
 
+	@Test
 	public void testSortOrderPaths() {
 		IFileSystem lfs = LocalFileSystem.getInstance();
 		boolean isWindows = java.io.File.separatorChar == '\\';

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileSystemTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileSystemTest.java
@@ -16,11 +16,15 @@ package org.eclipse.core.tests.filesystem;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import org.eclipse.core.filesystem.*;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * Abstract superclass for all generic file system tests.
@@ -34,6 +38,30 @@ public abstract class FileSystemTest extends CoreTest {
 
 	public FileSystemTest(String name) {
 		super(name);
+	}
+
+	/**
+	 * Bridge method to be able to run subclasses with JUnit4 as well as with
+	 * JUnit3.
+	 *
+	 * @throws Exception
+	 *             comes from {@link #setUp()}
+	 */
+	@Before
+	public final void before() throws Exception {
+		setUp();
+	}
+
+	/**
+	 * Bridge method to be able to run subclasses with JUnit4 as well as with
+	 * JUnit3.
+	 *
+	 * @throws Exception
+	 *             comes from {@link #tearDown()}
+	 */
+	@After
+	public final void after() throws Exception {
+		tearDown();
 	}
 
 	protected void ensureDoesNotExist(IFileStore store) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
@@ -27,7 +27,12 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class SymlinkTest extends FileSystemTest {
 	/**
 	 * Symbolic links on Windows behave differently compared to Unix-based systems. Symbolic links
@@ -37,7 +42,7 @@ public class SymlinkTest extends FileSystemTest {
 	 */
 	private static final boolean SYMLINKS_ARE_FIRST_CLASS_FILES_OR_DIRECTORIES = Platform.OS_WIN32
 			.equals(Platform.getOS()) ? true : false;
-	private static String specialCharName = "äöüß ÄÖÜ àÀâÂ µ²³úá"; //$NON-NLS-1$
+	private static String specialCharName = "Ã¤Ã¶Ã¼ÃŸ Ã„Ã–Ãœ Ã Ã€Ã¢Ã‚ ÂµÂ²Â³ÃºÃ¡"; //$NON-NLS-1$
 
 	protected IFileStore aDir, aFile; //actual Dir, File
 	protected IFileInfo iDir, iFile, ilDir, ilFile, illDir, illFile;
@@ -105,11 +110,11 @@ public class SymlinkTest extends FileSystemTest {
 		baseStore.delete(EFS.NONE, null);
 	}
 
+	@Test
 	public void testBrokenSymlinkAttributes() {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		long testStartTime = System.currentTimeMillis();
 		makeLinkStructure();
 		//break links by removing actual dir and file
@@ -153,11 +158,11 @@ public class SymlinkTest extends FileSystemTest {
 	}
 
 	// Moving a broken symlink is possible.
+	@Test
 	public void testBrokenSymlinkMove() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		ensureDoesNotExist(aFile);
 		ensureDoesNotExist(aDir);
@@ -199,11 +204,11 @@ public class SymlinkTest extends FileSystemTest {
 	}
 
 	// Removing a broken symlink is possible.
+	@Test
 	public void testBrokenSymlinkRemove() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		ensureDoesNotExist(aFile);
 		ensureDoesNotExist(aDir);
@@ -219,11 +224,11 @@ public class SymlinkTest extends FileSystemTest {
 		assertEquals(infos.length, 0);
 	}
 
+	@Test
 	public void testRecursiveSymlink() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		mkLink(baseStore, "l1", "l2", false);
 		mkLink(baseStore, "l2", "l1", false);
 		IFileStore l1 = baseStore.getChild("l1");
@@ -270,11 +275,11 @@ public class SymlinkTest extends FileSystemTest {
 		assertEquals(infos.length, 1);
 	}
 
+	@Test
 	public void testSymlinkAttributes() {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		assertFalse(iFile.getAttribute(EFS.ATTRIBUTE_SYMLINK));
 		assertFalse(iDir.getAttribute(EFS.ATTRIBUTE_SYMLINK));
@@ -311,11 +316,11 @@ public class SymlinkTest extends FileSystemTest {
 	}
 
 	// Reading from a directory pointed to by a link is possible.
+	@Test
 	public void testSymlinkDirRead() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		IFileStore childDir = aDir.getChild("subDir");
 		ensureExists(childDir, true);
@@ -329,11 +334,11 @@ public class SymlinkTest extends FileSystemTest {
 	}
 
 	// Writing to symlinked dir.
+	@Test
 	public void testSymlinkDirWrite() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		IFileStore childFile = llDir.getChild("subFile");
 		ensureExists(childFile, false);
@@ -361,6 +366,7 @@ public class SymlinkTest extends FileSystemTest {
 		assertTrue(exceptionThrown);
 	}
 
+	@Test
 	public void testSymlinkEnabled() {
 		assertTrue(haveSymlinks());
 	}
@@ -370,9 +376,8 @@ public class SymlinkTest extends FileSystemTest {
 	 */
 	public void _testSymlinkExtendedChars() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		IFileStore childDir = baseStore.getChild(specialCharName);
 		ensureExists(childDir, true);
 		IFileStore childFile = baseStore.getChild("ff" + specialCharName);
@@ -397,15 +402,14 @@ public class SymlinkTest extends FileSystemTest {
 		}
 	}
 
+	@Test
 	public void testSymlinkPutLastModified() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
-		if (Platform.OS_MACOSX.equals(Platform.getOS())) {
-			// flag EFS.SET_LAST_MODIFIED is set by java.io and it fails on Mac OS
-			return;
-		}
+		assumeCanCreateSymLinks();
+
+		// flag EFS.SET_LAST_MODIFIED is set by java.io and it fails on Mac OS
+		Assume.assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()));
+
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
 		long oldTime = iFile.getLastModified();
@@ -432,11 +436,11 @@ public class SymlinkTest extends FileSystemTest {
 		assertEquals(illDir.getStringAttribute(EFS.ATTRIBUTE_LINK_TARGET), "lDir");
 	}
 
+	@Test
 	public void testSymlinkPutReadOnly() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
 		illFile.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
@@ -468,17 +472,14 @@ public class SymlinkTest extends FileSystemTest {
 		assertEquals(illDir.getStringAttribute(EFS.ATTRIBUTE_LINK_TARGET), "lDir");
 	}
 
+	@Test
 	public void testSymlinkPutExecutable() throws Exception {
-		if (!isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE)) {
-			return;
-		}
+		Assume.assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
+
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks())
-		 {
-			return;
 		// ATTRIBUTE_EXECUTABLE is not supported on Windows, so
 		// SYMLINKS_ARE_FIRST_CLASS_FILES_OR_DIRECTORIES is false in this context.
-		}
+		assumeCanCreateSymLinks();
 
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
@@ -501,17 +502,14 @@ public class SymlinkTest extends FileSystemTest {
 		assertEquals(illDir.getStringAttribute(EFS.ATTRIBUTE_LINK_TARGET), "lDir");
 	}
 
+	@Test
 	public void testSymlinkPutHidden() throws Exception {
-		if (!isAttributeSupported(EFS.ATTRIBUTE_HIDDEN)) {
-			return;
-		}
+		Assume.assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
+
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks())
-		 {
-			return;
 		// ATTRIBUTE_HIDDEN is supported only on Windows, so
 		// SYMLINKS_ARE_FIRST_CLASS_FILES_OR_DIRECTORIES is true in this context.
-		}
+		assumeCanCreateSymLinks();
 
 		// Check that putInfo() applies the attribute to the symlink itself.
 		makeLinkStructure();
@@ -540,11 +538,11 @@ public class SymlinkTest extends FileSystemTest {
 
 	// Removing a symlink keeps the link target intact.
 	// Symlinks being broken due to remove are set to non-existent.
+	@Test
 	public void testSymlinkRemove() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		makeLinkStructure();
 		lFile.delete(EFS.NONE, getMonitor());
 		illFile = lFile.fetchInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
-
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.IFileSystem;
@@ -45,11 +44,16 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
 import org.eclipse.core.tests.resources.ResourceTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests basic API methods in the face of aliased resources, and ensures that
  * nothing is ever out of sync.
  */
+@RunWith(JUnit4.class)
 public class BasicAliasTest extends ResourceTest {
 	//resource handles (p=project, f=folder, l=file)
 	private IProject pNoOverlap;
@@ -196,6 +200,7 @@ public class BasicAliasTest extends ResourceTest {
 	 * This tests regression of bug 32785.  In this bug, moving a linked folder,
 	 * then copying a linked folder, resulted in the alias table having a stale entry
 	 */
+	@Test
 	public void testBug32785() throws CoreException {
 		IProject project = pNoOverlap;
 		IFolder link = project.getFolder("Source");
@@ -233,6 +238,7 @@ public class BasicAliasTest extends ResourceTest {
 	 * other projects, but the other projects don't overlap each other.  I.e.,
 	 * Project Top overlaps Sub1 and Sub2, but Sub1 and Sub2 do not overlap each other.
 	 */
+	@Test
 	public void testBug156082() throws CoreException {
 		IProject top = getWorkspace().getRoot().getProject("Bug156082_Top");
 		IProject sub1 = getWorkspace().getRoot().getProject("Bug156082_Sub1");
@@ -256,16 +262,13 @@ public class BasicAliasTest extends ResourceTest {
 	 * Regression test for bug 198571.  Device ids should be respected by the comparator
 	 * used in the locations map of AliasManager.
 	 */
+	@Test
 	public void testBug198571() {
-		if (!isWindows()) {
-			return;
-		}
+		Assume.assumeTrue(isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		if (devices[0] == null || devices[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
 		String location = getUniqueString();
 		IProject testProject1 = getWorkspace().getRoot().getProject(location + "1");
@@ -321,6 +324,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	/* Bug570896 */
+	@Test
 	public void testCompareUriAuthorityDistinct() throws URISyntaxException {
 		// AliasManager requires that different authority (server:port) are distinct
 		// (doesnt actually matter if compare yields +1 or -1 for different values)
@@ -343,6 +347,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	/* Bug570896 */
+	@Test
 	public void testCompareUriPathHierarchy() throws URISyntaxException {
 		// AliasManager requires that the path is ordered such path < path%00
 		// and that any subpath of path yields path < subpath < path%00
@@ -366,6 +371,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	/* Bug570896 */
+	@Test
 	public void testCompareUriOctets() throws URISyntaxException {
 		// uri.getPath() will normalize the octets
 		assertPreOrdered(List.of( //
@@ -377,6 +383,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	/* Bug570896 */
+	@Test
 	public void testCompareUriCase() throws URISyntaxException {
 		// its not a requirement but a back compatibility that the order is
 		// case sensitive even on case insensitive OSes:
@@ -387,6 +394,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	/* Bug570896 */
+	@Test
 	public void testCompareUriFragment() throws URISyntaxException {
 		// fragments should NOT be distinct! Even though they might not be used:
 		assertPreOrdered(List.of( //
@@ -405,6 +413,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertEquals("1.0", batfsList, sorted);
 	}
 
+	@Test
 	public void testBug256837() throws CoreException {
 		final AliasManager aliasManager = ((Workspace) getWorkspace()).getAliasManager();
 		//force AliasManager to restart (simulates a shutdown/startup)
@@ -436,6 +445,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertEquals("8.0", link2TempFolder, resources[0]);
 	}
 
+	@Test
 	public void testBug258987() throws CoreException {
 		// Create the directory to which you will link. The directory needs a single file.
 		IFileStore dirStore = getTempStore();
@@ -471,6 +481,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertNull("8.0", resources);
 	}
 
+	@Test
 	public void testCloseOpenProject() throws CoreException {
 		// close the project and make sure aliases in that project are no longer updated
 		pOverlap.close(getMonitor());
@@ -488,6 +499,7 @@ public class BasicAliasTest extends ResourceTest {
 	/**
 	 * Tests adding a file to a duplicate region by copying.
 	 */
+	@Test
 	public void testCopyFile() throws CoreException {
 		IFile sourceFile = pNoOverlap.getFile("CopySource");
 		ensureExistsInWorkspace(sourceFile, true);
@@ -537,6 +549,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertOverlap("3.6", linkDest, overlapDest);
 	}
 
+	@Test
 	public void testCopyFolder() throws CoreException {
 		IFolder source = pNoOverlap.getFolder("CopyFolder");
 		ensureExistsInWorkspace(source, true);
@@ -562,6 +575,7 @@ public class BasicAliasTest extends ResourceTest {
 	/**
 	 * Test copying a linked folder into a child of its alias.
 	 */
+	@Test
 	public void testCopyToChild() throws CoreException {
 		//copying link to child should fail
 		IFolder copyDest = fLinkOverlap1.getFolder("CopyDest");
@@ -580,6 +594,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertThrows(CoreException.class, () -> copyDest.move(copyDest2.getFullPath(), IResource.NONE, getMonitor()));
 	}
 
+	@Test
 	public void testCreateDeleteFile() throws CoreException {
 		// file in linked folder
 		lChildLinked.delete(IResource.NONE, getMonitor());
@@ -610,6 +625,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertOverlap("1.2", lChildLinked, lChildOverlap);
 	}
 
+	@Test
 	public void testCreateDeleteFolder() throws CoreException {
 		// folder in overlapping project
 		fOverlap.delete(IResource.NONE, getMonitor());
@@ -646,6 +662,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertFalse("3.5", child2.exists());
 	}
 
+	@Test
 	public void testCreateDeleteLink() throws CoreException {
 		IFolder folder = pNoOverlap.getFolder("folder");
 		IFile folderChild = folder.getFile("Child.txt");
@@ -666,6 +683,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertFalse("1.3", linkChild.exists());
 	}
 
+	@Test
 	public void testDeepLink() throws CoreException {
 		IFolder folder = pNoOverlap.getFolder("folder");
 		IFile folderChild = folder.getFile("Child.txt");
@@ -717,6 +735,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertNull("Unexpected aliases: " + Arrays.toString(aliases), aliases);
 	}
 
+	@Test
 	public void testCreateOpenProject() throws CoreException {
 		//test creating a project whose location is within an existing link
 		IProject newProject = getWorkspace().getRoot().getProject("createOpenProject");
@@ -731,6 +750,7 @@ public class BasicAliasTest extends ResourceTest {
 
 	}
 
+	@Test
 	public void testDeleteLink() throws CoreException {
 		//test deletion of a link that overlaps a project location
 		IFolder linkOnProject = pLinked.getFolder("LinkOnProject");
@@ -749,6 +769,7 @@ public class BasicAliasTest extends ResourceTest {
 	 * the location of another project.  The nested project should
 	 * be deleted automatically in this case.
 	 */
+	@Test
 	public void testDeleteProjectUnderProject() throws CoreException {
 		IProject parent = getWorkspace().getRoot().getProject("parent");
 		IProject child = getWorkspace().getRoot().getProject("child");
@@ -784,6 +805,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertFalse("4.3", childProjectFileInParent.exists());
 	}
 
+	@Test
 	public void testDeleteProjectContents() throws CoreException {
 		//delete the overlapping project - it should delete the children of the linked folder
 		//but leave the actual links intact in the resource tree
@@ -793,6 +815,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertExistsInWorkspace("1.3", new IResource[] {pLinked, fLinked, lLinked});
 	}
 
+	@Test
 	public void testFileAppendContents() throws CoreException {
 		//linked file
 		lLinked.appendContents(getRandomContents(), IResource.NONE, getMonitor());
@@ -809,6 +832,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertOverlap("3.1", lChildLinked, lChildOverlap);
 	}
 
+	@Test
 	public void testFileSetContents() throws CoreException {
 		//linked file
 		lLinked.setContents(getRandomContents(), IResource.NONE, getMonitor());
@@ -829,6 +853,7 @@ public class BasicAliasTest extends ResourceTest {
 	 * Tests moving a file into and out of an overlapping area (similar to
 	 * creation/deletion).
 	 */
+	@Test
 	public void testMoveFile() throws CoreException {
 		IFile destination = pNoOverlap.getFile("MoveDestination");
 		//file in linked folder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
@@ -60,7 +60,6 @@ public class EmptyDeltaTest extends AbstractBuilderTest {
 			verifier.assertLifecycleEvents("3.1");
 		} catch (CoreException e) {
 			fail("3.2", e);
-			return;
 		}
 		// Now do another incremental build. Even though the delta is empty, it should be called
 		try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
@@ -858,8 +858,6 @@ public class DeltaDataTreeTest {
 			caught = true;
 		}
 		assertTrue("13", caught);
-
-		return;
 	}
 
 	/**
@@ -884,8 +882,6 @@ public class DeltaDataTreeTest {
 		assertFalse(tree.includes(leftKey.append("bogus")));
 		assertFalse(tree.includes(leftKey.append("one").append("bogus")));
 		assertFalse(tree.includes(rightKey.append("bogus")));
-
-		return;
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -16,10 +16,15 @@ package org.eclipse.core.tests.internal.localstore;
 import org.eclipse.core.internal.resources.*;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests the move operation.
  */
+@RunWith(JUnit4.class)
 public class MoveTest extends LocalStoreTest {
 
 	@Override
@@ -30,16 +35,13 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * This test has Windows as the target OS. Drives C: and D: should be available.
 	 */
+	@Test
 	public void testMoveFileAcrossVolumes() {
-		if (!isWindows()) {
-			return;
-		}
+		Assume.assumeTrue(isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		if (devices[0] == null || devices[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
 		// create common objects
 		String location = getUniqueString();
@@ -110,6 +112,7 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * Move one file from one project to another.
 	 */
+	@Test
 	public void testMoveFileBetweenProjects() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -154,16 +157,13 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * This test has Windows as the target OS. Drives C: and D: should be available.
 	 */
+	@Test
 	public void testMoveFolderAcrossVolumes() {
-		if (!isWindows()) {
-			return;
-		}
+		Assume.assumeTrue(isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		if (devices[0] == null || devices[1] == null) {
-			return;
-		}
+		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
 		// create common objects
 		String location = getUniqueString();
@@ -235,6 +235,7 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * Move one folder from one project to another.
 	 */
+	@Test
 	public void testMoveFolderBetweenProjects() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -279,6 +280,7 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * Move some hierarchy of folders and files.
 	 */
+	@Test
 	public void testMoveHierarchy() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -349,6 +351,7 @@ public class MoveTest extends LocalStoreTest {
 	 * Move some hierarchy of folders and files between projects. It also test moving a
 	 * hierarchy across volumes.
 	 */
+	@Test
 	public void testMoveHierarchyBetweenProjects() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -413,6 +416,7 @@ public class MoveTest extends LocalStoreTest {
 		}
 	}
 
+	@Test
 	public void testMoveResource() throws Exception {
 		/* create common objects */
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -535,6 +539,7 @@ public class MoveTest extends LocalStoreTest {
 	/**
 	 * A simple test that renames a file.
 	 */
+	@Test
 	public void testRenameFile() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -586,6 +591,7 @@ public class MoveTest extends LocalStoreTest {
 	 * - assert rename worked
 	 * - assert properties still exist
 	 */
+	@Test
 	public void testRenameFolder() throws Exception {
 		// create common objects
 		IProject[] projects = getWorkspace().getRoot().getProjects();
@@ -636,6 +642,7 @@ public class MoveTest extends LocalStoreTest {
 	 *	- assert properties are correct
 	 *	- assert resources are correct
 	 */
+	@Test
 	public void testRenameProjects() throws Exception {
 		/* create common objects */
 		IProject[] projects = getWorkspace().getRoot().getProjects();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalPerformanceTest.java
@@ -19,8 +19,12 @@ import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.resources.ResourceTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-//
+@RunWith(JUnit4.class)
 public class RefreshLocalPerformanceTest extends ResourceTest {
 	/** big site default volume (windows) */
 	public static final String bigSiteDevice = "d:";
@@ -71,11 +75,10 @@ public class RefreshLocalPerformanceTest extends ResourceTest {
 	/**
 	 * Defines only a default mapping to a project and refreshes locally.
 	 */
+	@Test
 	public void testLocalRefreshPerformance() throws Exception {
 		// test if the test can be done in this machine
-		if (!bigSiteLocation.toFile().isDirectory()) {
-			return;
-		}
+		Assume.assumeTrue(bigSiteLocation.toFile().isDirectory());
 
 		// create common objects
 		int n = 10;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
@@ -20,7 +20,11 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class SymlinkResourceTest extends LocalStoreTest {
 
 	protected void mkLink(IFileStore dir, String src, String tgt, boolean isDir) {
@@ -67,11 +71,11 @@ public class SymlinkResourceTest extends LocalStoreTest {
 	 * been visited before.
 	 * See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=232426">bug 232426</a>
 	 */
+	@Test
 	public void testBug232426() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		/* Re-use projects which are cleaned up automatically */
 		final IProject project = projects[0];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
@@ -98,11 +102,11 @@ public class SymlinkResourceTest extends LocalStoreTest {
 		});
 	}
 
+	@Test
 	public void testBug358830() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeCanCreateSymLinks();
+
 		/* Re-use projects which are cleaned up automatically */
 		final IProject project = projects[0];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -35,7 +34,11 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class IFileTest extends ResourceTest {
 	//name of files according to sync category
 	public static final String DOES_NOT_EXIST = "DoesNotExistFile";
@@ -262,6 +265,7 @@ public class IFileTest extends ResourceTest {
 		super.tearDown();
 	}
 
+	@Test
 	public void testAppendContents() {
 		IFile target = projects[0].getFile("file1");
 		try {
@@ -285,6 +289,7 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testAppendContents2() {
 		IFile file = projects[0].getFile("file1");
 		ensureDoesNotExistInWorkspace(file);
@@ -397,6 +402,7 @@ public class IFileTest extends ResourceTest {
 	 * Performs black box testing of the following method:
 	 *     void create(InputStream, boolean, IProgressMonitor)
 	 */
+	@Test
 	public void testCreate() {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testCreate") {
@@ -457,6 +463,7 @@ public class IFileTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
+	@Test
 	public void testCreateDerived() {
 		IFile derived = projects[0].getFile("derived.txt");
 		ensureExistsInWorkspace(projects[0], true);
@@ -485,6 +492,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.1", !derived.isTeamPrivateMember());
 	}
 
+	@Test
 	public void testDeltaOnCreateDerived() {
 		IFile derived = projects[0].getFile("derived.txt");
 		ensureExistsInWorkspace(projects[0], true);
@@ -505,6 +513,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.0", verifier.isDeltaValid());
 	}
 
+	@Test
 	public void testCreateDerivedTeamPrivate() {
 		IFile teamPrivate = projects[0].getFile("teamPrivateDerived.txt");
 		ensureExistsInWorkspace(projects[0], true);
@@ -533,6 +542,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
 
+	@Test
 	public void testCreateTeamPrivate() {
 		IFile teamPrivate = projects[0].getFile("teamPrivate.txt");
 		ensureExistsInWorkspace(projects[0], true);
@@ -562,6 +572,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
 
+	@Test
 	public void testFileCreation() {
 		IFile target = projects[0].getFile("file1");
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -721,6 +732,7 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testFileCreation_Bug107188() {
 		//create from stream that is canceled
 		IFile target = projects[0].getFile("file1");
@@ -747,6 +759,7 @@ public class IFileTest extends ResourceTest {
 		assertDoesNotExistInFileSystem("4.0", target);
 	}
 
+	@Test
 	public void testFileDeletion() throws Throwable {
 		IFile target = projects[0].getFile("file1");
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -759,6 +772,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.1", !target.exists());
 	}
 
+	@Test
 	public void testFileEmptyDeletion() throws Throwable {
 		IFile target = projects[0].getFile("file1");
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -771,6 +785,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.1", !target.exists());
 	}
 
+	@Test
 	public void testFileInFolderCreation() {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		IFolder folder = projects[0].getFolder("folder1");
@@ -792,6 +807,7 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testFileInFolderCreation1() throws Throwable {
 		IFolder folder = projects[0].getFolder("folder1");
 		folder.create(false, true, null);
@@ -803,6 +819,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.0", target.exists());
 	}
 
+	@Test
 	public void testFileInFolderCreation2() {
 
 		IFolder folder = projects[0].getFolder("folder1");
@@ -825,6 +842,7 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testFileMove() throws Throwable {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		IFile target = projects[0].getFile("file1");
@@ -840,6 +858,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.1", !target.exists());
 	}
 
+	@Test
 	public void testFileOverFolder() throws Throwable {
 		IFolder existing = projects[0].getFolder("ExistingFolder");
 		IFile target = projects[0].getFile("ExistingFolder");
@@ -851,7 +870,6 @@ public class IFileTest extends ResourceTest {
 			fail("Should not be able to create file over folder");
 		} catch (CoreException e) {
 			assertTrue("1.1", existing.exists());
-			return;
 		}
 	}
 
@@ -859,6 +877,7 @@ public class IFileTest extends ResourceTest {
 	 * Performs black box testing of the following method:
 	 *     InputStream getContents()
 	 */
+	@Test
 	public void testGetContents() {
 		Object[][] inputs = new Object[][] {interestingFiles()};
 		new TestPerformer("IFileTest.testGetContents") {
@@ -907,6 +926,7 @@ public class IFileTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
+	@Test
 	public void testGetContents2() throws IOException {
 		IFile target = projects[0].getFile("file1");
 		String testString = getRandomString();
@@ -982,6 +1002,7 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Tests creation and manipulation of file names that are reserved on some platforms.
 	 */
+	@Test
 	public void testInvalidFileNames() {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		IProject project = projects[0];
@@ -1046,6 +1067,7 @@ public class IFileTest extends ResourceTest {
 	 * Performs black box testing of the following method:
 	 *     void setContents(InputStream, boolean, IProgressMonitor)
 	 */
+	@Test
 	public void testSetContents1() {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testSetContents1") {
@@ -1101,6 +1123,7 @@ public class IFileTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
+	@Test
 	public void testSetContents2() {
 		IFile target = projects[0].getFile("file1");
 		try {
@@ -1133,6 +1156,7 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testSetGetFolderPersistentProperty() throws Throwable {
 		IResource target = getWorkspace().getRoot().getFile(new Path("/Project/File.txt"));
 		String value = "this is a test property value";

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -23,17 +23,22 @@ import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class IWorkspaceRootTest extends ResourceTest {
 
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
+	@Test
 	public void testFindFilesNonCanonicalPath() {
 		// this test is for windows only
-		if (!isWindows()) {
-			return;
-		}
+		Assume.assumeTrue(isWindows());
+
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
 		ensureExistsInWorkspace(project, true);
 
@@ -59,6 +64,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method findContainersForLocation.
 	 */
+	@Test
 	public void testFindContainersForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject("p1");
@@ -72,6 +78,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		project.move(projectDesc, IResource.REPLACE, null);
 	}
 
+	@Test
 	public void testFindContainersForLocationOnWrappedFileSystem() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject("p1");
@@ -93,7 +100,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method findContainersForLocation.
 	 */
-	public void testFindContainersForLocation(IProject p1, IProject p2) {
+	private void testFindContainersForLocation(IProject p1, IProject p2) {
 		//should find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IContainer[] result = root.findContainersForLocation(root.getLocation());
@@ -164,6 +171,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method findFilesForLocation.
 	 */
+	@Test
 	public void testFindFilesForLocationOnWrappedFileSystem() {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -180,6 +188,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method findFilesForLocation on non-default file system.
 	 */
+	@Test
 	public void testFindFilesForLocation() {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -189,7 +198,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method findFilesForLocation.
 	 */
-	public void testFindFilesForLocation(IProject project) {
+	private void testFindFilesForLocation(IProject project) {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IFile[] result = root.findFilesForLocation(root.getLocation());
@@ -271,6 +280,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method getContainerForLocation.
 	 */
+	@Test
 	public void testGetContainerForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		assertEquals("1.0", root, root.getContainerForLocation(root.getLocation()));
@@ -279,6 +289,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the AP method getFile(IPath)
 	 */
+	@Test
 	public void testGetFile() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IFile file = root.getFile(new Path("//P1/a.txt"));
@@ -288,11 +299,13 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Tests the API method getFileForLocation
 	 */
+	@Test
 	public void testGetFileForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		assertTrue("1.0", root.getFileForLocation(root.getLocation()) == null);
 	}
 
+	@Test
 	public void testPersistentProperty() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		String value = "this is a test property value";
@@ -324,6 +337,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	 * operation, try it inside an operation to make sure it still works.
 	 * (See bug 14179).
 	 */
+	@Test
 	public void testPersistentPropertyInRunnable() {
 		final IWorkspaceRoot root = getWorkspace().getRoot();
 		final String value = "this is a test property value";
@@ -352,6 +366,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testRefreshLocal() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");
@@ -369,6 +384,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testBug234343_folderInHiddenProject() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
@@ -394,6 +410,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		assertEquals("3.0", 1, containers.length);
 	}
 
+	@Test
 	public void testBug234343_fileInHiddenProject() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
@@ -428,6 +445,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/**
 	 * Regression test for bug 476585: IWorkspaceRoot#getFileForLocation(IPath) should return IFile in nested project
 	 */
+	@Test
 	public void testBug476585() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("a");
@@ -466,6 +484,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	/*
 	* see bug 232765 for details
 	*/
+	@Test
 	public void testFindMethodsWithHiddenAndTeamPrivateFlags() {
 		checkFindMethods(IResource.NONE, new int[][] {{IResource.NONE, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0}, {IContainer.INCLUDE_HIDDEN, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0}, {IContainer.INCLUDE_HIDDEN | IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, {IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}});
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
@@ -19,6 +19,10 @@ import java.net.URI;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Measure speed of a project "Import with Snapshot" operation compared
@@ -29,6 +33,7 @@ import org.eclipse.core.tests.harness.PerformanceTestRunner;
  * to be available on a slow file system (bigSiteLocation). Modify
  * bigSiteLocation to suit your needs, then run-as &gt; JUnit Plug-in Test.
  */
+@RunWith(JUnit4.class)
 public class ProjectSnapshotPerfManualTest extends ResourceTest {
 	/** big site default volume (windows) */
 	public static final String bigSiteDevice = "c:";
@@ -71,11 +76,10 @@ public class ProjectSnapshotPerfManualTest extends ResourceTest {
 	 * the snapshot and compare the times for opening with and without the
 	 * snapshot.
 	 */
+	@Test
 	public void testSnapshotImportPerformance() throws Exception {
 		// test if the test can be done in this machine
-		if (!bigSiteLocation.toFile().isDirectory()) {
-			return;
-		}
+		Assume.assumeTrue(bigSiteLocation.toFile().isDirectory());
 
 		// create common objects
 		final IProject project = getWorkspace().getRoot().getProject("MyTestProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -52,10 +52,10 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IPath;
@@ -69,6 +69,8 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.FileSystemHelper;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * Superclass for tests that use the Eclipse Platform workspace.
@@ -168,6 +170,26 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
+	 * Returns whether the current platform is linux.
+	 *
+	 * @return <code>true</code> if this platform is linux, and <code>false</code>
+	 *         otherwise.
+	 */
+	protected static boolean isLinux() {
+		return Platform.getOS().equals(Platform.OS_LINUX);
+	}
+
+	/**
+	 * Returns whether the current platform is mac OSX.
+	 *
+	 * @return <code>true</code> if this platform is mac OSX, and <code>false</code>
+	 *         otherwise.
+	 */
+	protected static boolean isMacOSX() {
+		return Platform.getOS().equals(Platform.OS_MACOSX);
+	}
+
+	/**
 	 * Convenience method to copy contents from one stream to another.
 	 */
 	public static void transferStreams(InputStream source, OutputStream destination, String path) {
@@ -198,6 +220,30 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public ResourceTest(String name) {
 		super(name);
+	}
+
+	/**
+	 * Bridge method to be able to run subclasses with JUnit4 as well as with
+	 * JUnit3.
+	 *
+	 * @throws Exception
+	 *             comes from {@link #setUp()}
+	 */
+	@Before
+	public final void before() throws Exception {
+		setUp();
+	}
+
+	/**
+	 * Bridge method to be able to run subclasses with JUnit4 as well as with
+	 * JUnit3.
+	 *
+	 * @throws Exception
+	 *             comes from {@link #tearDown()}
+	 */
+	@After
+	public final void after() throws Exception {
+		tearDown();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -15,7 +15,8 @@ package org.eclipse.core.tests.resources.regression;
 
 import java.io.*;
 import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -131,7 +132,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Linux with natives.
 	 */
 	public void testDeleteOpenProjectLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX) && isReadOnlySupported())) {
+		if (!(isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -279,7 +280,7 @@ public class Bug_026294 extends ResourceTest {
 	 * TODO: enable this test once bug 48321 is fixed.
 	 */
 	public void testDeleteClosedProjectLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX))) {
+		if (!isLinux()) {
 			return;
 		}
 
@@ -416,7 +417,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Linux with natives.
 	 */
 	public void testDeleteFolderLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX))) {
+		if (!isLinux()) {
 			return;
 		}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -19,7 +19,6 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -303,7 +302,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testFileBugOnLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX) && isReadOnlySupported())) {
+		if (!(isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -389,7 +388,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testFolderBugOnLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX) && isReadOnlySupported())) {
+		if (!(isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -493,7 +492,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testProjectBugOnLinux() {
-		if (!(Platform.getOS().equals(Platform.OS_LINUX) && isReadOnlySupported())) {
+		if (!(isLinux() && isReadOnlySupported())) {
 			return;
 		}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -15,9 +15,11 @@ package org.eclipse.core.tests.resources.regression;
 
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -89,7 +91,7 @@ public class Bug_044106 extends ResourceTest {
 	 * @param deleteFlags The flags to use on the resource deletion call
 	 */
 	public void doTestDeleteLinkedFolder(IFolder linkedFolder, boolean deleteParent, int deleteFlags) {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IFileStore linkDestLocation = getTempStore();
@@ -137,14 +139,14 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFile() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		doTestDeleteLinkedFile(IResource.NONE);
 	}
 
 	public void testDeleteLinkedFolder() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -153,7 +155,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedResourceInProject() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -162,14 +164,14 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFileKeepHistory() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		doTestDeleteLinkedFile(IResource.KEEP_HISTORY);
 	}
 
 	public void testDeleteLinkedFolderParentKeepHistory() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -179,7 +181,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFolderKeepHistory() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -188,7 +190,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedResourceInProjectKeepHistory() {
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
+		if (!isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
@@ -29,7 +29,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
  */
 public class Bug_185247_LinuxTests extends ResourceTest {
 
-	private static final boolean IS_LINUX = Platform.getOS().equals(Platform.OS_LINUX);
+	private static final boolean IS_LINUX = isLinux();
 	private final List<IProject> testProjects = new ArrayList<>();
 	private IPath testCasesLocation;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -15,9 +15,13 @@ package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class IFileTest extends ResourceTest {
 	private final boolean DISABLED = true;
 
@@ -26,25 +30,20 @@ public class IFileTest extends ResourceTest {
 	 * you try to create a file in a read-only folder on Linux should be
 	 * ERROR_WRITE.
 	 */
+	@Test
 	public void testBug25658() {
 
 		// This test is no longer valid since the error code is dependent on whether
 		// or not the parent folder is marked as read-only. We need to write a different
 		// test to make the file.create fail.
-		if (DISABLED ) {
-			return;
-		}
+		Assume.assumeFalse(DISABLED);
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		if (!isReadOnlySupported()) {
-			return;
-		}
+		Assume.assumeTrue(isReadOnlySupported());
 
 		// Don't test this on Windows
-		if (isWindows()) {
-			return;
-		}
+		Assume.assumeFalse(isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -70,19 +69,16 @@ public class IFileTest extends ResourceTest {
 	 * parent to see if it is read-only so we can return a better error code and message
 	 * to the user.
 	 */
+	@Test
 	public void testBug25662() {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		if (!isReadOnlySupported()) {
-			return;
-		}
+		Assume.assumeTrue(isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
-			return;
-		}
+		Assume.assumeTrue(isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -106,6 +102,7 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Tests setting local timestamp of project description file
 	 */
+	@Test
 	public void testBug43936() {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -17,28 +17,29 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class IFolderTest extends ResourceTest {
 	/**
 	 * Bug requests that if a failed folder creation occurs on Linux that we check
 	 * the immediate parent to see if it is read-only so we can return a better
 	 * error code and message to the user.
 	 */
+	@Test
 	public void testBug25662() {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		if (!isReadOnlySupported()) {
-			return;
-		}
+		Assume.assumeTrue(isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		if (!Platform.getOS().equals(Platform.OS_LINUX)) {
-			return;
-		}
+		Assume.assumeTrue(isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder parentFolder = project.getFolder("parentFolder");
@@ -62,6 +63,7 @@ public class IFolderTest extends ResourceTest {
 	/**
 	 * Bug 11510 [resources] Non-local folders do not become local when directory is created.
 	 */
+	@Test
 	public void testBug11510() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("TestProject");
@@ -111,6 +113,7 @@ public class IFolderTest extends ResourceTest {
 	/**
 	 * Bug 514831: "shallow" mkdir fails if the directory already exists
 	 */
+	@Test
 	public void testBug514831() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("TestProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import junit.framework.Test;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -40,7 +39,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 	private boolean skipTest() {
 		//skip on Mac due to unknown failure (bug 127752)
 		//TODO re-enable after M5 build
-		return Platform.getOS().equals(Platform.OS_MACOSX);
+		return isMacOSX();
 	}
 
 	public void test1() {

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.junit.Assume;
 
 /**
  * @since 3.1
@@ -267,6 +268,10 @@ public class CoreTest extends TestCase {
 		} catch (IOException | InterruptedException e) {
 			fail("createSymLink", e);
 		}
+	}
+
+	protected void assumeCanCreateSymLinks() {
+		Assume.assumeTrue("Can't create symbolic links in this platform: " + Platform.getOS(), canCreateSymLinks());
 	}
 
 	/**


### PR DESCRIPTION
The objective is to let tests be skipped "visibly" i.e. they should be marked as *skipped* instead of *successful* in the test reports. In order to do this, I need to let these tests run with the "JUnit4" runner (the older runner "JUnit38" reports the tests as "failed" when the condition in `Assume.assumeXYZ(...)` is not met).

I also extracted 3 new methods in order to improve the readability of some tests, these are:
* `ResourceTest.isLinux()` and `ResourceTest.isMacOSX()` are similar to the already existing `ResourceTest.isWindows()`
* `CoreTest.assumeCanCreateSymLinks()` uses the already existing `canCreateSymlinks()` and assumes it is `true`

I also removed some unnecessary `return` statements.