### PR TITLE
Use equinox preferences APIs in UserStringMappings #497

### DIFF
--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/FileContentManager.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/FileContentManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2017, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Nikifor Fedorov (ArSysOp) - Use equinox preferences APIs in UserStringMappings #497
  *******************************************************************************/
 
 package org.eclipse.team.internal.core;
@@ -30,9 +31,11 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.team.core.IFileContentManager;
 import org.eclipse.team.core.IStringMapping;
 import org.eclipse.team.core.Team;
+import org.osgi.service.prefs.BackingStoreException;
 
 /**
  * TODO: implement extension point
@@ -73,7 +76,11 @@ public class FileContentManager implements IFileContentManager {
 		protected Map<String, Integer> loadMappingsFromPreferences() {
 			final Map<String, Integer> result= super.loadMappingsFromPreferences();
 			if (loadMappingsFromOldWorkspace(result)) {
-				TeamPlugin.getPlugin().savePluginPreferences();
+				try {
+					InstanceScope.INSTANCE.getNode(TeamPlugin.ID).flush();
+				} catch (BackingStoreException e) {
+					TeamPlugin.log(IStatus.ERROR, e.getMessage(), e);
+				}
 			}
 			return result;
 		}

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/UserStringMappings.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/UserStringMappings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2017, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Nikifor Fedorov (ArSysOp) - Use equinox preferences APIs in UserStringMappings #497
  *******************************************************************************/
 
 package org.eclipse.team.internal.core;
@@ -18,56 +19,64 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.StringTokenizer;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.Preferences;
-import org.eclipse.core.runtime.Preferences.PropertyChangeEvent;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.team.core.Team;
+import org.osgi.service.prefs.BackingStoreException;
 
