### PR TITLE
Reactivate tests in org.eclipse.core.tests.resources #525

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,13 @@
+name: CodeQL call
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '15 8 * * 1'
+
+jobs:
+  callCodeQLworkflow:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/codeQLworkflow.yml@master

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -235,7 +235,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
-	public void _testPerformanceOneResource() {
+	public void testPerformanceOneResource() {
 		debug("testPerformanceOneResource");
 		long start;
 		long stop;


### PR DESCRIPTION
In this commit, the performance test from the Marker Test class in org.eclipse.core.tests.resources is reactivated because it can be run quickly and successfully. Contributes to #525