### PR TITLE
Reactivate tests in org.eclipse.ua.tests #525

### DIFF
--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexEntryTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexEntryTest.java
@@ -287,8 +287,7 @@ public class IndexEntryTest {
 		checkCreatedEntry(entry);
 	}
 
-	/*
-	 * Disabled, see Bug 210024 [Help] Topic element problems constructing from an ITopic
+	@Test
 	public void testUserEntryChildEnablement() {
 		UserIndexEntry u1 = createUserEntry();
 		IndexEntry entry = new IndexEntry(u1);
@@ -296,7 +295,7 @@ public class IndexEntryTest {
 		assertTrue(entry.isEnabled(HelpEvaluationContext.getContext()));
 		checkEntryChildEnablement(entry);
 	}
-	*/
+
 	@Test
 	public void testCopyUserEntry() {
 		UserIndexEntry u1 = createUserEntry();

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/TocServiceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/TocServiceTest.java
@@ -42,8 +42,7 @@ public class TocServiceTest extends TocServletTest {
 		}
 	}
 
-	/*
-	 * Disabled, see Bug 339274
+	@Test
 	public void testTocServiceXMLSchema()
 			throws Exception {
 		int port = WebappManager.getPort();
@@ -55,7 +54,7 @@ public class TocServiceTest extends TocServletTest {
 
 		assertEquals("URL: \"" + uri + "\" is ", "valid", result);
 	}
-	*/
+
 	@Test
 	public void testTocServiceJSONSchema()
 			throws Exception {


### PR DESCRIPTION
This change reactivates all working disabled tests from project org.eclipse.ua.tests. Bug 210024 has status CLOSED WONTFIX but test still runs successfully. Bug 339274 has status RESOLVED FIXED. Contributes to #525