### PR TITLE
Add JUnit 5 Suite API to ConfigurationSessionTestSuite

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.xml.parsers,
  org.apiguardian.api,
  org.junit.jupiter.api,
+ org.junit.platform.suite.api,
  org.junit.platform.commons,
  org.opentest4j,
  org.w3c.dom,

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
@@ -119,6 +119,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 		addBundle(org.junit.Test.class); // org.junit
 		addBundle(org.junit.jupiter.api.Test.class); // junit-jupiter-api
 		addBundle(org.junit.platform.commons.JUnitException.class); // junit-platform-commons
+		addBundle(org.junit.platform.suite.api.Suite.class); // junit-platform-suite-api
 		addBundle(org.apiguardian.api.API.class); // org.apiguardian.api
 		addBundle(org.opentest4j.AssertionFailedError.class); // org.opentest4j
 	}


### PR DESCRIPTION
The minimal bundle set of the `ConfigurationSessionTestSuite` does not contain the `junit-platform-suite-api` yet. Since it was added to `org.eclipse.test.performance`, which is also contained in that minimal bundle set, dependencies for this test suite cannot properly be resolved anymore. This change adds the missing bundle to the `ConfigurationSessionTestSuite` bundle set.

See issue in https://github.com/eclipse-equinox/equinox/pull/386.