### PR TITLE
fix BucketTree.translateSegment for Integer.MIN_VALUE

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/BucketTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/BucketTree.java
@@ -158,6 +158,6 @@ public class BucketTree {
 
 	private char[] translateSegment(String segment) {
 		// String.hashCode algorithm is API
-		return HEX_STRINGS[Math.abs(segment.hashCode()) % SEGMENT_QUOTA];
+		return HEX_STRINGS[Math.abs(Math.abs(segment.hashCode()) % SEGMENT_QUOTA)];
 	}
 }


### PR DESCRIPTION
Special case that unintuitive abs(Integer.MIN_VALUE) < 0, -1 % n < 0