### PR TITLE
Temporarily disable OrderedLockTest.testComplex on Windows #447

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -21,16 +22,20 @@ import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import org.eclipse.core.internal.jobs.*;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.LockListener;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.runtime.jobs.LockAcquiringRunnable.RandomOrder;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests implementation of ILock objects
  */
+@RunWith(JUnit4.class)
 @SuppressWarnings("restriction")
 public class OrderedLockTest {
 	@Rule
@@ -47,6 +52,9 @@ public class OrderedLockTest {
 
 	@Test
 	public void testComplex() {
+		// FIXME Disabled on Windows due to #477; must be re-enabled when merging fix
+		// for the issue
+		assumeFalse(Platform.getOS().equals(Platform.OS_WIN32));
 		DeadlockDetector.runSilent(() -> {
 			ArrayList<LockAcquiringRunnable> allRunnables = new ArrayList<>();
 			LockManager manager = new LockManager();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/RetryTestRule.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/RetryTestRule.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -37,6 +38,9 @@ public class RetryTestRule implements TestRule {
 				for (int i = 0; i < retryCount; i++) {
 					try {
 						base.evaluate();
+					} catch (AssumptionViolatedException e) {
+						// re-throw assumption violation as it should not make the test fail
+						throw e;
 					} catch (Throwable t) {
 						caughtThrowable = t;
 						System.err.println(description.getDisplayName() + ": run " + (i + 1) + " failed:");


### PR DESCRIPTION
The current deadlock recovery strategy for acquiring `OrderedLocks` has the risk of resulting in a `StackOverflowError` because it performs a try-and-error recovery in a recursive fashion (see #447).
This makes the test method `OrderedLockTest.testComplex randomly` fail due to running into a `StackOverflowError`.

Since the error has primarily been observed when executing the test on Windows systems, this change temporarily disables the test case on Windows until a proper improvement of the deadlock recovery has been merged.

Serves as a temporary fix (as stated in https://github.com/eclipse-platform/eclipse.platform/pull/450#issuecomment-1548250289) for the test failure mentioned in #447. Will properly be fixed by merging #450.