### PR TITLE
Support jakarta.inject / jakarta.annotation in E4 as an alternative

### DIFF
--- a/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui.launchview;singleton:=true
-Bundle-Version: 1.1.200.qualifier
+Bundle-Version: 1.1.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.di,
  org.eclipse.e4.ui.services
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation;version="[1.0.0,2.0.0)",
- javax.inject;version="[1.0.0,2.0.0)"
+Import-Package: jakarta.annotation;version="[2.0.0,3.0.0)",
+ jakarta.inject;version="[2.0.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/org.eclipse.debug.ui.launchview.internal.model.LaunchViewModel.xml,
  OSGI-INF/org.eclipse.debug.ui.launchview.internal.impl.DebugCoreProvider.xml

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
@@ -23,10 +23,6 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -60,6 +56,10 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.dialogs.FilteredTree;
 import org.eclipse.ui.dialogs.PatternFilter;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 
 public class LaunchViewImpl implements Supplier<Set<ILaunchObject>> {
 

--- a/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -1,14 +1,15 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.core.contexts
-Bundle-Version: 1.12.300.qualifier
+Bundle-Version: 1.12.400.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.e4.core.di
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.inject;version="[1.0.0,2.0.0)",
+Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  org.osgi.framework;version="[1.5.0,2.0.0)",
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Export-Package: org.eclipse.e4.core.contexts;version="1.7.0",

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/Active.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/Active.java
@@ -18,18 +18,18 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Inject;
-import javax.inject.Qualifier;
 
 /**
- * This annotation can be added to injectable fields ands methods
- * to indicate that the injected value should come from the active context.
+ * This annotation can be added to injectable fields ands methods to indicate
+ * that the injected value should come from the active context.
  *
- * @see Inject
+ * @see javax.inject.Inject
+ * @see jakarta.inject.Inject
  * @see IEclipseContext#activate
  * @since 1.3
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/ContextInjectionFactory.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/ContextInjectionFactory.java
@@ -14,9 +14,9 @@
  *******************************************************************************/
 package org.eclipse.e4.core.contexts;
 
+import jakarta.inject.Scope;
+import jakarta.inject.Singleton;
 import java.lang.annotation.Annotation;
-import javax.inject.Scope;
-import javax.inject.Singleton;
 import org.eclipse.e4.core.di.IInjector;
 import org.eclipse.e4.core.di.InjectionException;
 import org.eclipse.e4.core.di.InjectorFactory;

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/ContextObjectSupplier.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/ContextObjectSupplier.java
@@ -19,7 +19,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.Stack;
-import javax.inject.Named;
 import org.eclipse.e4.core.contexts.Active;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.contexts.RunAndTrack;
@@ -189,8 +188,12 @@ public class ContextObjectSupplier extends PrimaryObjectSupplier {
 	}
 
 	private String getKey(IObjectDescriptor descriptor) {
-		if (descriptor.hasQualifier(Named.class)) {
-			Named namedAnnotation = descriptor.getQualifier(Named.class);
+		if (descriptor.hasQualifier(javax.inject.Named.class)) {
+			javax.inject.Named namedAnnotation = descriptor.getQualifier(javax.inject.Named.class);
+			return namedAnnotation.value();
+		}
+		if (descriptor.hasQualifier(jakarta.inject.Named.class)) {
+			jakarta.inject.Named namedAnnotation = descriptor.getQualifier(jakarta.inject.Named.class);
 			return namedAnnotation.value();
 		}
 		Type elementType = descriptor.getDesiredType();

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
@@ -2,9 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.core.di.annotations
-Bundle-Version: 1.8.100.qualifier
+Bundle-Version: 1.8.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.annotations;version="1.6.0"
-Import-Package: javax.inject;version="[1.0.0,2.0.0)"
+Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.e4.core.di.annotations

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Creatable.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Creatable.java
@@ -18,13 +18,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
 
 /**
  * Specifies that the target class can be created by an injector as needed.
  * @since 1.3
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Optional.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Optional.java
@@ -21,8 +21,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.inject.Qualifier;
-
 /**
  * This annotation can be applied to methods, fields, and parameters to mark
  * them as optional for the dependency injection. Typically, if the injector is
@@ -53,7 +51,8 @@ import javax.inject.Qualifier;
  *
  * @since 1.3
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
@@ -3,10 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.e4.core.di.extensions;singleton:=true
-Bundle-Version: 0.18.0.qualifier
+Bundle-Version: 0.18.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.extensions;version="0.16.0"
 Bundle-Localization: fragment
-Import-Package: javax.inject;version="[1.0.0,2.0.0)"
+Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.e4.core.di.extensions

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/EventTopic.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/EventTopic.java
@@ -19,7 +19,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
 
 /**
  * This annotation can be applied to arguments and fields that want to receive notifications on the
@@ -46,7 +45,8 @@ import javax.inject.Qualifier;
  *
  * @since 0.16
  */
-@Qualifier
+@jakarta.inject.Qualifier
+@javax.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/OSGiBundle.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/OSGiBundle.java
@@ -18,7 +18,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
 
 /**
  * A method or field of type {@link org.osgi.framework.BundleContext} and
@@ -53,7 +52,8 @@ import javax.inject.Qualifier;
  *
  * @since 0.16
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Preference.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Preference.java
@@ -18,12 +18,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
 
 /**
  * @since 0.16
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Service.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Service.java
@@ -18,14 +18,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
 
 /**
  * Annotation to use with DI to support dynamics and multiple services
  *
  * @since 0.16
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
@@ -15,6 +15,8 @@ Export-Package: org.eclipse.e4.core.di;version="1.7.0",
 Require-Bundle: org.eclipse.e4.core.di.annotations;bundle-version="[1.4.0,2.0.0)";visibility:=reexport
 Import-Package: javax.annotation;version="[1.3.5,2.0.0)",
  javax.inject;version="[1.0.0,2.0.0)",
+ jakarta.inject;version="[2,3)",
+ jakarta.annotation;version="[2,3)",
  org.eclipse.osgi.framework.log;version="1.1.0",
  org.osgi.framework;version="[1.8.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.1,2.0.0)"

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.e4.core.di;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Scope;
+import jakarta.inject.Singleton;
 import java.lang.annotation.Annotation;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Scope;
-import javax.inject.Singleton;
 import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
 
 /**

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/IObjectDescriptor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/IObjectDescriptor.java
@@ -15,7 +15,6 @@ package org.eclipse.e4.core.di.suppliers;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import javax.inject.Qualifier;
 
 /**
  * This interface describes objects created by the dependency injection.
@@ -24,7 +23,7 @@ import javax.inject.Qualifier;
  * set of optional qualifiers.
  * </p>
  *
- * @see Qualifier
+ * @see javax.inject.Qualifier
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 1.7

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.e4.core.internal.di;
 
+import jakarta.inject.Named;
 import java.lang.reflect.Field;
-import javax.inject.Named;
 import org.eclipse.e4.core.di.IInjector;
 import org.eclipse.e4.core.di.InjectionException;
 import org.eclipse.e4.core.di.annotations.Optional;

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ObjectDescriptor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ObjectDescriptor.java
@@ -17,7 +17,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import javax.inject.Qualifier;
 import org.eclipse.e4.core.di.suppliers.IObjectDescriptor;
 
 public class ObjectDescriptor implements IObjectDescriptor {
@@ -97,7 +96,8 @@ public class ObjectDescriptor implements IObjectDescriptor {
 		Annotation[] result;
 		List<Annotation> qualifiers = new ArrayList<>();
 		for (Annotation annotation : allAnnotations) {
-			if (annotation.annotationType().isAnnotationPresent(Qualifier.class))
+			if (annotation.annotationType().isAnnotationPresent(javax.inject.Qualifier.class)
+					|| annotation.annotationType().isAnnotationPresent(jakarta.inject.Qualifier.class))
 				qualifiers.add(annotation);
 		}
 		if (qualifiers.isEmpty())

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ProviderImpl.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ProviderImpl.java
@@ -13,12 +13,11 @@
  *******************************************************************************/
 package org.eclipse.e4.core.internal.di;
 
-import javax.inject.Provider;
 import org.eclipse.e4.core.di.IInjector;
 import org.eclipse.e4.core.di.suppliers.IObjectDescriptor;
 import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
 
-public class ProviderImpl<T> implements Provider<T> {
+public class ProviderImpl<T> implements javax.inject.Provider<T>, jakarta.inject.Provider<T> {
 
 	final private PrimaryObjectSupplier objectProvider;
 	final private IObjectDescriptor objectDescriptor;

--- a/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Localization: plugin
 Bundle-Version: 2.4.200.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+Import-Package: jakarta.annotation;version="[2.0.0,3.0.0)",
+ jakarta.inject;version="[2.0.0,3.0.0)",
+ javax.annotation;version="[1.3.0,2.0.0)",
  javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.debug;version="1.1.0",
  org.eclipse.osgi.service.localization;version="1.1.0",

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/BundleTranslationProvider.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/BundleTranslationProvider.java
@@ -14,8 +14,8 @@
  ******************************************************************************/
 package org.eclipse.e4.core.internal.services;
 
+import jakarta.inject.Inject;
 import java.util.ResourceBundle;
-import javax.inject.Inject;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.services.translation.ResourceBundleProvider;
 import org.eclipse.e4.core.services.translation.TranslationService;

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/MessageFactoryServiceImpl.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/MessageFactoryServiceImpl.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.e4.core.internal.services;
 
+import jakarta.annotation.PostConstruct;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -29,7 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
-import javax.annotation.PostConstruct;
 import org.eclipse.e4.core.services.nls.IMessageFactoryService;
 import org.eclipse.e4.core.services.nls.Message;
 import org.eclipse.e4.core.services.nls.Message.ReferenceType;
@@ -254,7 +254,8 @@ public class MessageFactoryServiceImpl implements IMessageFactoryService {
 		if (messageObject != null) {
 			Method[] methods = messageClass.getDeclaredMethods();
 			for (Method method : methods) {
-				if (!method.isAnnotationPresent(PostConstruct.class)) {
+				if (!method.isAnnotationPresent(javax.annotation.PostConstruct.class)
+						&& !method.isAnnotationPresent(jakarta.annotation.PostConstruct.class)) {
 					continue;
 				} else {
 					try {

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/TranslationObjectSupplier.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/TranslationObjectSupplier.java
@@ -14,6 +14,8 @@
  ******************************************************************************/
 package org.eclipse.e4.core.internal.services;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -25,8 +27,6 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import javax.inject.Inject;
-import javax.inject.Named;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.suppliers.ExtendedObjectSupplier;

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/BaseMessageRegistry.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/BaseMessageRegistry.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.e4.core.services.nls;
 
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.AccessController;
@@ -21,8 +23,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.osgi.service.log.Logger;
 import org.osgi.service.log.LoggerFactory;

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Translation.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Translation.java
@@ -18,8 +18,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Inject;
-import javax.inject.Qualifier;
 
 /**
  * <p>
@@ -38,7 +36,8 @@ import javax.inject.Qualifier;
  *
  * @since 1.2
  */
-@Qualifier
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
 @Documented
 @Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/translation/TranslationService.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/translation/TranslationService.java
@@ -15,11 +15,11 @@
  ******************************************************************************/
 package org.eclipse.e4.core.services.translation;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import javax.inject.Inject;
-import javax.inject.Named;
 
 /**
  * Provides localization service.


### PR DESCRIPTION
The javax.annotation / javax.inject are effectively deprecated as they are now supersede by the jakarta.inject / jakarta.annotation 2.0 API.

This adds support for E4 to optionally process these annotations as well so users can migrate their code away from the old namespace.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1129

Lets see if this breaks anything....