### PR TITLE
Provide static acessors in the ILog interface as an alternative to Platform

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.27.100.qualifier
+Bundle-Version: 3.28.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -54,6 +54,8 @@ public final class InternalPlatform {
 
 	private static final String[] ARCH_LIST = { Platform.ARCH_AARCH64, Platform.ARCH_X86, Platform.ARCH_X86_64 };
 
+	public static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+
 	// debug support:  set in loadOptions()
 	public static boolean DEBUG = false;
 	public static boolean DEBUG_PLUGIN_PREFERENCES = false;

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/ILog.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/ILog.java
@@ -14,7 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.runtime;
 
+import org.eclipse.core.internal.runtime.InternalPlatform;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * A log to which status events can be written.  Logs appear on individual
@@ -131,5 +133,46 @@ public interface ILog {
 	 */
 	default void error(String message, Throwable throwable) {
 		log(new Status(IStatus.ERROR, getBundle().getSymbolicName(), message, throwable));
+	}
+
+	/**
+	 * Returns the log for the given bundle. If no such log exists, one is created.
+	 *
+	 * @param bundle the bundle whose log is returned
+	 * @return the log for the given bundle
+	 * @since 3.28
+	 */
+	public static ILog of(Bundle bundle) {
+		return InternalPlatform.getDefault().getLog(bundle);
+	}
+
+	/**
+	 * Returns the log for the bundle of the given class. If no such log exists, one
+	 * is created.
+	 *
+	 * @param clazz the class in a bundle whose log is returned
+	 * @return the log for the bundle to which the clazz belongs
+	 *
+	 * @since 3.28
+	 */
+	public static ILog of(Class<?> clazz) {
+		Bundle bundle = FrameworkUtil.getBundle(clazz);
+		return InternalPlatform.getDefault().getLog(bundle);
+	}
+
+	/**
+	 * Returns the log for the bundle of the calling class. If no such log exists,
+	 * one is created.
+	 *
+	 * @return the log for the bundle to which the caller belongs
+	 *
+	 * @since 3.28
+	 */
+	public static ILog get() {
+		try {
+			return of(InternalPlatform.STACK_WALKER.getCallerClass());
+		} catch (IllegalCallerException e) {
+			return of(ILog.class);
+		}
 	}
 }

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -922,7 +922,7 @@ public final class Platform {
 	 * @since 3.0
 	 */
 	public static ILog getLog(Bundle bundle) {
-		return InternalPlatform.getDefault().getLog(bundle);
+		return ILog.of(bundle);
 	}
 
 	/**
@@ -935,8 +935,7 @@ public final class Platform {
 	 * @since 3.16
 	 */
 	public static ILog getLog(Class<?> clazz) {
-		Bundle bundle = FrameworkUtil.getBundle(clazz);
-		return InternalPlatform.getDefault().getLog(bundle);
+		return ILog.of(clazz);
 	}
 
 	/**

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Plugin.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Plugin.java
@@ -230,13 +230,15 @@ public abstract class Plugin implements BundleActivator {
 
 
 	/**
-	 * Returns the log for this plug-in.  If no such log exists, one is created.
+	 * Returns the log for this plug-in. If no such log exists, one is created.
+	 * <b>Hint: </b> instead of caling this method, consider using
+	 * {@link ILog#of(Class)} instead that is independent from implementing a
+	 * {@link Plugin}
 	 *
 	 * @return the log for this plug-in
-	 * XXX change this into a LogMgr service that would keep track of the map. See if it can be a service factory.
 	 */
 	public final ILog getLog() {
-		return InternalPlatform.getDefault().getLog(getBundle());
+		return ILog.of(getBundle());
 	}
 
 	/**
@@ -354,7 +356,7 @@ public abstract class Plugin implements BundleActivator {
 			// need to save them because someone else might have
 			// made changes via the OSGi APIs.
 			getPluginPreferences();
-	
+
 			// Performance: isolate PreferenceForwarder and BackingStoreException into
 			// an inner class to avoid class loading (and then activation of the Preferences plugin)
 			// as the Plugin class is loaded.


### PR DESCRIPTION
Currently one obtains ILog either by injection/di or a static call to Platform.getLog(...)., but is is more semantic to only use ILog interface and also decreases the coupling of the code to a central singleton class.

This is similar to the recent changes in IPath and will also help in decreasing the need to call `Platform.getXXX` methods so we can easier adapt for changes here especially in the context of https://github.com/eclipse-equinox/equinox/pull/253.

A next step would to to replace references, and possibly moving `ILog` to equinox common to reduce the amount of split package classes.