### PR TITLE
Revert "Reactivate tests in org.eclipse.core.tests.net #525"

### DIFF
--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
@@ -276,14 +276,10 @@ public class NetTest {
 		assertProxyDataEqual(data);
 	}
 
-	// This comment is for informational purposes in case the test will fail again
-	// once the bundle can be executed by Tycho:
-	// The test once failed due to Bug 403311. The Bug got probably fixed so this
-	// test was reactivated. Mind that the test is not executed in CI builds, as the whole
-	// test bundle is deactivated during Maven builds. The tests runs fine when
-	// started from every system.
 	@Test
-	public void testSimpleHost() throws CoreException {
+	@Ignore("Disabled due to bug 403311")
+	public void _testSimpleHost() throws CoreException {
+
 		setDataTest(IProxyData.HTTP_PROXY_TYPE);
 		setDataTest(IProxyData.HTTPS_PROXY_TYPE);
 		setDataTest(IProxyData.SOCKS_PROXY_TYPE);


### PR DESCRIPTION
Reactivated test fails in CI builds and is thus deactivated again. This reverts commit 3ff60eb2634fc8df1496f86dab11bdc24741708e.