### PR TITLE
Cleanup of new o.e.resources.undo API

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/AbstractResourceSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/AbstractResourceSnapshot.java
@@ -83,7 +83,7 @@ abstract class AbstractResourceSnapshot<T extends IResource> implements IResourc
 	@Override
 	public T createResource(IProgressMonitor monitor) throws CoreException {
 		T resource = createResourceHandle();
-		createExistentResourceFromHandle(resource, monitor);
+		createExistentResourceFromHandle(monitor);
 		restoreResourceAttributes(resource);
 		return resource;
 	}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/ContainerSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/ContainerSnapshot.java
@@ -19,9 +19,7 @@ import java.lang.reflect.Array;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceFilterDescription;
@@ -183,20 +181,16 @@ public abstract class ContainerSnapshot<T extends IContainer> extends AbstractRe
 	}
 
 	@Override
-	public void recordStateFromHistory(T resource, IProgressMonitor mon) throws CoreException {
+	public void recordStateFromHistory(IProgressMonitor mon) throws CoreException {
 		if (members != null) {
 			SubMonitor subMonitor = SubMonitor.convert(mon, ResourceSnapshotMessages.FolderDescription_SavingUndoInfoProgress,
 					members.size());
 			for (IResourceSnapshot<? extends IResource> member : members) {
 				SubMonitor iterationMonitor = subMonitor.split(1);
 				if (member instanceof FileSnapshot fileSnapshot) {
-					IPath path = resource.getFullPath().append(fileSnapshot.name);
-					IFile fileHandle = resource.getWorkspace().getRoot().getFile(path);
-					fileSnapshot.recordStateFromHistory(fileHandle, iterationMonitor);
+					fileSnapshot.recordStateFromHistory(iterationMonitor);
 				} else if (member instanceof FolderSnapshot folderSnapshot) {
-					IPath path = resource.getFullPath().append(folderSnapshot.name);
-					IFolder folderHandle = resource.getWorkspace().getRoot().getFolder(path);
-					folderSnapshot.recordStateFromHistory(folderHandle, iterationMonitor);
+					folderSnapshot.recordStateFromHistory(iterationMonitor);
 				}
 			}
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/FileSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/FileSnapshot.java
@@ -94,8 +94,8 @@ public class FileSnapshot extends AbstractResourceSnapshot<IFile> {
 	}
 
 	@Override
-	public void recordStateFromHistory(IFile resource,
-			IProgressMonitor monitor) throws CoreException {
+	public void recordStateFromHistory(IProgressMonitor monitor) throws CoreException {
+		IFile resource = createResourceHandle();
 		Assert.isLegal(resource.getType() == IResource.FILE);
 		if (location != null) {
 			// file is linked, no need to record any history
@@ -131,7 +131,8 @@ public class FileSnapshot extends AbstractResourceSnapshot<IFile> {
 	}
 
 	@Override
-	public void createExistentResourceFromHandle(IFile fileHandle, IProgressMonitor mon) throws CoreException {
+	public void createExistentResourceFromHandle(IProgressMonitor mon) throws CoreException {
+		IFile fileHandle = createResourceHandle();
 		if (fileHandle.exists()) {
 			return;
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/FolderSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/FolderSnapshot.java
@@ -16,7 +16,6 @@
 package org.eclipse.core.internal.resources.undo.snapshot;
 
 import java.net.URI;
-
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceFilterDescription;
@@ -74,7 +73,8 @@ public class FolderSnapshot extends ContainerSnapshot<IFolder> {
 	}
 
 	@Override
-	public void createExistentResourceFromHandle(final IFolder folderHandle, IProgressMonitor mon) throws CoreException {
+	public void createExistentResourceFromHandle(IProgressMonitor mon) throws CoreException {
+		IFolder folderHandle = createResourceHandle();
 		if (folderHandle.exists()) {
 			return;
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/ProjectSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/undo/snapshot/ProjectSnapshot.java
@@ -78,7 +78,8 @@ public class ProjectSnapshot extends ContainerSnapshot<IProject> {
 	}
 
 	@Override
-	public void createExistentResourceFromHandle(IProject projectHandle, IProgressMonitor monitor) throws CoreException {
+	public void createExistentResourceFromHandle(IProgressMonitor monitor) throws CoreException {
+		IProject projectHandle = createResourceHandle();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 200);
 		if (projectHandle.exists()) {
 			return;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/undo/snapshot/IResourceSnapshot.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/undo/snapshot/IResourceSnapshot.java
@@ -61,13 +61,11 @@ public interface IResourceSnapshot<T extends IResource> {
 	 * Given a resource handle, create an actual resource with the attributes of
 	 * the receiver resource description.
 	 *
-	 * @param resource
-	 *            the resource handle
 	 * @param monitor
 	 *            the progress monitor to be used when creating the resource
 	 * @throws CoreException if creation failed
 	 */
-	public void createExistentResourceFromHandle(T resource, IProgressMonitor monitor) throws CoreException;
+	public void createExistentResourceFromHandle(IProgressMonitor monitor) throws CoreException;
 
 	/**
 	 * Return a boolean indicating whether this resource description has enough
@@ -82,13 +80,11 @@ public interface IResourceSnapshot<T extends IResource> {
 	 * Record the appropriate state of this resource description using
 	 * any available resource history.
 	 *
-	 * @param resource
-	 *            the resource whose state is to be recorded.
 	 * @param monitor
 	 *            the progress monitor to be used
 	 * @throws CoreException in case of error
 	 */
-	public void recordStateFromHistory(T resource, IProgressMonitor monitor) throws CoreException;
+	public void recordStateFromHistory(IProgressMonitor monitor) throws CoreException;
 
 	/**
 	 * Return a boolean indicating whether this description represents an


### PR DESCRIPTION
The new org.eclipse.core.resources.undo API has some usability issues. 

The main problem is that it has two functions that take a "T" as a parameter, but the primary method of creating one of these objects is via the `ResourceSnapshotFactory.fromResource(etc)` call. When calling this function, it is very common to pass in an IResource. We won't know in advance what type the return is, whether it be a IResourceSnapshot<IFile> or a IResourceSnapshot<IContainer> or IResourceSnapshot<IProject>, so we cannot store it in an appropriately typed variable.  

This means, when we try to later call `recordStateFromHistory(IFile)` (or IContainer or IProejct, depending on the type of the snapshot type) we are unable to pass in the appropriately typed object. 

In reality, the parameter is duplicative. The IResourceSnapshot already has access to its internal object and we should not need to be passing it in as a parameter. It only adds to confusion. These parameters should be removed. 