### PR TITLE
Add VirtualViewerCheckTests for automated execution of JFace CheckTests

### DIFF
--- a/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.tests;singleton:=true
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.14.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AutomatedSuite.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -50,6 +50,7 @@ import org.eclipse.debug.tests.view.memory.TableRenderingTests;
 import org.eclipse.debug.tests.viewer.model.ChildrenUpdateTests;
 import org.eclipse.debug.tests.viewer.model.FilterTransformTests;
 import org.eclipse.debug.tests.viewer.model.PresentationContextTests;
+import org.eclipse.debug.tests.viewer.model.VirtualViewerCheckTests;
 import org.eclipse.debug.tests.viewer.model.VirtualViewerContentTests;
 import org.eclipse.debug.tests.viewer.model.VirtualViewerDeltaTests;
 import org.eclipse.debug.tests.viewer.model.VirtualViewerFilterTests;
@@ -78,6 +79,7 @@ import org.junit.runners.Suite;
 		// (Bug 343308).
 
 		// Virtual viewer tests
+		VirtualViewerCheckTests.class,
 		VirtualViewerDeltaTests.class,
 		VirtualViewerContentTests.class,
 		VirtualViewerLazyModeTests.class,

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/VirtualViewerCheckTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/VirtualViewerCheckTests.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.debug.tests.viewer.model;
+
+import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
+import org.eclipse.debug.internal.ui.viewers.model.provisional.PresentationContext;
+import org.eclipse.debug.internal.ui.viewers.model.provisional.VirtualTreeModelViewer;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * @since 3.14
+ */
+public class VirtualViewerCheckTests extends CheckTests {
+	@Override
+	protected IInternalTreeModelViewer createViewer(Display display, Shell shell) {
+		return new VirtualTreeModelViewer(fDisplay, 0, new PresentationContext("TestViewer")); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
Tests using JFace viewers have been replaced by tests on a mock viewer implementation for execution in automated builds. The CheckTests class, however, only has an implementation for a JFace viewer to be executed locally, but no implementation for a mock viewer to be executed in automated builds.

This change adds an according test class and adds it to the test suite for automated builds.

This also serves as a means to enable automated testing of changes proposed in #681.