### PR TITLE
Fix random failing of  ProcessConsoleTest.testProcessTerminationNotificationWithInputFile (and some more)

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -244,7 +244,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		assertTrue("Failed to prepare input file.", fileCreated);
 		try {
 			ILaunchConfigurationType launchType = DebugPlugin.getDefault().getLaunchManager().getLaunchConfigurationType(LaunchConfigurationTests.ID_TEST_LAUNCH_TYPE);
-			ILaunchConfigurationWorkingCopy launchConfiguration = launchType.newInstance(null, "testProcessTerminationNotificationWithInputFromFile");
+			ILaunchConfigurationWorkingCopy launchConfiguration = launchType.newInstance(null, name.getMethodName());
 			launchConfiguration.setAttribute(IDebugUIConstants.ATTR_CAPTURE_STDIN_FILE, inFile.getAbsolutePath());
 			TestUtil.log(IStatus.INFO, name.getMethodName(), "Process terminates after Console is initialized.");
 			processTerminationTest(launchConfiguration, false);
@@ -267,7 +267,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 	public void processTerminationTest(ILaunchConfiguration launchConfig, boolean terminateBeforeConsoleInitialization) throws Exception {
 		final AtomicBoolean terminationSignaled = new AtomicBoolean(false);
 		final Process mockProcess = new MockProcess(null, null, terminateBeforeConsoleInitialization ? 0 : -1);
-		final IProcess process = DebugPlugin.newProcess(new Launch(launchConfig, ILaunchManager.RUN_MODE, null), mockProcess, "testProcessTerminationNotification");
+		final IProcess process = DebugPlugin.newProcess(new Launch(launchConfig, ILaunchManager.RUN_MODE, null), mockProcess, name.getMethodName());
 		@SuppressWarnings("restriction")
 		final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider());
 		console.addPropertyChangeListener(event -> {
@@ -281,8 +281,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			if (mockProcess.isAlive()) {
 				mockProcess.destroy();
 			}
-			TestUtil.waitForJobs(name.getMethodName(), 50, 10000);
-			assertTrue("No console complete notification received.", terminationSignaled.get());
+			waitWhile(__ -> !terminationSignaled.get(), 10_000, __ -> "No console complete notification received.");
 		} finally {
 			consoleManager.removeConsoles(new IConsole[] { console });
 			TestUtil.waitForJobs(name.getMethodName(), 0, 10000);


### PR DESCRIPTION
Fixes #548 

The test `ProcessConsoleTest.testProcessTerminationNotificationWithInputFile` calls `TestUtil.waitForJobs`. The problem with this is that `waitForJobs` doesn't wait for any particular job; it simply waits for the `JobManager` to finish all its **current** jobs. 

This is a problem because sometimes the job that is relevant to the test (in this case, `DebugPlugin.fEventDispatchJob`) might not even be scheduled by the time `waitForJobs` is called, which lets `waitForJobs` return immediately and lets the test fail.

This PR replaces `waitForJobs` with `waitWhile` which will wait for the relevant condition to be met and it also has a timeout.

NIT-PICKING: I also replaced 2 hard-coded Strings with the actual name of the current test.