### PR TITLE
Fix race condition in ThreadJob.waitForRun #659

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -142,6 +142,17 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 	}
 
 	@Test
+	public void testIndividualProjectBuilds_WithManyProjects_ProjectRelaxedRule() throws Exception {
+		int numberOfParallelBuilds = 60;
+		var longRunningProjects = createMultipleTestProjects(numberOfParallelBuilds, BuildDurationType.LONG_RUNNING,
+				RuleType.CURRENT_PROJECT_RELAXED);
+		executeIndividualFullProjectBuilds(numberOfParallelBuilds, () -> {
+			assertBuildsToStart(getAllProjects());
+			assertMinimumNumberOfSimultaneousBuilds(longRunningProjects.size());
+		});
+	}
+
+	@Test
 	public void testWorkspaceBuild_NoConflictRule() throws Exception {
 		int numberOfParallelBuilds = 3;
 		setWorkspaceMaxNumberOfConcurrentBuilds(numberOfParallelBuilds);


### PR DESCRIPTION
`ThreadJob.waitForRun()` suffers from a race condition. Between checking for a blocking job with a conflicting scheduling rule and starting to wait on the state lock of that blocking job to get notified when the scheduling rule is released, the blocking job may have already changed its state and acquired a different scheduling rule, such that no conflict exists anymore. Since this condition is not reevaluated but waiting on the lock object is started without a timeout, the blocked job unnecessarily waits for the initially blocking job to change its state again, i.e., to finish its execution.

One relevant situation in which the scheduling rule of a job can change is if the job is an internally used `ThreadJob`. They are started whenever a rule is acquired on the `JobManager` and are reused for the same thread. When the same thread acquires multiple rules, one after another, the rule of the `ThreadJob` may effectively change. This, for example, happens during a workspace build operation, which changes the rule for two times. Thus, if the blocking job in `ThreadJob.waitForRun()` is a
`ThreadJob`, it may change its rule, in particular when that job performs a build operation.

With this change, the scheduling rules of blocking and blocked thread are checked for conflicts again before starting to wait on the state lock in the blocked job. This leads to a reevaluation of the block condition in case the scheduling rule of the blocking job has changed in between and avoids the job to unnecessarily block until the blocking job finishes.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/659.