### PR TITLE
Select the current tab after displaying them

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -842,8 +842,9 @@ public class LaunchConfigurationTabGroupViewer {
 			fInitializingTabs = false;
 			return;
 		}
+		Class<? extends ILaunchConfigurationTab> lastActiveTabKind = null;
 		if(redrawTabs) {
-			showInstanceTabsFor(type);
+			lastActiveTabKind = showInstanceTabsFor(type);
 		}
 		// show the name area
 		updateVisibleControls(true);
@@ -875,17 +876,25 @@ public class LaunchConfigurationTabGroupViewer {
 		// Turn off initializing flag to update message
 		fInitializingTabs = false;
 
+		// Try to activate the same (type of) tab that was active before.
+		if (!setActiveTab(lastActiveTabKind)) {
+			// The tab with the wanted class wasn't found. Try to activate the first one
+			setActiveTab(0);
+		}
+
 		if (!fViewform.isVisible()) {
 			fViewform.setVisible(true);
 		}
 	}
 
 	/**
-	 * Populate the tabs in the configuration edit area to be appropriate to the current
-	 * launch configuration type.
+	 * Populate the tabs in the configuration edit area to be appropriate to the
+	 * current launch configuration type.
+	 *
 	 * @param configType the type to show tabs for
+	 * @return The class of the last active tab.
 	 */
-	private void showInstanceTabsFor(ILaunchConfigurationType configType) {
+	private Class<? extends ILaunchConfigurationTab> showInstanceTabsFor(ILaunchConfigurationType configType) {
 		// try to keep on same tab
 		Class<? extends ILaunchConfigurationTab> tabKind = null;
 		if (getActiveTab() != null) {
@@ -897,7 +906,7 @@ public class LaunchConfigurationTabGroupViewer {
 			group = createGroup();
 		} catch (CoreException ce) {
 			DebugUIPlugin.errorDialog(getShell(), LaunchConfigurationsMessages.LaunchConfigurationDialog_Error_19, LaunchConfigurationsMessages.LaunchConfigurationDialog_Exception_occurred_creating_launch_configuration_tabs_27,ce); //
-			return;
+			return null;
 		}
 		disposeExistingTabs();
 		fTabGroup = group;
@@ -926,18 +935,8 @@ public class LaunchConfigurationTabGroupViewer {
 				tab.setControl(control.getParent());
 			}
 		}
-		//set the default tab as the first one
-		if (tabs.length > 0) {
-			setActiveTab(tabs[0]);
-		}
-		// select same tab as before, if possible
-		for (ILaunchConfigurationTab t : tabs) {
-			if (t.getClass().equals(tabKind)) {
-				setActiveTab(t);
-				break;
-			}
-		}
 		fDescription = getDescription(configType);
+		return tabKind;
 	}
 
 	/**
@@ -1604,6 +1603,29 @@ public class LaunchConfigurationTabGroupViewer {
 	 */
 	protected void errorDialog(CoreException exception) {
 		ErrorDialog.openError(getShell(), null, null, exception.getStatus());
+	}
+
+	/**
+	 * @param tabKind The class of the tab that has to be activated.
+	 * @return <code>true</code> if a tab was activated, <code>false</code>
+	 *         otherwise.
+	 */
+	private boolean setActiveTab(Class<? extends ILaunchConfigurationTab> tabKind) {
+		if (tabKind == null) {
+			return false;
+		}
+
+		ILaunchConfigurationTab[] tabs = getTabs();
+
+		// select same tab as before, if possible
+		for (ILaunchConfigurationTab t : tabs) {
+			if (t.getClass().equals(tabKind)) {
+				setActiveTab(t);
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Call `handleTabSelected` right after displaying all tabs in the `LaunchConfigurationTabGroupViewer::displayInstanceTabs` so that the "activated" method of the tab is called.

This is necessary in order to give every tab the chance to compute/show its content when it is first selected by changing between _Run configurations_ in the _Run Configurations Dialog_.

Contributes to https://github.com/eclipse-pde/eclipse.pde/pull/674

## How to test
1. Run *sdk.product*
2.  Open the _Run configurations Dialog_
3. Create 2 run configurations
4. Select one configuration and click on any Tab other than the first tab
5. Switch to the other configuration
 * The same tab should be active in the newly selected _run configuration_
 * The `activated` method of that tab should have been called (the method extends/overrides `org.eclipse.debug.ui.ILaunchConfigurationTab.activated(ILaunchConfigurationWorkingCopy)`)

### _e.g._ testing with _Product Run Configurations (PDE)_
1. Run *sdk.product*
2.  Open the _Run configurations Dialog_
3. Create 2 **Product Run configurations**
4. Select one configuration and click on the Tab **Java Arguments** 
 4.1. Add a breakpoint in `org.eclipse.jdt.debug.ui.launchConfigurations.JavaArgumentsTab.activated(ILaunchConfigurationWorkingCopy)` 
6. Switch to the other configuration
 * The tab **Java Arguments** should be active in the newly selected _run configuration_
 * The execution should stop at the breakpoint 
