### PR TITLE
Use equinox preferences APIs in RefreshManager class #497

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/properties/PropertyManager2.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/properties/PropertyManager2.java
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
  *     Mickael Istria (Red Hat Inc.) - Bug 488937
+ *     Latha Patil (ETAS GmbH) - GitHub Issue 468
  *******************************************************************************/
 package org.eclipse.core.internal.properties;
 
@@ -23,6 +24,7 @@ import org.eclipse.core.internal.localstore.BucketTree;
 import org.eclipse.core.internal.properties.PropertyBucket.PropertyEntry;
 import org.eclipse.core.internal.resources.*;
 import org.eclipse.core.internal.utils.Messages;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.runtime.*;
@@ -119,7 +121,8 @@ public class PropertyManager2 implements IPropertyManager {
 
 	@Override
 	public void deleteResource(IResource target) throws CoreException {
-		deleteProperties(target, IResource.DEPTH_INFINITE);
+		deleteProperties(target, ((target instanceof IFile) && (null != target.getProject())) ? IResource.DEPTH_ZERO
+				: IResource.DEPTH_INFINITE);
 	}
 
 	@Override

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/refresh/RefreshManager.java
@@ -12,9 +12,11 @@
  *     IBM - Initial API and implementation
  *     Christoph Läubrich 	- Issue #84 - RefreshManager access ResourcesPlugin.getWorkspace in the init phase
  *     						- Issue #97 - RefreshManager.manageAutoRefresh calls ResourcesPlugin.getWorkspace before the Workspace is fully open
+ *     Latha Patil(ETAS GmbH)	- GitHub Issue #497- Get rid of deprecated org.eclipse.core.runtime.Preferences in platform code
  *******************************************************************************/
 package org.eclipse.core.internal.refresh;
 
+import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.internal.resources.IManager;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
@@ -23,7 +25,9 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.refresh.IRefreshMonitor;
 import org.eclipse.core.resources.refresh.IRefreshResult;
 import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.Preferences.PropertyChangeEvent;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 
 /**
  * Manages auto-refresh functionality, including maintaining the active
@@ -32,7 +36,7 @@ import org.eclipse.core.runtime.Preferences.PropertyChangeEvent;
  *
  * @since 3.0
  */
-public class RefreshManager implements IRefreshResult, IManager, Preferences.IPropertyChangeListener {
+public class RefreshManager implements IRefreshResult, IManager, EclipsePreferences.IPreferenceChangeListener {
 	public static final String DEBUG_PREFIX = "Auto-refresh: "; //$NON-NLS-1$
 	volatile MonitorManager monitors;
 	private volatile RefreshJob refreshJob;
@@ -75,16 +79,15 @@ public class RefreshManager implements IRefreshResult, IManager, Preferences.IPr
 	}
 
 	/**
-	 * Checks for changes to the PREF_AUTO_UPDATE property.
-	 * @see org.eclipse.core.runtime.Preferences.IPropertyChangeListener#propertyChange(Preferences.PropertyChangeEvent)
+	 * Checks for changes to the PREF_AUTO_REFRESH property.
+	 * @see org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener#preferenceChange(IEclipsePreferences.PreferenceChangeEvent)
 	 */
-	@Deprecated
 	@Override
-	public void propertyChange(PropertyChangeEvent event) {
-		String property = event.getProperty();
+	public void preferenceChange(PreferenceChangeEvent event) {
+		String property = event.getKey();
 		if (ResourcesPlugin.PREF_AUTO_REFRESH.equals(property)) {
-			Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
-			final boolean autoRefresh = preferences.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH);
+			final boolean autoRefresh = Platform.getPreferencesService().getBoolean(ResourcesPlugin.PI_RESOURCES,
+					ResourcesPlugin.PREF_AUTO_REFRESH, false, null);
 			String jobName = autoRefresh ? Messages.refresh_installMonitorsOnWorkspace : Messages.refresh_uninstallMonitorsOnWorkspace;
 			MonitorJob.createSystem(jobName, getWorkspace().getRoot(),
 					(ICoreRunnable) monitor -> manageAutoRefresh(autoRefresh, monitor)).schedule();
@@ -109,7 +112,7 @@ public class RefreshManager implements IRefreshResult, IManager, Preferences.IPr
 			// do nothing if we have already shutdown
 			return;
 		}
-		ResourcesPlugin.getPlugin().getPluginPreferences().removePropertyChangeListener(this);
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).removePreferenceChangeListener(this);
 		if (monitors != null) {
 			monitors.stop();
 			monitors = null;
@@ -129,9 +132,9 @@ public class RefreshManager implements IRefreshResult, IManager, Preferences.IPr
 		refreshJob = new RefreshJob(workspace);
 		monitors = new MonitorManager(workspace, this);
 
-		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
-		preferences.addPropertyChangeListener(this);
-		boolean autoRefresh = preferences.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH);
+		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).addPreferenceChangeListener(this);
+		boolean autoRefresh = Platform.getPreferencesService().getBoolean(ResourcesPlugin.PI_RESOURCES,
+				ResourcesPlugin.PREF_AUTO_REFRESH, false, null);
 		if (autoRefresh) {
 			SubMonitor subMonitor = SubMonitor.convert(monitor, 1);
 			manageAutoRefresh(autoRefresh, subMonitor.split(1));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Latha Patil (ETAS GmbH) - GitHub Issue 468
  *******************************************************************************/
 package org.eclipse.core.tests.internal.properties;
 
@@ -17,6 +18,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ PropertyManagerTest.class })
+@Suite.SuiteClasses({ PropertyManagerTest.class, Bug468PerformanceTest.class })
 public class AllPropertiesTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) ETAS GmbH 2023, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.properties;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import junit.framework.TestCase;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.QualifiedName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+//Test case for GitHub Issue 468
