### PR TITLE
Throw exception when build job is waiting and JobManager is suspended

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
@@ -19,22 +19,71 @@
  *******************************************************************************/
 package org.eclipse.core.internal.events;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.eclipse.core.internal.resources.*;
 import org.eclipse.core.internal.resources.ComputeProjectOrder.Digraph;
+import org.eclipse.core.internal.resources.ICoreConstants;
+import org.eclipse.core.internal.resources.IManager;
+import org.eclipse.core.internal.resources.Project;
+import org.eclipse.core.internal.resources.ProjectDescription;
+import org.eclipse.core.internal.resources.ResourceStatus;
+import org.eclipse.core.internal.resources.WorkManager;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.internal.watson.ElementTree;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IBuildContext;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IIncrementalProjectBuilder2;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.ISafeRunnable;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.runtime.SafeRunner;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.ILock;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobGroup;
+import org.eclipse.core.runtime.jobs.MultiRule;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.Bundle;
 
 public class BuildManager implements ICoreConstants, IManager, ILifecycleListener {
+
+	public static class JobManagerSuspendedException extends RuntimeException {
+		private static final long serialVersionUID = 330426099787223028L;
+
+		public JobManagerSuspendedException(String message) {
+			super(message);
+		}
+	}
 
 	private static final String BUILDER_INIT = "BuilderInitInfo"; //$NON-NLS-1$
 
@@ -750,12 +799,19 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 	}
 
 	private static void waitFor(Job job) {
+		IJobManager jobManager = Job.getJobManager();
+
 		// Need to loop because jobs can reschedule itself and concurrent running
 		// background jobs change the states too
-		while (!(job.getState() == Job.NONE)) {
+		while (job.getState() != Job.NONE) {
 			// Need to wake up thread to finish as soon as possible:
-			while (!(job.getState() == Job.RUNNING || job.getState() == Job.NONE)) {
-				Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
+			while (job.getState() != Job.RUNNING && job.getState() != Job.NONE) {
+				if (jobManager.isSuspended())
+					throw new JobManagerSuspendedException("The JobManager is suspended, waiting for " //$NON-NLS-1$
+							+ "a job to finish will just block this thread forever. Activate the JobManager again before waiting " //$NON-NLS-1$
+							+ "for a job to finish"); //$NON-NLS-1$
+
+				jobManager.wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
 				Thread.yield();
 				// After wakeup the woken job may go into sleep again when asynchronous
 				// workspace save interrupts autobuild so we need to wait till RUNNING or NONE
@@ -763,7 +819,7 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 			}
 			// Need to wait till job finished:
 			try {
-				Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+				jobManager.join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
 			} catch (OperationCanceledException | InterruptedException e) {
 				// Ignore
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -13,16 +13,32 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.core.internal.events.BuildManager;
+import org.eclipse.core.internal.events.BuildManager.JobManagerSuspendedException;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Policy;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.IJobChangeListener;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.tests.internal.builders.TestBuilder.BuilderRuleCallback;
+import org.junit.Test;
 
 /**
  * Test for various AutoBuildJob scheduling use cases
@@ -82,8 +98,11 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 	private void requestAutoBuildJobExecution() {
 		// Simulates autobuild job triggering from build thread
 		// basically same as autoBuildJob.build(true);
-		BuildManager buildManager = ((Workspace) project.getWorkspace()).getBuildManager();
-		buildManager.endTopLevel(true);
+		getBuildManager().endTopLevel(true);
+	}
+
+	private BuildManager getBuildManager() {
+		return ((Workspace) project.getWorkspace()).getBuildManager();
 	}
 
 	public void testNoBuildIfBuildRequestedFromSameThread() throws Exception {
@@ -109,10 +128,7 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 			}
 		});
 
-		// triggers autobuild
-		project.touch(getMonitor());
-
-		Thread.sleep(Policy.MAX_BUILD_DELAY);
+		triggerAutoBuildAndWait();
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
 		assertEquals("Should see one scheduled() call", 1, scheduled.get());
 		assertEquals("Should see one running() call", 1, running.get());
@@ -139,11 +155,81 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 			}
 		});
 
-		// triggers autobuild
-		project.touch(getMonitor());
-		Thread.sleep(Policy.MAX_BUILD_DELAY);
+		triggerAutoBuildAndWait();
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
 		assertEquals("Should see two scheduled() calls", 2, scheduled.get());
 		assertEquals("Should see two running() calls", 2, running.get());
 	}
+
+	@Test
+	public void testWaitForAutoBuild_JobManagerIsSuspended_ExceptionIsThrown()
+			throws InterruptedException, CoreException, ExecutionException {
+		Job.getJobManager().suspend();
+
+		assertEquals("Scheduled calls", 0, scheduled.get());
+		assertEquals("Running calls", 0, running.get());
+
+		triggerAutoBuildAndWait();
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+
+		assertEquals("Scheduled calls", 1, scheduled.get());
+		assertEquals("Running calls", 0, running.get());
+
+		assertThrows(JobManagerSuspendedException.class, () -> waitForAutoBuild(2_000));
+
+		Job.getJobManager().resume();
+	}
+
+	@Test
+	public void testWaitForAutoBuild_JobManagerIsRunning_NoExceptionIsThrown()
+			throws Throwable {
+		assertEquals("Scheduled calls", 0, scheduled.get());
+		assertEquals("Running calls", 0, running.get());
+
+		triggerAutoBuildAndWait();
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+
+		assertEquals("Scheduled calls", 1, scheduled.get());
+		assertEquals("Running calls", 1, running.get());
+
+		waitForAutoBuild(2_000);
+	}
+
+	/**
+	 * Trigger an auto-build and wait for it to start.
+	 *
+	 * @throws CoreException
+	 * @throws InterruptedException
+	 */
+	private void triggerAutoBuildAndWait() throws CoreException, InterruptedException {
+		project.touch(getMonitor());
+		Thread.sleep(Policy.MAX_BUILD_DELAY);
+	}
+
+	/**
+	 * Wait for an auto-build operation to finish.
+	 *
+	 * @param timeoutMillis
+	 *            after this timeout, a <code>TimeoutException</code> will be
+	 *            thrown.
+	 * @return the exception thrown by {@linkplain BuildManager#waitForAutoBuild()},
+	 *         it can be <code>null</code>.
+	 * @throws InterruptedException
+	 *             if the thread waiting for the auto-build is interrupted.
+	 */
+	private void waitForAutoBuild(long timeoutMillis) throws Throwable {
+		try {
+			ForkJoinPool.commonPool()//
+					.submit(() -> getBuildManager().waitForAutoBuild())//
+					.get(timeoutMillis, TimeUnit.MILLISECONDS);
+		} catch (ExecutionException e) {
+			// Since the wait is happening in a Future, the original exception is packed
+			// inside the ExecutionException
+			throw e.getCause();
+		} catch (TimeoutException e) {
+			fail("This test timed out which means there is no safeguard to avoid waiting indefinitely "
+					+ "for an auto-build job while the JobManager is suspended", e);
+		}
+	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -1127,6 +1127,7 @@ public abstract class ResourceTest extends CoreTest {
 
 	@Override
 	protected void tearDown() throws Exception {
+		boolean wasSuspended = resumeJobManagerIfNecessary();
 		Platform.removeLogListener(errorLogListener);
 		TestUtil.log(IStatus.INFO, getName(), "tearDown");
 		// Ensure everything is in a clean state for next one.
@@ -1135,6 +1136,17 @@ public abstract class ResourceTest extends CoreTest {
 		cleanup();
 		super.tearDown();
 		FreezeMonitor.done();
+		assertFalse("This test stopped the JobManager, which could have affected other tests.", //
+				wasSuspended);
+	}
+
+	private boolean resumeJobManagerIfNecessary() {
+		if (Job.getJobManager().isSuspended()) {
+			Job.getJobManager().resume();
+			return true;
+		}
+
+		return false;
 	}
 
 	protected void assertNoErrorsLogged() {


### PR DESCRIPTION
If a test suspends the `JobManager` and then waits for the build job to finish then a deadlock occurs. The reason for this is that waiting for a build job while the `JobManager` is not running is an endless wait since `JobManager.waitFor` keeps yielding the execution while the build job is in the `WAITING` state and since the `JobManager` is suspended, the job will never be scheduled.

This PR solves this problem by doing 2 things:
1. It restores the original state of the `JobManager` in the `ResourceTest::tearDown` in case a test suspends it and forgets to resume it. I did this since the original default state of the `JobManager` is `suspended == false` (i.e. "running") which means that restoring the original state would in most cases mean "enable it again" and ergo avoid the deadlock.
2. It throws an `Exception` in case the `JobManager` is suspended and some test wants to wait for a build job that will never end. This is for the (hopefully seldom) case where the fallback described in 1. did not solve the problem. If this happens then probably some other test suspended the `JobManager` and is affecting this test (isolation problem).

I also added 2 tests.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/626

## How to reproduce the error (before this PR)
Create and run this class. It will hang in the `main` thread:

```java
public class HangTest extends ResourceTest {

	@Test
	public void testHang() throws Exception {
		Job.getJobManager().suspend();
	}
}
```