### PR TITLE
Restore public access on WorkManager.isLockAlreadyAcquired()

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/WorkManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/WorkManager.java
@@ -249,7 +249,7 @@ public class WorkManager implements IManager {
 	 * Returns true if the workspace lock has already been acquired by this
 	 * thread, and false otherwise.
 	 */
-	boolean isLockAlreadyAcquired() {
+	public boolean isLockAlreadyAcquired() {
 		boolean result = false;
 		try {
 			boolean success = lock.acquire(0L);


### PR DESCRIPTION
WorkManager.isLockAlreadyAcquired() is not a public API but it was there since ever (2003, see e9154ab).

With 28d4794 the method was made package protected, which is technically OK but unnecessarily breaks all clients that used non-API code before (Xtext is one example:
org.eclipse.xtext.ui.workspace.WorkspaceLockAccess.isWorkspaceLockedByCurrentThread(IWorkspace)).

To avoid unnecessarily breaking existing code, this method should be made public again.

This shouldn't be an issue, as we had no issues having this code public for 20 years, should be OK to keep it public for the next 20 years.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/490