### PR TITLE
Migrate UA performance tests to JUnit 5

### DIFF
--- a/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -17,7 +17,9 @@ Require-Bundle: org.junit,
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0"
+ javax.servlet.http;version="3.1.0",
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.ua.tests,
  org.eclipse.ua.tests.browser.servlet,

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/AllCheatSheetPerformanceTests.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/AllCheatSheetPerformanceTests.java
@@ -14,15 +14,14 @@
 package org.eclipse.ua.tests.cheatsheet;
 
 import org.eclipse.ua.tests.cheatsheet.performance.OpenCheatSheetTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /*
  * Tests help performance (automated).
  */
-@RunWith(Suite.class)
-@SuiteClasses({ OpenCheatSheetTest.class })
+@Suite
+@SelectClasses({ OpenCheatSheetTest.class })
 public class AllCheatSheetPerformanceTests {
 
 }

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/performance/OpenCheatSheetTest.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/performance/OpenCheatSheetTest.java
@@ -15,22 +15,27 @@ package org.eclipse.ua.tests.cheatsheet.performance;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ua.tests.intro.performance.OpenIntroTest;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.cheatsheets.OpenCheatSheetAction;
 import org.eclipse.ui.internal.cheatsheets.ICheatSheetResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-public class OpenCheatSheetTest extends PerformanceTestCase {
+public class OpenCheatSheetTest extends PerformanceTestCaseJunit5 {
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		OpenIntroTest.closeIntro();
 	}
 
+	@Test
 	public void testOpenSimpleCheatSheet() throws Exception {
 		tagAsSummary("Open simple cheat sheet", Dimension.ELAPSED_PROCESS);
 
@@ -52,6 +57,7 @@ public class OpenCheatSheetTest extends PerformanceTestCase {
 		assertPerformance();
 	}
 
+	@Test
 	public void testOpenCompositeCheatSheet() throws Exception {
 		tagAsSummary("Open composite cheat sheet", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/AllHelpPerformanceTests.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/AllHelpPerformanceTests.java
@@ -16,23 +16,22 @@ package org.eclipse.ua.tests.help;
 import org.eclipse.ua.tests.help.performance.BuildHtmlSearchIndex;
 import org.eclipse.ua.tests.help.performance.HelpServerTest;
 import org.eclipse.ua.tests.help.performance.IndexAssemblePerformanceTest;
+import org.eclipse.ua.tests.help.performance.LowIterationHelpServerTest;
 import org.eclipse.ua.tests.help.performance.TocAssemblePerformanceTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /*
  * Tests help performance (automated).
  */
-@RunWith(Suite.class)
-@SuiteClasses({ TocAssemblePerformanceTest.class, IndexAssemblePerformanceTest.class, BuildHtmlSearchIndex.class,
-		HelpServerTest.class })
+@Suite
+@SelectClasses({ TocAssemblePerformanceTest.class,
+	IndexAssemblePerformanceTest.class,
+	LowIterationHelpServerTest.class,
+	BuildHtmlSearchIndex.class,
+	HelpServerTest.class,
+	// OpenHelpTest.class // Disabled due to inability to get reliable results. Browser/SWT changes in timing of listener events no longer consistent in 3.3.
+})
 public class AllHelpPerformanceTests {
 
-	/*
-	 * Disabled due to inability to get reliable results. Browser/SWT changes in
-	 * timing of listener events no longer consistent in 3.3.
-	 */
-
-	// addTest(OpenHelpTest.suite());
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/BuildHtmlSearchIndex.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/BuildHtmlSearchIndex.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.performance;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.net.URL;
 
 import org.eclipse.core.runtime.IStatus;
@@ -28,18 +30,23 @@ import org.eclipse.help.internal.toc.TocFile;
 import org.eclipse.help.internal.toc.TocFileProvider;
 import org.eclipse.help.internal.toc.TocManager;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.osgi.framework.FrameworkUtil;
 
-public class BuildHtmlSearchIndex extends PerformanceTestCase {
+public class BuildHtmlSearchIndex extends PerformanceTestCaseJunit5 {
 
 	private AbstractTocProvider[] tocProviders;
 	private AbstractIndexProvider[] indexProviders;
 	private AnalyzerDescriptor analyzerDesc;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		TocManager tocManager = HelpPlugin.getTocManager();
 		tocProviders = tocManager.getTocProviders();
 		tocManager.setTocProviders(new AbstractTocProvider[] { new TestTocFileProvider() });
@@ -52,8 +59,9 @@ public class BuildHtmlSearchIndex extends PerformanceTestCase {
 		analyzerDesc = new AnalyzerDescriptor("en-us");
 	}
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		super.tearDown();
 		TocManager tocManager = HelpPlugin.getTocManager();
 		tocManager.setTocProviders(tocProviders);
@@ -67,6 +75,7 @@ public class BuildHtmlSearchIndex extends PerformanceTestCase {
 		indexProviders = null;
 	}
 
+	@Test
 	public void testCreateHtmlSearchIndex() throws Exception {
 		tagAsGlobalSummary("Create HTML Search Index", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/HelpServerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/HelpServerTest.java
@@ -15,21 +15,25 @@
 package org.eclipse.ua.tests.help.performance;
 
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ua.tests.help.util.LoadServletUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the performance of the help server without launching the Help UI
  */
 
-public class HelpServerTest extends PerformanceTestCase {
+public class HelpServerTest extends PerformanceTestCaseJunit5 {
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		LoadServletUtil.stopServer();
 		super.tearDown();
 	}
 
+	@Test
 	public void testServletRead100x() throws Exception {
 		tagAsSummary("Servlet Read", Dimension.ELAPSED_PROCESS);
 		LoadServletUtil.startServer();
@@ -53,6 +57,7 @@ public class HelpServerTest extends PerformanceTestCase {
 		assertPerformance();
 	}
 
+	@Test
 	public void testStartServer() throws Exception {
 		tagAsSummary("Start Server", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/IndexAssemblePerformanceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/IndexAssemblePerformanceTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.performance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,12 +29,14 @@ import org.eclipse.help.internal.index.IndexContribution;
 import org.eclipse.help.internal.index.IndexFile;
 import org.eclipse.help.internal.index.IndexFileParser;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 import org.xml.sax.SAXException;
 
-public class IndexAssemblePerformanceTest extends PerformanceTestCase {
+public class IndexAssemblePerformanceTest extends PerformanceTestCaseJunit5 {
 
+	@Test
 	public void testIndexAssemble() throws Exception {
 		tagAsSummary("Assemble Index", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/LowIterationHelpServerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/LowIterationHelpServerTest.java
@@ -15,21 +15,25 @@
 package org.eclipse.ua.tests.help.performance;
 
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ua.tests.help.util.LoadServletUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A version of the servlet read test with a low iteration count
  */
 
-public class LowIterationHelpServerTest extends PerformanceTestCase {
+public class LowIterationHelpServerTest extends PerformanceTestCaseJunit5 {
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		LoadServletUtil.stopServer();
 		super.tearDown();
 	}
 
+	@Test
 	public void testServletRead20x() throws Exception {
 		tagAsSummary("Servlet Read", Dimension.ELAPSED_PROCESS);
 		LoadServletUtil.startServer();
@@ -53,6 +57,7 @@ public class LowIterationHelpServerTest extends PerformanceTestCase {
 		assertPerformance();
 	}
 
+	@Test
 	public void testStartServer() throws Exception {
 		tagAsSummary("Start Server", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/OpenHelpTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/OpenHelpTest.java
@@ -31,19 +31,24 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ui.PlatformUI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.osgi.framework.FrameworkUtil;
 
-public class OpenHelpTest extends PerformanceTestCase {
+public class OpenHelpTest extends PerformanceTestCaseJunit5 {
 
 	private AbstractTocProvider[] tocProviders;
 	private AbstractIndexProvider[] indexProviders;
 	private Shell shell;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		TocManager tocManager = HelpPlugin.getTocManager();
 		tocProviders = tocManager.getTocProviders();
 		tocManager.setTocProviders(new AbstractTocProvider[] { new TestTocFileProvider() });
@@ -55,8 +60,9 @@ public class OpenHelpTest extends PerformanceTestCase {
 		indexManager.clearCache();
 	}
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		super.tearDown();
 		TocManager tocManager = HelpPlugin.getTocManager();
 		tocManager.setTocProviders(tocProviders);
@@ -67,6 +73,7 @@ public class OpenHelpTest extends PerformanceTestCase {
 		indexManager.clearCache();
 	}
 
+	@Test
 	public void testOpenHelp() throws Exception {
 		tagAsGlobalSummary("Open help", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/TocAssemblePerformanceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/TocAssemblePerformanceTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ua.tests.help.performance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,11 +28,12 @@ import org.eclipse.help.internal.toc.TocContribution;
 import org.eclipse.help.internal.toc.TocFile;
 import org.eclipse.help.internal.toc.TocFileParser;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 import org.xml.sax.SAXException;
 
-public class TocAssemblePerformanceTest extends PerformanceTestCase {
+public class TocAssemblePerformanceTest extends PerformanceTestCaseJunit5 {
 
 	private TocContribution parse(TocFileParser parser, String tocFile)
 			throws IOException, SAXException, ParserConfigurationException {
@@ -64,6 +67,7 @@ public class TocAssemblePerformanceTest extends PerformanceTestCase {
 		return result;
 	}
 
+	@Test
 	public void testTocAssemble() throws Exception {
 		tagAsSummary("Assemble TOC", Dimension.ELAPSED_PROCESS);
 

--- a/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/AllIntroPerformanceTests.java
+++ b/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/AllIntroPerformanceTests.java
@@ -14,14 +14,13 @@
 package org.eclipse.ua.tests.intro;
 
 import org.eclipse.ua.tests.intro.performance.OpenIntroTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /*
  * Tests help performance (automated).
  */
-@RunWith(Suite.class)
-@SuiteClasses({ OpenIntroTest.class })
+@Suite
+@SelectClasses({ OpenIntroTest.class })
 public class AllIntroPerformanceTests {
 }

--- a/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/performance/OpenIntroTest.java
+++ b/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/performance/OpenIntroTest.java
@@ -15,28 +15,34 @@ package org.eclipse.ua.tests.intro.performance;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.intro.impl.model.loader.ExtensionPointManager;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.intro.config.CustomizableIntroPart;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.osgi.framework.FrameworkUtil;
 
-public class OpenIntroTest extends PerformanceTestCase {
+public class OpenIntroTest extends PerformanceTestCaseJunit5 {
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		closeIntro();
 		// test extensions filter by this system property
 		System.setProperty("org.eclipse.ua.tests.property.isTesting", "true"); //$NON-NLS-1$ //$NON-NLS-2$
 		ExtensionPointManager.getInst().setExtensionFilter(FrameworkUtil.getBundle(getClass()).getSymbolicName());
 	}
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		super.tearDown();
 		closeIntro();
 		// test extensions filter by this system property
@@ -44,6 +50,7 @@ public class OpenIntroTest extends PerformanceTestCase {
 		ExtensionPointManager.getInst().setExtensionFilter(null);
 	}
 
+	@Test
 	public void testOpenIntro() throws Exception {
 		tagAsSummary("Open welcome", Dimension.ELAPSED_PROCESS);
 


### PR DESCRIPTION
The performance tests in `org.eclipse.ua.tests  still rely on the JUnit 3 `PerformanceTestCase`. In addition, one test class is missing in an according test suite.

* Migrates all UA performance tests and test suites to JUnit 5
* Adds the missing `LowIterationHelpServerTest` to the `AllHelpPerformanceTests` suite

Note that the performance tests are not executed in CI builds, so the change will probably not have any effect that is automatically validated.