### PR TITLE
Don't replace the monitor set by a group when starting a new job

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.jobs; singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.jobs;x-internal:=true,

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -554,15 +554,12 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 
 	/**
 	 * Returns a new progress monitor for this job.  Never returns null.
-	 * @GuardedBy("lock")
 	 */
 	private IProgressMonitor createMonitor(Job job) {
-		IProgressMonitor monitor = null;
-		if (progressProvider != null)
-			monitor = progressProvider.createMonitor(job);
-		if (monitor == null)
-			monitor = new NullProgressMonitor();
-		return monitor;
+		if (progressProvider != null) {
+			return progressProvider.createMonitor(job);
+		}
+		return new NullProgressMonitor();
 	}
 
 	@Override
@@ -1785,7 +1782,10 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 				synchronized (internal.jobStateLock) {
 					if (internal.internalGetState() == InternalJob.ABOUT_TO_RUN) {
 						if (shouldReallyRun && !internal.isAboutToRunCanceled()) {
-							internal.setProgressMonitor(createMonitor(j));
+							// only set the monitor if it wasn't already set.
+							if (internal.getProgressMonitor() == null) {
+								internal.setProgressMonitor(createMonitor(j));
+							}
 							//change from ABOUT_TO_RUN to RUNNING
 							internal.setThread(worker);
 							internal.internalSetState(Job.RUNNING);


### PR DESCRIPTION
* Only set the progress monitor of the Job if it hasn't one already. This makes sure that the progress monitor set via `Job::setProgressGroup` is not replaced with a new one and ergo when the group is canceled, all the monitors in that group are canceled too.

* Add regression test: `JobTest.testSetProgressGroup_progressGroupIsCanceled_monitorInJobIsCanceled()`

* Simplify private method `JobManager::createMonitor(Job)` and remove the annotation `@GuardedBy` in it. 

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/664