### PR TITLE
Change "override" of ant BuildLogger.getMessageOutputLevel() to public

### DIFF
--- a/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/NullBuildLogger.java
+++ b/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/NullBuildLogger.java
@@ -41,7 +41,7 @@ public class NullBuildLogger extends AbstractEclipseBuildLogger implements Build
 		fMessageOutputLevel = level;
 	}
 
-	protected int getMessageOutputLevel() {
+	public int getMessageOutputLevel() {
 		return fMessageOutputLevel;
 	}
 

--- a/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.tests.core; singleton:=true
-Bundle-Version: 3.7.100.qualifier
+Bundle-Version: 3.7.200.qualifier
 Bundle-ClassPath: anttestscore.jar
 Bundle-Activator: org.eclipse.ant.tests.core.testplugin.AntTestPlugin
 Bundle-Vendor: %providerName

--- a/ant/org.eclipse.ant.tests.core/test support/org/eclipse/ant/tests/core/support/testloggers/TestBuildLogger.java
+++ b/ant/org.eclipse.ant.tests.core/test support/org/eclipse/ant/tests/core/support/testloggers/TestBuildLogger.java
@@ -42,7 +42,7 @@ public class TestBuildLogger implements BuildLogger {
 		fMessageOutputLevel = level;
 	}
 
-	protected int getMessageOutputLevel() {
+	public int getMessageOutputLevel() {
 		return fMessageOutputLevel;
 	}
 

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
@@ -31,14 +31,23 @@ import org.eclipse.ant.tests.core.AbstractAntTest;
 import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.junit.Test;
+import org.osgi.framework.Version;
 
 public class OptionTests extends AbstractAntTest {
 
 	protected static final String UNKNOWN_ARG = "Unknown argument: "; //$NON-NLS-1$
 	protected static final String START_OF_HELP = "ant [options] [target [target2 [target3] ...]]"; //$NON-NLS-1$
-	protected static final String VERSION = "Apache Ant(TM) version 1.10.12"; //$NON-NLS-1$
-	protected static final String PLUGIN_VERSION = "org.apache.ant_1.10.12"; //$NON-NLS-1$
+	protected static final String VERSION;
+	protected static final String PLUGIN_VERSION;
+
+	static {
+		Version antVersion = Platform.getBundle("org.apache.ant").getVersion(); //$NON-NLS-1$
+		VERSION = "Apache Ant(TM) version " + antVersion.getMajor() + '.' + antVersion.getMinor() + '.' //$NON-NLS-1$
+				+ antVersion.getMicro();
+		PLUGIN_VERSION = antVersion.toString();
+	}
 
 	/**
 	 * Tests the "-help" option

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
@@ -19,15 +19,23 @@ import org.eclipse.ant.internal.launching.debug.model.AntThread;
 import org.eclipse.ant.internal.launching.debug.model.AntValue;
 import org.eclipse.ant.launching.IAntLaunchConstants;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.ILineBreakpoint;
 import org.eclipse.debug.core.model.IVariable;
+import org.osgi.framework.Version;
 
 public class PropertyTests extends AbstractAntDebugTest {
 
-	private static final String ANT_VERSION = "Apache Ant(TM) version 1.10.12"; //$NON-NLS-1$
+	private static final String ANT_VERSION;
+
+	static {
+		Version antVersion = Platform.getBundle("org.apache.ant").getVersion(); //$NON-NLS-1$
+		ANT_VERSION = "Apache Ant(TM) version " + antVersion.getMajor() + '.' + antVersion.getMinor() + '.' //$NON-NLS-1$
+				+ antVersion.getMicro();
+	}
 
 	public PropertyTests(String name) {
 		super(name);

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
@@ -31,6 +31,7 @@ import org.eclipse.ant.tests.ui.testplugin.ProjectHelper;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
@@ -42,7 +43,11 @@ import org.eclipse.ui.console.IHyperlink;
 @SuppressWarnings("restriction")
 public class SeparateVMTests extends AbstractAntUIBuildTest {
 
-	protected static final String PLUGIN_VERSION = "org.apache.ant_1.10.12"; //$NON-NLS-1$
+	protected static final String PLUGIN_VERSION;
+
+	static {
+		PLUGIN_VERSION = Platform.getBundle("org.apache.ant").getVersion().toString(); //$NON-NLS-1$
+	}
 
 	public SeparateVMTests(String name) {
 		super(name);


### PR DESCRIPTION
Modify the ant tests to avoid hard coded versions.

https://github.com/eclipse-platform/eclipse.platform/issues/701