### PR TITLE
Avoid potential Threadlocal.set(null) memory leak

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
@@ -216,7 +216,11 @@ public class CharsetDeltaJob extends Job implements IContentTypeManager.IContent
 	 */
 	public void setDisabled(boolean disabled) {
 		// using a thread local because this can be called by multiple threads concurrently
-		this.disabled.set(disabled ? Boolean.TRUE : null);
+		if (disabled) {
+			this.disabled.set(Boolean.TRUE);
+		} else {
+			this.disabled.remove();
+		}
 	}
 
 	public void shutdown() {


### PR DESCRIPTION
Threadlocal.set(null) keeps a reference to ThreadLocal.this
see https://rules.sonarsource.com/java/RSPEC-5164