### PR TITLE
Improve error message and fail behavior of ParallelBuildChainTest #657

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.30.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.200-SNAPSHOT</version>
+  <version>3.11.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -51,7 +51,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 
 	private static final int MAXIMUM_NUMBER_OF_CONCURRENT_BUILDS = 3;
 
-	private static final int TIMEOUT_IN_MILLIS = 60_000;
+	private static final int TIMEOUT_IN_MILLIS = 20_000;
 
 	private static enum BuildDurationType {
 		/*

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TimerBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TimerBuilder.java
@@ -36,6 +36,8 @@ public class TimerBuilder extends IncrementalProjectBuilder {
 	public static final String DURATION_ARG = "duration";
 	public static final String RULE_TYPE_ARG = "ruleType";
 
+	private static final int SHUTDOWN_TIMEOUT_IN_MILLIS = 60_000;
+
 	private static BuildExecutionState executionState = new BuildExecutionState(-1);
 
 	private static class BuildExecutionState {
@@ -72,11 +74,14 @@ public class TimerBuilder extends IncrementalProjectBuilder {
 
 		private synchronized void abortAndWaitForAllBuilds() {
 			shallAbort = true;
-			while (isExecuting()) {
+			long durationInMillis = 0;
+			long waitingStartTimeInMillis = System.currentTimeMillis();
+			while (isExecuting() && durationInMillis < SHUTDOWN_TIMEOUT_IN_MILLIS) {
 				try {
-					wait();
+					wait(SHUTDOWN_TIMEOUT_IN_MILLIS);
 				} catch (InterruptedException e) {
 				}
+				durationInMillis = System.currentTimeMillis() - waitingStartTimeInMillis;
 			}
 		}
 


### PR DESCRIPTION
The `ParallelBuildChainTest` has some flaws in error message design and failure handling, which are addressed by this change:
1. The timeout for builds to start/finish is higher than the execution time of a long running build. Thus in case builds are unexpectedly not run in parallel, the assertion for timely build start/finish is not evaluated as expected.
2. In case an error occurs before starting a build operation, the number of expected builds in the TimerBuilder may be higher than the number of builds that will every be executed. Since the TimerBuilder abortion tries to wait for all expected builds indefinitely, the operation (and thus test tear down) may never terminate.