### PR TITLE
Add missing Automatic-Module-Name

### DIFF
--- a/resources/examples/org.eclipse.ui.examples.filesystem/META-INF/MANIFEST.MF
+++ b/resources/examples/org.eclipse.ui.examples.filesystem/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.ui.examples.filesystem
 Bundle-Name: Efs Examples Plug-in
 Bundle-SymbolicName: org.eclipse.ui.examples.filesystem;singleton:=true
 Bundle-Version: 1.1.200.qualifier

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant1
 Bundle-Name: Save Participant 1
 Bundle-Activator: org.eclipse.core.tests.resources.saveparticipant1.SaveParticipant1Plugin
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant1

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant2
 Bundle-Name: Save Participant 2
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant2
 Bundle-Version: 3.6.0.qualifier

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Save Participant 3
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant3
+Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant3
 Bundle-Version: 3.6.0.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant3


### PR DESCRIPTION
Fixes warnings in the workspace