### PR TITLE
Show number of differences in the Compare editor #504

### DIFF
--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.9.400.qualifier
+Bundle-Version: 3.10.0.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/LabelContributionItem.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/LabelContributionItem.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.compare;
+
+import org.eclipse.core.runtime.Platform.OS;
+import org.eclipse.jface.action.ControlContribution;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+
+
+/**
+ * @since 3.10
+ *
+ *        A contribution item which delegates to a label on the tool bar.
+ *
+ */
+public class LabelContributionItem extends ControlContribution {
+
+	private Label toolbarLabel;
+	private String labelName;
+
+	/**
+	 * @param id
+	 * @param name
+	 */
+	public LabelContributionItem(String id, String name) {
+		super(id);
+		this.labelName = name;
+	}
+
+	@Override
+	protected Control createControl(Composite parent) {
+		Composite composite = new Composite(parent, SWT.NONE);
+		this.toolbarLabel = new Label(composite, SWT.NONE);
+
+		GridLayout compositeLayout = new GridLayout(1, false);
+		if (OS.isWindows()) {
+			compositeLayout.marginTop = -3;
+			compositeLayout.marginBottom = -6;
+		}
+		composite.setLayout(compositeLayout);
+		GridData labelLayout = new GridData(SWT.LEFT, SWT.CENTER, true, true);
+
+		this.toolbarLabel.setLayoutData(labelLayout);
+		this.toolbarLabel.setText(this.labelName);
+		return composite;
+	}
+
+	public Label getToolbarLabel() {
+		return toolbarLabel;
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/ContentMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/ContentMergeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Alex Blewitt <alex.blewitt@gmail.com> - replace new Boolean with Boolean.valueOf - https://bugs.eclipse.org/470344
  *     Stefan Xenos <sxenos@gmail.com> (Google) - bug 448968 - Add diagnostic logging
  *     Conrad Groth - Bug 213780 - Compare With direction should be configurable
+ *     Latha Patil (ETAS GmbH) - Issue #504 Show number of differences in the Compare editor
  *******************************************************************************/
 
 package org.eclipse.compare.contentmergeviewer;
@@ -795,7 +796,7 @@ public abstract class ContentMergeViewer extends ContentViewer
 			updateHeader();
 			if (Utilities.okToUse(fComposite) && Utilities.okToUse(fComposite.getParent())) {
 				ToolBarManager tbm = (ToolBarManager) getToolBarManager(fComposite.getParent());
-				if (tbm != null ) {
+				if (tbm != null) {
 					updateToolItems();
 					tbm.update(true);
 					tbm.getControl().getParent().layout(true);
@@ -897,6 +898,7 @@ public abstract class ContentMergeViewer extends ContentViewer
 			tbm.removeAll();
 
 			// Define groups.
+			tbm.add(new Separator("diffLabel")); //$NON-NLS-1$
 			tbm.add(new Separator("modes"));	//$NON-NLS-1$
 			tbm.add(new Separator("merge"));	//$NON-NLS-1$
 			tbm.add(new Separator("navigation"));	//$NON-NLS-1$

--- a/team/tests/org.eclipse.compare.tests/labelContributionData/file1.java
+++ b/team/tests/org.eclipse.compare.tests/labelContributionData/file1.java
@@ -1,0 +1,23 @@
+package testPackage;
+import java.math.*;
+public class Javaclass1 {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		
+		int a=0;
+		
+		System.out.println("");
+		
+		call_me();
+		
+
+	}
+
+	private static void call_me() {
+		// TODO Auto-generated method stub
+		System.out.println();
+
+	}
+
+}

--- a/team/tests/org.eclipse.compare.tests/labelContributionData/file2.java
+++ b/team/tests/org.eclipse.compare.tests/labelContributionData/file2.java
@@ -1,0 +1,31 @@
+package testPackage;
+
+import java.io.File;
+
+public class Javaclass1 {
+
+	public static void main(String[] args) {
+		
+		
+		int a=0;
+		
+		System.out.println("");
+		
+		call_me();
+		
+		callMe(a);
+
+	}
+
+	private static void callMe(int a) {
+		// TODO Auto-generated method stub
+		System.out.println();
+		
+	}
+
+	private static void call_me() {
+		File f= new File("");
+		System.out.println("I am calledJavaclass1.java");
+	}
+
+}


### PR DESCRIPTION
Show number of differences (Ex: 6 Differences) in the toolbar of compare editor
which matches "Change markers" next to the scroll bar in compare editor

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/504

Tested only in Linux and Windows OS