### PR TITLE
Ensure target exists calling FileSystemResourceManager.write() #103

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
@@ -70,8 +70,8 @@ public class File extends Resource implements IFile {
 			try {
 				workspace.prepareOperation(rule, newChild);
 				ResourceInfo info = getResourceInfo(false, false);
-				checkAccessible(getFlags(info));
 				workspace.beginOperation(true);
+				checkAccessible(getFlags(info));
 				IFileInfo fileInfo = getStore().fetchInfo();
 				internalSetContents(content, fileInfo, updateFlags, true, subMonitor.newChild(99));
 			} catch (OperationCanceledException e) {
@@ -354,8 +354,8 @@ public class File extends Resource implements IFile {
 			try {
 				workspace.prepareOperation(rule, newChild);
 				ResourceInfo info = getResourceInfo(false, false);
-				checkAccessible(getFlags(info));
 				workspace.beginOperation(true);
+				checkAccessible(getFlags(info));
 				IFileInfo fileInfo = getStore().fetchInfo();
 				internalSetContents(content, fileInfo, updateFlags, false, subMonitor.newChild(99));
 			} catch (OperationCanceledException e) {


### PR DESCRIPTION
The `FileSystemResourceManager.write()` method assumes the passed target to exist. Some operations in the `File` class do not properly ensure that. They check the file existence before starting a workspace operation, which allows some other operation, such as a refresh, to remove the file from the workspace between the check and the start of the operation.

With this change, the existence check in the `File` class is performed after starting a workspace operation, such that no other operation is able to remove the file concurrently and make the write operation file.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/103.