### PR TITLE
Remove test IJobManagerTest.testReverseOrder() #469

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -1750,35 +1750,6 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		}
 	}
 
-	public void testReverseOrder() {
-		//ensure jobs are run in order from lowest to highest sleep time.
-		final Queue<Job> done = new ConcurrentLinkedQueue<>();
-		int[] sleepTimes = new int[] { 600, 400, 200, 5 };
-		Job[] jobs = new Job[sleepTimes.length];
-		for (int i = 0; i < sleepTimes.length; i++) {
-			jobs[i] = new Job("testReverseOrder(" + i + ")") {
-
-				@Override
-				protected IStatus run(IProgressMonitor monitor) {
-					done.add(this);
-					return Status.OK_STATUS;
-				}
-
-			};
-		}
-		for (int i = 0; i < sleepTimes.length; i++) {
-			jobs[i].schedule(sleepTimes[i]);
-		}
-		while (done.size() != jobs.length) {
-			Thread.yield();
-		}
-		Job[] doneOrder = done.toArray(new Job[done.size()]);
-		assertEquals("1.0", jobs.length, doneOrder.length);
-		for (int i = 0; i < doneOrder.length; i++) {
-			assertEquals("1.1." + i, jobs[i], doneOrder[doneOrder.length - 1 - i]);
-		}
-	}
-
 	/**
 	 * Tests conditions where there is a race to schedule the same job multiple times.
 	 */


### PR DESCRIPTION
The test was added in 2003, its intention is not completely clear and it can not be designed in a way that is independent of the hardware. This makes the test fail when running in slow machines and succeed when running in fast machines.

The problem with the test is that the `Job.schedule(long delay)` does not really guarantee the order of execution, it only says that:
>Jobs of equal priority and delay with conflicting schedulingrules are guaranteed to run in the order they are scheduled. No guaranteesare made about the relative execution order of jobs with unrelated or null scheduling rules, or different priorities. 

Which means the test can only try to schedule the jobs with such delays that they will run in reverse order. 

### How to reproduce the error?
Change the delay between the jobs in such a way that 2 consecutive jobs are "too close", e.g.:
```
int[] sleepTimes = new int[] { 600, 400, 1, 0 }; // it was { 600, 400, 200, 5} before
...
for (int i = 0; i < sleepTimes.length; i++) {
	jobs[i].schedule(sleepTimes[i]);
}
```
In this scenario, the 3rd job will be scheduled to run in `1` ms and that will not be enough for the test to even reach the line were the 4th job is scheduled.