### PR TITLE
Add tracing info for AbstractDataTree.immutable() calls

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/.options
+++ b/resources/bundles/org.eclipse.core.resources/.options
@@ -82,3 +82,10 @@ org.eclipse.core.resources/contenttype/cache=false
 
 # Prints debug information about resource change event notifications
 org.eclipse.core.resources/notifications=false
+
+# Reports calls to AbstractDataTree.immutable()
+org.eclipse.core.resources/tree/immutable=false
+
+# Prints stack trace for calls to AbstractDataTree.immutable()
+# Requires org.eclipse.core.resources/tree/immutable=true
+org.eclipse.core.resources/tree/immutablestack=false

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DeltaDataTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DeltaDataTree.java
@@ -1004,9 +1004,9 @@ public class DeltaDataTree extends AbstractDataTree {
 		}
 
 		return this.getClass().getSimpleName() + ' ' + getRootData() //
-				+ "->" + (parent == null ? null : parent.getRootData()) // $NON-NLS-1$ //$NON-NLS-1$
-				+ "->...depth " + depth + "..." //$NON-NLS-1$ //$NON-NLS-2$
-				+ "->" + (parent == null ? null : root.getRootData()) // $NON-NLS-1$ //$NON-NLS-1$
-				+ " rootNode=" + rootNode.toShortString(); //$NON-NLS-1$
+				+ "-> " + (parent == null ? null : parent.getRootData()) // $NON-NLS-1$ //$NON-NLS-1$
+				+ "-> depth " + depth //$NON-NLS-1$
+				+ "-> " + (parent == null ? null : root.getRootData()) // $NON-NLS-1$ //$NON-NLS-1$
+				+ " / rootNode=" + rootNode.toShortString(); //$NON-NLS-1$
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -42,6 +42,9 @@ public class Policy {
 			DEBUG_BUILD_NEEDED_STACK = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/needbuildstack", false); //$NON-NLS-1$
 			DEBUG_BUILD_STACK = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/build/stacktrace", false); //$NON-NLS-1$
 
+			Policy.DEBUG_TREE_IMMUTABLE = Policy.DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/tree/immutable", false); //$NON-NLS-1$
+			Policy.DEBUG_TREE_IMMUTABLE_STACK = Policy.DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/tree/immutablestack", false); //$NON-NLS-1$
+			
 			DEBUG_CONTENT_TYPE = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/contenttype", false); //$NON-NLS-1$
 			DEBUG_CONTENT_TYPE_CACHE = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/contenttype/cache", false); //$NON-NLS-1$
 			DEBUG_HISTORY = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/history", false); //$NON-NLS-1$
@@ -56,7 +59,6 @@ public class Policy {
 			DEBUG_RESTORE_SNAPSHOTS = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/restore/snapshots", false); //$NON-NLS-1$
 			DEBUG_RESTORE_SYNCINFO = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/restore/syncinfo", false); //$NON-NLS-1$
 			DEBUG_RESTORE_TREE = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/restore/tree", false); //$NON-NLS-1$
-
 			DEBUG_SAVE = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/save", false); //$NON-NLS-1$
 			DEBUG_SAVE_MARKERS = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/save/markers", false); //$NON-NLS-1$
 			DEBUG_SAVE_MASTERTABLE = DEBUG && options.getBooleanOption(ResourcesPlugin.PI_RESOURCES + "/save/mastertable", false); //$NON-NLS-1$
@@ -84,6 +86,9 @@ public class Policy {
 	public static boolean DEBUG_BUILD_NEEDED_DELTA = false;
 	public static boolean DEBUG_BUILD_NEEDED_STACK = false;
 	public static boolean DEBUG_BUILD_STACK = false;
+
+	public static boolean DEBUG_TREE_IMMUTABLE_STACK = false;
+	public static boolean DEBUG_TREE_IMMUTABLE = false;
 
 	public static boolean DEBUG_CONTENT_TYPE = false;
 	public static boolean DEBUG_CONTENT_TYPE_CACHE = false;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/messages.properties
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/messages.properties
@@ -19,7 +19,7 @@
 ### Resources plugin messages.
 
 ### dtree
-dtree_immutable = Illegal attempt to modify an immutable tree.
+dtree_immutable = Illegal attempt to modify an immutable tree: {0}.
 dtree_malformedTree = Malformed tree.
 dtree_missingChild = Missing child node: {0}.
 dtree_notFound = Tree element ''{0}'' not found.


### PR DESCRIPTION
- Added two new tracing options
 - org.eclipse.core.resources/tree/immutable=false
 - org.eclipse.core.resources/tree/immutablestack=false
- added tracing on immutable() and handleImmutableTree()
- removed unused setImmutable() call

See https://github.com/eclipse-platform/eclipse.platform/issues/200