### PR TITLE
fix Console Scroll Lock is disabled with key "End" without CTRL #648

### DIFF
--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -293,9 +293,9 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 					setScrollLock(true);
 				} else if ((e.keyCode == SWT.PAGE_UP || e.keyCode == SWT.ARROW_UP) && !checkStartOfDocument()) {
 					setScrollLock(true);
-				} else if (e.keyCode == SWT.END || e.keyCode == SWT.BOTTOM) {
-					setScrollLock(false);// selecting END makes it reveal the
-					// end
+				} else if ((e.keyCode == SWT.END && (e.stateMask & SWT.CTRL) != 0) || e.keyCode == SWT.BOTTOM) {
+					// pressing CTRL+END reveals the end
+					setScrollLock(false);
 				} else if ((e.keyCode == SWT.PAGE_DOWN || e.keyCode == SWT.ARROW_DOWN) && checkEndOfDocument()) {
 					// unlock if Down at the end of document
 					setScrollLock(false);

--- a/runtime/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/runtime/features/org.eclipse.core.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.core.runtime.feature"
       label="%featureName"
-      version="1.4.100.qualifier"
+      version="1.4.200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
only ctrl+end should disable Scroll Lock

https://github.com/eclipse-platform/eclipse.platform/issues/648