### PR TITLE
Migrate compare performance tests to JUnit 5

### DIFF
--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -15,6 +15,8 @@ Require-Bundle: org.junit,
  org.eclipse.core.tests.harness,
  org.eclipse.core.filesystem,
  org.eclipse.team.ui
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-Activator: org.eclipse.compare.tests.CompareTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/PerformanceTestSuite.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/PerformanceTestSuite.java
@@ -13,19 +13,16 @@
  *******************************************************************************/
 package org.eclipse.compare.tests.performance;
 
-import junit.framework.Test;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
 import junit.framework.TestSuite;
 
 /**
  * @since 3.1
  */
+@Suite
+@SelectClasses({RangeDifferencerTest.class})
 public class PerformanceTestSuite extends TestSuite {
-
-	public static Test suite() {
-		TestSuite suite= new TestSuite("Compare performance tests"); //$NON-NLS-1$
-		//$JUnit-BEGIN$
-		suite.addTestSuite(RangeDifferencerTest.class);
-		//$JUnit-END$
-		return suite;
-	}
+	//
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/RangeDifferencerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/RangeDifferencerTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.compare.tests.performance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.compare.contentmergeviewer.ITokenComparator;
 import org.eclipse.compare.internal.DocLineComparator;
 import org.eclipse.compare.rangedifferencer.RangeDifference;
@@ -21,16 +23,13 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
+import org.junit.jupiter.api.Test;
 
-public class RangeDifferencerTest extends PerformanceTestCase {
+public class RangeDifferencerTest extends PerformanceTestCaseJunit5 {
 
 
 	// static private final String EXPLANATION = "Performance decrease caused by changes in the compare framework, see bug 210688";
-
-	public RangeDifferencerTest(String name) {
-		super(name);
-	}
 
 	/*
 	 * Creates document with 5000 lines.
@@ -62,6 +61,7 @@ public class RangeDifferencerTest extends PerformanceTestCase {
 		return new Document(sb.toString());
 	}
 
+	@Test
 	public void testLargeDocument() {
 
 		tagAsGlobalSummary("3-way compare, 5000 lines", Dimension.ELAPSED_PROCESS); //$NON-NLS-1$


### PR DESCRIPTION
The performance test in `org.eclipse.compare.tests` still relies on the JUnit 3 `PerformanceTestCase`. This change migrates the compare performance test and test suite to JUnit 5.

Note that the performance tests are not executed in CI builds, so the change will probably not have any effect that is automatically validated.