### PR TITLE
Enable 'Clear Console' key binding for all consoles

### DIFF
--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -81,7 +81,7 @@ Export-Package: org.eclipse.debug.internal.ui;
  org.eclipse.debug.ui.stringsubstitution
 Require-Bundle: org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
  org.eclipse.ui;bundle-version="[3.115.0,4.0.0)",
- org.eclipse.ui.console;bundle-version="[3.10.0,4.0.0)",
+ org.eclipse.ui.console;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.9.0,4.0.0)";visibility:=reexport,
  org.eclipse.jface.text;bundle-version="[3.5.0,4.0.0)",

--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -202,9 +202,6 @@ ActionContext.breakpointsview.description=The breakpoints view context
 ActionDefinition.eof.name= EOF
 ActionDefinition.eof.description= Send end of file
 
-ActionDefinition.clear.name=Clear Console
-ActionDefinition.clear.description=Clear Console
-
 ActionDefinition.addMemoryBlock.name= Add Memory Block
 ActionDefinition.addMemoryBlock.description=Add memory block
 

--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -2036,12 +2036,6 @@ M4 = Platform-specific fourth key
             description="%ActionDefinition.eof.description"
             id="org.eclipse.debug.ui.commands.eof">
       </command>
-      <command
-            name="%ActionDefinition.clear.name"
-            categoryId="org.eclipse.debug.ui.category.run"
-            description="%ActionDefinition.clear.description"
-            id="org.eclipse.debug.ui.commands.console.clear">
-      </command>
 <!-- Memory View -->
  	  <command
        		categoryId="org.eclipse.debug.ui.category.run"

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsolePageParticipant.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsolePageParticipant.java
@@ -133,6 +133,7 @@ public class ProcessConsolePageParticipant implements IConsolePageParticipant, I
 		fEOFHandler = new EOFHandler();
 		fClearConsoleHandler = new ClearConsoleHandler();
 		fClearConsoleAction = new ClearOutputAction(fConsole);
+		fClearConsoleAction.setActionDefinitionId(IConsoleConstants.COMMAND_ID_CLEAR_CONSOLE);
 	}
 
 	@Override
@@ -248,8 +249,8 @@ public class ProcessConsolePageParticipant implements IConsolePageParticipant, I
 			IContextService contextService = site.getService(IContextService.class);
 			fActivatedContext = contextService.activateContext(fContextId);
 			fEOFActivatedHandler = handlerService.activateHandler("org.eclipse.debug.ui.commands.eof", fEOFHandler); //$NON-NLS-1$
-			fClearConsoleActivatedHandler = handlerService
-					.activateHandler("org.eclipse.debug.ui.commands.console.clear", fClearConsoleHandler); //$NON-NLS-1$
+			fClearConsoleActivatedHandler = handlerService.activateHandler(IConsoleConstants.COMMAND_ID_CLEAR_CONSOLE,
+					fClearConsoleHandler);
 		}
 	}
 

--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/plugin.properties
+++ b/debug/org.eclipse.ui.console/plugin.properties
@@ -23,6 +23,9 @@ ConsoleFactoryName= Console Factories
 
 consoleViewConsoleFactory.name=New Console View
 
+command.clear.name=Clear Console
+command.clear.description=Clear Console
+
 context.consoleview.name=In Console View
 context.consoleview.description=In Console View
 

--- a/debug/org.eclipse.ui.console/plugin.xml
+++ b/debug/org.eclipse.ui.console/plugin.xml
@@ -176,4 +176,14 @@ M4 = Platform-specific fourth key
       </consolePageParticipant>
     </extension>
 
+   <extension
+          point="org.eclipse.ui.commands">
+      <command
+            name="%command.clear.name"
+            categoryId="org.eclipse.ui.category.edit"
+            description="%command.clear.description"
+            id="org.eclipse.debug.ui.commands.console.clear">
+      </command>
+   </extension>
+
 </plugin>

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
@@ -170,4 +170,15 @@ public interface IConsoleConstants {
 	 */
 	int DEFAULT_TAB_SIZE = 8;
 
+	/**
+	 * Command ID of the 'clear' command.
+	 * <p>
+	 * Note: The command ID intentionally starts with
+	 * <code>org.eclipse.debug.ui</code>, because it was moved from that plugin and
+	 * kept stable to not break existing bindings.
+	 *
+	 * @since 3.13
+	 */
+	String COMMAND_ID_CLEAR_CONSOLE = "org.eclipse.debug.ui.commands.console.clear"; //$NON-NLS-1$
+
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsolePage.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsolePage.java
@@ -261,6 +261,8 @@ public class TextConsolePage implements IPageBookViewPage, IPropertyChangeListen
 		setGlobalAction(actionBars, ActionFactory.PASTE.getId(), action);
 
 		fClearOutputAction = new ClearOutputAction(fConsole);
+		fClearOutputAction.setActionDefinitionId(IConsoleConstants.COMMAND_ID_CLEAR_CONSOLE);
+		setGlobalAction(actionBars, IConsoleConstants.COMMAND_ID_CLEAR_CONSOLE, fClearOutputAction);
 
 		ResourceBundle bundle = ConsoleResourceBundleMessages.getBundle();
 		FindReplaceAction fraction = new FindReplaceAction(bundle, "find_replace_action_", fConsoleView); //$NON-NLS-1$


### PR DESCRIPTION
Previously, in the 'Keys' preference page, binding a key to the 'Clear Console' command, would only affect process consoles, such as the 'Run as -> Java Application' console.

It did not work in any other consoles.

Solution:
* Move the 'org.eclipse.debug.ui.commands.console.clear from org.eclipse.debug.ui to org.eclipse.ui.console. The ID is kept stable to not break any existing key bindings. The Category is changed to org.eclipse.ui.category.edit.

* Set action defintion ID for the clear command to also show an active key binding in the context menu.

* Enable the 'clear console' handler also in in the generic TextConsolePage.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/541