### PR TITLE
Remove recycling of ThreadJob in ImplicitJobs #724

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ThreadJob.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ThreadJob.java
@@ -417,30 +417,6 @@ class ThreadJob extends Job {
 		}
 	}
 
-	/**
-	 * Reset all of this job's fields so it can be reused.  Returns false if
-	 * reuse is not possible
-	 * 	@GuardedBy("JobManager.implicitJobs")
-	 */
-	boolean recycle() {
-		//don't recycle if still running for any reason
-		if (getState() != Job.NONE) {
-			return false;
-		}
-		//clear and reset all fields
-		acquireRule = isRunning = isBlocked = false;
-		realJob = null;
-		setRule(null);
-		setThread(null);
-		if (ruleStack.length != 2) {
-			ruleStack = new ISchedulingRule[2];
-		} else {
-			ruleStack[0] = ruleStack[1] = null;
-		}
-		top = -1;
-		return true;
-	}
-
 	@Override
 	public IStatus run(IProgressMonitor monitor) {
 		synchronized (this) {


### PR DESCRIPTION
The `JobManager` uses the `ImplicitJobs` implementation to spawn internal jobs for the execution on a specific `ISchedulingRule` within an executed job. This implementation creates instances of `ThreadJob`. These instances are reused, such that the same `ThreadJob` instance is reused for different rules and potentially different jobs. This is achieved by a recycle functionality, which caches a `ThreadJob` for reuse once it is not used anymore. This functionality results in the same job occurring with different rules at different places and points in time. This is both unexpected and error prone.

Since this reuse functionality only seems to be a performance improvement whose value does nowadays not outweigh the added complexity and risk of error, this change removes the recycling functionality.

Note that the recyle functionality also fulfilled some kind of dispose functionality, as it assigned `null` values to the fields of `ThreadJob`. I did not find a reason why this should still be necessary when not reusing the `ThreadJobs` since there should be no further references to the object and the GC should clean them up anyway.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/724.