### PR TITLE
Ensure ResourceTests still provide name when executed with JUnit 4

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -70,6 +70,8 @@ import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  * Superclass for tests that use the Eclipse Platform workspace.
@@ -114,6 +116,12 @@ public abstract class ResourceTest extends CoreTest {
 	 * test method.
 	 */
 	private final Queue<IStatus> loggedErrors = new ConcurrentLinkedQueue<>();
+
+	/**
+	 * For retrieving the test name when executing test class with JUnit 4.
+	 */
+	@Rule
+	public final TestName testName = new TestName();
 
 	/** Listener to count error messages while testing. */
 	private final ILogListener errorLogListener = (IStatus status, String plugin) -> {
@@ -190,6 +198,17 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public ResourceTest(String name) {
 		super(name);
+	}
+
+	@Override
+	public String getName() {
+		String name = super.getName();
+		// Ensure that in case this test class is executed with JUnit 4 the test name
+		// will not be null but retrieved via a TestName rule.
+		if (name == null) {
+			name = testName.getMethodName();
+		}
+		return name;
 	}
 
 	/**


### PR DESCRIPTION
`ResourceTests` rely on the `getName()` method returning the test name. This method is provided by the JUnit 3 TestCase superclass and will thus not work properly when executing the test via JUnit 4 but returns null instead. Some tests have been migrated to be executed with JUnit 4 and will always log null as the test name. This change adds a `TestName` rule to `ResourceTest` to be considered whenever the name provided by `getName()` is null because the test is not run as a JUnit 3 test.

Has been introduced with #446.