### PR TITLE
Fix test in org.eclipse.compare.tests #525

### DIFF
--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.tests;singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Require-Bundle: org.junit,
  org.eclipse.compare,
  org.eclipse.jface.text,

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
@@ -61,9 +61,8 @@ public class FilterTest {
 
 	@Test
 	public void testVerify() {
-		// Assert.assertNull("filters don't verify",
-		// Filter.validateResourceFilters("*.class, .cvsignore, bin/"));
-		// Assert.assertNotNull("filters shouldn't verify",
-		// Filter.validateResourceFilters("bin//"));
+		Assert.assertNull("filters don't verify",
+				CompareResourceFilter.validateResourceFilters("*.class, .cvsignore, bin/"));
+		Assert.assertNotNull("filters shouldn't verify", CompareResourceFilter.validateResourceFilters("bin//"));
 	}
 }


### PR DESCRIPTION
This commit reactivates and fixes the test testVerify() from FilterTest.java in org.eclipse.compare.tests. The test was outcommented in the past probably because Filter.validateResourceFilters(String) could not be performed anymore. Now validateResourceFilters(String) is performed on CompareResourceFilter. Contributes to #525.