### PR TITLE
Fix warnings in org.eclipse.debug.tests

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
@@ -154,12 +154,10 @@ public class TestUtil {
 	 * @return value of condition when method returned
 	 */
 	public static boolean waitWhile(Supplier<Boolean> condition, long timeout) throws Exception {
-		if (condition == null) {
-			condition = () -> true;
-		}
+		Supplier<Boolean> nonNullCondition = condition != null ? condition : () -> true;
 		long start = System.currentTimeMillis();
 		Display display = Display.getCurrent();
-		while (System.currentTimeMillis() - start < timeout && condition.get()) {
+		while (System.currentTimeMillis() - start < timeout && nonNullCondition.get()) {
 			Thread.yield();
 			if (display != null && !display.isDisposed()) {
 				if (!display.readAndDispatch()) {
@@ -169,7 +167,7 @@ public class TestUtil {
 				Thread.sleep(5);
 			}
 		}
-		return condition.get();
+		return nonNullCondition.get();
 	}
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/AbstractLaunchTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/AbstractLaunchTest.java
@@ -49,20 +49,20 @@ public abstract class AbstractLaunchTest extends AbstractDebugTest {
 	/**
 	 * Returns a launch configuration with the given name, creating one if required.
 	 *
-	 * @param name configuration name
+	 * @param configurationName configuration name
 	 * @return launch configuration
 	 * @throws CoreException
 	 */
-	protected ILaunchConfiguration getLaunchConfiguration(String name) throws CoreException {
+	protected ILaunchConfiguration getLaunchConfiguration(String configurationName) throws CoreException {
 		ILaunchManager manager = getLaunchManager();
 		ILaunchConfiguration[] configurations = manager.getLaunchConfigurations();
 		for (ILaunchConfiguration config : configurations) {
-			if (config.getName().equals(name)) {
+			if (config.getName().equals(configurationName)) {
 				return config;
 			}
 		}
 		 ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(LaunchConfigurationTests.ID_TEST_LAUNCH_TYPE);
-		 ILaunchConfigurationWorkingCopy wc = type.newInstance(null, name);
+		 ILaunchConfigurationWorkingCopy wc = type.newInstance(null, configurationName);
 		 ILaunchConfiguration saved = wc.doSave();
 		 return saved;
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
@@ -110,8 +110,8 @@ public class ArgumentParsingTests extends AbstractDebugTest {
 
 	private static ArrayList<String> runCommandLine(String[] execArgs)
 			throws CoreException, IOException {
-		execArgs = quoteWindowsArgs(execArgs);
-		Process process = DebugPlugin.exec(execArgs, null);
+		String[] systemDependentExecArgs = quoteWindowsArgs(execArgs);
+		Process process = DebugPlugin.exec(systemDependentExecArgs, null);
 		BufferedReader procOut = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
 		ArrayList<String> procArgs = new ArrayList<>();
@@ -124,14 +124,15 @@ public class ArgumentParsingTests extends AbstractDebugTest {
 
 	private static String[] quoteWindowsArgs(String[] cmdLine) {
 		// see https://bugs.eclipse.org/387504#c13 , workaround for http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6511002
+		String[] systemDependentCmdLine = cmdLine;
 		if (Platform.getOS().equals(Constants.OS_WIN32)) {
 			String[] winCmdLine = new String[cmdLine.length];
 			for (int i = 0; i < cmdLine.length; i++) {
 				winCmdLine[i] = winQuote(cmdLine[i]);
 			}
-			cmdLine = winCmdLine;
+			systemDependentCmdLine = winCmdLine;
 		}
-		return cmdLine;
+		return systemDependentCmdLine;
 	}
 
 
@@ -155,9 +156,7 @@ public class ArgumentParsingTests extends AbstractDebugTest {
 		if (! needsQuoting(s)) {
 			return s;
 		}
-		s = s.replaceAll("([\\\\]*)\"", "$1$1\\\\\""); //$NON-NLS-1$ //$NON-NLS-2$
-		s = s.replaceAll("([\\\\]*)\\z", "$1$1"); //$NON-NLS-1$ //$NON-NLS-2$
-		return "\"" + s + "\""; //$NON-NLS-1$ //$NON-NLS-2$
+		return "\"" + s.replaceAll("([\\\\]*)\"", "$1$1\\\\\"").replaceAll("([\\\\]*)\\z", "$1$1") + "\"";
 	}
 
 	// -- tests:

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -237,11 +237,11 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 *  - Boolean1 = true
 	 *  - Boolean2 = false
 	 */
-	protected ILaunchConfigurationWorkingCopy newConfiguration(IContainer container, String name) throws CoreException {
+	protected ILaunchConfigurationWorkingCopy newConfiguration(IContainer container, String configurationName) throws CoreException {
 		ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(ID_TEST_LAUNCH_TYPE);
 		assertTrue("Should support debug mode", type.supportsMode(ILaunchManager.DEBUG_MODE)); //$NON-NLS-1$
 		assertTrue("Should support run mode", type.supportsMode(ILaunchManager.RUN_MODE)); //$NON-NLS-1$
-		ILaunchConfigurationWorkingCopy wc = type.newInstance(container, name);
+		ILaunchConfigurationWorkingCopy wc = type.newInstance(container, configurationName);
 		wc.setAttribute("String1", "String1"); //$NON-NLS-1$ //$NON-NLS-2$
 		wc.setAttribute("Int1", 1); //$NON-NLS-1$
 		wc.setAttribute("Boolean1", true); //$NON-NLS-1$
@@ -254,9 +254,9 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 * Creates and returns a new launch configuration with the given name, local
 	 * or shared, with no attributes
 	 */
-	protected ILaunchConfigurationWorkingCopy newEmptyConfiguration(IContainer container, String name) throws CoreException {
+	protected ILaunchConfigurationWorkingCopy newEmptyConfiguration(IContainer container, String configurationName) throws CoreException {
 		ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(ID_TEST_LAUNCH_TYPE);
-		ILaunchConfigurationWorkingCopy wc = type.newInstance(container, name);
+		ILaunchConfigurationWorkingCopy wc = type.newInstance(container, configurationName);
 		assertEquals("Should have no attributes", 0, wc.getAttributes().size()); //$NON-NLS-1$
 		return wc;
 	}
@@ -269,11 +269,11 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 *  - Boolean1 = true
 	 *  - Boolean2 = false
 	 */
-	protected ILaunchConfigurationWorkingCopy newPrototype(IContainer container, String name) throws CoreException {
+	protected ILaunchConfigurationWorkingCopy newPrototype(IContainer container, String configurationName) throws CoreException {
 		ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(ID_TEST_LAUNCH_TYPE);
 		assertTrue("Should support debug mode", type.supportsMode(ILaunchManager.DEBUG_MODE)); //$NON-NLS-1$
 		assertTrue("Should support run mode", type.supportsMode(ILaunchManager.RUN_MODE)); //$NON-NLS-1$
-		ILaunchConfigurationWorkingCopy wc = type.newPrototypeInstance(container, name);
+		ILaunchConfigurationWorkingCopy wc = type.newPrototypeInstance(container, configurationName);
 		wc.setAttribute("String1", "String1"); //$NON-NLS-1$ //$NON-NLS-2$
 		wc.setAttribute("Int1", 1); //$NON-NLS-1$
 		wc.setAttribute("Boolean1", true); //$NON-NLS-1$
@@ -286,9 +286,9 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 * Creates and returns a new launch configuration prototype with the given name, local
 	 * or shared, with no attributes
 	 */
-	protected ILaunchConfigurationWorkingCopy newEmptyPrototype(IContainer container, String name) throws CoreException {
+	protected ILaunchConfigurationWorkingCopy newEmptyPrototype(IContainer container, String configurationName) throws CoreException {
 		ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(ID_TEST_LAUNCH_TYPE);
-		ILaunchConfigurationWorkingCopy wc = type.newPrototypeInstance(container, name);
+		ILaunchConfigurationWorkingCopy wc = type.newPrototypeInstance(container, configurationName);
 		assertEquals("Should have no attributes", 0, wc.getAttributes().size()); //$NON-NLS-1$
 		return wc;
 	}
@@ -513,9 +513,9 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		ILaunchConfiguration[] configs = getLaunchManager().getLaunchConfigurations();
 		assertTrue("Configuration should exist in project index", existsIn(configs, handle)); //$NON-NLS-1$
 
-		String name = wc.getName();
+		String configurationName = wc.getName();
 		wc.rename("newName"); //$NON-NLS-1$
-		wc.rename(name);
+		wc.rename(configurationName);
 		assertTrue("Should be dirty", wc.isDirty()); //$NON-NLS-1$
 		wc.doSave();
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.core.runtime.CoreException;
@@ -49,9 +48,9 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenereateConfigName() {
-		String configname = "launch_configuration"; //$NON-NLS-1$
-		String name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertTrue("the name nust be '" + configname + "'", name.equals(configname)); //$NON-NLS-1$ //$NON-NLS-2$
+		String originalName = "launch_configuration";
+		String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", originalName, generatedName);
 	}
 
 	/**
@@ -60,9 +59,9 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenereateConfigNameBadChar() {
-		String configname = "config:name"; //$NON-NLS-1$
-		String name = getLaunchManager().generateUniqueLaunchConfigurationNameFrom(configname);
-		assertEquals("config name should be '" + configname + "'", configname, name); //$NON-NLS-1$ //$NON-NLS-2$
+		String originalName = "config:name";
+		String generatedName = getLaunchManager().generateUniqueLaunchConfigurationNameFrom(originalName);
+		assertEquals("unexpected generated configuration name", originalName, generatedName);
 	}
 
 	/**
@@ -70,9 +69,9 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenerateValidName() {
-		String configname = "thisisavalidname"; //$NON-NLS-1$
-		String name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertEquals("Should be the same as the seed", configname, name); //$NON-NLS-1$
+		String originalName = "thisisavalidname";
+		String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", originalName, generatedName);
 	}
 
 	/**
@@ -82,9 +81,9 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	@Test
 	public void testGenerateConfigNameReservedName() {
 		if(Platform.OS_WIN32.equals(Platform.getOS())) {
-			String configname = "aux"; //$NON-NLS-1$
-			String name = getLaunchManager().generateUniqueLaunchConfigurationNameFrom(configname);
-			assertEquals("config name should be 'aux'", configname, name); //$NON-NLS-1$
+			String originalName = "aux";
+			String generatedName = getLaunchManager().generateUniqueLaunchConfigurationNameFrom(originalName);
+			assertEquals("unexpected generated configuration name", originalName, generatedName);
 		}
 	}
 
@@ -93,9 +92,10 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenerateBadConfigName() {
-		String configname = "config:name"; //$NON-NLS-1$
-		String name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertEquals("config name should be 'config_name'", "config_name", name); //$NON-NLS-1$ //$NON-NLS-2$
+		String originalName = "config:name";
+		String expectedName = "config_name";
+		String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", expectedName, generatedName);
 	}
 
 	/**
@@ -105,9 +105,10 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	@Test
 	public void testGenerateConflictingName() {
 		if(Platform.OS_WIN32.equals(Platform.getOS())) {
-			String configname = "aux"; //$NON-NLS-1$
-			String name = getLaunchManager().generateLaunchConfigurationName(configname);
-			assertEquals("config name should be 'launch_configuration'", "launch_configuration", name); //$NON-NLS-1$ //$NON-NLS-2$
+			String originalName = "aux";
+			String expectedName = "launch_configuration";
+			String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+			assertEquals("unexpected generated configuration name", expectedName, generatedName);
 		}
 	}
 
@@ -117,13 +118,15 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenerateBadCharConflict() throws Exception {
-		String configname = "config:name"; //$NON-NLS-1$
-		String name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertEquals("config name should be 'config_name'", "config_name", name); //$NON-NLS-1$ //$NON-NLS-2$
-		getLaunchConfiguration(name);
-		name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertEquals("config name should be 'config_name (1)'", "config_name (1)", name); //$NON-NLS-1$ //$NON-NLS-2$
-		ILaunchConfiguration config = getLaunchConfiguration("config_name"); //$NON-NLS-1$
+		String originalName = "config:name";
+		String expectedName =  "config_name";
+		String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", expectedName, generatedName);
+		getLaunchConfiguration(generatedName);
+		expectedName = "config_name (1)";
+		generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", expectedName, generatedName);
+		ILaunchConfiguration config = getLaunchConfiguration("config_name");
 		config.delete();
 	}
 
@@ -135,13 +138,15 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	@Test
 	public void testGenerateBadNameConflict() throws Exception {
 		if(Platform.OS_WIN32.equals(Platform.getOS())) {
-			String configname = "com2"; //$NON-NLS-1$
-			String name = getLaunchManager().generateLaunchConfigurationName(configname);
-			assertEquals("config name should be 'launch_configuration'", "launch_configuration", name); //$NON-NLS-1$ //$NON-NLS-2$
-			getLaunchConfiguration(name);
-			name = getLaunchManager().generateLaunchConfigurationName(configname);
-			assertEquals("config name should be 'launch_configuration (1)'", "launch_configuration (1)", name); //$NON-NLS-1$ //$NON-NLS-2$
-			ILaunchConfiguration config = getLaunchConfiguration("launch_configuration"); //$NON-NLS-1$
+			String originalName = "com2";
+			String expectedName = "launch_configuration";
+			String generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+			assertEquals("unexpected generated configuration name", expectedName, generatedName);
+			getLaunchConfiguration(generatedName);
+			expectedName = "launch_configuration (1)";
+			generatedName = getLaunchManager().generateLaunchConfigurationName(originalName);
+			assertEquals("unexpected generated configuration name", expectedName, generatedName);
+			ILaunchConfiguration config = getLaunchConfiguration("launch_configuration");
 			config.delete();
 		}
 	}
@@ -205,18 +210,18 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 */
 	@Test
 	public void testGenerateNameExistingConfig() throws Exception {
-		String configname = "x.y.z.configname"; //$NON-NLS-1$
-		getLaunchConfiguration(configname);
-		String name = getLaunchManager().generateLaunchConfigurationName(configname);
-		assertEquals("the configuration name should have been " + configname + " (1)", configname + " (1)", name); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		getLaunchConfiguration(name);
-		name = getLaunchManager().generateLaunchConfigurationName(name);
-		assertEquals("the configuration name should have been " + configname + " (2)", configname + " (2)", name); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		ILaunchConfiguration config = getLaunchConfiguration(configname);
+		String originalName = "x.y.z.configname"; //$NON-NLS-1$
+		getLaunchConfiguration(originalName);
+		String generatedConfigurationName = getLaunchManager().generateLaunchConfigurationName(originalName);
+		assertEquals("unexpected generated configuration name", originalName + " (1)", generatedConfigurationName); //$NON-NLS-1$ //$NON-NLS-2$
+		getLaunchConfiguration(generatedConfigurationName);
+		generatedConfigurationName = getLaunchManager().generateLaunchConfigurationName(generatedConfigurationName);
+		assertEquals("unexpected generated configuration name", originalName + " (2)", generatedConfigurationName); //$NON-NLS-1$ //$NON-NLS-2$
+		ILaunchConfiguration config = getLaunchConfiguration(originalName);
 		if(config != null) {
 			config.delete();
 		}
-		config = getLaunchConfiguration(configname + " (1)"); //$NON-NLS-1$
+		config = getLaunchConfiguration(originalName + " (1)"); //$NON-NLS-1$
 		if(config != null) {
 			config.delete();
 		}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchTests.java
@@ -54,8 +54,8 @@ public class LaunchTests extends AbstractLaunchTest {
 		final Launch launch = new Launch(null, ILaunchManager.RUN_MODE, null);
 
 		handler = (proxy, method, args) -> {
-			String name = method.getName();
-			if (name.equals("equals")) { //$NON-NLS-1$
+			String methodName = method.getName();
+			if (methodName.equals("equals")) { //$NON-NLS-1$
 				return args.length == 1 && proxy == args[0];
 			}
 			return Boolean.TRUE;

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ContentTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ContentTests.java
@@ -100,7 +100,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 		boolean fCaptureLabelUpdates = false;
 		boolean fCaptureChildrenUpdates = false;
 
-		List<IViewerUpdate> fCapturedUpdates = Collections.synchronizedList(new ArrayList<IViewerUpdate>());
+		List<IViewerUpdate> fCapturedUpdates = Collections.synchronizedList(new ArrayList<>());
 
 		@Override
 		public void update(IChildrenUpdate[] updates) {
@@ -161,7 +161,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 		waitWhile(t -> model.fCapturedUpdates.size() < model.getRootElement().fChildren.length, createModelErrorMessage(model));
 
 		List<IViewerUpdate> firstUpdates = model.fCapturedUpdates;
-		model.fCapturedUpdates = Collections.synchronizedList(new ArrayList<IViewerUpdate>(2));
+		model.fCapturedUpdates = Collections.synchronizedList(new ArrayList<>(2));
 
 //      // Change the model and run another update set.
 		model.getElement(model.findElement("1")).setLabelAppendix(" - changed"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -216,7 +216,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
 		waitWhile(t -> model.fCapturedUpdates.size() < model.getRootElement().fChildren.length, createModelErrorMessage(model));
 		List<IViewerUpdate> firstUpdates = model.fCapturedUpdates;
-		model.fCapturedUpdates = Collections.synchronizedList(new ArrayList<IViewerUpdate>(2));
+		model.fCapturedUpdates = Collections.synchronizedList(new ArrayList<>(2));
 
 		// Change the model and run another update set.
 		model.setElementChildren(TreePath.EMPTY, new TestElement[] {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModel.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModel.java
@@ -564,10 +564,9 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 	}
 
 	public ModelDelta addElementChild(TreePath parentPath, ModelDelta rootDelta, int index, TestElement newChild) {
-		if (rootDelta == null) {
-			rootDelta = new ModelDelta(fInput, IModelDelta.NO_CHANGE);
-		}
-		ModelDelta baseDelta = getBaseDelta(rootDelta);
+		ModelDelta nonNullRootDelta = rootDelta != null ? rootDelta : new ModelDelta(fInput, IModelDelta.NO_CHANGE);
+
+		ModelDelta baseDelta = getBaseDelta(nonNullRootDelta);
 		TreePath relativePath = getRelativePath(parentPath);
 
 		// Find the parent element and generate the delta node for it.
@@ -581,7 +580,7 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 		delta.setChildCount(element.getChildren().length);
 		delta.addNode(newChild, index, IModelDelta.ADDED);
 
-		return rootDelta;
+		return nonNullRootDelta;
 	}
 
 	public ModelDelta insertElementChild(TreePath parentPath, int index, TestElement newChild) {
@@ -589,10 +588,9 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 	}
 
 	public ModelDelta insertElementChild(ModelDelta rootDelta, TreePath parentPath, int index, TestElement newChild) {
-		if (rootDelta == null) {
-			rootDelta = new ModelDelta(fInput, IModelDelta.NO_CHANGE);
-		}
-		ModelDelta baseDelta = getBaseDelta(rootDelta);
+		ModelDelta nonNullRootDelta = rootDelta != null ? rootDelta : new ModelDelta(fInput, IModelDelta.NO_CHANGE);
+
+		ModelDelta baseDelta = getBaseDelta(nonNullRootDelta);
 		TreePath relativePath = getRelativePath(parentPath);
 
 		// Find the parent element and generate the delta node for it.
@@ -606,7 +604,7 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 		delta.setChildCount(element.getChildren().length);
 		delta.addNode(newChild, index, IModelDelta.INSERTED);
 
-		return rootDelta;
+		return nonNullRootDelta;
 	}
 
 	private TestElement[] doInsertElementInArray(TestElement[] children, int index, TestElement newChild) {
@@ -721,12 +719,12 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 		}
 		int count = levelCounts[0];
 		int[] oldLevelCounts = levelCounts;
-		levelCounts = new int[levelCounts.length - 1];
-		System.arraycopy(oldLevelCounts, 1, levelCounts, 0, levelCounts.length);
+		int[] newlevelCounts = new int[levelCounts.length - 1];
+		System.arraycopy(oldLevelCounts, 1, newlevelCounts, 0, newlevelCounts.length);
 		TestElement[] elements = new TestElement[count];
 		for (int i = 0; i < count; i++) {
 			String name = prefix + i;
-			elements[i] = new TestElement(model, name, makeMultiLevelElements2(model, levelCounts, name + ".")); //$NON-NLS-1$
+			elements[i] = new TestElement(model, name, makeMultiLevelElements2(model, newlevelCounts, name + ".")); //$NON-NLS-1$
 		}
 		return elements;
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModelUpdatesListener.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModelUpdatesListener.java
@@ -356,11 +356,12 @@ public class TestModelUpdatesListener implements IViewerUpdateListener, ILabelUp
 	 */
 	private TreePath getViewerTreePath(IModelDelta node) {
 		ArrayList<Object> list = new ArrayList<>();
-		IModelDelta parentDelta = node.getParentDelta();
+		IModelDelta currentDelta = node;
+		IModelDelta parentDelta = currentDelta.getParentDelta();
 		while (parentDelta != null) {
-			list.add(0, node.getElement());
-			node = parentDelta;
-			parentDelta = node.getParentDelta();
+			list.add(0, currentDelta.getElement());
+			currentDelta = parentDelta;
+			parentDelta = currentDelta.getParentDelta();
 		}
 		return new TreePath(list.toArray());
 	}
@@ -400,7 +401,7 @@ public class TestModelUpdatesListener implements IViewerUpdateListener, ILabelUp
 			}
 		}
 
-		if (levels-- != 0) {
+		if (levels != 0) {
 			TestElement[] children = element.getChildren();
 			if (children.length > 0 && (viewer == null || path.getSegmentCount() == 0 || viewer.getExpandedState(path))) {
 				if ((flags & CHILD_COUNT_UPDATES) != 0) {
@@ -417,7 +418,7 @@ public class TestModelUpdatesListener implements IViewerUpdateListener, ILabelUp
 				}
 
 				for (TestElement child : children) {
-					addUpdates(viewer, path.createChildPath(child), child, filters, levels, flags);
+					addUpdates(viewer, path.createChildPath(child), child, filters, levels - 1, flags);
 				}
 			}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/VisibleVirtualItemValidator.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/VisibleVirtualItemValidator.java
@@ -46,11 +46,12 @@ public class VisibleVirtualItemValidator implements IVirtualItemValidator {
 	@Override
 	public boolean isItemVisible(VirtualItem item) {
 		int position = 0;
-		while (item.getParent() != null) {
-			position += item.getIndex().intValue();
-			item = item.getParent();
+		VirtualItem currentItem = item;
+		while (currentItem.getParent() != null) {
+			position += currentItem.getIndex().intValue();
+			currentItem = currentItem.getParent();
 		}
-		return position >= fStart && position < fEnd || isSelected(item);
+		return position >= fStart && position < fEnd || isSelected(currentItem);
 	}
 
 	@Override
@@ -62,9 +63,10 @@ public class VisibleVirtualItemValidator implements IVirtualItemValidator {
 
 	private int calcPosition(VirtualItem item) {
 		int position = 0;
-		while (item.getParent() != null) {
-			position += item.getIndex().intValue();
-			item = item.getParent();
+		VirtualItem currentItem = item;
+		while (currentItem.getParent() != null) {
+			position += currentItem.getIndex().intValue();
+			currentItem = currentItem.getParent();
 		}
 		return position;
 	}
@@ -92,9 +94,10 @@ public class VisibleVirtualItemValidator implements IVirtualItemValidator {
 	}
 
 	private VirtualTree getTree(VirtualItem item) {
-		while (item != null && !(item instanceof VirtualTree)) {
-			item = item.getParent();
+		VirtualItem currentItem = item;
+		while (currentItem != null && !(currentItem instanceof VirtualTree)) {
+			currentItem = currentItem.getParent();
 		}
-		return (VirtualTree)item;
+		return (VirtualTree) currentItem;
 	}
 }


### PR DESCRIPTION
Contains no functional changes, only renames and other minor refactorings that remove warnings.