### PR TITLE
DefaultTipManager: fix javadoc

### DIFF
--- a/ua/org.eclipse.tips.ui/src/org/eclipse/tips/ui/internal/DefaultTipManager.java
+++ b/ua/org.eclipse.tips.ui/src/org/eclipse/tips/ui/internal/DefaultTipManager.java
@@ -53,7 +53,7 @@ public abstract class DefaultTipManager extends TipManager {
 	 *                       null;
 	 *
 	 * @return this tip manager.
-	 * @see #open()
+	 * @see #open(boolean)
 	 *
 	 */
 	public ITipManager open(boolean startUp, IDialogSettings dialogSettings) {


### PR DESCRIPTION
fixes Error during build:
/tips/ui/internal/DefaultTipManager.java:56: error: reference not found