### PR TITLE
Disable the cancel button of progress indicator in run configurations accordingly

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
@@ -1371,7 +1371,9 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 				fLastControl = null;
 			}
 			// Attach the progress monitor part to the cancel button
-			fProgressMonitorPart.attachToCancelComponent(null);
+			if (cancelable) {
+				fProgressMonitorPart.attachToCancelComponent(null);
+			}
 			fProgressMonitorPart.getParent().setVisible(true);
 			fActiveRunningOperations++;
 
@@ -1393,7 +1395,9 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 				updateRunnnableControls(true, prev);
 				if (getShell() != null) {
 					fProgressMonitorPart.getParent().setVisible(false);
-					fProgressMonitorPart.removeFromCancelComponent(null);
+					if (cancelable) {
+						fProgressMonitorPart.removeFromCancelComponent(null);
+					}
 					if (fLastControl != null && !fLastControl.isDisposed()) {
 						fLastControl.setFocus();
 					}


### PR DESCRIPTION
## What it does
Enable/disable the little red button in the progress indicator at the bottom of the "Run configurations..." dialog accordingly. It was always being enabled, which let the user cancel the operation even if the task had been explicitly set to **NOT** cancelable.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/593
Discovered while testing https://github.com/eclipse-pde/eclipse.pde/issues/679

## How to test

* Generate an idle wait by adding this code right at the beginning of `org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationsDialog.handleLaunchConfigurationSelectionChanged(SelectionChangedEvent)`:

```java
try {
	run(true, false, monitor -> { // NOTICE: the task is NOT cancelable
		monitor.beginTask("Idling for 3 seconds", IProgressMonitor.UNKNOWN); //$NON-NLS-1$
		for (int i = 0; i < 3; i++) {
			Thread.sleep(1000);
		}
	});
} catch (InvocationTargetException | InterruptedException e) {
	e.printStackTrace();
}
```
* Open the _Run configurations..._ dialog (ignore the first progress dialog since that one already works as expected)
* Select something on the left-side panel --> You should see the progress indicator at the bottom and the _cancel_ button should be **deactivated**, like this:
![image](https://github.com/eclipse-platform/eclipse.platform/assets/2205684/401f4847-816d-4955-b0b5-f76f824227ca)
* Change the call to `run`, make the task cancelable _i.e._ `run(true, true, monitor -> { ...` --> You should see the progress indicator at the bottom and the _cancel_ button should be **activated**, like this:
![image](https://github.com/eclipse-platform/eclipse.platform/assets/2205684/4bde2253-1397-4eac-a1b7-9d1dd464c736)
