### PR TITLE
Revert "Compare: asyncExec propertyChange() to avoid Deadlock #282"

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -177,7 +177,11 @@ public class Utilities {
 				SafeRunner.run(() -> listener.propertyChange(event));
 			}
 		};
-		Display.getDefault().execute(runnable);
+		if (Display.getCurrent() == null) {
+			Display.getDefault().syncExec(runnable);
+		} else {
+			runnable.run();
+		}
 	}
 
 	public static boolean okToUse(Widget widget) {


### PR DESCRIPTION
This reverts commit ba2faa704d7a77baefe0d34c65c3a23ad8fbe580 as it causes severe regression with compare editor.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/464