### PR TITLE
Use at least 2GB heap to run org.eclipse.core.tests.resources

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -50,6 +50,7 @@
   			<configuration>
   				<useUIHarness>false</useUIHarness>
   			 	<useUIThread>false</useUIThread>
+  			 	<argLine>-Xmx2G ${tycho.surefire.argLine}</argLine>
   			 	<appArgLine>-consoleLog</appArgLine>
   			 	<dependencies>
   			 		<dependency>


### PR DESCRIPTION
Should avoid OOM during tycho test execution on Jenkins.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1463