### PR TITLE
Improve debug output in LaunchConfigurationTest #582

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -1363,8 +1363,9 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		IProcess process = null;
 		try {
 			process = DebugPlugin.newProcess(launch, new MockProcess(0), "test-terminate-timestamp");
+			final IProcess finalProcess = process;
 			waitWhile(__ -> !terminatedLaunches.contains(launch), testTimeout,
-					__ -> "Launch did not finish");
+					__ -> "Launch termination event did not occur and termination state of launched process is: " + finalProcess.isTerminated());
 			String launchTerminateTimestampUntyped = launch.getAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP);
 			assertNotNull("Time stamp is missing", launchTerminateTimestampUntyped);
 			long launchTerminateTimestamp = Long.parseLong(launchTerminateTimestampUntyped);


### PR DESCRIPTION
The test `LaunchConfigurationTest.testTerminateTimeStamp` randomly fails because no termination of the the executed launch is detected. In order to distinguish whether the execution did actually not terminate or whether only the event was not properly received or processed, this change improves the according error message.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/582