### PR TITLE
Replace deprecated ResourceManager methods

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
@@ -341,7 +341,7 @@ public class CompareConfiguration {
 			return null;
 		}
 		ResourceManager rm = getResourceManager();
-		return rm.createImage(id);
+		return rm.create(id);
 	}
 
 	private synchronized ResourceManager getResourceManager() {
@@ -369,7 +369,7 @@ public class CompareConfiguration {
 			return null;
 		ImageDescriptor id = new DiffImageDescriptor(base, getImageDescriptor(kind), ICompareUIConstants.COMPARE_IMAGE_WIDTH, false);
 		ResourceManager rm = getResourceManager();
-		return rm.createImage(id);
+		return rm.create(id);
 	}
 
 	/**

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/HunkTypedElement.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/HunkTypedElement.java
@@ -45,7 +45,7 @@ public class HunkTypedElement implements ITypedElement, IEncodedStreamContentAcc
 	public Image getImage() {
 		LocalResourceManager imageCache = PatchCompareEditorInput.getImageCache(fHunkResult.getDiffResult().getConfiguration());
 		ImageDescriptor imageDesc = CompareUIPlugin.getImageDescriptor(ICompareUIConstants.HUNK_OBJ);
-		Image image = imageCache.createImage(imageDesc);
+		Image image = imageCache.create(imageDesc);
 		if (!fHunkResult.isOK()) {
 			return getHunkErrorImage(image, imageCache, true);
 		}  else if (fHunkResult.getFuzz() > 0) {
@@ -60,7 +60,7 @@ public class HunkTypedElement implements ITypedElement, IEncodedStreamContentAcc
 
 	private static Image getHunkOverlayImage(Image baseImage, LocalResourceManager imageCache, String path, boolean onLeft) {
 		ImageDescriptor desc = new DiffImageDescriptor(baseImage, CompareUIPlugin.getImageDescriptor(path), ICompareUIConstants.COMPARE_IMAGE_WIDTH, onLeft);
-		Image image = imageCache.createImage(desc);
+		Image image = imageCache.create(desc);
 		return image;
 	}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchCompareEditorInput.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchCompareEditorInput.java
@@ -127,14 +127,14 @@ public abstract class PatchCompareEditorInput extends CompareEditorInput {
 				PatchDiffNode node = (PatchDiffNode) element;
 				if (!node.isEnabled() && image != null) {
 					LocalResourceManager imageCache = PatchCompareEditorInput.getImageCache(getPatcher().getConfiguration());
-					return imageCache.createImage(createOverlay(image, CompareUIPlugin.getImageDescriptor(ICompareUIConstants.REMOVED_OVERLAY), IDecoration.TOP_LEFT));
+					return imageCache.create(createOverlay(image, CompareUIPlugin.getImageDescriptor(ICompareUIConstants.REMOVED_OVERLAY), IDecoration.TOP_LEFT));
 				}
 			}
 			if (element instanceof HunkDiffNode) {
 				HunkDiffNode node = (HunkDiffNode) element;
 				if (node.isManuallyMerged()) {
 					LocalResourceManager imageCache = PatchCompareEditorInput.getImageCache(getPatcher().getConfiguration());
-					return imageCache.createImage(PatchCompareEditorInput.createOverlay(image, CompareUIPlugin.getImageDescriptor(ICompareUIConstants.IS_MERGED_OVERLAY), IDecoration.TOP_LEFT));
+					return imageCache.create(PatchCompareEditorInput.createOverlay(image, CompareUIPlugin.getImageDescriptor(ICompareUIConstants.IS_MERGED_OVERLAY), IDecoration.TOP_LEFT));
 				}
 			}
 			return image;

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ImageManager.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/ImageManager.java
@@ -63,7 +63,7 @@ public class ImageManager {
 		if (descriptor == null || disposed)
 			return null;
 		ResourceManager manager = getResourceManager();
-		Image image = manager.createImage(descriptor);
+		Image image = manager.create(descriptor);
 		return image;
 	}
 


### PR DESCRIPTION
Replace `ResourceManager` methods deprecated since https://github.com/eclipse-platform/eclipse.platform.ui/pull/838.