### PR TITLE
Add missing super.setUp() calls in ResourceTest implementations

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.core.tests.internal.resources;
 
 import org.eclipse.core.internal.resources.BuildConfiguration;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -34,6 +36,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 
 	@Override
 	public void setUp() throws Exception {
+		super.setUp();
 		project = getWorkspace().getRoot().getProject("ProjectBuildConfigsTest_Project");
 		ensureExistsInWorkspace(new IProject[] {project}, true);
 		variant0 = new BuildConfiguration(project, variantId0);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -13,9 +13,19 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
-import java.util.*;
-import org.eclipse.core.resources.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IDynamicReferenceProvider;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace.ProjectOrder;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -37,6 +47,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 
 	@Override
 	public void setUp() throws Exception {
+		super.setUp();
 		project0 = getWorkspace().getRoot().getProject(PROJECT_0_NAME);
 		project1 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p2");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.core.tests.internal.resources;
 
 import org.eclipse.core.internal.resources.BuildConfiguration;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -40,6 +42,7 @@ public class ProjectReferencesTest extends ResourceTest {
 
 	@Override
 	public void setUp() throws Exception {
+		super.setUp();
 		project0 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p0");
 		project1 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p2");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -282,6 +282,7 @@ public class WorkspaceTest extends ResourceTest {
 
 	@Override
 	public void setUp() throws Exception {
+		super.setUp();
 		IProject target = getTestProject();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		target.create(null, monitor);


### PR DESCRIPTION
The JUnit-3-based `ResourceTests` execute `setUp()` before the test and `tearDown()` afterwards. Some implementations of `ResourceTest` overwrite the `setUp(  method without calling the method of the super class, thus not properly initializing the test. This, e.g., leads to teardown log outputs for every test method in such a class without an accoring setup log output.