### PR TITLE
CharsetDeltaJob: cancel job on shutdown - fixes #355

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
@@ -236,6 +236,14 @@ public class CharsetDeltaJob extends Job implements IContentTypeManager.IContent
 	}
 
 	public void shutdown() {
+		try {
+			// try to prevent execution of this job to avoid prevent "already shutdown.":
+			cancel();
+			// if job is already running wait for it to finish:
+			join();
+		} catch (InterruptedException e) {
+			// ignore
+		}
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		//if the service is already gone there is nothing to do
 		if (contentTypeManager != null)


### PR DESCRIPTION
fixes "Workspace was not properly initialized or has already shutdown." 
https://github.com/eclipse-platform/eclipse.platform/issues/355