### PR TITLE
Disable the automatic snapshots for TestBug297635

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1464,6 +1464,22 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	}
 
 	/**
+	 * Tries to determine if the workspace has changes and calls
+	 * {@link #snapshotIfNeeded(boolean)}. If an exception occurs while trying to
+	 * determine whether or not the workspace has changes then the snapshot might be
+	 * taken anyway, the workspace will be simply assumed unchanged.
+	 */
+	private void snapshotIfNeeded() {
+		boolean workspaceHasTreeChanges = false;
+		try {
+			workspaceHasTreeChanges = workspace.hasTreeChanges();
+		} catch (CoreException e) {
+			Policy.log(e);
+		}
+		snapshotIfNeeded(workspaceHasTreeChanges);
+	}
+
+	/**
 	 * Performs a snapshot if one is deemed necessary.
 	 * Encapsulates rules for determining when a snapshot is needed.
 	 * This should be called at the end of every top level operation.
@@ -2204,5 +2220,14 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		output.writeLong(workspace.nextMarkerId.get());
 		// save the registered sync partners in the synchronizer
 		((Synchronizer) workspace.getSynchronizer()).savePartners(output);
+	}
+
+	public void suspendSnapshotJob() {
+		snapshotJob.suspend();
+	}
+
+	public void resumeSnapshotJob() {
+		snapshotJob.resume();
+		snapshotIfNeeded();
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -1578,11 +1578,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 				// build() and snapshot() should not fail if they are called.
 				workManager.rebalanceNestedOperations();
 
-				//find out if any operation has potentially modified the tree
-				hasTreeChanges = workManager.shouldBuild();
-				//double check if the tree has actually changed
-				if (hasTreeChanges)
-					hasTreeChanges = operationTree != null && ElementTree.hasChanges(tree, operationTree, ResourceComparator.getBuildComparator(), true);
+				hasTreeChanges = hasTreeChanges();
 				broadcastPostChange();
 				// Request a snapshot if we are sufficiently out of date.
 				saveManager.snapshotIfNeeded(hasTreeChanges);
@@ -1599,6 +1595,13 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 		}
 		if (depthOne)
 			buildManager.endTopLevel(hasTreeChanges);
+	}
+
+	boolean hasTreeChanges() throws CoreException {
+		return getWorkManager().shouldBuild() // find out if any operation has potentially modified the tree
+		//double check if the tree has actually changed
+				&& operationTree != null
+				&& ElementTree.hasChanges(tree, operationTree, ResourceComparator.getBuildComparator(), true);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug297635.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug297635.java
@@ -55,6 +55,22 @@ public class TestBug297635 extends ResourceTest implements ISaveParticipant {
 		return Platform.getBundle(PI_RESOURCES_TESTS).getBundleContext();
 	}
 
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		getSaveManager().suspendSnapshotJob();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		getSaveManager().resumeSnapshotJob();
+	}
+
+	private SaveManager getSaveManager() {
+		return ((Workspace) getWorkspace()).getSaveManager();
+	}
+
 	public void testBug() throws Exception {
 		installBundle();
 
@@ -136,11 +152,11 @@ public class TestBug297635 extends ResourceTest implements ISaveParticipant {
 		// there
 		Field field = SaveManager.class.getDeclaredField("savedStates");
 		field.setAccessible(true);
-		return (Map<String, SavedState>) field.get(((Workspace) getWorkspace()).getSaveManager());
+		return (Map<String, SavedState>) field.get(getSaveManager());
 	}
 
 	private void saveSnapshot() throws CoreException {
-		((Workspace) getWorkspace()).getSaveManager().save(ISaveContext.SNAPSHOT, true, null, getMonitor());
+		getSaveManager().save(ISaveContext.SNAPSHOT, true, null, getMonitor());
 	}
 
 	private void assertStateTrees(SavedState savedState, boolean isNull)


### PR DESCRIPTION
Automatic snapshots might cause `TestBug297635::testBug` to fail if the snapshot is taken right before `assertStateTreesIsNotNull`. The reason for this is that a by taking a snapshot, `org.eclipse.core.internal.resources.SaveManager.forgetSavedTree(String)` will be called and it will delete the state-trees.

This PR disables the automatic snapshots while running tests in TestBug297635 to avoid such random failures.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/460