### PR TITLE
Fix compilation errors after moving API to  o.e.jdt.core.manipulation

### DIFF
--- a/runtime/bundles/org.eclipse.core.tools/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.tools; singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.tools;x-internal:=true,
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.1.0,4.0.0)";resolu
  org.eclipse.ltk.core.refactoring,
  org.eclipse.core.filebuffers,
  org.eclipse.ui.ide,
- org.eclipse.search
+ org.eclipse.search,
+ org.eclipse.jdt.core.manipulation
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.core.tools


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/716