### PR TITLE
Increase lower-bound of reexported o.e.equinox.common to current version

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Export-Package: org.eclipse.core.internal.preferences.legacy;x-internal:=true,
  org.eclipse.core.internal.runtime;x-internal:=true,
  org.eclipse.core.runtime;version="3.7.0"
 Require-Bundle: org.eclipse.osgi;bundle-version="[3.17.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.common;bundle-version="3.16.0";visibility:=reexport,
+ org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.jobs;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.registry;bundle-version="[3.11.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.preferences;bundle-version="[3.10.0,4.0.0)";visibility:=reexport,


### PR DESCRIPTION
With https://github.com/eclipse-equinox/equinox/pull/228 new APIs where added to the IPath interface which is often delivered to Plug-ins through this re-export. In order to prevent potential runtime errors increase the lower bound to its current version.