### PR TITLE
Migrate Expression tests to JUnit 4

### DIFF
--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/AllExpressionTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/AllExpressionTests.java
@@ -13,18 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
+@RunWith(Suite.class)
+@SuiteClasses({ PropertyTesterTests.class, ExpressionTests.class, ExpressionInfoTests.class,
+		CountExpressionTest.class })
 public class AllExpressionTests {
 
-	public static Test suite() {
-		TestSuite suite= new TestSuite("All Expression Language Tests"); //$NON-NLS-1$
-		suite.addTest(PropertyTesterTests.suite());
-		suite.addTest(new JUnit4TestAdapter(ExpressionTests.class));
-		suite.addTest(ExpressionInfoTests.suite());
-		suite.addTest(CountExpressionTest.suite());
-		return suite;
-	}
 }

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/CountExpressionTest.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/CountExpressionTest.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.Test;
 
 import org.eclipse.core.expressions.CountExpression;
 import org.eclipse.core.expressions.EvaluationContext;
@@ -24,14 +26,7 @@ import org.eclipse.core.expressions.EvaluationResult;
 
 import org.eclipse.core.runtime.CoreException;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
-public class CountExpressionTest extends TestCase {
-	public static Test suite() {
-		return new TestSuite(CountExpressionTest.class);
-	}
+public class CountExpressionTest {
 
 	private static EvaluationContext evaluationContext(int size) {
 		List<Integer> variable = new ArrayList<>(size + 1);
@@ -40,56 +35,64 @@ public class CountExpressionTest extends TestCase {
 		return new EvaluationContext(null, variable);
 	}
 
+	@Test
 	public void testNoneExpression() throws CoreException {
 		CountExpression e = new CountExpression("!"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(0)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(1)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(0)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(1)));
 	}
 
+	@Test
 	public void testNoneOrOneExpression() throws CoreException {
 		CountExpression e = new CountExpression("?"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(0)));
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(0)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
 	}
 
+	@Test
 	public void testExactExpression() throws CoreException {
 		CountExpression e = new CountExpression("5"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(7)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(7)));
 	}
 
+	@Test
 	public void testAnyNumberExpression() throws CoreException {
 		CountExpression e = new CountExpression("*"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
 	}
 
+	@Test
 	public void testLessThanOrEqualToExpression() throws CoreException {
 		CountExpression e = new CountExpression("-3]"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(3)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(4)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(3)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(4)));
 	}
 
+	@Test
 	public void testLessThanExpression() throws CoreException {
 		CountExpression e = new CountExpression("-3)"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(3)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(4)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(1)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(3)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(4)));
 	}
 
+	@Test
 	public void testGreaterThanOrEqualToExpression() throws CoreException {
 		CountExpression e = new CountExpression("[3-"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(3)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(3)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
 	}
 
+	@Test
 	public void testGreaterThanExpression() throws CoreException {
 		CountExpression e = new CountExpression("(3-"); //$NON-NLS-1$
-		Assert.assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(3)));
-		Assert.assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
+		assertEquals(EvaluationResult.TRUE, e.evaluate(evaluationContext(5)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(3)));
+		assertEquals(EvaluationResult.FALSE, e.evaluate(evaluationContext(2)));
 	}
 
 }

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionInfoTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionInfoTests.java
@@ -13,9 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.junit.Test;
 
 import org.eclipse.core.expressions.AndExpression;
 import org.eclipse.core.expressions.CountExpression;
@@ -30,26 +37,19 @@ import org.eclipse.core.internal.expressions.NotExpression;
 import org.eclipse.core.internal.expressions.ResolveExpression;
 import org.eclipse.core.internal.expressions.SystemTestExpression;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
-
 @SuppressWarnings("restriction")
