### PR TITLE
Fix debug onboarding text. Add full stop, like in other perspectives.

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -71,7 +71,7 @@ LaunchConfigurationTabsExtension.name=Launch Configuration Tabs
 
 DebugPerspective.name=Debug
 DebugPerspective.description=This Debug perspective supports application debugging by providing views for displaying the debug stack, variables and breakpoints.
-DebugPerspective.onboarding=Go hunt your bugs here
+DebugPerspective.onboarding=Go hunt your bugs here.
 
 command.openDebugPerspective.description = Open the debug perspective
 DebugPreferencePage.name=Run/Debug


### PR DESCRIPTION
Follow up of https://github.com/eclipse-platform/eclipse.platform.debug/pull/149