+public class Bug468PerformanceTest extends TestCase {
+
+	private static final String TO_BE_DELETED_FILE_NAME_PREFIX = "file_";
+
+	private static final String TEMP_FOLDER_NAME = "temp";
+
+	private IProject project;
+
+	/**
+	 * Creates project with below folder and file structure.
+	 * <ol>
+	 * <li>Project contains 1 single temp folder.</li>
+	 * <li>'temp' folder contains 10 folders and 6000 files as direct children.</li>
+	 * <li>each folder under 'temp' contains 10 folders (called as GrandChildren)
+	 * and a single file.</li>
+	 * <li>each GrandChildren, inturn contains another 10 folders (3rd level folder)
+	 * and a single file.</li>
+	 * <li>each 3rd level folder contains a single file.
+	 * <li>
+	 * </ol>
+	 * A dummy property is created for all the files to ensure that the folder
+	 * structure are created in the workspace .metadata area.
+	 *
+	 * @throws Exception
+	 *             If anything goes wrong during the set up.
+	 */
+	@Override
+	@Before
+	protected void setUp() throws Exception {
+
+		super.setUp();
+		ResourcesPlugin.getWorkspace().run((ICoreRunnable) monitor -> {
+			createTestProject();
+			List<IFolder> childFolders = new ArrayList<>();
+			List<IFolder> grandChildFolders = new ArrayList<>();
+			IFolder tempFolder = Bug468PerformanceTest.this.project.getFolder(TEMP_FOLDER_NAME);
+			tempFolder.create(true, true, new NullProgressMonitor());
+			// 'temp' folder contains 10 folder and 6000 files as direct children.
+			for (int fileIndex = 0; fileIndex < 6000; fileIndex++) {
+				createFile(tempFolder, TO_BE_DELETED_FILE_NAME_PREFIX + fileIndex);
+			}
+			for (int childIndex = 0; childIndex < 10; childIndex++) {
+				IFolder childFolder = createFolder(tempFolder, "temp_child_" + childIndex);
+				// each child contains 10 folders and a single file.
+				createTempFile(childFolder);
+				childFolders.add(childFolder);
+			}
+			for (int grandChildIndex = 0; grandChildIndex < 10; grandChildIndex++) {
+				IFolder grandChildFolder = createFolder(childFolders.get(grandChildIndex),
+						"temp_grandChild_" + grandChildIndex);
+				// each GrandChildren, intern contains another 10 folders and a single file.
+				createTempFile(grandChildFolder);
+				grandChildFolders.add(grandChildFolder);
+
+			}
+			for (int thirdLevelIndex = 0; thirdLevelIndex < 10; thirdLevelIndex++) {
+				IFolder thirdLvLChildFolder = createFolder(grandChildFolders.get(thirdLevelIndex),
+						"temp_3rdLvlChild_" + thirdLevelIndex);
+				// each 3rd level folder contains a single file.
+				createTempFile(thirdLvLChildFolder);
+			}
+		}, this.project, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+	}
+
+	private void createTestProject() throws CoreException {
+		Bug468PerformanceTest.this.project = ResourcesPlugin.getWorkspace().getRoot()
+				.getProject(getName() + "_TestProject");
+		Bug468PerformanceTest.this.project.create(new NullProgressMonitor());
+		Bug468PerformanceTest.this.project.open(new NullProgressMonitor());
+	}
+
+	private IFolder createFolder(final IFolder parent, final String folderName) throws CoreException {
+		IFolder childFolder = parent.getFolder(folderName);
+		childFolder.create(true, true, new NullProgressMonitor());
+		return childFolder;
+	}
+
+	private IFile createFile(final IFolder parent, final String fileName) throws CoreException {
+		IFile file = parent.getFile(fileName);
+		InputStream source = new ByteArrayInputStream(file.getName().getBytes());
+		file.create(source, true, new NullProgressMonitor());
+		file.setPersistentProperty(new QualifiedName(this.getClass().getName(), file.getName()), file.getName());
+		return file;
+	}
+
+	private IFile createTempFile(final IFolder parent) throws CoreException {
+		return createFile(parent, "tempFile");
+	}
+
+	/**
+	 * Deletes the project
+	 *
+	 * @throws Exception
+	 *             if any exception happens during the deleting of the project.
+	 */
+	@Override
+	@After
+	protected void tearDown() throws Exception {
+		this.project.delete(true, new NullProgressMonitor());
+		super.tearDown();
+	}
+
+	/*
+	 * Test the timings for file deletion
+	 */
+	// For 3 tries, the time was around 18000 ms to 25000 ms in windows 10 machine,
+	// so, set a limit of 1 minute.
+	@Test
+	public void test() throws CoreException {
+		IFolder tempFolder = this.project.getFolder(TEMP_FOLDER_NAME);
+		long[] timeTakenForDeletingFiles = new long[1];
+
+		ResourcesPlugin.getWorkspace().run((ICoreRunnable) monitor -> {
+			long startTime = System.currentTimeMillis();
+
+			for (int fileIndex = 0; fileIndex < 6000; fileIndex++) {
+				IFile fileToBeDeleted = tempFolder.getFile(TO_BE_DELETED_FILE_NAME_PREFIX + fileIndex);
+				fileToBeDeleted.delete(true, new NullProgressMonitor());
+			}
+
+			long endTime = System.currentTimeMillis();
+			timeTakenForDeletingFiles[0] = endTime - startTime;
+		}, this.project, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+
+		long maxTime = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
+		assertTrue("The expected min time(ms): " + 0 + ", actual time(ms): " + timeTakenForDeletingFiles[0],
+				0 <= timeTakenForDeletingFiles[0]);
+		assertTrue("The expected max time(ms): " + maxTime + ", actual time(ms): " + timeTakenForDeletingFiles[0],
+				timeTakenForDeletingFiles[0] <= maxTime);
+	}
+}


### PR DESCRIPTION
Replacing deprecated Preferences API usage with modern Equinox
Preferences API.

Partially fixes https://github.com/eclipse-platform/eclipse.platform/issues/497