-public class ExpressionInfoTests extends TestCase {
-
-	public static Test suite() {
-		return new TestSuite(ExpressionInfoTests.class);
-	}
+public class ExpressionInfoTests {
 
 	// ---- test merging ------------------------------------------------------------------------
 
+	@Test
 	public void testMergeEmpty() {
 		ExpressionInfo info= new ExpressionInfo();
 		info.merge(new ExpressionInfo());
 		assertNoAccess(info);
 	}
 
+	@Test
 	public void testMergeDefaultVariable() {
 		ExpressionInfo info;
 		ExpressionInfo other;
@@ -73,6 +73,7 @@ public class ExpressionInfoTests extends TestCase {
 		assertDefaultAccessOnly(info);
 	}
 
+	@Test
 	public void testMergeSystemProperty() {
 		ExpressionInfo info;
 		ExpressionInfo other;
@@ -96,6 +97,7 @@ public class ExpressionInfoTests extends TestCase {
 		assertSystemPropertyOnly(info);
 	}
 
+	@Test
 	public void testMergeVariableNames() {
 		ExpressionInfo info;
 		ExpressionInfo other;
@@ -126,6 +128,7 @@ public class ExpressionInfoTests extends TestCase {
 		assertVariableAccess(info, new String[] {"variable_one", "variable_two"});
 	}
 
+	@Test
 	public void testMergePropertyNames() {
 		ExpressionInfo info;
 		ExpressionInfo other;
@@ -156,6 +159,7 @@ public class ExpressionInfoTests extends TestCase {
 		assertPropertyAccess(info, new String[] { "prop1", "prop2" }, false);
 	}
 
+	@Test
 	public void testMergeMisbehavingExpressionTypes() {
 		ExpressionInfo info;
 		ExpressionInfo other;
@@ -188,26 +192,32 @@ public class ExpressionInfoTests extends TestCase {
 
 	// ---- test expression ---------------------------------------------------------------------
 
+	@Test
 	public void testCountExpression() {
 		assertDefaultAccessOnly((new CountExpression("10")).computeExpressionInfo());
 	}
 
+	@Test
 	public void testEqualsExpression() {
 		assertDefaultAccessOnly((new EqualsExpression(new Object())).computeExpressionInfo());
 	}
 
+	@Test
 	public void testInstanceofExpression() {
 		assertDefaultAccessOnly((new InstanceofExpression("java.lang.Object")).computeExpressionInfo());
 	}
 
+	@Test
 	public void testNotExpression() {
 		assertDefaultAccessOnly((new NotExpression(new CountExpression("10"))).computeExpressionInfo());
 	}
 
+	@Test
 	public void testSystemExpression() {
 		assertSystemPropertyOnly((new SystemTestExpression("property", "value")).computeExpressionInfo());
 	}
 
+	@Test
 	public void testTestExpression() {
 		assertPropertyAccess((new TestExpression("namespace", "property", null,
 				new Object())).computeExpressionInfo(), "namespace.property", true);
@@ -215,10 +225,12 @@ public class ExpressionInfoTests extends TestCase {
 
 	// ---- composite expressions ---------------------------------------------------------
 
+	@Test
 	public void testAdaptExpression() throws Exception {
 		assertDefaultAccessOnly(new AdaptExpression("java.lang.Object").computeExpressionInfo());
 	}
 
+	@Test
 	public void testAndExpression() throws Exception {
 		AndExpression and= new AndExpression();
 		assertNoAccess(and.computeExpressionInfo());
@@ -226,10 +238,12 @@ public class ExpressionInfoTests extends TestCase {
 		assertDefaultAccessOnly(and.computeExpressionInfo());
 	}
 
+	@Test
 	public void testIterateExpression() throws Exception {
 		assertDefaultAccessOnly(new IterateExpression("or").computeExpressionInfo());
 	}
 
+	@Test
 	public void testResolveExpression() {
 		ResolveExpression resolve= new ResolveExpression("variable", null);
 		assertNoAccess(resolve.computeExpressionInfo());
@@ -237,6 +251,7 @@ public class ExpressionInfoTests extends TestCase {
 		assertVariableAccess(resolve.computeExpressionInfo(), "variable");
 	}
 
+	@Test
 	public void testWithExpression() {
 		WithExpression with= new WithExpression("variable");
 		assertNoAccess(with.computeExpressionInfo());

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/PropertyTesterTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/PropertyTesterTests.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.core.expressions.EvaluationContext;
@@ -25,12 +30,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.core.runtime.Platform;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 @SuppressWarnings("restriction")
-public class PropertyTesterTests extends TestCase {
+public class PropertyTesterTests {
 
 	private A a;
 	private B b;
@@ -41,23 +42,21 @@ public class PropertyTesterTests extends TestCase {
 	// Needs additional local test plug-ins
 	private static final boolean TEST_DYNAMIC_AND_ACTIVATION= false;
 
-	public static Test suite() {
-		return new TestSuite(PropertyTesterTests.class);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		a= new A();
 		b= new B();
 		i= b;
 	}
 
+	@Test
 	public void testSimple() throws Exception {
 		assertTrue(test(a, "simple", null,"simple")); //$NON-NLS-1$ //$NON-NLS-2$
 		// second pass to check if cache is populated correctly
 		assertTrue(test(a, "simple", null,"simple")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testInherited() throws Exception {
 		assertTrue(test(b, "simple", null, "simple")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue(test(i, "simple", null, "simple")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -66,6 +65,7 @@ public class PropertyTesterTests extends TestCase {
 		assertTrue(test(i, "simple", null, "simple")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testUnknown() throws Exception {
 		try {
 			test(a, "unknown", null, null); //$NON-NLS-1$
@@ -75,6 +75,7 @@ public class PropertyTesterTests extends TestCase {
 		assertTrue(false);
 	}
 
+	@Test
 	public void testOverridden() throws Exception {
 		assertTrue(test(a, "overridden", null, "A")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue(test(b, "overridden", null, "B")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -88,7 +89,8 @@ public class PropertyTesterTests extends TestCase {
 		assertTrue(test(i, "overridden", null, "B")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	public void testOdering() throws Exception {
+	@Test
+	public void testOrdering() throws Exception {
 		assertTrue(test(b, "ordering", null, "A")); //$NON-NLS-1$ //$NON-NLS-2$
 		I other= new I() {};
 		assertTrue(test(other, "ordering", null, "I")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -97,6 +99,7 @@ public class PropertyTesterTests extends TestCase {
 		assertTrue(test(other, "ordering", null, "I")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testChaining() throws Exception {
 		assertTrue(test(a, "chaining", null, "A2")); //$NON-NLS-1$ //$NON-NLS-2$
 		// second pass to check if cache is populated correctly
@@ -105,12 +108,14 @@ public class PropertyTesterTests extends TestCase {
 
 	// This test is questionable. It depends on if core runtime can
 	// guaratee any ordering in the plug-in registry.
+	@Test
 	public void testChainOrdering() throws Exception {
 		assertTrue(test(a, "chainOrdering", null, "A")); //$NON-NLS-1$ //$NON-NLS-2$
 		// second pass to check if cache is populated correctly
 		assertTrue(test(a, "chainOrdering", null, "A")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testWrongNameSpace() throws Exception {
 		try {
 			test(a, "differentNamespace", null, null); //$NON-NLS-1$
@@ -120,6 +125,7 @@ public class PropertyTesterTests extends TestCase {
 		assertTrue(false);
 	}
 
+	@Test
 	public void testDynamicPlugin() throws Exception {
 		if (TEST_DYNAMIC_AND_ACTIVATION) {
 			A receiver= new A();
@@ -144,6 +150,7 @@ public class PropertyTesterTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testPluginActivation() throws Exception {
 		if (TEST_DYNAMIC_AND_ACTIVATION) {
 			Bundle bundle= Platform.getBundle("org.eclipse.core.expressions.tests.forceActivation"); //$NON-NLS-1$
@@ -166,6 +173,7 @@ public class PropertyTesterTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testPlatformTester() throws Exception {
 		TestExpression exp = new TestExpression("org.eclipse.core.runtime",
 				"bundleState",
@@ -175,6 +183,7 @@ public class PropertyTesterTests extends TestCase {
 		assertEquals(EvaluationResult.TRUE, result);
 	}
 
+	@Test
 	public void testDifferentNameSpace() throws Exception {
 		assertTrue(test("org.eclipse.core.internal.expressions.tests2", a, "differentNamespace", null, "A3"));		 //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}


### PR DESCRIPTION
Most of the tests in `org.eclipse.core.expressions.tests` are still based on JUnit 3, i.e., implement the `TestCase` class. This change migrates the test classes and the according test suite to JUnit 4.