### PR TITLE
Use proper (native OS) encoding for file names

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,11 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.10.100.qualifier
+Bundle-Version: 1.10.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.osgi;bundle-version="[3.2.0,4.0.0)"
+ org.eclipse.osgi;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Export-Package: org.eclipse.core.filesystem,
  org.eclipse.core.filesystem.provider,
  org.eclipse.core.internal.filesystem;x-internal:=true,

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Convert.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Convert.java
@@ -15,12 +15,13 @@
 package org.eclipse.core.internal.filesystem.local;
 
 import java.io.UnsupportedEncodingException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.service.environment.Constants;
 
 public class Convert {
 
-	/** Indicates the default string encoding on this platform */
-	private static String defaultEncoding = new java.io.InputStreamReader(new java.io.ByteArrayInputStream(new byte[0])).getEncoding();
+	/** Indicates the default native encoding on this platform */
+	private static String defaultEncoding = Platform.getSystemCharset().name();
 
 	/** Indicates if we are running on windows */
 	private static final boolean isWindows = Constants.OS_WIN32.equals(LocalFileSystem.getOS());


### PR DESCRIPTION
See related commit 2a98c94825b83cfa9f3294ece815dfe34c7e6e2d.

With the recent Java changes motivated by
https://openjdk.java.net/jeps/400 native system encoding can't be derived from Java default API's anymore, that use UTF-8 by default.

In order to properly encode file names we have to use org.eclipse.core.runtime.Platform.getSystemCharset() API.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/642