### PR TITLE
Add methods to identify the current OS to the class Platform

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -41,6 +41,7 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.junit.Assume;
@@ -263,7 +264,7 @@ public class BasicAliasTest extends ResourceTest {
 	 */
 	@Test
 	public void testBug198571() {
-		Assume.assumeTrue(isWindows());
+		Assume.assumeTrue(OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -27,6 +27,7 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.junit.Assume;
 import org.junit.Test;
@@ -49,7 +50,7 @@ public class MoveTest extends LocalStoreTest {
 	 */
 	@Test
 	public void testMoveFileAcrossVolumes() {
-		Assume.assumeTrue(isWindows());
+		Assume.assumeTrue(OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
@@ -171,7 +172,7 @@ public class MoveTest extends LocalStoreTest {
 	 */
 	@Test
 	public void testMoveFolderAcrossVolumes() {
-		Assume.assumeTrue(isWindows());
+		Assume.assumeTrue(OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -43,13 +43,14 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.xml.sax.InputSource;
 
 public class ModelObjectReaderWriterTest extends ResourceTest {
-	static final IPath LONG_LOCATION = IPath.fromOSString("/eclipse/dev/i0218/eclipse/pffds/fds//fds///fdsfsdfsd///fdsfdsf/fsdfsdfsd/lugi/dsds/fsd//f/ffdsfdsf/fsdfdsfsd/fds//fdsfdsfdsf/fdsfdsfds/fdsfdsfdsf/fdsfdsfdsds/ns/org.eclipse.help.ui_2.1.0/contexts.xml").setDevice(isWindows() ? "D:" : null);
+	static final IPath LONG_LOCATION = IPath.fromOSString("/eclipse/dev/i0218/eclipse/pffds/fds//fds///fdsfsdfsd///fdsfdsf/fsdfsdfsd/lugi/dsds/fsd//f/ffdsfdsf/fsdfdsfsd/fds//fdsfdsfdsf/fdsfdsfds/fdsfdsfdsf/fdsfdsfdsds/ns/org.eclipse.help.ui_2.1.0/contexts.xml").setDevice(OS.isWindows() ? "D:" : null);
 	static final URI LONG_LOCATION_URI = LONG_LOCATION.toFile().toURI();
-	private static final String PATH_STRING = IPath.fromOSString("/abc/def").setDevice(isWindows() ? "D:" : null).toString();
+	private static final String PATH_STRING = IPath.fromOSString("/abc/def").setDevice(OS.isWindows() ? "D:" : null).toString();
 
 	private HashMap<String, ProjectDescription> buildBaselineDescriptors() {
 		HashMap<String, ProjectDescription> result = new HashMap<>();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.junit.Test;
@@ -1019,7 +1020,7 @@ public class IFileTest extends ResourceTest {
 
 		//do some tests with invalid names
 		names = new String[0];
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//invalid windows names
 			names = new String[] {"a  ", "foo::bar", "prn", "nul", "con", "aux", "clock$", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", "AUX", "con.foo", "LPT4.txt", "*", "?", "\"", "<", ">", "|"};
 		} else {
@@ -1041,7 +1042,7 @@ public class IFileTest extends ResourceTest {
 		}
 
 		//do some tests with valid names that are *almost* invalid
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//these names are valid on windows
 			names = new String[] {"  a", "hello.prn.txt", "null", "con3", "foo.aux", "lpt0", "com0", "com10", "lpt10", ",", "'", ";", "clock$.class"};
 		} else {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -21,6 +21,7 @@ import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 
 public class IFolderTest extends ResourceTest {
@@ -315,7 +316,7 @@ public class IFolderTest extends ResourceTest {
 
 		//do some tests with invalid names
 		String[] names = new String[0];
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//invalid windows names
 			names = new String[] {"prn", "nul", "con", "aux", "clock$", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", "AUX", "con.foo", "LPT4.txt", "*", "?", "\"", "<", ">", "|"};
 		} else {
@@ -336,7 +337,7 @@ public class IFolderTest extends ResourceTest {
 		}
 
 		//do some tests with valid names that are *almost* invalid
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//these names are valid on windows
 			names = new String[] {"hello.prn.txt", "null", "con3", "foo.aux", "lpt0", "com0", "com10", "lpt10", ",", "'", ";"};
 		} else {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -40,6 +40,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
@@ -198,7 +199,7 @@ public class IProjectTest extends ResourceTest {
 		}
 		//do some tests with invalid names
 		names = new String[0];
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//invalid windows names
 			names = new String[] {"foo:bar", "prn", "nul", "con", "aux", "clock$", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", "AUX", "con.foo", "LPT4.txt", "*", "?", "\"", "<", ">", "|", "::"};
 		}
@@ -221,7 +222,7 @@ public class IProjectTest extends ResourceTest {
 		}
 
 		//do some tests with valid names that are *almost* invalid
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			//these names are valid on windows
 			names = new String[] {"hello.prn.txt", "null", "con3", "foo.aux", "lpt0", "com0", "com10", "lpt10", ",", "'", ";"};
 		} else {
@@ -615,7 +616,7 @@ public class IProjectTest extends ResourceTest {
 	 * Tests creating a project whose location already exists with different case
 	 */
 	public void testProjectCreationLocationExistsWithDifferentCase() {
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			String projectName = getUniqueString() + "a";
 			IProject project = getWorkspace().getRoot().getProject(projectName);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -30,6 +30,7 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
 import org.junit.Assume;
@@ -46,7 +47,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	@Test
 	public void testFindFilesNonCanonicalPath() {
 		// this test is for windows only
-		Assume.assumeTrue(isWindows());
+		Assume.assumeTrue(OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
 		ensureExistsInWorkspace(project, true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -38,6 +38,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Platform.OS;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -822,7 +823,7 @@ public class IWorkspaceTest extends ResourceTest {
 		/* normal name */
 		assertTrue("1.1", getWorkspace().validateName("abcdef", IResource.FILE).isOK());
 		/* invalid characters (windows only) */
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			assertFalse("2.1", getWorkspace().validateName("dsa:sf", IResource.FILE).isOK());
 			assertFalse("2.2", getWorkspace().validateName("*dsasf", IResource.FILE).isOK());
 			assertFalse("2.3", getWorkspace().validateName("?dsasf", IResource.FILE).isOK());
@@ -903,7 +904,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("1.1", getWorkspace().validatePath("/one/two/three/four/", IResource.FILE | IResource.FOLDER).isOK());
 
 		/* invalid characters (windows only) */
-		final boolean WINDOWS = isWindows();
+		final boolean WINDOWS = OS.isWindows();
 		if (WINDOWS) {
 			assertFalse("2.1", (getWorkspace().validatePath("\\dsa:sf", IResource.FILE).isOK()));
 			assertFalse("2.2", (getWorkspace().validatePath("/abc/*dsasf", IResource.FILE).isOK()));
@@ -963,7 +964,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("1.1", workspace.validateProjectLocation(project, IPath.fromOSString("/one/two/three/four/")).isOK());
 
 		/* invalid characters (windows only) */
-		final boolean WINDOWS = isWindows();
+		final boolean WINDOWS = OS.isWindows();
 		if (WINDOWS) {
 			assertFalse("2.1", workspace.validateProjectLocation(project, IPath.fromOSString("d:\\dsa:sf")).isOK());
 			assertFalse("2.2", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/*dsasf")).isOK());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -42,6 +42,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.harness.CancelingProgressMonitor;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 
@@ -203,7 +204,7 @@ public class LinkedResourceTest extends ResourceTest {
 		}
 
 		//try to create with local path that can never exist
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			location = IPath.fromOSString("b:\\does\\not\\exist");
 		} else {
 			location = IPath.fromOSString("/dev/null/does/not/exist");
@@ -1022,7 +1023,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 */
 	public void testFindFilesForLocationCaseVariant() {
 		//this test only applies to file systems with a device in the path
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IFolder link = nonExistingFolderInExistingProject;
@@ -1455,7 +1456,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 */
 	public void testLocationWithColon() {
 		//windows does not allow a location with colon in the name
-		if (isWindows()) {
+		if (OS.isWindows()) {
 			return;
 		}
 		IFolder folder = nonExistingFolderInExistingProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -160,35 +160,6 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Returns whether the current platform is windows.
-	 * @return <code>true</code> if this platform is windows, and
-	 * <code>false</code> otherwise.
-	 */
-	protected static boolean isWindows() {
-		return Platform.getOS().equals(Platform.OS_WIN32);
-	}
-
-	/**
-	 * Returns whether the current platform is linux.
-	 *
-	 * @return <code>true</code> if this platform is linux, and <code>false</code>
-	 *         otherwise.
-	 */
-	protected static boolean isLinux() {
-		return Platform.getOS().equals(Platform.OS_LINUX);
-	}
-
-	/**
-	 * Returns whether the current platform is mac OSX.
-	 *
-	 * @return <code>true</code> if this platform is mac OSX, and <code>false</code>
-	 *         otherwise.
-	 */
-	protected static boolean isMacOSX() {
-		return Platform.getOS().equals(Platform.OS_MACOSX);
-	}
-
-	/**
 	 * Convenience method to copy contents from one stream to another.
 	 */
 	public static void transferStreams(InputStream source, OutputStream destination, String path) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -31,7 +32,7 @@ public class Bug_025457 extends ResourceTest {
 
 	public void testFile() {
 		//this test only works on windows
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IProject source = getWorkspace().getRoot().getProject("project");
@@ -77,7 +78,7 @@ public class Bug_025457 extends ResourceTest {
 	public void testFolder() {
 		//this test only works on windows
 		//native code must also be present so move can detect the case change
-		if (!isWindows() || !isReadOnlySupported()) {
+		if (!OS.isWindows() || !isReadOnlySupported()) {
 			return;
 		}
 		IProject source = getWorkspace().getRoot().getProject("SourceProject");
@@ -120,7 +121,7 @@ public class Bug_025457 extends ResourceTest {
 
 	public void testProject() {
 		//this test only works on windows
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IProject source = getWorkspace().getRoot().getProject("project");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -23,6 +23,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -37,7 +38,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Windows.
 	 */
 	public void testDeleteOpenProjectWindows() {
-		if (!(isWindows())) {
+		if (!(OS.isWindows())) {
 			return;
 		}
 
@@ -138,7 +139,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Linux with natives.
 	 */
 	public void testDeleteOpenProjectLinux() {
-		if (!(isLinux() && isReadOnlySupported())) {
+		if (!(OS.isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -206,7 +207,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Windows.
 	 */
 	public void testDeleteClosedProjectWindows() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 
@@ -286,7 +287,7 @@ public class Bug_026294 extends ResourceTest {
 	 * TODO: enable this test once bug 48321 is fixed.
 	 */
 	public void testDeleteClosedProjectLinux() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 
@@ -358,7 +359,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Windows.
 	 */
 	public void testDeleteFolderWindows() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 
@@ -423,7 +424,7 @@ public class Bug_026294 extends ResourceTest {
 	 * Works only for Linux with natives.
 	 */
 	public void testDeleteFolderLinux() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.regression;
 import org.eclipse.core.resources.IPathVariableManager;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.Preferences;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -55,7 +56,7 @@ public class Bug_027271 extends ResourceTest {
 
 	public void testBug() {
 		//this bug is only relevant on Windows
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IPathVariableManager pvm = getWorkspace().getPathVariableManager();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -19,6 +19,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -28,7 +29,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
 public class Bug_032076 extends ResourceTest {
 
 	public void testFileBugOnWindows() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 
@@ -119,7 +120,7 @@ public class Bug_032076 extends ResourceTest {
 	}
 
 	public void testFolderBugOnWindows() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 
@@ -219,7 +220,7 @@ public class Bug_032076 extends ResourceTest {
 	}
 
 	public void testProjectBugOnWindows() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 
@@ -302,7 +303,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testFileBugOnLinux() {
-		if (!(isLinux() && isReadOnlySupported())) {
+		if (!(OS.isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -388,7 +389,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testFolderBugOnLinux() {
-		if (!(isLinux() && isReadOnlySupported())) {
+		if (!(OS.isLinux() && isReadOnlySupported())) {
 			return;
 		}
 
@@ -492,7 +493,7 @@ public class Bug_032076 extends ResourceTest {
 	 * TODO: This test is currently failing and needs further investigation (bug 203078)
 	 */
 	public void _testProjectBugOnLinux() {
-		if (!(isLinux() && isReadOnlySupported())) {
+		if (!(OS.isLinux() && isReadOnlySupported())) {
 			return;
 		}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -20,6 +20,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -91,7 +92,7 @@ public class Bug_044106 extends ResourceTest {
 	 * @param deleteFlags The flags to use on the resource deletion call
 	 */
 	public void doTestDeleteLinkedFolder(IFolder linkedFolder, boolean deleteParent, int deleteFlags) {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IFileStore linkDestLocation = getTempStore();
@@ -139,14 +140,14 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFile() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		doTestDeleteLinkedFile(IResource.NONE);
 	}
 
 	public void testDeleteLinkedFolder() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -155,7 +156,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedResourceInProject() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -164,14 +165,14 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFileKeepHistory() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		doTestDeleteLinkedFile(IResource.KEEP_HISTORY);
 	}
 
 	public void testDeleteLinkedFolderParentKeepHistory() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -181,7 +182,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedFolderKeepHistory() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
@@ -190,7 +191,7 @@ public class Bug_044106 extends ResourceTest {
 	}
 
 	public void testDeleteLinkedResourceInProjectKeepHistory() {
-		if (!isLinux()) {
+		if (!OS.isLinux()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.filesystem.*;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 /**
@@ -22,7 +23,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
  */
 public class Bug_092108 extends ResourceTest {
 	public void testBug() {
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IFileStore root;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
@@ -21,6 +21,7 @@ import java.util.*;
 import org.eclipse.core.internal.resources.ProjectDescription;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 
@@ -29,7 +30,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
  */
 public class Bug_185247_LinuxTests extends ResourceTest {
 
-	private static final boolean IS_LINUX = isLinux();
+	private static final boolean IS_LINUX = OS.isLinux();
 	private final List<IProject> testProjects = new ArrayList<>();
 	private IPath testCasesLocation;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.junit.Assume;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class IFileTest extends ResourceTest {
 		Assume.assumeTrue(isReadOnlySupported());
 
 		// Don't test this on Windows
-		Assume.assumeFalse(isWindows());
+		Assume.assumeFalse(OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -78,7 +79,7 @@ public class IFileTest extends ResourceTest {
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		Assume.assumeTrue(isLinux());
+		Assume.assumeTrue(OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -17,6 +17,7 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.junit.Assume;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class IFolderTest extends ResourceTest {
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		Assume.assumeTrue(isLinux());
+		Assume.assumeTrue(OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder parentFolder = project.getFolder("parentFolder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -37,6 +37,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.resources.ResourceDeltaVerifier;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -236,7 +237,7 @@ public class IResourceTest extends ResourceTest {
 
 	public void testBug111821() {
 		//this test only makes sense on Windows
-		if (!isWindows()) {
+		if (!OS.isWindows()) {
 			return;
 		}
 		IProject project = getWorkspace().getRoot().getProject("testBug111821");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import junit.framework.Test;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -39,7 +40,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 	private boolean skipTest() {
 		//skip on Mac due to unknown failure (bug 127752)
 		//TODO re-enable after M5 build
-		return isMacOSX();
+		return OS.isMac();
 	}
 
 	public void test1() {

--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.29.100.qualifier
+Bundle-Version: 3.30.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -19,8 +19,15 @@ package org.eclipse.core.runtime;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.*;
-import org.eclipse.core.internal.runtime.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import org.eclipse.core.internal.runtime.AuthorizationHandler;
+import org.eclipse.core.internal.runtime.InternalPlatform;
+import org.eclipse.core.internal.runtime.Messages;
+import org.eclipse.core.internal.runtime.MetaDataKeeper;
+import org.eclipse.core.internal.runtime.PlatformActivator;
 import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.equinox.app.IApplicationContext;
@@ -51,6 +58,52 @@ import org.osgi.framework.FrameworkUtil;
  */
 public final class Platform {
 
+	/**
+	 * Convenience class to query for the current OS.
+	 *
+	 * @since 3.30
+	 */
+	public static final class OS {
+		private OS() {
+			// avoid instantiation
+		}
+
+		/**
+		 * @param osString the identifier for the OS (use one of the constants that
+		 *                 start with <code>OS_</code> in the <code>Platform</code>
+		 *                 class).
+		 *
+		 * @return <code>true</code> if the current platform is the one specified as a
+		 *         parameter, <code>false</code> in all other cases.
+		 * @see Platform#getOS()
+		 * @since 3.30
+		 */
+		public static boolean is(String osString) {
+			return Platform.getOS().equals(osString);
+		}
+
+		/**
+		 * @return <code>true</code> if the current OS is Windows
+		 */
+		public static boolean isWindows() {
+			return is(OS_WIN32);
+		}
+
+		/**
+		 * @return <code>true</code> if the current OS is Linux
+		 */
+		public static boolean isLinux() {
+			return is(OS_LINUX);
+		}
+
+		/**
+		 * @return <code>true</code> if the current OS is MacOSX
+		 */
+		public static boolean isMac() {
+			return is(OS_MACOSX);
+		}
+
+	}
 	/**
 	 * The unique identifier constant (value "<code>org.eclipse.core.runtime</code>")
 	 * of the Core Runtime (pseudo-) plug-in.


### PR DESCRIPTION
(fulfill the changes requested in https://github.com/eclipse-platform/eclipse.platform/pull/446#discussion_r1190047831)

Move the methods `isLinux()`, `isWindows()` and `isMacOSX()` (renamed to `isMac()`) to the new internal class `org.eclipse.core.runtime.Platform.OS` and add a new method `OS.is(String)` for legacy/flexibility purposes.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/448