### PR TITLE
Reactivate tests in org.eclipse.debug.tests #525

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.internal.ui.model.elements.SerialExecutor;
 import org.eclipse.debug.tests.AbstractDebugTest;
-import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
@@ -118,7 +117,6 @@ public class SerialExecutorTest extends AbstractDebugTest {
 	}
 
 	@Test
-	@Ignore("See https://bugs.eclipse.org/bugs/show_bug.cgi?id=574883")
 	public void testHeavyScheduling() throws InterruptedException {
 		// Executor has to execute every task. Even when they are scheduled fast
 		// and execute fast

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
@@ -939,7 +939,8 @@ public class ConsoleDocumentAdapterTests extends AbstractDebugTest {
 	/**
 	 * Test if invalid arguments produces error log messages.
 	 */
-	public void _testInvalidInvocations() {
+	@Test
+	public void testInvalidInvocations() {
 		final AtomicInteger expectedErrors = new AtomicInteger(0);
 		final ILogListener logListener = new ILogListener() {
 			@Override


### PR DESCRIPTION
This change reactivates all working disabled tests from project org.eclipse.debug.tests. The tests were forgotten after the corresponding bug was fixed. Contributes to #525