### PR TITLE
CharsetManager#setCharsetFor: split function into private subfunctions

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
@@ -489,9 +489,8 @@ public class CharsetManager implements IManager {
 	}
 
 	private void setCharsetForHasFailed(IPath resourcePath, BackingStoreException e) throws ResourceException {
-		IProject project = workspace.getRoot().getProject(resourcePath.segment(0));
 		String message = Messages.resources_savingEncoding;
-		throw new ResourceException(IResourceStatus.FAILED_SETTING_CHARSET, project.getFullPath(), message, e);
+		throw new ResourceException(IResourceStatus.FAILED_SETTING_CHARSET, resourcePath, message, e);
 	}
 
 	@Override


### PR DESCRIPTION
This PR refactors a single method of the CharsetManager.

### Purpose
I am preparing to enable a disabled unit test which touches CharsetManager. In order to "get my feet wet", I decided to refactor this method.

### ~Changes in behaviour~
~In case the Name `resourcePath` passed to the method is not a valid resource path, the method currently performed no operation. I introduced an exception that throws `ResourceException` for this case. This might *not* be expected behaviour, I did not find any documentation detailing this. It is possible that other parts rely on `setCharsetFor` to silently fail on invalid resources. I am open for feedback on this!~
I removed all changes in behaviour and made this PR a pure refactoring-PR, preserving behaviour