### PR TITLE
Add command line history to IOConsole/ProcessConsole.

### DIFF
--- a/debug/org.eclipse.debug.tests/plugin.xml
+++ b/debug/org.eclipse.debug.tests/plugin.xml
@@ -163,4 +163,10 @@
          priority="-1"
          class="org.eclipse.debug.tests.ui.TestVariableValueEditor3"/>
    </extension>
-</plugin>
+   <extension
+         point="org.eclipse.ui.console.consolePageParticipants">
+      <consolePageParticipant
+            class="org.eclipse.debug.tests.TestsConsolePageParticipant"
+            id="org.eclipse.debug.tests.consolePageParticipant">
+      </consolePageParticipant>
+   </extension></plugin>

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsConsolePageParticipant.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsConsolePageParticipant.java
@@ -1,0 +1,39 @@
+package org.eclipse.debug.tests;
+
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsolePageParticipant;
+import org.eclipse.ui.console.IIOConsolePage;
+import org.eclipse.ui.console.TextConsole;
+import org.eclipse.ui.part.IPageBookViewPage;
+
+public class TestsConsolePageParticipant implements IConsolePageParticipant {
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public void init(IPageBookViewPage page, IConsole console) {
+		if (console instanceof TextConsole textConsole) {
+			Object history = textConsole.getAttribute("history");
+			if (history != null && history.equals("true")) {
+				if (page instanceof IIOConsolePage iocPage) {
+					iocPage.setEnableCommandLineHistory(true);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	public void activated() {
+	}
+
+	@Override
+	public void deactivated() {
+	}
+}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
@@ -21,8 +21,8 @@ import org.eclipse.debug.tests.TestUtil;
 public class IOConsoleFixedWidthTests extends IOConsoleTests {
 
 	@Override
-	protected IOConsoleTestUtil getTestUtil(String title) {
-		final IOConsoleTestUtil c = super.getTestUtil(title);
+	protected IOConsoleTestUtil getTestUtil(String title, String... attrValues) {
+		final IOConsoleTestUtil c = super.getTestUtil(title, attrValues);
 		// Varying the width may reveal new bugs. There is no width value
 		// which is invalid. (but remember most test output is quite short)
 		// And try the most beautiful width of 1 aka the vertical console.

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -401,6 +401,10 @@ public final class IOConsoleTestUtil {
 		return this;
 	}
 
+	public int getTextPanelCharCount() {
+		return textPanel.getCharCount();
+	}
+
 	/**
 	 * Set caret to offset relative to start of current line.
 	 *

--- a/debug/org.eclipse.ui.console/plugin.properties
+++ b/debug/org.eclipse.ui.console/plugin.properties
@@ -22,10 +22,12 @@ ConsolePageParticipantName= Console Page Participants
 ConsoleFactoryName= Console Factories
 
 consoleViewConsoleFactory.name=New Console View
-
-command.clear.name=Clear Console
-command.clear.description=Clear Console
-
+consoleViewCategory=active within a process console
+consoleViewCategoryName=Console
+consoleViewPrevCommandDescription=Retrieve a previously-executed command
+consoleViewPrevCommandName=Show Previous Command In History
+consoleViewNextCommandDescription=Retrieve a later-executed command
+consoleViewNextCommandName=Show Next Command In History
 context.consoleview.name=In Console View
 context.consoleview.description=In Console View
 
@@ -35,5 +37,7 @@ command.copy_with_escapes.name = Copy Text With ANSI Escapes
 command.copy_with_escapes.description = Copy the console content to clipboard, including the escape sequences
 command.copy_without_escapes.name = Copy Text Without ANSI Escapes
 command.copy_without_escapes.description = Copy the console content to clipboard, removing the escape sequences
+command.clear.name=Clear Console
+command.clear.description=Clear Console
 command.enable_disable.name = Enable / Disable ANSI Support
 command.enable_disable.description = Enable / disable ANSI Support

--- a/debug/org.eclipse.ui.console/plugin.xml
+++ b/debug/org.eclipse.ui.console/plugin.xml
@@ -178,12 +178,63 @@ M4 = Platform-specific fourth key
 
    <extension
           point="org.eclipse.ui.commands">
+      <category
+            description="%consoleViewCategory"
+            id="org.eclipse.ui.console.history_commands.category"
+            name="%consoleViewCategoryName">
+      </category>
       <command
             name="%command.clear.name"
             categoryId="org.eclipse.ui.category.edit"
             description="%command.clear.description"
             id="org.eclipse.debug.ui.commands.console.clear">
       </command>
-   </extension>
-
+      <command
+            categoryId="org.eclipse.ui.console.history_commands.category"
+            description="%consoleViewPrevCommandDescription"
+            id="org.eclipse.ui.console.showPreviousCommand"
+            name="%consoleViewPrevCommandName">
+      </command>
+      <command
+            categoryId="org.eclipse.ui.console.history_commands.category"
+            description="%consoleViewNextCommandDescription"
+            id="org.eclipse.ui.console.showNextCommand"
+            name="%consoleViewNextCommandName">
+      </command>
+    </extension>
+    <extension
+          point="org.eclipse.ui.handlers">
+       <handler
+             class="org.eclipse.ui.console.actions.ShowPreviousCommandHandler"
+             commandId="org.eclipse.ui.console.showPreviousCommand">
+          <activeWhen>
+          	<with variable="activePartId">
+        		<equals value="org.eclipse.ui.console.ConsoleView"/>
+    		</with>
+          </activeWhen>
+       </handler>
+       <handler
+             class="org.eclipse.ui.console.actions.ShowNextCommandHandler"
+             commandId="org.eclipse.ui.console.showNextCommand">
+          <activeWhen>
+          	<with variable="activePartId">
+        		<equals value="org.eclipse.ui.console.ConsoleView"/>
+    		</with>
+          </activeWhen>
+       </handler>
+    </extension>
+    <extension point="org.eclipse.ui.bindings">
+      <key
+            commandId="org.eclipse.ui.console.showPreviousCommand"
+            contextId="org.eclipse.debug.ui.console"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+ARROW_UP">
+      </key>
+      <key
+            commandId="org.eclipse.ui.console.showNextCommand"
+            contextId="org.eclipse.debug.ui.console"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+ARROW_DOWN">
+      </key>
+    </extension>
 </plugin>

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IIOConsolePage.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IIOConsolePage.java
@@ -1,0 +1,23 @@
+package org.eclipse.ui.console;
+
+import org.eclipse.ui.part.IPageBookViewPage;
+
+/**
+ * An IO console page appears in a page book and can be used to enable command
+ * line history for the console.
+ *
+ * @since 3.13
+ */
+public interface IIOConsolePage extends IPageBookViewPage {
+	/**
+	 * Enable command line history. Command lines (lines entered by the user) will
+	 * be collected and maintained in a history. Ctrl-up arrow and ctrl-down arrow
+	 * can be used to move through the history. The history line will be shown as
+	 * user input.
+	 * <p>
+	 * Generally called from an {@link IConsolePageParticipant}
+	 *
+	 * @param enable enable command line history.
+	 */
+	void setEnableCommandLineHistory(boolean enable);
+}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
@@ -23,9 +23,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.ui.WorkbenchEncoding;
+import org.eclipse.ui.internal.console.ConsoleDocument;
 import org.eclipse.ui.internal.console.IOConsolePage;
 import org.eclipse.ui.internal.console.IOConsolePartitioner;
 import org.eclipse.ui.part.IPageBookViewPage;
@@ -122,6 +125,19 @@ public class IOConsole extends TextConsole {
 			partitioner.connect(document);
 			document.setDocumentPartitioner(partitioner);
 		}
+	}
+
+	/**
+	 * Enable command line history.
+	 * <p>
+	 * Not usually called directly. Instead call via {@link IConsolePageParticipant}
+	 * to ensure proper management of the cursor.
+	 *
+	 * @param enable Enable it.
+	 * @since 3.13
+	 */
+	public void setEnableCommandLineHistory(boolean enable) {
+		partitioner.setEnableCommandLineHistory(enable);
 	}
 
 	/**
@@ -410,5 +426,46 @@ public class IOConsole extends TextConsole {
 		synchronized (openStreams) {
 			openStreams.add(stream);
 		}
+	}
+
+	/**
+	 * Show the previous command line history entry.
+	 *
+	 * @throws ExecutionException Previous command line entry in history exists, but
+	 *                            was unable insert it.
+	 * @since 3.13
+	 */
+	public void showPreviousCommand() throws ExecutionException {
+		IOConsolePartitioner ioConsolePartitioner = findIOConsoleParitioner();
+		if (ioConsolePartitioner != null) {
+			ioConsolePartitioner.showPreviousCommand();
+		}
+	}
+
+	/**
+	 * Show the next command line history entry.
+	 *
+	 * @throws ExecutionException Next command line entry in history exists, but was
+	 *                            unable insert it.
+	 * @since 3.13
+	 */
+	public void showNextCommand() throws ExecutionException {
+		IOConsolePartitioner ioConsolePartitioner = findIOConsoleParitioner();
+		if (ioConsolePartitioner != null) {
+			ioConsolePartitioner.showNextCommand();
+		}
+	}
+
+	private IOConsolePartitioner findIOConsoleParitioner() {
+		final IDocument document = getDocument();
+		if (document instanceof ConsoleDocument) {
+			final ConsoleDocument consoleDocument = (ConsoleDocument) document;
+			// Find the document partitioner for the text document.
+			final IDocumentPartitioner documentPartitioner = consoleDocument.getDocumentPartitioner();
+			if (documentPartitioner instanceof IOConsolePartitioner) {
+				return (IOConsolePartitioner) documentPartitioner;
+			}
+		}
+		return null;
 	}
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsoleInputStream.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsoleInputStream.java
@@ -77,9 +77,15 @@ public class IOConsoleInputStream extends InputStream {
 	/**
 	 * Constructs a new input stream on the given console.
 	 *
+	 * This constructor is public so clients can use it to intercept keyboard output
+	 * from an IOConsole by using
+	 * <code>IOConsole.setInputStream(InputStream inputStream)</code>. This can be
+	 * used to log, filter, transform user input.
+	 *
 	 * @param console I/O console
+	 * @since 3.13
 	 */
-	IOConsoleInputStream(IOConsole console) {
+	public IOConsoleInputStream(IOConsole console) {
 		this.console = console;
 	}
 

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -93,7 +93,6 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 
 	private boolean consoleAutoScrollLock = true;
 
-
 	private IPropertyChangeListener propertyChangeListener;
 
 	private IScrollLockStateProvider scrollLockStateProvider;
@@ -224,8 +223,6 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 	public TextConsoleViewer(Composite parent, TextConsole console, IScrollLockStateProvider scrollLockStateProvider) {
 		this(parent, console);
 		this.scrollLockStateProvider = scrollLockStateProvider;
-
-
 	}
 
 	/**
@@ -853,5 +850,11 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 		}
 	}
 
-
+	/**
+	 * @return The console this viewer shows.
+	 * @since 3.13
+	 */
+	public TextConsole getConsole() {
+		return console;
+	}
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowNextCommandHandler.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowNextCommandHandler.java
@@ -1,0 +1,29 @@
+package org.eclipse.ui.console.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IOConsole;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.internal.console.ConsoleView;
+
+/**
+ * @since 3.13
+ */
+public class ShowNextCommandHandler extends AbstractHandler {
+	@Override
+	public final Object execute(ExecutionEvent event) throws ExecutionException {
+		// First find the console window.
+		final IWorkbenchPart part = HandlerUtil.getActivePart(event);
+		if (part instanceof ConsoleView) {
+			final IConsole console = ((ConsoleView) part).getConsole();
+			if (console instanceof IOConsole) {
+				IOConsole ioConsole = (IOConsole) console;
+				ioConsole.showNextCommand();
+			}
+		}
+		return null;
+	}
+}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowPreviousCommandHandler.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowPreviousCommandHandler.java
@@ -1,0 +1,29 @@
+package org.eclipse.ui.console.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IOConsole;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.internal.console.ConsoleView;
+
+/**
+ * @since 3.13
+ */
+public class ShowPreviousCommandHandler extends AbstractHandler {
+	@Override
+	public final Object execute(ExecutionEvent event) throws ExecutionException {
+		// First find the console window.
+		final IWorkbenchPart part = HandlerUtil.getActivePart(event);
+		if (part instanceof ConsoleView) {
+			final IConsole console = ((ConsoleView) part).getConsole();
+			if (console instanceof IOConsole) {
+				IOConsole ioConsole = (IOConsole) console;
+				ioConsole.showPreviousCommand();
+			}
+		}
+		return null;
+	}
+}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CommandLineHistory.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CommandLineHistory.java
@@ -1,0 +1,67 @@
+package org.eclipse.ui.internal.console;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Maintains a history of ProcessConsole commands entered by the user.
+ */
+public class CommandLineHistory {
+	/** The list of commands that have been executed. (no nulls) */
+	private List<String> _history = new ArrayList<>();
+
+	/**
+	 * The currently selected command in the list. Always >= 0 and <=
+	 * _commandHistory.size().
+	 */
+	private int _currentIndex = 0;
+
+	public void addCommand(String command) {
+		assert command != null;
+		synchronized (this) {
+			_history.add(command.replaceFirst("^(.*)(\r|\n|\r\n)$", "$1")); //$NON-NLS-1$ //$NON-NLS-2$
+			_currentIndex = _history.size();
+		}
+	}
+
+	/**
+	 * Retreat to the previous command in the given document's command history and
+	 * return it. Returns an empty string if the history is empty. Does not retreat
+	 * if the current command is the first in the history.
+	 *
+	 * @return The previous command in the history.
+	 */
+	public String prevCommand() {
+		synchronized (this) {
+			if (_currentIndex > 0) {
+				--_currentIndex;
+			}
+			return currentCommand();
+		}
+	}
+
+	/**
+	 * Advance (if possible) to the next command in the given document's command
+	 * history and return it. Returns an empty string if the history is empty. Can
+	 * advance to at most one position past the last command in the history (which
+	 * will result in an empty string).
+	 *
+	 * @return The next command in the history.
+	 */
+	public String nextCommand() {
+		synchronized (this) {
+			if (_currentIndex < _history.size()) {
+				++_currentIndex;
+			}
+			return currentCommand();
+		}
+	}
+
+	/**
+	 * @return Return the current command if it's within the history, or an empty
+	 *         string otherwise.
+	 */
+	private String currentCommand() {
+		return (_currentIndex < _history.size()) ? _history.get(_currentIndex) : ""; //$NON-NLS-1$
+	}
+}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePage.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePage.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsoleView;
+import org.eclipse.ui.console.IIOConsolePage;
 import org.eclipse.ui.console.TextConsole;
 import org.eclipse.ui.console.TextConsolePage;
 import org.eclipse.ui.console.TextConsoleViewer;
@@ -31,7 +32,7 @@ import org.eclipse.ui.console.TextConsoleViewer;
  * @since 3.1
  *
  */
-public class IOConsolePage extends TextConsolePage {
+public class IOConsolePage extends TextConsolePage implements IIOConsolePage {
 
 	private ScrollLockAction fScrollLockAction;
 	private WordWrapAction fWordWrapAction;
@@ -74,6 +75,14 @@ public class IOConsolePage extends TextConsolePage {
 		if (viewer != null) {
 			viewer.setAutoScroll(scroll);
 			fScrollLockAction.setChecked(!scroll);
+		}
+	}
+
+	@Override
+	public void setEnableCommandLineHistory(boolean enable) {
+		IOConsoleViewer viewer = (IOConsoleViewer) getViewer();
+		if (viewer != null) {
+			viewer.setEnableCommandLineHistory(enable);
 		}
 	}
 


### PR DESCRIPTION
Once enabled, ctrl-up and ctrl-down can be used to move through history.

To enable history use an IOConsolePageParticipant.  When the console is created, Eclipse will create a page book view page, finally the IConolePageParticpant will be created where history can be enabled.

	public class TestsConsolePageParticipant
		implements IConsolePageParticipant {

		@Override
		public void init(IPageBookViewPage page, IConsole console) {
			...
			if (page instanceof IIOConsolePage iocPage) {
				iocPage.setEnableCommandLineHistory(true);

--
IIOConsolePage has been added to expose the setEnableCommandLineHistory method for use by IConsolePageParticipants. IOConsolePage implements IOConsolePage.

IOConsoleViewer has been modified to move the cursor to the end of the line when command line history is enabled.

A unit test for command line history has been added in IOConsoleTests.testHistory()