### PR TITLE
Add sanity checks to prevent DLL hijacking

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
@@ -18,10 +18,11 @@ import java.nio.file.FileSystems;
 import java.util.Set;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.provider.FileInfo;
-import org.eclipse.core.internal.filesystem.local.nio.*;
+import org.eclipse.core.internal.filesystem.local.nio.DefaultHandler;
+import org.eclipse.core.internal.filesystem.local.nio.DosHandler;
+import org.eclipse.core.internal.filesystem.local.nio.PosixHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileNatives;
-import org.eclipse.osgi.service.environment.Constants;
 
 /**
  * <p>Dispatches methods backed by native code to the appropriate platform specific
@@ -57,12 +58,11 @@ public class LocalFileNativesManager {
 	 */
 	public static boolean setUsingNative(boolean useNatives) {
 		boolean nativesAreUsed;
-		boolean isWindowsOS = Constants.OS_WIN32.equals(LocalFileSystem.getOS());
 
-		if (useNatives && !isWindowsOS && UnixFileNatives.isUsingNatives()) {
+		if (useNatives && UnixFileNatives.isUsingNatives()) {
 			HANDLER = new UnixFileHandler();
 			nativesAreUsed = true;
-		} else if (useNatives && isWindowsOS && LocalFileNatives.isUsingNatives()) {
+		} else if (useNatives && LocalFileNatives.isUsingNatives()) {
 			HANDLER = new LocalFileHandler();
 			nativesAreUsed = true;
 		} else {


### PR DESCRIPTION
Currently we only perform a soft check that a given OS is there and rely on failing to load a library, but this allows so called "DLL Hijack" attacs because the JVM search in several places if a library is not found.

This adds some more sanity check even before an attempt is made to load a library with the follwoing steps:

1) a suitable OS must be detected
2) a bundle with a well konw name has to be present in the system 3) the library is accessibly from the bundles classloader

Fix https://github.com/eclipse-platform/eclipse.platform/issues/168

FYI @vishnusarathashling @jonahgraham with this check I would assume the linked issue fixed, as `git.exe` is not searched by Eclipse Platform but by egi/jgit

@tjwatson I'm a bit curious as the bundles do not use any `Bundle-NativeCode` header in the bundle or in the fragment, is this a special extension of Equinox that it searches for `os/<name>/<library>` even if the header is not present? Should we probably migrate this code to using `Bundle-NativeCode` instead?

@jukzi @HannesWell I testes this under linux, could you check with windows that it works well under windows and early exit for the linux/mac checks?
@eclipse-platform/eclipse-platform-committers anyone with mac can verify the fix?