### PR TITLE
Make AbstractDataTree.immutable field volatile

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/AbstractDataTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/AbstractDataTree.java
@@ -30,7 +30,7 @@ public abstract class AbstractDataTree {
 	/**
 	 * Whether modifications to the given source tree are allowed
 	 */
-	private boolean immutable = false;
+	private volatile boolean immutable;
 
 	/**
 	 * Singleton indicating no children


### PR DESCRIPTION
The write access is synchronized, but read access is not. Make sure other threads see the right value immediately.

This most likely does not fix issue #200, but looks suspicious enough.

See https://github.com/eclipse-platform/eclipse.platform/issues/200