### PR TITLE
Migrate Ant UI tests to JUnit 4

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.ant.internal.launching.debug.model.AntDebugTarget;
 import org.eclipse.ant.internal.launching.debug.model.AntLineBreakpoint;
 import org.eclipse.ant.internal.launching.debug.model.AntStackFrame;
@@ -56,6 +60,10 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.IHyperlink;
 import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 /**
  * Tests for launch configurations
@@ -65,16 +73,27 @@ public abstract class AbstractAntDebugTest extends AbstractAntUIBuildTest {
 
 	public static final int DEFAULT_TIMEOUT = 20000;
 
+	private static boolean wasAutomatedModeEnabled;
+	private static boolean wasIgnoreErrorEnabled;
+
 	/**
 	 * The last relevant event set - for example, that caused a thread to suspend
 	 */
 	protected DebugEvent[] fEventSet;
 
-	public AbstractAntDebugTest(String name) {
-		super(name);
+	@BeforeClass
+	public static void setupClass() {
 		// set error dialog to non-blocking to avoid hanging the UI during test
+		wasAutomatedModeEnabled = ErrorDialog.AUTOMATED_MODE;
 		ErrorDialog.AUTOMATED_MODE = true;
+		wasIgnoreErrorEnabled = SafeRunnable.getIgnoreErrors();
 		SafeRunnable.setIgnoreErrors(true);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		ErrorDialog.AUTOMATED_MODE = wasAutomatedModeEnabled;
+		SafeRunnable.setIgnoreErrors(wasIgnoreErrorEnabled);
 	}
 
 	/**
@@ -785,8 +804,8 @@ public abstract class AbstractAntDebugTest extends AbstractAntUIBuildTest {
 		debugUIPreferences.setValue(IDebugUIConstants.PREF_ACTIVATE_WORKBENCH, activate);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (fEventSet != null) {
 			fEventSet = null;
 		}
@@ -796,11 +815,11 @@ public abstract class AbstractAntDebugTest extends AbstractAntUIBuildTest {
 		debugUIPreferences.setToDefault(IDebugPreferenceConstants.CONSOLE_OPEN_ON_OUT);
 		debugUIPreferences.setToDefault(IInternalDebugUIConstants.PREF_ACTIVATE_DEBUG_VIEW);
 		debugUIPreferences.setToDefault(IDebugUIConstants.PREF_ACTIVATE_WORKBENCH);
-		super.tearDown();
 	}
 
+	@Before
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		setPreferences();
 		DebugUIPlugin.getStandardDisplay().syncExec(() -> {

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/BreakpointTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/BreakpointTests.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,20 +31,19 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.core.model.ILineBreakpoint;
+import org.junit.Test;
 
 /**
  * Tests Ant breakpoints.
  */
 public class BreakpointTests extends AbstractAntDebugTest {
 
-	public BreakpointTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testDeferredBreakpoints() throws Exception {
 		deferredBreakpoints(false);
 	}
 
+	@Test
 	public void testDeferredBreakpointsSepVM() throws Exception {
 		deferredBreakpoints(true);
 	}
@@ -80,10 +83,12 @@ public class BreakpointTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testDisabledBreakpoint() throws Exception {
 		disabledBreakpoint(false);
 	}
 
+	@Test
 	public void testDisabledBreakpointSepVM() throws Exception {
 		disabledBreakpoint(true);
 	}
@@ -102,10 +107,12 @@ public class BreakpointTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testEnableDisableBreakpoint() throws Exception {
 		enableDisableBreapoint(false);
 	}
 
+	@Test
 	public void testEnableDisableBreakpointSepVM() throws Exception {
 		enableDisableBreapoint(true);
 	}
@@ -141,10 +148,12 @@ public class BreakpointTests extends AbstractAntDebugTest {
 		wait(1000);
 	}
 
+	@Test
 	public void testSkipLineBreakpoint() throws Exception {
 		skipLineBreakpoint(false);
 	}
 
+	@Test
 	public void testSkipLineBreakpointSepVM() throws Exception {
 		skipLineBreakpoint(true);
 	}
@@ -170,26 +179,32 @@ public class BreakpointTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testBreakpoint() throws Exception {
 		breakpoints(false, "default", 5, 15); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBreakpointSepVM() throws Exception {
 		breakpoints(true, "default", 5, 15); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTargetBreakpoint() throws Exception {
 		breakpoints(false, "entry2", 4, 24); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTaskOutOfTargetBreakpoint() throws Exception {
 		breakpoints(false, "entry2", 36, 5); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTaskOutOfTargetBreakpointSepVm() throws Exception {
 		breakpoints(true, "entry2", 36, 5); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTargetBreakpointSepVM() throws Exception {
 		breakpoints(true, "entry2", 4, 24); //$NON-NLS-1$
 	}

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.ant.internal.launching.debug.model.AntProperty;
 import org.eclipse.ant.internal.launching.debug.model.AntStackFrame;
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
@@ -25,6 +29,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.ILineBreakpoint;
 import org.eclipse.debug.core.model.IVariable;
+import org.junit.Test;
 import org.osgi.framework.Version;
 
 public class PropertyTests extends AbstractAntDebugTest {
@@ -37,14 +42,12 @@ public class PropertyTests extends AbstractAntDebugTest {
 				+ antVersion.getMicro();
 	}
 
-	public PropertyTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testSystemProperties() throws Exception {
 		systemProperties(false);
 	}
 
+	@Test
 	public void testSystemPropertiesSepVM() throws Exception {
 		systemProperties(true);
 	}
@@ -75,10 +78,12 @@ public class PropertyTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testUserProperties() throws Exception {
 		userProperties(false);
 	}
 
+	@Test
 	public void testUserPropertiesSepVM() throws Exception {
 		userProperties(true);
 	}
@@ -110,6 +115,7 @@ public class PropertyTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testRuntimeProperties() throws Exception {
 		runtimeProperties(false);
 	}

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/RunToLineTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/RunToLineTests.java
@@ -7,11 +7,14 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.ant.internal.launching.debug.model.AntLineBreakpoint;
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
@@ -35,16 +38,13 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.Test;
 
 /**
  * Tests run to line debug functionality
  */
 @SuppressWarnings("restriction")
 public class RunToLineTests extends AbstractAntDebugTest {
-
-	public RunToLineTests(String name) {
-		super(name);
-	}
 
 	private final Object fLock = new Object();
 	private IEditorPart fEditor = null;
@@ -79,6 +79,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLine() throws Exception {
 		runToLine(14, 14, true, false);
 	}
@@ -88,6 +89,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLineSepVM() throws Exception {
 		runToLine(14, 14, true, true);
 	}
@@ -97,6 +99,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLineSkipBreakpoint() throws Exception {
 		createLineBreakpoint(6, "breakpoints.xml"); //$NON-NLS-1$
 		runToLine(14, 14, true, false);
@@ -108,6 +111,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLineSkipBreakpointSepVM() throws Exception {
 		createLineBreakpoint(6, "breakpoints.xml"); //$NON-NLS-1$
 		runToLine(14, 14, true, true);
@@ -118,6 +122,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLineHitBreakpoint() throws Exception {
 		createLineBreakpoint(6, "breakpoints.xml"); //$NON-NLS-1$
 		runToLine(14, 6, false, false);
@@ -128,6 +133,7 @@ public class RunToLineTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRunToLineHitBreakpointSepVM() throws Exception {
 		createLineBreakpoint(6, "breakpoints.xml"); //$NON-NLS-1$
 		runToLine(14, 6, false, true);

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
@@ -13,22 +13,23 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.model.ILineBreakpoint;
 import org.eclipse.debug.core.model.IStackFrame;
+import org.junit.Test;
 
 public class StackTests extends AbstractAntDebugTest {
 
-	public StackTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testStackForAntCall() throws Exception {
 		antCallStack(false);
 	}
 
+	@Test
 	public void testStackForAntCallVM() throws Exception {
 		antCallStack(true);
 	}

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/SteppingTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/SteppingTests.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.ant.internal.launching.debug.model.AntStackFrame;
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
 import org.eclipse.core.runtime.CoreException;
@@ -21,16 +24,14 @@ import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.ILineBreakpoint;
 import org.eclipse.debug.core.model.IStackFrame;
+import org.junit.Test;
 
 public class SteppingTests extends AbstractAntDebugTest {
-
-	public SteppingTests(String name) {
-		super(name);
-	}
 
 	/**
 	 * bug 84400
 	 */
+	@Test
 	public void testStepBackFromAntCall() throws Exception {
 		antCallStack(false, 12, DebugEvent.STEP_OVER, "default: echo", 7); //$NON-NLS-1$
 	}
@@ -38,6 +39,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	/**
 	 * bug 84400
 	 */
+	@Test
 	public void testStepBackFromAntCallSepVM() throws Exception {
 		antCallStack(true, 12, DebugEvent.STEP_OVER, "default: echo", 7); //$NON-NLS-1$
 	}
@@ -45,6 +47,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	/**
 	 * bug 88218, 85769
 	 */
+	@Test
 	public void testStepIntoAntCall() throws Exception {
 		AntThread thread = null;
 		try {
@@ -61,6 +64,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	/**
 	 * bug 88218, 85769
 	 */
+	@Test
 	public void testStepIntoAntCallSepVM() throws Exception {
 		AntThread thread = null;
 		try {
@@ -74,10 +78,12 @@ public class SteppingTests extends AbstractAntDebugTest {
 		}
 	}
 
+	@Test
 	public void testStepOverAntCall() throws Exception {
 		antCallStack(false, 5, DebugEvent.STEP_OVER, "default: echo", 7); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testStepOverAntCallSepVM() throws Exception {
 		antCallStack(true, 5, DebugEvent.STEP_OVER, "default: echo", 7); //$NON-NLS-1$
 	}
@@ -85,6 +91,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	/**
 	 * bug 96022
 	 */
+	@Test
 	public void testStepOverAntCallPastOtherAntCalls() throws Exception {
 		debugStack(false, 7, DebugEvent.STEP_OVER, "default: echo", 9, "96022", true); //$NON-NLS-1$ //$NON-NLS-2$
 	}
@@ -92,16 +99,19 @@ public class SteppingTests extends AbstractAntDebugTest {
 	/**
 	 * bug 96022
 	 */
+	@Test
 	public void testStepOverAntCallPastOtherAntCallsSepVm() throws Exception {
 		debugStack(true, 7, DebugEvent.STEP_OVER, "default: echo", 9, "96022", true); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testStepOverAntCallHitBreakpoint() throws Exception {
 		String fileName = "debugAntCall"; //$NON-NLS-1$
 		createLineBreakpoint(12, fileName + ".xml"); //$NON-NLS-1$
 		antCallStack(false, 5, DebugEvent.BREAKPOINT, "call: sleep", 12); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testStepOverAntCallHitBreakpointSepVM() throws Exception {
 		String fileName = "debugAntCall"; //$NON-NLS-1$
 		createLineBreakpoint(12, fileName + ".xml"); //$NON-NLS-1$
@@ -174,6 +184,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void testStepOutOfMacrodef() throws CoreException {
 		String fileName = "macrodef"; //$NON-NLS-1$
 		debugStack(false, 8, DebugEvent.STEP_OVER, "type: eclipseMacro", 16, fileName, true); //$NON-NLS-1$
@@ -184,6 +195,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void testStepOutOfMacrodefSepVM() throws CoreException {
 		String fileName = "macrodef"; //$NON-NLS-1$
 		debugStack(true, 8, DebugEvent.STEP_OVER, "type: eclipseMacro", 16, fileName, true); //$NON-NLS-1$
@@ -194,6 +206,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void testStepIntoMacrodef() throws CoreException {
 		testMacroDef(false);
 	}
@@ -203,6 +216,7 @@ public class SteppingTests extends AbstractAntDebugTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void testStepIntoMacrodefSepVM() throws CoreException {
 		testMacroDef(true);
 	}

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorContentOutlineTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorContentOutlineTests.java
@@ -17,6 +17,11 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.eclipse.ant.internal.ui.model.AntElementNode;
@@ -24,20 +29,18 @@ import org.eclipse.ant.internal.ui.model.AntModel;
 import org.eclipse.ant.internal.ui.model.IAntElement;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 import org.eclipse.jface.text.BadLocationException;
+import org.junit.Test;
 
 /**
  * Tests the correct creation of the outline for an xml file.
- * 
+ *
  */
 public class AntEditorContentOutlineTests extends AbstractAntUITest {
-
-	public AntEditorContentOutlineTests(String name) {
-		super(name);
-	}
 
 	/**
 	 * Tests the creation of the AntElementNode, that includes parsing a file and determining the correct location of the tags.
 	 */
+	@Test
 	public void testCreationOfOutlineTree() throws BadLocationException {
 		AntModel model = getAntModel("buildtest1.xml"); //$NON-NLS-1$
 
@@ -125,6 +128,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	/**
 	 * Tests the creation of the AntElementNode, that includes parsing a non-valid file.
 	 */
+	@Test
 	public void testParsingOfNonValidFile() throws BadLocationException {
 		AntModel model = getAntModel("buildtest2.xml"); //$NON-NLS-1$
 
@@ -146,6 +150,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	/**
 	 * Tests whether the outline can handle a build file with only the {@literal <project></project>} tags.
 	 */
+	@Test
 	public void testWithProjectOnlyBuildFile() {
 		AntModel model = getAntModel("projectOnly.xml"); //$NON-NLS-1$
 		AntElementNode rootProject = model.getProjectNode();
@@ -155,6 +160,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	/**
 	 * Tests whether the outline can handle an empty build file.
 	 */
+	@Test
 	public void testWithEmptyBuildFile() {
 		AntModel model = getAntModel("empty.xml"); //$NON-NLS-1$
 		AntElementNode rootProject = model.getProjectNode();
@@ -164,6 +170,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	/**
 	 * Some testing of getting the right location of tags.
 	 */
+	@Test
 	public void testAdvancedTaskLocation() throws BadLocationException {
 		AntModel model = getAntModel("outline_select_test_build.xml"); //$NON-NLS-1$
 
@@ -193,6 +200,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	/**
 	 * Tests if target is internal or not
 	 */
+	@Test
 	public void testInternalTargets() {
 		AntModel model = getAntModel("internalTargets.xml"); //$NON-NLS-1$
 		assertTrue("Target without description should be internal", model.getTargetNode("internal1").isInternal()); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
@@ -14,6 +14,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 
 import org.eclipse.ant.internal.ui.editor.AntEditor;
@@ -28,14 +32,13 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
+import org.junit.After;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class AntEditorTests extends AbstractAntUITest {
 
-	public AntEditorTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testHoverForPath() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -48,6 +51,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertTrue("Expected the following hover text to match regex: " + correctResultRegEx, hoverText.matches(correctResultRegEx)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testHoverForProperty() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -60,6 +64,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertTrue("Expected the following hover text to end with: " + correctResult, hoverText.endsWith(correctResult)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPropertyOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -71,6 +76,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "property", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testPatternSetHover() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -83,6 +89,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertTrue("Expected the following hover text to end with: " + correctResult + "was: " + hoverText, hoverText.endsWith(correctResult)); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBadPatternSetHover() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -95,6 +102,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertTrue("Expected the following hover text to ends with: " + correctResult, hoverText.endsWith(correctResult)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFileSetHover() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -117,6 +125,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertTrue("Expected to see '<li>**/.hgtags</li>'", hoverText.contains(text)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTaskdefOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("taskdef.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -135,6 +144,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "taskdef", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testMacroDefOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("macrodef.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -156,6 +166,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	/**
 	 * from bug 98853
 	 */
+	@Test
 	public void testMacroDefOpenDeclarationWithURI() throws PartInitException, BadLocationException {
 		IFile file = getIFile("98853.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -170,6 +181,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	/**
 	 * Bug 95061
 	 */
+	@Test
 	public void testSelfClosingTagOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("macrodef.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -181,6 +193,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "macrodef", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testMacroDefAttributeOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("macrodef.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -192,6 +205,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "attribute", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testRefOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -203,6 +217,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "path", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testTargetOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -214,6 +229,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertEquals("Selection is not correct", "target", selection.getText()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testExtensionPointOpenDeclaration() throws PartInitException, BadLocationException {
 		IFile file = getIFile("antextpoint.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -230,6 +246,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	 *
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
+	@Test
 	public void testAugmentOpenInEditor() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
 		IEditorPart part = EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -241,6 +258,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	 *
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
+	@Test
 	public void testAugmentOpenAndSelect() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
 		IEditorPart part = EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -257,6 +275,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	 *
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
+	@Test
 	public void testAugmentOpenSelectHover() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
 		IEditorPart part = EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -279,12 +298,14 @@ public class AntEditorTests extends AbstractAntUITest {
 	 *
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=396219
 	 */
+	@Test
 	public void testAugmentMissingId() throws Exception {
 		IFile file = getIFile("bug396219.ent"); //$NON-NLS-1$
 		IEditorPart part = EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
 		assertTrue("The opened editor must be the AntEditor", part instanceof AntEditor); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testHoverRegionWithSpaces() throws PartInitException, BadLocationException {
 		IFile file = getIFile("refid.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -300,6 +321,7 @@ public class AntEditorTests extends AbstractAntUITest {
 				+ text, region.getLength() == 7 && "compile".equals(text)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testOpenImport() throws PartInitException {
 		IFile file = getIFile("import.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -309,6 +331,7 @@ public class AntEditorTests extends AbstractAntUITest {
 		assertNotNull("Should have a document", doc); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testOpenImportViaClasspath() throws PartInitException {
 		IFile file = getIFile("importViaClasspath.xml"); //$NON-NLS-1$
 		AntEditor editor = (AntEditor) EditorTestHelper.openInEditor(file, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
@@ -334,6 +357,7 @@ public class AntEditorTests extends AbstractAntUITest {
 	/**
 	 * bug 195840 Import a XML file with BOM character in ant editor fails Runs on 1.5 vms or newer.
 	 */
+	@Test
 	public void testOpenImportWithByteOrderMark() throws PartInitException {
 		if (ProjectCreationDecorator.isJ2SE15Compatible()) {
 			IFile file = getIFile("importWithByteOrderMark.xml"); //$NON-NLS-1$
@@ -348,9 +372,8 @@ public class AntEditorTests extends AbstractAntUITest {
 		return offset;
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		EditorTestHelper.closeAllEditors();
-		super.tearDown();
 	}
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
@@ -18,6 +18,13 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 
@@ -40,6 +47,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.PartInitException;
+import org.junit.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -53,17 +61,9 @@ import org.w3c.dom.Element;
 public class CodeCompletionTest extends AbstractAntUITest {
 
 	/**
-	 * Constructor for CodeCompletionTest.
-	 *
-	 * @param name
-	 */
-	public CodeCompletionTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Tests the code completion for attributes of tasks.
 	 */
+	@Test
 	public void testAttributeProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
@@ -117,6 +117,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for properties, including unquoted (bug 40871)
 	 */
+	@Test
 	public void testPropertyProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -144,6 +145,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested elements that no templates are presented Bug 76414
 	 */
+	@Test
 	public void testPropertyTemplateProposals() throws BadLocationException, PartInitException {
 		try {
 			IFile file = getIFile("buildtest1.xml"); //$NON-NLS-1$
@@ -167,6 +169,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for "system" properties
 	 */
+	@Test
 	public void testSystemPropertyProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -184,6 +187,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for "built-in" properties
 	 */
+	@Test
 	public void testBuiltInPropertyProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -207,6 +211,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for extension point / preference properties
 	 */
+	@Test
 	public void testPreferencePropertyProposals() throws BadLocationException {
 		AntCorePreferences prefs = AntCorePlugin.getPlugin().getPreferences();
 		try {
@@ -237,6 +242,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for the depend attribute of a target.
 	 */
+	@Test
 	public void testTargetDependProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 		// simple depends
@@ -269,6 +275,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the image for a code completion proposal for the depend attribute of a target.
 	 */
+	@Test
 	public void testTargetDependProposalImages() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest3.xml")); //$NON-NLS-1$
 		// simple depends
@@ -301,6 +308,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the image for a code completion proposal for the default attribute of a project.
 	 */
+	@Test
 	public void testProjectDefaultProposalImages() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest4.xml")); //$NON-NLS-1$
 		// simple depends
@@ -333,6 +341,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the image for a code completion proposal for the target attribute of an antcall task.
 	 */
+	@Test
 	public void testAntcallTargetProposalImages() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest4.xml")); //$NON-NLS-1$
 		int lineNumber = 4;
@@ -361,6 +370,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for the if attribute of a target.
 	 */
+	@Test
 	public void testTargetIfProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -379,6 +389,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for the unless attribute of a target.
 	 */
+	@Test
 	public void testTargetUnlessProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -398,6 +409,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test the code completion for the target attribute of antcall.
 	 */
+	@Test
 	public void testAntCallTargetProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("debugAntCall.xml")); //$NON-NLS-1$
 		int lineNumber = 4;
@@ -445,6 +457,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the property proposals for the case that they are defined in a dependent targets.
 	 */
+	@Test
 	public void testPropertyProposalDefinedInDependantTargets() throws FileNotFoundException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("dependencytest.xml")); //$NON-NLS-1$
 
@@ -469,6 +482,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined in the buildfile
 	 */
+	@Test
 	public void testCustomTaskProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("taskdef.xml")); //$NON-NLS-1$
 
@@ -482,6 +496,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined via the task extension point
 	 */
+	@Test
 	public void testExtensionPointTaskProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("taskdef.xml")); //$NON-NLS-1$
 		ICompletionProposal[] proposals = processor.getTaskProposals(getCurrentDocument(), "target", "cool"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -493,6 +508,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined via macrodef in the buildfile
 	 */
+	@Test
 	public void testMacrodefProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("macrodef.xml")); //$NON-NLS-1$
 
@@ -506,6 +522,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined via macrodef with uri in the buildfile
 	 */
+	@Test
 	public void testNamespacedMacrodefProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("98853.xml")); //$NON-NLS-1$
 
@@ -519,6 +536,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested element attributes
 	 */
+	@Test
 	public void testMacrodefNestedElementAttributeProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("macrodef.xml")); //$NON-NLS-1$
 		int lineNumber = 5;
@@ -538,6 +556,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined via macrodef in the buildfile
 	 */
+	@Test
 	public void testMacrodefAttributeProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("macrodef.xml")); //$NON-NLS-1$
 		int lineNumber = 12;
@@ -557,6 +576,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks that have been defined via macrodef in the buildfile
 	 */
+	@Test
 	public void testNamespacedMacrodefAttributeProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("98853.xml")); //$NON-NLS-1$
 		int lineNumber = 16;
@@ -574,6 +594,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for elements that have been defined via macrodef in the buildfile
 	 */
+	@Test
 	public void testMacrodefElementProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("macrodef.xml")); //$NON-NLS-1$
 		int lineNumber = 13;
@@ -592,6 +613,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks having parent tasks.
 	 */
+	@Test
 	public void testTaskProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -616,6 +638,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.dispose();
 	}
 
+	@Test
 	public void testTargetTemplateProposals() throws BadLocationException, PartInitException {
 		try {
 			IFile file = getIFile("buildtest1.xml"); //$NON-NLS-1$
@@ -655,6 +678,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for the fail task bug 73637
 	 */
+	@Test
 	public void testFailProposals() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -670,6 +694,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Test for bug 40951
 	 */
+	@Test
 	public void testMixedElements() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("mixed.xml")); //$NON-NLS-1$
 		// String string = "<project><target><sql driver=\"\" password=\"\" url=\"\" userid=\"\"></sql><concat></concat>";
@@ -689,6 +714,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the algorithm for finding a child as used by the processor.
 	 */
+	@Test
 	public void testFindChildElement() throws ParserConfigurationException {
 
 		// Create the test data
@@ -718,6 +744,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests that the processor correctly determines the attribute proposal mode
 	 */
+	@Test
 	public void testDeterminingAttributeProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 		int mode = processor.determineProposalMode("<project><property ta", 21, "ta"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -737,6 +764,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests that the processor correctly determines the attribute value proposal mode
 	 */
+	@Test
 	public void testDeterminingAttributeValueProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 		int mode = processor.determineProposalMode("<project><property take=\"", 25, ""); //$NON-NLS-1$ //$NON-NLS-2$
@@ -752,6 +780,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests how the processor determines the proposal mode.
 	 */
+	@Test
 	public void testDeterminingPropertyProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 		int mode = processor.determineProposalMode("<project><target name=\"$\"", 24, ""); //$NON-NLS-1$ //$NON-NLS-2$
@@ -768,6 +797,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests how the processor determines the proposal mode.
 	 */
+	@Test
 	public void testDeterminingTaskProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
@@ -804,6 +834,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests how the processor determines the proposal mode.
 	 */
+	@Test
 	public void testDeterminingTaskClosingProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
@@ -814,6 +845,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests how the prefix will be determined.
 	 */
+	@Test
 	public void testDeterminingPrefix() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
@@ -843,6 +875,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests how the processor determines the proposal mode.
 	 */
+	@Test
 	public void testDeterminingNoneProposalMode() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
@@ -855,6 +888,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for tasks in an empty build file (no parent).
 	 */
+	@Test
 	public void testTaskProposalsForEmptyBuildFile() {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("empty.xml")); //$NON-NLS-1$
 
@@ -873,6 +907,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for refids (Bug 49830)
 	 */
+	@Test
 	public void testRefidProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("refid.xml")); //$NON-NLS-1$
 
@@ -894,6 +929,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for custom task that has a boolean attribute
 	 */
+	@Test
 	public void testCustomBooleanProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("customBoolean.xml")); //$NON-NLS-1$
 
@@ -915,6 +951,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for custom task that has an enumerated attribute
 	 */
+	@Test
 	public void testCustomEnumeratedProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("extensionPointTaskSepVM.xml")); //$NON-NLS-1$
 		int lineNumber = 2;
@@ -934,6 +971,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for custom task that have a reference attribute
 	 */
+	@Test
 	public void testCustomReferenceProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("extensionPointTaskSepVM.xml")); //$NON-NLS-1$
 		int lineNumber = 2;
@@ -952,6 +990,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested element attributes of custom tasks
 	 */
+	@Test
 	public void testNestedElementAttributeProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("nestedElementAttributes.xml")); //$NON-NLS-1$
 		int lineNumber = 4;
@@ -969,6 +1008,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested elements
 	 */
+	@Test
 	public void testNestedElementProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("nestedElementAttributes.xml")); //$NON-NLS-1$
 		int lineNumber = 4;
@@ -986,6 +1026,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested elements that no templates are presented Bug 76414
 	 */
+	@Test
 	public void testNestedElementTemplateProposals() throws BadLocationException, PartInitException {
 		try {
 			IFile file = getIFile("nestedElementAttributes.xml"); //$NON-NLS-1$
@@ -1008,6 +1049,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for nested element attribute values of custom tasks
 	 */
+	@Test
 	public void testNestedElementAttributeValueProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("nestedElementAttributes.xml")); //$NON-NLS-1$
 		int lineNumber = 4;
@@ -1025,6 +1067,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion when a parse error occurs in the project definition bug 63151
 	 */
+	@Test
 	public void testBadProjectProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("badproject.xml")); //$NON-NLS-1$
 		int lineNumber = 0;
@@ -1042,6 +1085,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for attribute value proposals both with and without leading whitespace
 	 */
+	@Test
 	public void testAttributeValueProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("javac.xml")); //$NON-NLS-1$
 		int lineNumber = 2;
@@ -1079,6 +1123,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for an empty buildfile
 	 */
+	@Test
 	public void testEmptyBuildfileProposals() throws PartInitException {
 		try {
 			IFile file = getIFile("empty.xml"); //$NON-NLS-1$
@@ -1101,6 +1146,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for refids (Bug 65480)
 	 */
+	@Test
 	public void testJavacReferencesProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("refid.xml")); //$NON-NLS-1$
 
@@ -1145,6 +1191,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for the default target of a project (Bug 78030)
 	 */
+	@Test
 	public void testProjectDefaultProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -1165,6 +1212,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 	/**
 	 * Tests the code completion for project attributes (bug 82031)
 	 */
+	@Test
 	public void testProjectAttributeProposals() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
@@ -1192,6 +1240,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.dispose();
 	}
 
+	@Test
 	public void testExtensionPoint() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("antextpoint1.xml")); //$NON-NLS-1$
 
@@ -1207,6 +1256,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.dispose();
 	}
 
+	@Test
 	public void testExtensionOf() throws BadLocationException {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("antextpoint2.xml")); //$NON-NLS-1$
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.eclipse.ant.internal.ui.editor.AntEditor;
@@ -24,14 +27,12 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 import org.eclipse.ui.PartInitException;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class OccurrencesFinderTests extends AbstractAntUITest {
 
-	public OccurrencesFinderTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testFromPropertyName() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -56,6 +57,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		assertContainsPosition(positions, newoffset, 8);
 	}
 
+	@Test
 	public void testFromPropertyLocation() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -70,6 +72,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testFromPropertyValue() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -84,6 +87,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testPropertyRefFromTaskText() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -115,6 +119,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testFromMacrodefAttributeDecl() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -139,6 +144,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		assertContainsPosition(positions, newoffset, 7);
 	}
 
+	@Test
 	public void testFromMacrodefAttributeRef() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -153,6 +159,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testTargetFromAnt() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -174,6 +181,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testTargetFromAntCall() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -198,6 +206,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	/**
 	 * bug 89115
 	 */
+	@Test
 	public void testTargetFromProjectDefault() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("89115.xml"); //$NON-NLS-1$
@@ -223,6 +232,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	 * @throws PartInitException
 	 * @throws BadLocationException
 	 */
+	@Test
 	public void testTargetFromTargetDepends() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("89115.xml"); //$NON-NLS-1$
@@ -262,6 +272,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	 * @throws PartInitException
 	 * @throws BadLocationException
 	 */
+	@Test
 	public void testTargetFromTargetIf() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("occurrencesTest.xml"); //$NON-NLS-1$
@@ -276,6 +287,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 		}
 	}
 
+	@Test
 	public void testNoRefFromProjectDefault() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("89115.xml"); //$NON-NLS-1$
@@ -317,6 +329,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	/**
 	 * Bug 89901
 	 */
+	@Test
 	public void testPropertyAndTargetWithSameName() throws PartInitException, BadLocationException {
 		try {
 			IFile file = getIFile("89901.xml"); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/TaskDescriptionProviderTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/TaskDescriptionProviderTest.java
@@ -16,8 +16,13 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.ant.internal.ui.editor.TaskDescriptionProvider;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.junit.Test;
 
 /**
  * Tests the tasks description provider.
@@ -26,13 +31,10 @@ import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 @SuppressWarnings("restriction")
 public class TaskDescriptionProviderTest extends AbstractAntUITest {
 
-	public TaskDescriptionProviderTest(String name) {
-		super(name);
-	}
-
 	/**
 	 * Tests getting the description of a task.
 	 */
+	@Test
 	public void testGettingTaskDescription() {
 		TaskDescriptionProvider provider = TaskDescriptionProvider.getDefault();
 		String description = provider.getDescriptionForTask("apply"); //$NON-NLS-1$
@@ -43,6 +45,7 @@ public class TaskDescriptionProviderTest extends AbstractAntUITest {
 	/**
 	 * Tests getting the description of an attribute.
 	 */
+	@Test
 	public void testGettingAttribute() {
 		TaskDescriptionProvider provider = TaskDescriptionProvider.getDefault();
 		String description = provider.getDescriptionForTaskAttribute("apply", "executable"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -53,6 +56,7 @@ public class TaskDescriptionProviderTest extends AbstractAntUITest {
 	/**
 	 * Tests getting the required value of an attribute.
 	 */
+	@Test
 	public void testGettingRequired() {
 		TaskDescriptionProvider provider = TaskDescriptionProvider.getDefault();
 		String required = provider.getRequiredAttributeForTaskAttribute("apply", "executable"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/FormattingPreferencesTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/FormattingPreferencesTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class FormattingPreferencesTest extends AbstractAntUITest {
 
-	public FormattingPreferencesTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public final void testGetCanonicalIndent() {
 
 		FormattingPreferences prefs;

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 John-Mason P. Shackelford and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
@@ -13,20 +13,20 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlDocumentFormatter;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class XmlDocumentFormatterTest extends AbstractAntUITest {
 
-	public XmlDocumentFormatterTest(String name) {
-		super(name);
-	}
-
 	/**
 	 * General Test
 	 */
+	@Test
 	public final void testGeneralFormat() throws Exception {
 		FormattingPreferences prefs = new FormattingPreferences() {
 			@Override
@@ -45,6 +45,7 @@ public class XmlDocumentFormatterTest extends AbstractAntUITest {
 	/**
 	 * Insure that tab width is not hard coded
 	 */
+	@Test
 	public final void testTabWidth() throws Exception {
 		FormattingPreferences prefs = new FormattingPreferences() {
 			@Override
@@ -63,6 +64,7 @@ public class XmlDocumentFormatterTest extends AbstractAntUITest {
 	/**
 	 * Test with tab characters instead of spaces.
 	 */
+	@Test
 	public final void testTabsInsteadOfSpaces() throws Exception {
 		FormattingPreferences prefs = new FormattingPreferences() {
 			@Override

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2013 John-Mason P. Shackelford and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
@@ -14,7 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -22,6 +26,7 @@ import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlTagFormatter;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlTagFormatter.AttributePair;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class XmlTagFormatterTest extends AbstractAntUITest {
@@ -95,10 +100,6 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		}
 	}
 
-	public XmlTagFormatterTest(String name) {
-		super(name);
-	}
-
 	private FormattingPreferences getPreferences(final boolean wrapLongTags, final boolean alignCloseChar,
 			final int maxLineWidth) {
 
@@ -130,6 +131,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	/* ---------------- Test Methods ---------------- */
 
+	@Test
 	public void testParserGetElementName() throws Exception {
 
 		InnerClassFactory.TagParser tagParser = InnerClassFactory.createTagParser();
@@ -155,6 +157,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	}
 
+	@Test
 	public void testParserGetAttributes() throws Exception {
 		InnerClassFactory.TagParser tagParser = InnerClassFactory.createTagParser();
 
@@ -187,6 +190,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		assertTrue(e3.getClass().isAssignableFrom(InnerClassFactory.ParseException.class));
 	}
 
+	@Test
 	public void testFormat01() throws Exception {
 		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
 		String indent = "\t"; //$NON-NLS-1$
@@ -198,6 +202,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		simpleTest(source, target, getPreferences(true, false, 60), indent, lineSep);
 	}
 
+	@Test
 	public void testFormat02() throws Exception {
 		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
 		String indent = "\t"; //$NON-NLS-1$
@@ -210,6 +215,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		simpleTest(source, target, getPreferences(true, true, 60), indent, lineSep);
 	}
 
+	@Test
 	public void testBug73411() throws Exception {
 		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
 		String indent = "\t"; //$NON-NLS-1$
@@ -222,6 +228,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		simpleTest(source, target, getPreferences(true, true, 60), indent, lineSep);
 	}
 
+	@Test
 	public void testLineRequiresWrap() throws Exception {
 
 		InnerClassFactory.TagFormatter tagFormatter = InnerClassFactory.createTagFormatter();
@@ -237,6 +244,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	}
 
+	@Test
 	public void testTabExpandedLineWidth() throws Exception {
 
 		InnerClassFactory.TagFormatter tagFormatter = InnerClassFactory.createTagFormatter();
@@ -246,6 +254,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		assertEquals(19, tagFormatter.tabExpandedLineWidth("\t1\t2	34567890", 3)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTabToStringAndMinimumLength() throws Exception {
 		InnerClassFactory.Tag tag = InnerClassFactory.createTag();
 
@@ -270,6 +279,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		assertEquals(tag.toString().length(), tag.minimumLength());
 	}
 
+	@Test
 	public void testWrapTag() throws Exception {
 
 		InnerClassFactory.Tag tag = InnerClassFactory.createTag();
@@ -318,6 +328,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	}
 
+	@Test
 	public void testBug63558() throws Exception {
 
 		// Ordinarily the double space after the element name would be repaired

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/NonInitialTypingTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/NonInitialTypingTest.java
@@ -23,10 +23,6 @@ import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
  */
 public class NonInitialTypingTest extends AbstractAntUITest {
 
-	public NonInitialTypingTest(String name) {
-		super(name);
-	}
-
 	// private ITextEditor fEditor;
 	//
 	// private static final char[] TARGET= ("<target name=\"newTarget\" >\r" +

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -18,31 +18,24 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
+import org.junit.After;
+import org.junit.Before;
 
 public class AbstractAntUIBuildPerformanceTest extends AbstractAntUIBuildTest {
 
 	protected PerformanceMeter fPerformanceMeter;
 
 	/**
-	 * Constructs a performance test case with the given name.
-	 * 
-	 * @param name
-	 *            the name of the performance test case
-	 */
-	public AbstractAntUIBuildPerformanceTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Overridden to create a default performance meter for this test case.
 	 * 
 	 * @throws Exception
 	 */
+	@Before
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		Performance performance = Performance.getDefault();
-		fPerformanceMeter = performance.createPerformanceMeter(performance.getDefaultScenarioId(this));
+		fPerformanceMeter = performance.createPerformanceMeter(performance.getDefaultScenarioId(this.getClass()));
 	}
 
 	/**
@@ -50,8 +43,8 @@ public class AbstractAntUIBuildPerformanceTest extends AbstractAntUIBuildTest {
 	 * 
 	 * @throws Exception
 	 */
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		fPerformanceMeter.dispose();
 	}
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
@@ -19,49 +19,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.console.IHyperlink;
-
-import junit.framework.TestResult;
+import org.junit.Rule;
 
 public abstract class AbstractAntUIBuildTest extends AbstractAntUITest {
 
-	/**
-	 * Flag that indicates test are in progress
-	 */
-	protected boolean testing = true;
-
-	public AbstractAntUIBuildTest(String name) {
-		super(name);
-	}
-
-	/**
-	 * Runs the test and collects the result in a TestResult without blocking the UI
-	 * thread.
-	 */
-	@Override
-	public void run(final TestResult result) {
-		final Display display = Display.getCurrent();
-		Thread thread = null;
-		try {
-			Runnable r = () -> {
-				AbstractAntUIBuildTest.super.run(result);
-				testing = false;
-				display.wake();
-			};
-			thread = new Thread(r);
-			thread.start();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		while (testing) {
-			try {
-				if (!display.readAndDispatch())
-					display.sleep();
-			} catch (Throwable e) {
-				e.printStackTrace();
-			}
-		}
-	}
+	@Rule
+	public RunInSeparateThreadRule runInSeparateThread = new RunInSeparateThreadRule();
 
 	/**
 	 * Launches the launch configuration Waits for all of the lines to be appended

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
@@ -32,6 +37,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.junit.Assert;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class AntUtilTests extends AbstractAntUITest {
@@ -39,10 +45,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	private static final long EXECUTION_THRESHOLD_INCLUDE_TASK = 10000;
 	private static final long WINDOWS_EXECUTION_THRESHOLD_INCLUDE_TASK = 15000;
 
-	public AntUtilTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testGetTargetsLaunchConfiguration() throws CoreException {
 		String buildFileName = "echoing"; //$NON-NLS-1$
 		File buildFile = getBuildFile(buildFileName + ".xml"); //$NON-NLS-1$
@@ -55,6 +58,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		assertContains("echo3", targets); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testGetTargetsLaunchConfigurationMinusD() throws CoreException {
 		String buildFileName = "importRequiringUserProp"; //$NON-NLS-1$
 		File buildFile = getBuildFile(buildFileName + ".xml"); //$NON-NLS-1$
@@ -67,6 +71,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testGetTargetsLaunchConfigurationMinusDAndProperty() throws CoreException {
 		String buildFileName = "importRequiringUserProp"; //$NON-NLS-1$
 		File buildFile = getBuildFile(buildFileName + ".xml"); //$NON-NLS-1$
@@ -81,6 +86,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testGetTargetsLaunchConfigurationProperty() throws CoreException {
 		String buildFileName = "importRequiringUserProp"; //$NON-NLS-1$
 		File buildFile = getBuildFile(buildFileName + ".xml"); //$NON-NLS-1$
@@ -94,6 +100,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testGetTargetsLaunchConfigurationPropertyFile() throws CoreException {
 		String buildFileName = "importRequiringUserProp"; //$NON-NLS-1$
 		File buildFile = getBuildFile(buildFileName + ".xml"); //$NON-NLS-1$
@@ -107,6 +114,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Testing a simple "include-hierarchy" (only two levels setting the "as" property)
+	@Test
 	public void testGetIncludeTargetsSimpleHierarchyAlias() {
 		// The file itself contains one target. The included file contains the other one.
 		String buildFileName = "bug412809/simple/buildFileAlias"; //$NON-NLS-1$
@@ -116,6 +124,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Testing a simple "include-hierarchy" (only two levels without the "as" property)
+	@Test
 	public void testGetIncludeTargetsSimpleHierarchyNoAliases() {
 		// The file itself contains one target. The included file contains the other one.
 		String buildFileName = "bug412809/simple/buildFileNoAlias"; //$NON-NLS-1$
@@ -125,6 +134,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Testing a complex "include-hierarchy" (three levels, only non-aliases used)
+	@Test
 	public void testGetIncludeTargetsComplexHierarchyNoAlias() {
 		// The file itself contains one target. The included file contains the other one.
 		String buildFileName = "bug412809/complex/noAlias/buildFileHierarchical"; //$NON-NLS-1$
@@ -135,17 +145,19 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Testing a complex "include-hierarchy" (three levels, only aliases used)
+	@Test
 	public void testGetIncludeTargetsComplexHierarchyAlias() {
 		// The file itself contains one target. The included file contains the other one.
 		String buildFileName = "bug412809/complex/alias/buildFileHierarchical"; //$NON-NLS-1$
 		AntTargetNode[] targets = getAntTargetNodesOfBuildFile(buildFileName);
 		String[] expectedTargets = { "deploy", "commonLv1Prefix.deploy", "commonLv1Prefix.commonLv2Prefix.deploySuper", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				"commonLv1Prefix.commonLv2Prefix.commonLv3Prefix.deployLv3", //$NON-NLS-1$
-				"commonLv1Prefix.commonLv2Prefix.commonLv3Prefix.commonLv4Prefix.deployLv4" }; //$NON-NLS-1$
+		"commonLv1Prefix.commonLv2Prefix.commonLv3Prefix.commonLv4Prefix.deployLv4" }; //$NON-NLS-1$
 		assertTargets(targets, expectedTargets);
 	}
 
 	// for bugfix of bug 412809: Testing a complex "include-hierarchy" (three levels, aliases and non-aliases used)
+	@Test
 	public void testGetIncludeTargetsComplexHierarchyMisc() {
 		// The file itself contains one target. The included file contains the other one.
 		String buildFileName = "bug412809/complex/misc/buildFileHierarchical"; //$NON-NLS-1$
@@ -156,6 +168,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Assure explicitly that the provided patch works on external as well as non-external build-files
+	@Test
 	public void testGetIncludeTargetsExternalFiles() {
 		// First assure that external and non-external files are included
 		String buildFileName = "bug412809/complex/misc/buildFileHierarchical"; //$NON-NLS-1$
@@ -195,6 +208,7 @@ public class AntUtilTests extends AbstractAntUITest {
 	}
 
 	// for bugfix of bug 412809: Testing the performance by including the huge build file from "/testbuildfiles/performance/build.xml"
+	@Test
 	public void testGetIncludeTargetsPerformance() {
 		/*
 		 * More or less the same files (noAlias-files because the parsing to search the project-name only occurs at includes where the alias-property
@@ -295,6 +309,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		assertEquals("Did not find target: " + targetName, true, found); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testIsKnownAntFileName() throws Exception {
 		assertTrue("The file name 'foo.xml' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.xml")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("The file name 'foo.ant' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.ant")); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.ant.tests.ui;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Method;
 import java.util.Collections;
 
@@ -28,14 +32,12 @@ import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PlatformUI;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class AntViewTests extends AbstractAntUITest {
 
-	public AntViewTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testAddBuildFilesAction() throws CoreException {
 		// Ensure that AddBuildFilesAction is present!
 		String viewId = "org.eclipse.ant.ui.views.AntView"; //$NON-NLS-1$
@@ -64,6 +66,7 @@ public class AntViewTests extends AbstractAntUITest {
 		return null;
 	}
 
+	@Test
 	public void testAntBuildFilesExtensionFilter() {
 		// Ensure coverage for the extension filter used by AddBuildFilesAction
 		// Create blocks to scope the vars to catch typos!

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/BuildTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/BuildTests.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.ant.tests.ui;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
@@ -33,17 +38,15 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.IHyperlink;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class BuildTests extends AbstractAntUIBuildTest {
 
-	public BuildTests(String name) {
-		super(name);
-	}
-
 	/**
 	 * Tests launching Ant and getting messages logged to the console.
 	 */
+	@Test
 	public void testOutput() throws CoreException {
 		launch("echoing"); //$NON-NLS-1$
 		assertEquals("Incorrect number of messages logged for build. Should be 8. Was " //$NON-NLS-1$
@@ -57,6 +60,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 * This build will fail. With verbose on you should be presented with a full
 	 * stack trace. Bug 82833
 	 */
+	@Test
 	public void testVerboseStackTrace() throws Exception {
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode("org.eclipse.ui.monitoring"); //$NON-NLS-1$
 		if (prefs != null) {
@@ -72,6 +76,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant and getting the build failed message logged to the
 	 * console with associated link. Bug 42333 and 44565
 	 */
+	@Test
 	public void testBuildFailedMessage() throws CoreException, BadLocationException {
 		launch("bad"); //$NON-NLS-1$
 		assertEquals("Incorrect number of messages logged for build. Should be 10. Was " //$NON-NLS-1$
@@ -89,6 +94,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	/**
 	 * Tests launching Ant and that the correct links are in the console doc
 	 */
+	@Test
 	public void testLinks() throws CoreException, BadLocationException {
 		launch("build"); //$NON-NLS-1$
 		int offset = 25; // buildfile link
@@ -106,6 +112,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant and that build failed presents links to the failures when
 	 * multi-line.
 	 */
+	@Test
 	public void testBuildFailedLinks() throws CoreException, BadLocationException {
 		launch("102282"); //$NON-NLS-1$
 		IDocument document = ConsoleLineTracker.getDocument();
@@ -118,6 +125,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	/**
 	 * Tests launching Ant and that the correct colors are in the console doc
 	 */
+	@Test
 	public void testColor() throws BadLocationException, CoreException {
 		launch("echoing"); //$NON-NLS-1$
 		ConsoleLineTracker.waitForConsole();
@@ -135,6 +143,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate vm and that the correct property
 	 * substitions occur
 	 */
+	@Test
 	public void testPropertySubstitution() throws CoreException {
 		ILaunchConfiguration config = getLaunchConfiguration("74840"); //$NON-NLS-1$
 		assertNotNull("Could not locate launch configuration for " + "74840", config); //$NON-NLS-1$ //$NON-NLS-2$
@@ -156,6 +165,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 *
 	 * @throws FileNotFoundException
 	 */
+	@Test
 	public void testXmlLoggerListener() throws CoreException, FileNotFoundException {
 		launch("echoing", "-listener org.apache.tools.ant.XmlLogger"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("Incorrect number of messages logged for build. Should be 8. Was " //$NON-NLS-1$
@@ -174,6 +184,7 @@ public class BuildTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant and getting the build failed message logged to the
 	 * console. Bug 42333.
 	 */
+	// @Test
 	// public void testBuildFailedMessageDebug() throws CoreException {
 	// launchInDebug("bad");
 	// assertTrue("Incorrect number of messages logged for build. Should be 35. Was

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/RunInSeparateThreadRule.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/RunInSeparateThreadRule.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.ant.tests.ui;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.swt.widgets.Display;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Runs the test in a separate thread and spins readAndDisplay in the UI thread.
+ * Terminates with the exception of the separate thread in case one occurred.
+ */
+class RunInSeparateThreadRule implements TestRule {
+
+	@Override
+	public Statement apply(final Statement base, final Description description) {
+		return new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				final Display display = Display.getCurrent();
+				CompletableFuture<Result> future = evaluateAsync(base);
+				future.thenRun(display::wake);
+				while (!future.isDone()) {
+					doReadAndDispatch(display);
+				}
+				Throwable thrownException = future.get().throwable;
+				if (thrownException != null) {
+					throw thrownException;
+				}
+			}
+		};
+	}
+
+	private static CompletableFuture<Result> evaluateAsync(final Statement statement) {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				statement.evaluate();
+				return new Result(null);
+			} catch (Throwable exception) {
+				return new Result(exception);
+			}
+		});
+	}
+
+	private static void doReadAndDispatch(final Display display) {
+		try {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+	}
+
+	private record Result(Throwable throwable) {
+	}
+
+}

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/SeparateVMTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/performance/SeparateVMTests.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ant.tests.ui.performance;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.eclipse.ant.tests.ui.AbstractAntUIBuildPerformanceTest;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.runtime.CoreException;
@@ -21,17 +23,15 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public class SeparateVMTests extends AbstractAntUIBuildPerformanceTest {
 
-	public SeparateVMTests(String name) {
-		super(name);
-	}
-
 	/**
 	 * Performance test for launching Ant in a separate vm.
 	 */
+	@Test
 	public void testBuild() throws CoreException {
 		// tagAsSummary("Separate JRE Build", Dimension.ELAPSED_PROCESS);
 		ILaunchConfiguration config = getLaunchConfiguration("echoingSepVM"); //$NON-NLS-1$
@@ -48,6 +48,7 @@ public class SeparateVMTests extends AbstractAntUIBuildPerformanceTest {
 	/**
 	 * Performance test for launching Ant in a separate vm with no console output.
 	 */
+	@Test
 	public void testBuildNoConsole() throws CoreException {
 		// tagAsSummary("Separate JRE Build; capture output off", Dimension.ELAPSED_PROCESS);
 		ILaunchConfiguration config = getLaunchConfiguration("echoingSepVM"); //$NON-NLS-1$
@@ -68,6 +69,7 @@ public class SeparateVMTests extends AbstractAntUIBuildPerformanceTest {
 	/**
 	 * Performance test for launching Ant in a separate vm with debug information.
 	 */
+	@Test
 	public void testBuildMinusDebug() throws CoreException {
 		// tagAsSummary("Separate JRE Build; -debug", Dimension.ELAPSED_PROCESS);
 		ILaunchConfiguration config = getLaunchConfiguration("echoingSepVM"); //$NON-NLS-1$
@@ -87,6 +89,7 @@ public class SeparateVMTests extends AbstractAntUIBuildPerformanceTest {
 	/**
 	 * Performance test for launching Ant in a separate vm with lots of links
 	 */
+	@Test
 	public void testBuildWithLotsOfLinks() throws CoreException {
 		// tagAsSummary("Separate JRE Build; links", Dimension.ELAPSED_PROCESS);
 		ILaunchConfiguration config = getLaunchConfiguration("echoPropertiesSepVM"); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.ant.tests.ui.separateVM;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
@@ -39,18 +44,20 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.IHyperlink;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
 @SuppressWarnings("restriction")
 public class SeparateVMTests extends AbstractAntUIBuildTest {
+
+	@Rule
+	public TestName testName = new TestName();
 
 	protected static final String PLUGIN_VERSION;
 
 	static {
 		PLUGIN_VERSION = Platform.getBundle("org.apache.ant").getVersion().toString(); //$NON-NLS-1$
-	}
-
-	public SeparateVMTests(String name) {
-		super(name);
 	}
 
 	/**
@@ -64,7 +71,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 		ConsoleLineTracker.waitForConsole();
 		if (ConsoleLineTracker.getNumberOfMessages() != expectedLines) {
 			List<String> lines = ConsoleLineTracker.getAllMessages();
-			System.out.println("Failed line count from " + getName() + ", tracked lines: "); //$NON-NLS-1$ //$NON-NLS-2$
+			System.out.println("Failed line count from " + testName.getMethodName() + ", tracked lines: "); //$NON-NLS-1$ //$NON-NLS-2$
 			for (String string : lines) {
 				System.out.println('\t' + string);
 			}
@@ -78,6 +85,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and getting messages logged to the
 	 * console.
 	 */
+	@Test
 	public void testBuild() throws CoreException {
 		launch("echoingSepVM"); //$NON-NLS-1$
 		assertLines(6);
@@ -89,6 +97,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and having an extra classpath entry
 	 * designated to be available.
 	 */
+	@Test
 	public void testExtraClasspathEntries() throws CoreException {
 		launch("extensionPointSepVM"); //$NON-NLS-1$
 		assertLines(8);
@@ -100,6 +109,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and having a property designated to be
 	 * available.
 	 */
+	@Test
 	public void testProperties() throws CoreException {
 		launch("extensionPointSepVM"); //$NON-NLS-1$
 		assertLines(8);
@@ -114,6 +124,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and having an task designated to be
 	 * available.
 	 */
+	@Test
 	public void testExtensionPointTask() throws CoreException {
 		launch("extensionPointTaskSepVM"); //$NON-NLS-1$
 		assertLines(7);
@@ -131,6 +142,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and having a type designated to be
 	 * available.
 	 */
+	@Test
 	public void testExtensionPointType() throws CoreException {
 		launch("extensionPointTypeSepVM"); //$NON-NLS-1$
 		assertLines(6);
@@ -144,6 +156,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and that the correct links are in the
 	 * console doc
 	 */
+	@Test
 	public void testLinks() throws CoreException, BadLocationException {
 		launch("echoingSepVM"); //$NON-NLS-1$
 		int offset = 15; // buildfile link
@@ -157,6 +170,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	/**
 	 * Tests launching Ant and that build failed presents links to the failures
 	 */
+	@Test
 	public void testBuildFailedLinks() throws CoreException, BadLocationException {
 		launch("102282"); //$NON-NLS-1$
 		IDocument document = ConsoleLineTracker.getDocument();
@@ -170,6 +184,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and that the correct colors are in the
 	 * console doc
 	 */
+	@Test
 	public void testColor() throws BadLocationException, CoreException {
 		launch("echoingSepVM"); //$NON-NLS-1$
 		int offset = 15; // buildfile
@@ -186,6 +201,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and that the correct working directory
 	 * is set
 	 */
+	@Test
 	public void testWorkingDirectory() throws CoreException {
 		ILaunchConfiguration config = getLaunchConfiguration("echoingSepVM"); //$NON-NLS-1$
 		assertNotNull("Could not locate launch configuration for " + "echoingSepVM", config); //$NON-NLS-1$ //$NON-NLS-2$
@@ -205,6 +221,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and that the correct property
 	 * substitutions occur
 	 */
+	@Test
 	public void testPropertySubstitution() throws CoreException {
 		ILaunchConfiguration config = getLaunchConfiguration("74840SepVM"); //$NON-NLS-1$
 		assertNotNull("Could not locate launch configuration for " + "74840SepVM", config); //$NON-NLS-1$ //$NON-NLS-2$
@@ -223,6 +240,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * Tests launching Ant in a separate VM and getting messages logged to the
 	 * console for project help.
 	 */
+	@Test
 	public void testProjectHelp() throws CoreException {
 		launch("echoingSepVM", "-p"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertLines(14);
@@ -235,6 +253,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 *
 	 * @throws FileNotFoundException
 	 */
+	@Test
 	public void testXmlLoggerListener() throws CoreException, FileNotFoundException {
 		launch("echoingSepVM", "-listener org.apache.tools.ant.XmlLogger"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertLines(6);
@@ -255,6 +274,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 	 * ANT_HOME is set from the Ant home set for the build and ant.home is set as a
 	 * property. Bug 75729
 	 */
+	@Test
 	public void testAntHome() throws CoreException {
 		launch("environmentVar"); //$NON-NLS-1$
 		assertLines(6);
@@ -282,6 +302,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 		return msg.endsWith(PLUGIN_VERSION);
 	}
 
+	@Test
 	public void testFailInputHandler() throws CoreException {
 		ILaunchConfiguration config = getLaunchConfiguration("echoingSepVM"); //$NON-NLS-1$
 		assertNotNull("Could not locate launch configuration for " + "echoingSepVM", config); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/AbstractExternalToolTest.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/AbstractExternalToolTest.java
@@ -16,8 +16,6 @@ package org.eclipse.ant.tests.ui.externaltools;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.eclipse.ant.launching.IAntLaunchConstants;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
@@ -31,6 +29,8 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.ui.externaltools.internal.model.BuilderUtils;
 
+import junit.framework.Test;
+
 /**
  * Abstract {@link Test} class for external tools
  * 
@@ -40,15 +40,6 @@ import org.eclipse.ui.externaltools.internal.model.BuilderUtils;
 public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 
 	static final String EXT_BUILD_FILE_NAME = "ext-builders.xml"; //$NON-NLS-1$
-
-	/**
-	 * Constructor
-	 * 
-	 * @param name
-	 */
-	public AbstractExternalToolTest(String name) {
-		super(name);
-	}
 
 	/**
 	 * Creates a new external tool builder for the given project from the given {@link ILaunchConfiguration}

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.externaltools;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +32,8 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for {@link BuilderCoreUtils}
@@ -35,12 +43,9 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 @SuppressWarnings("restriction")
 public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 
-	public BuilderCoreUtilsTests() {
-		super("BuilderCoreUtils Tests"); //$NON-NLS-1$
-	}
-
+	@Before
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		// create the external tool builder dir
 		BuilderCoreUtils.getBuilderFolder(getProject(), true);
@@ -53,6 +58,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs1() throws Exception {
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), new HashMap<>(), new String[] {
 				BuilderCoreUtils.VERSION_1_0 });
@@ -66,6 +72,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs2() throws Exception {
 		Map<String, String> args = get20AntArgumentMap();
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
@@ -79,6 +86,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs3() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "foo"); //$NON-NLS-1$
@@ -94,6 +102,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs4() throws Exception {
 		createExternalToolBuilder(getProject(), "testConfigFromBuildCommandArgs4", null); //$NON-NLS-1$
 		Map<String, String> args = new HashMap<>();
@@ -110,6 +119,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs5() throws Exception {
 		createExternalToolBuilder(getProject(), "testConfigFromBuildCommandArgs5", null); //$NON-NLS-1$
 		Map<String, String> args = new HashMap<>();
@@ -126,6 +136,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs6() throws Exception {
 		createExternalToolBuilder(getProject(), "testConfigFromBuildCommandArgs6", null); //$NON-NLS-1$
 		Map<String, String> args = new HashMap<>();
@@ -141,6 +152,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigFromBuildCommandArgs7() throws Exception {
 		createExternalToolBuilder(getProject(), "testConfigFromBuildCommandArgs7", null); //$NON-NLS-1$
 		Map<String, String> args = new HashMap<>();
@@ -157,6 +169,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers1() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AFTER_CLEAN_TARGETS, null);
@@ -179,6 +192,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers2() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AFTER_CLEAN_TARGETS, "def,clean"); //$NON-NLS-1$
@@ -203,6 +217,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers3() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_MANUAL_TARGETS, null);
@@ -228,6 +243,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers4() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_MANUAL_TARGETS, "def,inc"); //$NON-NLS-1$
@@ -251,6 +267,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers5() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AUTO_TARGETS, null);
@@ -273,6 +290,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers6() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AUTO_TARGETS, "def,auto"); //$NON-NLS-1$
@@ -295,6 +313,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers7() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_CLEAN_TARGETS, null);
@@ -317,6 +336,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers8() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_CLEAN_TARGETS, "def,clean"); //$NON-NLS-1$
@@ -340,6 +360,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers9() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AFTER_CLEAN_TARGETS, "def"); //$NON-NLS-1$
@@ -366,6 +387,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testConfigureTriggers10() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		args.put(IAntLaunchConstants.ATTR_ANT_AFTER_CLEAN_TARGETS, "def"); //$NON-NLS-1$
@@ -395,6 +417,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testIsUnmigratedConfig1() throws Exception {
 		ILaunchConfigurationType type = AbstractAntUITest.getLaunchManager().getLaunchConfigurationType(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE);
 		if (type != null) {
@@ -410,6 +433,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testIsUnmigratedConfig2() throws Exception {
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testIsUnmigratedConfig2", null); //$NON-NLS-1$
 		assertFalse("Shoudl not be considered 'unmigrated'", BuilderCoreUtils.isUnmigratedConfig(config)); //$NON-NLS-1$
@@ -424,6 +448,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testToBuildCommand1() throws Exception {
 		ILaunchConfigurationWorkingCopy copy = createExternalToolBuilderWorkingCopy(getProject(), "testToBuildCommand1", null); //$NON-NLS-1$
 		ICommand command = BuilderCoreUtils.toBuildCommand(getProject(), copy, getProject().getDescription().newCommand());
@@ -439,6 +464,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testToBuildCommand2() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		ILaunchConfiguration copy = createExternalToolBuilder(getProject(), "testToBuildCommand2", args); //$NON-NLS-1$
@@ -455,6 +481,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testToBuildCommand3() throws Exception {
 		Map<String, String> args = new HashMap<>();
 		ILaunchConfiguration copy = createExternalToolBuilder(getProject(), "testToBuildCommand3", args); //$NON-NLS-1$
@@ -467,6 +494,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testBuildTypesToArray1() throws Exception {
 		String kinds = IExternalToolConstants.BUILD_TYPE_CLEAN + "," + //$NON-NLS-1$
 				IExternalToolConstants.BUILD_TYPE_INCREMENTAL + "," + //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.externaltools;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Map;
 
 import org.eclipse.ant.internal.launching.AntLaunchingUtil;
@@ -24,6 +27,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.debug.ui.RefreshTab;
+import org.junit.Test;
 
 /**
  * Tests migration of Ant and External Tool configurations from old formats to the current format.
@@ -31,15 +35,12 @@ import org.eclipse.debug.ui.RefreshTab;
 @SuppressWarnings("restriction")
 public class MigrationTests extends AbstractExternalToolTest {
 
-	public MigrationTests() {
-		super("Migration Tests"); //$NON-NLS-1$
-	}
-
 	/**
 	 * Tests migration of arguments from an Eclipse 2.0 Ant buildfile configuration to a current launch configuration.
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void test20AntMigration() throws CoreException {
 		Map<String, String> argumentMap = get20AntArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
@@ -66,6 +67,7 @@ public class MigrationTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void test20ProgramMigration() throws CoreException {
 		Map<String, String> argumentMap = get20ProgramArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
@@ -85,6 +87,7 @@ public class MigrationTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void test21AntMigration() throws CoreException {
 		Map<String, String> argumentMap = get21AntArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
@@ -113,6 +116,7 @@ public class MigrationTests extends AbstractExternalToolTest {
 	 * 
 	 * @throws CoreException
 	 */
+	@Test
 	public void test21ProgramMigration() throws CoreException {
 		Map<String, String> argumentMap = get21ProgramArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.testplugin;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,30 +73,24 @@ import org.eclipse.ui.internal.console.IOConsolePartition;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.progress.UIJob;
+import org.junit.Before;
+import org.junit.Rule;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-
-import junit.framework.TestCase;
 
 /**
  * Abstract Ant UI test class
  */
 @SuppressWarnings("restriction")
-public abstract class AbstractAntUITest extends TestCase {
+public abstract class AbstractAntUITest {
 
 	public static String ANT_EDITOR_ID = "org.eclipse.ant.ui.internal.editor.AntEditor"; //$NON-NLS-1$
 	private boolean welcomeClosed = false;
 	private IDocument currentDocument;
 
-	/**
-	 * Constructor
-	 *
-	 * @param name
-	 */
-	public AbstractAntUITest(String name) {
-		super(name);
-	}
+	@Rule
+	public TestAgainExceptionRule testAgainRule = new TestAgainExceptionRule(5);
 
 	/**
 	 * Returns the {@link IFile} for the given build file name
@@ -116,34 +114,8 @@ public abstract class AbstractAntUITest extends TestCase {
 		return file.getLocation().toFile();
 	}
 
-	/**
-	 * When a test throws the 'try again' exception, try it again.
-	 *
-	 * @see junit.framework.TestCase#runBare()
-	 */
-	@Override
-	public void runBare() throws Throwable {
-		boolean tryAgain = true;
-		int attempts = 0;
-		while (tryAgain) {
-			try {
-				attempts++;
-				super.runBare();
-				tryAgain = false;
-			}
-			catch (TestAgainException e) {
-				System.out.println("Test failed attempt " + attempts + ". Re-testing: " + this.getName()); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
-				if (attempts > 5) {
-					tryAgain = false;
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		assertProject();
 		assertWelcomeScreenClosed();
 	}

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/TestAgainExceptionRule.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/TestAgainExceptionRule.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.ant.tests.ui.testplugin;
+
+import org.eclipse.ant.tests.ui.debug.TestAgainException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Executes the test again for a defined number of retries after in case an
+ * {@link TestAgainException} is thrown.
+ */
+class TestAgainExceptionRule implements TestRule {
+
+	private final int retryCount;
+
+	public TestAgainExceptionRule(int retryCount) {
+		this.retryCount = retryCount;
+	}
+
+	@Override
+	public Statement apply(final Statement base, final Description description) {
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				for (int attempt = 0; attempt < retryCount; attempt++) {
+					try {
+						base.evaluate();
+						return;
+					} catch (TestAgainException e) {
+						String errorMessage = String.format("%s failed attempt %s. Re-testing.", //$NON-NLS-1$
+								description.getDisplayName(), attempt);
+						System.out.println(errorMessage);
+						e.printStackTrace();
+					}
+				}
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
Most tests in `org.eclipse.ant.tests.ui` are subclasses of `AbstractAntUITest`, which is still based on JUnit 3 by implementing the `TestCase` class.

This change does the following:
* Migrates `AbstractAntUITest` and subclasses to JUnit 4
* Introduces `TestName` rules where necessary
* Adds the `TestAgainExceptionRule`, which handles `TestAgainExceptions` indicating the necessity of test retries
* Adds the `RunInSeparateThreadRule`, which runs the actual test code in a non-UI thread

The newly introduced rules replace the overwritten `runBare()` method of the JUnit 3 tests in a reusable way.