### PR TITLE
Remove unnecessary print statements from Tests

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
@@ -130,9 +130,7 @@ public class PlatformTest extends RuntimeTest {
 
 	public void testGetLogLocation() throws IOException {
 		IPath initialLocation = Platform.getLogFileLocation();
-		System.out.println(Platform.getLogFileLocation());
 		Platform.getStateLocation(Platform.getBundle("org.eclipse.equinox.common"));//causes DataArea to be initialzed
-		System.out.println(Platform.getLogFileLocation());
 
 		assertNotNull("1.0", initialLocation);
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
@@ -17,7 +17,10 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -204,7 +207,6 @@ public class Bug_574883 extends AbstractJobManagerTest {
 		Job[] jobs = Job.getJobManager().find(this);
 		int length = jobs.length;
 		int firstState = executions.get();
-		System.out.println(garbage);
 		try {
 		if (length > 0) {
 				// Check if that still would work?

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/GithubBug_193.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/GithubBug_193.java
@@ -15,12 +15,22 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import junit.framework.TestCase;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -47,13 +57,14 @@ public class GithubBug_193 extends TestCase {
 		int jobCount = 1000;
 		JobWatcher watcher = JobWatcher.startWatchingFor(JOB_FAMILY1, JOB_FAMILY2, JOB_FAMILY3);
 		List<Job> fewJobs = startFewJobs(jobCount);
-		watcher.waitUntilJobsAreDone();
-		assertEquals(Collections.emptyList(), watcher.getJobsToWaitFor());
-		assertEquals(watcher.getScheduled(), watcher.getDone());
-		assertEquals(fewJobs.size(), watcher.getDone());
 
-		System.out.println("Scheduled: " + watcher.getScheduled());
-		System.out.println("Done: " + watcher.getDone());
+		assertEquals("Unexpected number of started jobs.", jobCount, fewJobs.size());
+
+		watcher.waitUntilJobsAreDone();
+
+		assertEquals("There are still uncompleted jobs.", Collections.emptyList(), watcher.getJobsToWaitFor());
+		assertEquals("Unexpected number of scheduled jobs.", jobCount, watcher.getScheduled());
+		assertEquals("Unexpected number of done jobs.", jobCount, watcher.getDone());
 	}
 
 	private List<Job> startFewJobs(int jobCount) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderAsserter.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderAsserter.java
@@ -71,7 +71,6 @@ public class OrderAsserter {
 	volatile Exception potentialDeadlock;
 
 	public void expect(Event event, long waitMs) {
-		System.out.println(event + " happend in Thread '" + Thread.currentThread().getName() + "'");
 		if (!errors.isEmpty()) {
 			return;
 		}


### PR DESCRIPTION
This commit enhances the test execution output by removing unnecessary console prints when running the "All runtime tests" configuration. It provides cleaner and more useful feedback during test execution.

Additionally, in the GithubBug_193 test, more descriptive error messages have been added to all assert statements. These messages will provide useful context when a test fails, making it easier to diagnose and fix issues.