### PR TITLE
Provide static acessors in the interface as an alternative to Platform

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/ILog.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/ILog.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.runtime;
 
 import org.eclipse.core.internal.runtime.InternalPlatform;
+import org.eclipse.core.internal.runtime.RuntimeLog;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -174,5 +175,41 @@ public interface ILog {
 		} catch (IllegalCallerException e) {
 			return of(ILog.class);
 		}
+	}
+
+	/**
+	 * Adds a log listener that is notified about all log events of the runtime.
+	 * <p>
+	 * Once registered, a listener starts receiving notification as entries are
+	 * added via any <code>ILog.log()</code>. The listener continues to receive
+	 * notifications until it is replaced or removed.
+	 * </p>
+	 *
+	 * @param listener the listener to register
+	 * @see ILog#addLogListener(ILogListener)
+	 * @see #removeLogListener(ILogListener)
+	 * @since 3.31
+	 */
+	public static void addRuntimeLogListener(ILogListener listener) {
+		if (listener == null) {
+			return;
+		}
+		RuntimeLog.addLogListener(listener);
+	}
+
+	/**
+	 * Removes the log listener from receiving notfications about all log events of
+	 * the runtime. If no such listener exists, no action is taken.
+	 *
+	 * @param listener the listener to de-register
+	 * @see ILog#removeLogListener(ILogListener)
+	 * @see #addLogListener(ILogListener)
+	 * @since 3.31
+	 */
+	public static void removeRuntimeLogListener(ILogListener listener) {
+		if (listener == null) {
+			return;
+		}
+		RuntimeLog.removeLogListener(listener);
 	}
 }

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -584,7 +584,7 @@ public final class Platform {
 	 * @see #removeLogListener(ILogListener)
 	 */
 	public static void addLogListener(ILogListener listener) {
-		InternalPlatform.getDefault().addLogListener(listener);
+		ILog.addRuntimeLogListener(listener);
 	}
 
 	/**
@@ -789,7 +789,7 @@ public final class Platform {
 	 * @see #addLogListener(ILogListener)
 	 */
 	public static void removeLogListener(ILogListener listener) {
-		InternalPlatform.getDefault().removeLogListener(listener);
+		ILog.removeRuntimeLogListener(listener);
 	}
 
 	/**


### PR DESCRIPTION
Currently one cann add a global loglistenr via the Platform.add/removeLogListener(...)., but is is more semantic to only use ILog interface and also decreases the coupling of the code to a central singleton class.