### PR TITLE
Refactor regression test Bug_266907 #472

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -13,10 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
-import java.io.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
@@ -34,95 +42,54 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, Bug_266907.class);
 	}
 
-	public void test1stSession() {
+	public void test1CreateProjectAndDeleteProjectFile() throws Exception {
 		final IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_NAME);
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e1) {
-			fail("1.0", e1);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		IFile f = project.getFile(FILE_NAME);
-		try {
-			f.create(getContents("content"), true, getMonitor());
-		} catch (CoreException e1) {
-			fail("2.0", e1);
-		}
+		f.create(getContents("content"), true, getMonitor());
 
-		try {
-			IMarker marker = f.createMarker(IMarker.BOOKMARK);
-			marker.setAttribute(MARKER_ATTRIBUTE_NAME, MARKER_ATTRIBUTE);
-		} catch (CoreException e2) {
-			fail("3.0", e2);
-		}
+		IMarker marker = f.createMarker(IMarker.BOOKMARK);
+		marker.setAttribute(MARKER_ATTRIBUTE_NAME, MARKER_ATTRIBUTE);
 
 		// remember the location of .project to delete is at the end
 		File dotProject = project.getFile(".project").getLocation().toFile();
 
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		workspace.save(true, getMonitor());
 
 		// move .project to a temp location
 		File dotProjectCopy = getTempDir().append("dotProjectCopy").toFile();
-		try {
-			dotProjectCopy.createNewFile();
-			transferStreams(new FileInputStream(dotProject), new FileOutputStream(dotProjectCopy), null);
-			dotProject.delete();
-		} catch (FileNotFoundException e) {
-			fail("5.0", e);
-		} catch (IOException e) {
-			fail("5.1", e);
-		}
+		dotProjectCopy.createNewFile();
+		transferStreams(new FileInputStream(dotProject), new FileOutputStream(dotProjectCopy), null);
+		dotProject.delete();
 	}
 
-	public void test2ndSession() {
+	public void test2RestoreWorkspaceFile() throws Exception {
 		final IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_NAME);
 
 		// the project should be closed cause .project is removed
-		assertTrue("1.0", !project.isAccessible());
+		assertThat("project should not be accessible", project.isAccessible(), is(false));
 
 		// recreate .project
 		File dotProject = project.getFile(".project").getLocation().toFile();
 		File dotProjectCopy = getTempDir().append("dotProjectCopy").toFile();
-		try {
-			dotProject.createNewFile();
-			transferStreams(new FileInputStream(dotProjectCopy), new FileOutputStream(dotProject), null);
-			dotProjectCopy.delete();
-		} catch (IOException e1) {
-			fail("2.0", e1);
-		}
 
-		try {
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		dotProject.createNewFile();
+		transferStreams(new FileInputStream(dotProjectCopy), new FileOutputStream(dotProject), null);
+		dotProjectCopy.delete();
 
-		assertTrue("4.0", project.isAccessible());
+		project.open(getMonitor());
+		assertThat("project should be accessible", project.isAccessible(), is(true));
 
 		IFile file = project.getFile(FILE_NAME);
-		IMarker[] markers = null;
-		try {
-			markers = file.findMarkers(IMarker.BOOKMARK, false, IResource.DEPTH_ZERO);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		IMarker[] markers = file.findMarkers(IMarker.BOOKMARK, false, IResource.DEPTH_ZERO);
+		assertThat("unexpected number of markers in test project", markers.length, is(1));
 
-		assertNotNull("6.0", markers);
-		assertEquals("6.1", markers.length, 1);
-
-		Object attribute = null;
-		try {
-			attribute = markers[0].getAttribute(MARKER_ATTRIBUTE_NAME);
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
-		assertEquals("8.0", attribute, MARKER_ATTRIBUTE);
+		Object attribute = markers[0].getAttribute(MARKER_ATTRIBUTE_NAME);
+		assertThat("unexpected name of marker", attribute, is(MARKER_ATTRIBUTE));
 	}
+
 }


### PR DESCRIPTION
Remove unnecessary try-catches and improve assertions and failure messages in regression test for bug 266907.

This is a refactoring for the test class `Bug_266907`, separated from #509, which is a fix in that class for #472.