### PR TITLE
Avoid UI access in async viewers which operate on non UI threads

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
@@ -415,6 +415,11 @@ public abstract class AsynchronousViewer extends StructuredViewer implements Lis
 	}
 
 	@Override
+	public void refresh() {
+		refresh(getRoot());
+	}
+
+	@Override
 	protected void internalRefresh(Object element) {
 		// get the nodes in the model
 		AsynchronousModel model = getModel();


### PR DESCRIPTION
The AsynchronousViewer class hierarchy reuses the Viewer interface but adds additional constraints on it, in particular it allows many of its methods to be called from non-UI threads.

See javadoc summary:

https://github.com/eclipse-platform/eclipse.platform/blob/e92b72761b8543358ba9811ea49807f75e98bad5/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java#L57-L72

Commit 3b9c02c4e1f8364bfb05f66fc5d046ab4d2ff8a2 added UI access to method that used to not have any, therefore this patch restores that non-UI implementation locally consistent with other methods in the async viewer that operate on the model.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/710