### PR TITLE
Re-acquire locks via iterative instead of recursive execution #447

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/OrderedLock.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/OrderedLock.java
@@ -97,6 +97,21 @@ public class OrderedLock implements ILock, ISchedulingRule {
 
 	@Override
 	public boolean acquire(long delay) throws InterruptedException {
+		return acquire(delay, true);
+	}
+
+	/**
+	 * Acquires a lock as defined by {@link #acquire(long)} but only resumes
+	 * suspended locks if {@code resumeSuspendedLocks} is {@code true}.
+	 *
+	 * @param delay                the number of milliseconds to delay
+	 * @param resumeSuspendedLocks whether locks that were suspended because a lock
+	 *                             could not be acquired shall be re-acquired or not
+	 * @return {@code true} if the lock was successfully acquired, and {@code false}
+	 *         otherwise.
+	 * @exception InterruptedException if the thread was interrupted
+	 */
+	boolean acquire(long delay, boolean resumeSuspendedLocks) throws InterruptedException {
 		if (Thread.interrupted())
 			throw new InterruptedException();
 
@@ -108,7 +123,9 @@ public class OrderedLock implements ILock, ISchedulingRule {
 		if (DEBUG)
 			System.out.println("[" + Thread.currentThread() + "] Operation waiting to be executed... " + this); //$NON-NLS-1$ //$NON-NLS-2$
 		boolean success = doAcquire(semaphore, delay);
-		manager.resumeSuspendedLocks(Thread.currentThread());
+		if (resumeSuspendedLocks) {
+			manager.resumeSuspendedLocks(Thread.currentThread());
+		}
 		if (DEBUG)
 			System.out.println("[" + Thread.currentThread() + //$NON-NLS-1$
 					(success ? "] Operation started... " : "] Operation timed out... ") + this); //$NON-NLS-1$ //$NON-NLS-2$ //}


### PR DESCRIPTION
When multiple `OrderedLocks` are acquired by different threads, the deadlock recovery mechanism suspending and reacquiring the locks requires an indefinite number of tries until one thread holds all required locks. Since reacquisition is performed by recursive method invocation, the stack can become infinitely large with the change of resulting in a `StackOverflowError`.

These changes replace the recursive lock acqusition by an iterative one, such that still an indefinite number of tries for acquiring a set of locks is required but the chance of resulting in an error is eliminated. The `OrderedLockTest.testComplex`, which was randomly failing on Windows systems due to the recursive implementation and thus disabled in #455, is re-enabled.

The added test case does not deterministically reproduce the erroneous behavior, but since a proper regression test is very hard to define (as specific lock order across a magnitude of retries has to be ensured and coordinated between different threads), it at least executes more sophisticated locking scenarios to ensure proper lock retrieval and deadlock management.

Fixes #447. In particular, with this fix the build timeouts after 6h should hopefully disappear (which were only worked around by #455).