### PR TITLE
Remove 'Eclipse-LazyStart' headers in favor of 'Bundle-ActivationPolicy'

### DIFF
--- a/ant/org.eclipse.ant.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.core/META-INF/MANIFEST.MF
@@ -18,5 +18,4 @@ Require-Bundle: org.eclipse.core.variables;bundle-version="[3.1.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)"
 Bundle-ActivationPolicy: lazy;exclude:="org.eclipse.ant.internal.core.contentDescriber"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.ant.core

--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
 Bundle-Version: 3.21.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.examples.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.examples.core/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables;bundle-version="3.2.800",
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.apache.ant;bundle-version="1.9.2";resolution:=optional
-Eclipse-LazyStart: true
 Export-Package: org.eclipse.debug.examples.ant.tasks;x-friends:="org.eclipse.debug.examples.ui",
  org.eclipse.debug.examples.core.midi.launcher;x-friends:="org.eclipse.debug.examples.ui",
  org.eclipse.debug.examples.core.pda;x-friends:="org.eclipse.debug.examples.ui",

--- a/debug/org.eclipse.debug.examples.memory/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.examples.memory/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.debug.examples.memory;singleton:=true
 Bundle-Version: 1.104.0.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.debug.examples.internal.memory.MemoryViewSamplePlugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.ui.ide,
  org.eclipse.debug.examples.core;bundle-version="1.3.300",
  org.eclipse.core.expressions
-Eclipse-LazyStart: true
 Export-Package: org.eclipse.debug.examples.ui.midi.adapters;x-internal:=true,
  org.eclipse.debug.examples.ui.midi.detailpanes;x-internal:=true,
  org.eclipse.debug.examples.ui.midi.launcher;x-internal:=true,
@@ -29,5 +28,4 @@ Export-Package: org.eclipse.debug.examples.ui.midi.adapters;x-internal:=true,
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.debug.examples.ui

--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -92,7 +92,6 @@ Require-Bundle: org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.e4.ui.services;bundle-version="[1.3.700,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Import-Package: org.eclipse.ui.forms.widgets
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.debug.ui

--- a/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.expressions; singleton:=true
 Bundle-Version: 3.9.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.expressions,

--- a/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -43,7 +43,6 @@ Export-Package: org.eclipse.e4.core.internal.services;x-friends:="org.eclipse.e4
  org.eclipse.e4.core.services.statusreporter;x-friends:="org.eclipse.e4.ui.workbench.swt,org.eclipse.e4.ui.progress,org.eclipse.ui.ide",
  org.eclipse.e4.core.services.translation
 Eclipse-ExtensibleAPI: true
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml
 Require-Capability: osgi.extender;
   filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"

--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Require-Bundle: org.eclipse.help.base;bundle-version="[4.0.0,5.0.0)";visibility:
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)";visibility:=reexport,
  org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)"
-Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.help.ui

--- a/ua/org.eclipse.help/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help/META-INF/MANIFEST.MF
@@ -58,7 +58,6 @@ Export-Package: org.eclipse.help,
    org.eclipse.ui.intro"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.200,4.0.0)";visibility:=reexport
-Eclipse-LazyStart: true
 Import-Package: javax.xml.parsers,
  javax.xml.transform,
  javax.xml.transform.dom,

--- a/ua/org.eclipse.tips.json/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.tips.json/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.0.0",
  org.eclipse.tips.core;bundle-version="0.1.0"
 Export-Package: org.eclipse.tips.json,
  org.eclipse.tips.json.internal;x-internal:=true
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.tips.json
 Import-Package: com.google.gson;version="[2.8.6,3.0.0)"
 Bundle-Vendor: %Bundle-Vendor

--- a/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -22,7 +22,6 @@ Export-Package: org.eclipse.ui.cheatsheets,
  org.eclipse.ui.internal.provisional.cheatsheets;x-friends:="org.eclipse.ua.tests"
 Require-Bundle: org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.help.ui;bundle-version="[4.6.0,5.0.0)";resolution:=optional
-Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.cheatsheets

--- a/ua/org.eclipse.ui.intro.universal/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro.universal/META-INF/MANIFEST.MF
@@ -13,9 +13,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.intro;bundle-version="[3.4.0,4.0.0)"
-Eclipse-LazyStart: true; exceptions="org.eclipse.ui.internal.intro.universal.contentdetect"
 Bundle-Activator: org.eclipse.ui.internal.intro.universal.UniversalIntroPlugin
-Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy;exclude:="org.eclipse.ui.internal.intro.universal.contentdetect"
 Automatic-Module-Name: org.eclipse.ui.intro.universal

--- a/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -26,7 +26,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="3.4.200",
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.model.workbench
-Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  javax.inject;version="[1.0.0,2.0.0)",

--- a/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Bundle-Localization: plugin
 Export-Package: org.eclipse.update.configurator,
  org.eclipse.update.internal.configurator;x-friends:="org.eclipse.update.core",
  org.eclipse.update.internal.configurator.branding;x-friends:="org.eclipse.update.core"
-Eclipse-LazyStart: true
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.osgi;bundle-version="[3.2.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
... and remove unnecessary 'Bundle-ClassPath: .' entries.

Replace the use of the legacy and Eclipse-specific MANIFEST.MF header 'Eclipse-LazyStart: true' by the OSGi standard compliant header 'Bundle-ActivationPolicy: lazy' (which is already used in most cases.

The default value of 'Bundle-ClassPath' is the dot which is used when the header is not specified. Therefore there is no need to specify it with that value.