### PR TITLE
Fix random failing Bug_266907 #472

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -25,6 +25,7 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
@@ -43,6 +44,10 @@ public class Bug_266907 extends WorkspaceSessionTest {
 	}
 
 	public void test1CreateProjectAndDeleteProjectFile() throws Exception {
+		// Ensure that no asynchronous save job restores the .project file after
+		// deleting it by suspending the JobManager for this workspace session
+		Job.getJobManager().suspend();
+
 		final IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_NAME);
 		project.create(getMonitor());


### PR DESCRIPTION
The regression test for bug 266907 randomly fails. After deleting the `.project` file in the first workspace session of the test, an asynchronously executed save operation non-deterministically restores the `.project` file, which is assumed to be non-existing in the second workspace session.

With this change, the `JobManager` is suspended in the according workspace session to ensure that no asynchronous save operation restoring the `.project` file is executed. This is valid and reasonable since no job executions are required in the test and it prevents an auto-save job from being executed.

A refactoring improving the test class is provided in the subsequent PR #510.


Fixes eclipse-platform/eclipse.platform#472.