### PR TITLE
Migrate Ant UI performance tests to JUnit 5

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/OpenAntEditorTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/OpenAntEditorTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ant.tests.ui.editor.performance;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 
 import org.eclipse.ant.internal.ui.AntUIPlugin;
@@ -26,22 +28,28 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.PartInitException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 @SuppressWarnings("restriction")
 public class OpenAntEditorTest extends AbstractAntPerformanceTest {
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		EditorTestHelper.runEventQueue();
 	}
 
+	@Test
 	public void testOpenAntEditor1() throws Exception {
 		// cold run
 		IFile file = getIFile("build.xml"); //$NON-NLS-1$
 		measureOpenInEditor(file);
 	}
 
+	@Test
 	public void testOpenAntEditor2() throws Exception {
 		// warm run
 		IFile file = getIFile("build.xml"); //$NON-NLS-1$
@@ -49,6 +57,7 @@ public class OpenAntEditorTest extends AbstractAntPerformanceTest {
 		measureOpenInEditor(file);
 	}
 
+	@Test
 	public void testOpenAntEditorNoFolding() throws Exception {
 		IPreferenceStore store = AntUIPlugin.getDefault().getPreferenceStore();
 		try {
@@ -68,13 +77,13 @@ public class OpenAntEditorTest extends AbstractAntPerformanceTest {
 
 	protected File getBuildFile(String buildFileName) {
 		IFile file = getIFile(buildFileName);
-		assertTrue("Could not find build file named: " + buildFileName, file.exists()); //$NON-NLS-1$
+		assertTrue(file.exists(), "Could not find build file named: " + buildFileName); //$NON-NLS-1$
 		return file.getLocation().toFile();
 	}
 
 	/**
 	 * Returns the 'AntUITests' project.
-	 * 
+	 *
 	 * @return the test project
 	 */
 	protected IProject getProject() {

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/AbstractAntPerformanceTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/AbstractAntPerformanceTest.java
@@ -7,25 +7,28 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *      IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.performance;
 
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Abstract class for ant performance tests, ensures the test project is created and ready in the test workspace.
- * 
+ *
  * @since 3.5
  */
-public abstract class AbstractAntPerformanceTest extends PerformanceTestCase {
+public abstract class AbstractAntPerformanceTest extends PerformanceTestCaseJunit5 {
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		AbstractAntUITest.assertProject();
 	}
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/OpenLaunchConfigurationDialogTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/OpenLaunchConfigurationDialogTests.java
@@ -7,12 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.ant.tests.ui.performance;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ant.internal.ui.IAntUIConstants;
 import org.eclipse.ant.tests.ui.editor.performance.EditorTestHelper;
@@ -28,14 +30,19 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ui.externaltools.internal.model.IExternalToolConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 @SuppressWarnings("restriction")
-public class OpenLaunchConfigurationDialogTests extends PerformanceTestCase {
+public class OpenLaunchConfigurationDialogTests extends PerformanceTestCaseJunit5 {
 
 	public static String fgIdentifier = IExternalToolConstants.ID_EXTERNAL_TOOLS_LAUNCH_GROUP;
 
+	@Test
 	public void testOpenAntLaunchConfigurationDialog1() {
 		// cold run
 		ILaunchConfiguration configuration = getLaunchConfiguration("big"); //$NON-NLS-1$
@@ -48,6 +55,7 @@ public class OpenLaunchConfigurationDialogTests extends PerformanceTestCase {
 		assertPerformance();
 	}
 
+	@Test
 	public void testOpenAntLaunchConfigurationDialog2() {
 		// warm run
 		ILaunchConfiguration configuration = getLaunchConfiguration("big"); //$NON-NLS-1$
@@ -64,7 +72,7 @@ public class OpenLaunchConfigurationDialogTests extends PerformanceTestCase {
 	private ILaunchConfiguration getLaunchConfiguration(String buildFileName) {
 		IFile file = AbstractAntUITest.getJavaProject().getProject().getFolder("launchConfigurations").getFile(buildFileName + ".launch"); //$NON-NLS-1$ //$NON-NLS-2$
 		ILaunchConfiguration config = AbstractAntUITest.getLaunchManager().getLaunchConfiguration(file);
-		assertTrue("Could not find launch configuration for " + buildFileName, config.exists()); //$NON-NLS-1$
+		assertTrue(config.exists(), "Could not find launch configuration for " + buildFileName); //$NON-NLS-1$
 		return config;
 	}
 
@@ -86,9 +94,10 @@ public class OpenLaunchConfigurationDialogTests extends PerformanceTestCase {
 		stopMeasuring();
 	}
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	public void setUp(TestInfo testInfo) throws Exception {
+		super.setUp(testInfo);
 		IPreferenceStore debugPreferenceStore = DebugUIPlugin.getDefault().getPreferenceStore();
 		debugPreferenceStore.setValue(IInternalDebugUIConstants.PREF_FILTER_LAUNCH_CLOSED, false);
 		debugPreferenceStore.setValue(IInternalDebugUIConstants.PREF_FILTER_LAUNCH_DELETED, false);
@@ -97,8 +106,9 @@ public class OpenLaunchConfigurationDialogTests extends PerformanceTestCase {
 		EditorTestHelper.runEventQueue();
 	}
 
+	@AfterEach
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		super.tearDown();
 		IPreferenceStore debugPreferenceStore = DebugUIPlugin.getDefault().getPreferenceStore();
 		debugPreferenceStore.setToDefault(IInternalDebugUIConstants.PREF_FILTER_LAUNCH_CLOSED);

--- a/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
@@ -39,6 +39,8 @@ Require-Bundle: org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.ant.launching,
  org.eclipse.core.externaltools,
  org.eclipse.pde.core
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUIPerformanceTests.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUIPerformanceTests.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -15,18 +15,18 @@
 package org.eclipse.ant.tests.ui.testplugin;
 
 import org.eclipse.ant.tests.ui.editor.performance.OpenAntEditorTest;
+import org.eclipse.ant.tests.ui.performance.OpenLaunchConfigurationDialogTests;
 import org.eclipse.ant.tests.ui.performance.SeparateVMTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Performance Test suite for the Ant UI. All of the tests in this suite rely on
  * the setup that occurs in the ProjectCreationDecorator suite. It must always
  * run before any of the other test suites.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ OpenAntEditorTest.class, SeparateVMTests.class })
+@Suite
+@SelectClasses({ OpenAntEditorTest.class, OpenLaunchConfigurationDialogTests.class, SeparateVMTests.class })
 public class AntUIPerformanceTests {
-	// suite.addTest(new TestSuite(NonInitialTypingTest.class));
-	// suite.addTest(new TestSuite(OpenLaunchConfigurationDialogTests.class));
+	//
 }


### PR DESCRIPTION
The performance tests in `org.eclipse.ant.tests.ui` still rely on the JUnit 3 `PerformanceTestCase`. In addition, one test class is missing in the according test suite.

* Migrates all Ant UI performance tests and test suites to JUnit 5
* Adds the missing `OpenLaunchConfigurationDialogTest` performance test to the performance test suite

`SeparateVMTests` as part of the performance test suite is not yet migrated to JUnit 5, as it is derived from an ordinary Ant UI test, which is still based on JUnit 3. This will be migrated once the other, ordinary Ant UI tests are migrated to JUnit 4 / 5.

Note that the performance tests are not executed in CI builds, so the change will probably not have any effect that is automatically validated.