### PR TITLE
Reactivate tests in org.eclipse.team.tests.core #525

### DIFF
--- a/team/tests/org.eclipse.team.tests.core/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.team.tests.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.tests.core; singleton:=true
-Bundle-Version: 3.10.100.qualifier
+Bundle-Version: 3.10.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.team.tests.core,

--- a/team/tests/org.eclipse.team.tests.core/pom.xml
+++ b/team/tests/org.eclipse.team.tests.core/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.team</groupId>
   <artifactId>org.eclipse.team.tests.core</artifactId>
-  <version>3.10.100-SNAPSHOT</version>
+  <version>3.10.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
@@ -107,12 +107,12 @@ public class ScopeTests extends TeamTest {
 		assertProperContainment(sm);
 	}
 
-//	public void testScopeContraction() throws OperationCanceledException, InterruptedException, CoreException {
-//		workingSet.setElements( new IProject[] { project1, project2 });
-//		ISynchronizationScopeManager sm = createScopeManager();
-//		assertProperContainment(sm);
-//		workingSet.setElements( new IProject[] { project1 });
-//		assertProperContainment(sm);
-//	}
+	public void testScopeContraction() throws OperationCanceledException, InterruptedException, CoreException {
+		workingSet.setElements( new IProject[] { project1, project2 });
+		ISynchronizationScopeManager sm = createScopeManager();
+		assertProperContainment(sm);
+		workingSet.setElements( new IProject[] { project1 });
+		assertProperContainment(sm);
+	}
 
 }


### PR DESCRIPTION
This change reactivates all working disabled tests from project org.eclipse.team.tests.core. Contributes to #525