+public class UserStringMappings {
 
-public class UserStringMappings implements Preferences.IPropertyChangeListener {
-
-	public static final Integer BINARY= Integer.valueOf(Team.BINARY);
-	public  static final Integer TEXT= Integer.valueOf(Team.TEXT);
-	public static final Integer UNKNOWN= Integer.valueOf(Team.UNKNOWN);
-
+	public static final Integer BINARY = Integer.valueOf(Team.BINARY);
+	public static final Integer TEXT = Integer.valueOf(Team.TEXT);
+	public static final Integer UNKNOWN = Integer.valueOf(Team.UNKNOWN);
 
 	private static final String PREF_TEAM_SEPARATOR = "\n"; //$NON-NLS-1$
+	private static final String EMPTY_PREF = ""; //$NON-NLS-1$
 
-	private final Preferences fPreferences;
 	private final String fKey;
 
 	private Map<String, Integer> fMap;
 
 	public UserStringMappings(String key) {
-		fKey= key;
-		fPreferences= TeamPlugin.getPlugin().getPluginPreferences();
-		fPreferences.addPropertyChangeListener(this);
+		fKey = key;
+		InstanceScope.INSTANCE.getNode(TeamPlugin.ID).addPreferenceChangeListener(this::preferenceChanged);
 	}
 
 	public Map<String, Integer> referenceMap() {
 		if (fMap == null) {
-			fMap= loadMappingsFromPreferences();
+			fMap = loadMappingsFromPreferences();
 		}
 		return fMap;
 	}
 
 	public void addStringMappings(String[] names, int[] types) {
 		Assert.isTrue(names.length == types.length);
-		final Map<String, Integer> map= referenceMap();
+		final Map<String, Integer> map = referenceMap();
 
 		for (int i = 0; i < names.length; i++) {
 			switch (types[i]) {
-			case Team.BINARY:    map.put(names[i], BINARY);  break;
-			case Team.TEXT:       map.put(names[i], TEXT); break;
-			case Team.UNKNOWN:  map.put(names[i], UNKNOWN); break;
+			case Team.BINARY:
+				map.put(names[i], BINARY);
+				break;
+			case Team.TEXT:
+				map.put(names[i], TEXT);
+				break;
+			case Team.UNKNOWN:
+				map.put(names[i], UNKNOWN);
+				break;
 			}
 		}
 		save();
 	}
 
-	public void setStringMappings(String [] names, int [] types) {
+	public void setStringMappings(String[] names, int[] types) {
 		Assert.isTrue(names.length == types.length);
 		referenceMap().clear();
 		addStringMappings(names, types);
@@ -76,14 +85,8 @@ public class UserStringMappings implements Preferences.IPropertyChangeListener {
 	public int getType(String string) {
 		if (string == null)
 			return Team.UNKNOWN;
-		final Integer type= referenceMap().get(string);
+		final Integer type = referenceMap().get(string);
 		return type != null ? type.intValue() : Team.UNKNOWN;
-	}
-
-	@Override
-	public void propertyChange(PropertyChangeEvent event) {
-		if(event.getProperty().equals(fKey))
-			fMap= null;
 	}
 
 	public void save() {
@@ -92,32 +95,57 @@ public class UserStringMappings implements Preferences.IPropertyChangeListener {
 		final Iterator e = fMap.keySet().iterator();
 
 		while (e.hasNext()) {
-			final String filename = (String)e.next();
+			final String filename = (String) e.next();
 			buffer.append(filename);
 			buffer.append(PREF_TEAM_SEPARATOR);
 			final Integer type = fMap.get(filename);
 			buffer.append(type);
 			buffer.append(PREF_TEAM_SEPARATOR);
 		}
-		TeamPlugin.getPlugin().getPluginPreferences().setValue(fKey, buffer.toString());
+		try {
+			IEclipsePreferences node = InstanceScope.INSTANCE.getNode(TeamPlugin.ID);
+			node.put(fKey, buffer.toString());
+			node.flush();
+		} catch (BackingStoreException ex) {
+			TeamPlugin.log(IStatus.ERROR, ex.getMessage(), ex);
+		}
 	}
 
 	protected Map<String, Integer> loadMappingsFromPreferences() {
-		final Map<String, Integer> result= new HashMap<>();
+		final Map<String, Integer> result = new HashMap<>();
 
-		if (!fPreferences.contains(fKey))
+		if (!nodeAccessibleAndExists(fKey))
 			return result;
-
-		final String prefTypes = fPreferences.getString(fKey);
-		final StringTokenizer tok = new StringTokenizer(prefTypes, PREF_TEAM_SEPARATOR);
+		final StringTokenizer tok = new StringTokenizer(mappings(), PREF_TEAM_SEPARATOR);
 		try {
 			while (tok.hasMoreElements()) {
 				final String name = tok.nextToken();
-				final String mode= tok.nextToken();
+				final String mode = tok.nextToken();
 				result.put(name, Integer.valueOf(mode));
 			}
 		} catch (NoSuchElementException e) {
 		}
 		return result;
+	}
+
+	private String mappings() {
+		return Optional.ofNullable(InstanceScope.INSTANCE.getNode(TeamPlugin.ID)) //
+				.map(node -> node.get(fKey, null)) //
+				.orElse(EMPTY_PREF);
+	}
+
+	private boolean nodeAccessibleAndExists(String key) {
+		try {
+			IEclipsePreferences node = InstanceScope.INSTANCE.getNode(TeamPlugin.ID);
+			return Stream.of(node.keys()).anyMatch(candidate -> key.equals(candidate));
+		} catch (BackingStoreException e) {
+			TeamPlugin.log(IStatus.ERROR, e.getMessage(), e);
+			return false;
+		}
+	}
+
+	private void preferenceChanged(PreferenceChangeEvent event) {
+		if (fKey.equals(event.getKey()))
+			fMap = null;
 	}
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
@@ -42,6 +42,7 @@ public class AllTeamTests extends ResourceTest {
 		suite.addTest(StreamTests.suite());
 		suite.addTest(StorageMergerTests.suite());
 		suite.addTest(AllTeamRegressionTests.suite());
+		suite.addTest(UserMappingTest.suite());
 		return suite;
 	}
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/UserMappingTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/UserMappingTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ArSysOp and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Nikifor Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.team.tests.core;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.team.internal.core.TeamPlugin;
+import org.eclipse.team.internal.core.UserStringMappings;
+import org.osgi.service.prefs.BackingStoreException;
+
+import junit.framework.TestSuite;
+
+@SuppressWarnings("restriction")
+public final class UserMappingTest extends TeamTest {
+
+	private static final String KEY = "key";
+
+	public void testParsedCorrectly() {
+		UserStringMappings mappings = mappings();
+		assertEquals((int) UserStringMappings.TEXT, mappings.getType("*.ext"));
+		assertEquals((int) UserStringMappings.BINARY, mappings.getType("*.bn"));
+		assertEquals((int) UserStringMappings.UNKNOWN, mappings.getType("*.unkwn"));
+		assertEquals((int) UserStringMappings.UNKNOWN, mappings.getType("someunknowntype"));
+		assertEquals((int) UserStringMappings.UNKNOWN, mappings.getType(null));
+	}
+
+	public void testPicksExternalChanges() throws BackingStoreException {
+		UserStringMappings mappings = mappings();
+		assertEquals((int) UserStringMappings.UNKNOWN, mappings.getType("some"));
+		modify("some\n2\n");
+		assertEquals((int) UserStringMappings.BINARY, mappings.getType("some"));
+	}
+
+	public void testAcceptsCorruptedData() throws BackingStoreException {
+		UserStringMappings mappings = mappings();
+		assertEquals((int) UserStringMappings.TEXT, mappings.getType("*.ext"));
+		modify("corrupted");
+		assertTrue(mappings.referenceMap().isEmpty());
+	}
+
+	private void modify(String value) throws BackingStoreException {
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(TeamPlugin.ID);
+		node.put(KEY, value);
+		node.flush();
+	}
+
+	private UserStringMappings mappings() {
+		UserStringMappings mappings = new UserStringMappings(KEY);
+		mappings.setStringMappings( //
+				new String[] { "*.ext", "*.bn", "*.unkwn" }, //
+				new int[] { UserStringMappings.TEXT, UserStringMappings.BINARY, UserStringMappings.UNKNOWN });
+		return mappings;
+	}
+
+	public static TestSuite suite() {
+		return new TestSuite(UserMappingTest.class);
+	}
+
+}


### PR DESCRIPTION
Replace deprecated Preferences API usage with modern Equinox Preferences API in `UserStringMappings` and `UserExtensionMappings`.

Partially fixes
https://github.com/eclipse-platform/eclipse.platform/issues/497