### PR TITLE
Fixed Unit Test for Bug 67606

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.eclipse.core.internal.events.NotificationManager;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.internal.resources.CharsetDeltaJob;
@@ -174,22 +173,20 @@ public class CharsetTest extends ResourceTest {
 	 *
 	 * TODO enable when bug is fixed
 	 */
-	public void _testBug67606() throws CoreException {
+	public void testBug67606() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		final IProject project = workspace.getRoot().getProject("MyProject");
 		try {
 			final IFile file = project.getFile("file.txt");
 			ensureExistsInWorkspace(file, true);
 			project.setDefaultCharset("FOO", getMonitor());
-			workspace.run((IWorkspaceRunnable) monitor -> {
-				assertEquals("0.9", "FOO", file.getCharset());
-				file.setCharset("BAR", getMonitor());
-				assertEquals("1.0", "BAR", file.getCharset());
-				file.move(project.getFullPath().append("file2.txt"), IResource.NONE, monitor);
-				IFile file2 = project.getFile("file2.txt");
-				assertExistsInWorkspace(file2, false);
-				assertEquals("2.0", "BAR", file.getCharset());
-			}, null);
+			assertEquals("0.9", "FOO", file.getCharset());
+			file.setCharset("BAR", getMonitor());
+			assertEquals("1.0", "BAR", file.getCharset());
+			file.move(project.getFullPath().append("file2.txt"), IResource.NONE, getMonitor());
+			IFile file2 = project.getFile("file2.txt");
+			assertExistsInWorkspace(file2, false);
+			assertEquals("2.0", "BAR", file2.getCharset());
 		} finally {
 			ensureDoesNotExistInWorkspace(project);
 		}


### PR DESCRIPTION
## The unit-test was faulty for two reasons:
- It checked for the charset of the wrong file
- It ran as an ICoreRunnable in the Workspace context, which meant that
  notifications sent to a CharsetManager could not be seen from within

## Possible problems
- I am not sure if the CharsetManager receives the notification about the file-move in an asynchronous way. If it does, this change introduces a test that might be subject to race conditions. The race conditions would have existed in the test before, if it were enabled.
- I cannot tell precisely why running this Test synchronously makes it work
- I am confident that the [bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=67606) addressed by this test was fixed. However, a tangential bug was not:

## [Bug 3880114](https://bugs.eclipse.org/bugs/show_bug.cgi?id=3880114)

!! these bug reports are NOT duplicates of eachother

When moving files accross two projects with different charsets, we expect the charset of the file to be "sticky", to avoid data corruption. This is currently *not* the case.
I will create another PR introducing a disabled unit test which tests for this behaviour and move on to finding a solution to this faulty behaviour