### PR TITLE
Migrate Runtime tests to JUnit 4

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/IScopeContextTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/IScopeContextTest.java
@@ -14,37 +14,30 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.runtime.RuntimeTest;
+import org.junit.Test;
 import org.osgi.service.prefs.Preferences;
 
 /**
  * @since 3.0
  */
-public class IScopeContextTest extends RuntimeTest {
+public class IScopeContextTest {
 
-	public IScopeContextTest() {
-		super("");
-	}
-
-	public IScopeContextTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testGetNode() {
 		IScopeContext context = InstanceScope.INSTANCE;
 
 		// null
-		try {
-			context.getNode(null);
-			fail("1.0");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
+		assertThrows(IllegalArgumentException.class, () -> context.getNode(null));
 
 		// valid single segment
 		String qualifier = Long.toString(System.currentTimeMillis());
@@ -63,15 +56,12 @@ public class IScopeContextTest extends RuntimeTest {
 		assertEquals("3.1", expected, actual);
 	}
 
+	@Test
 	public void testBadContext() {
 		IScopeContext context = new BadTestScope();
 		IPreferencesService service = Platform.getPreferencesService();
-		try {
-			context.getNode("qualifier");
-			fail("0.5"); // should throw an exception
-		} catch (RuntimeException e) {
-			// expected
-		}
+		assertThrows(RuntimeException.class, () -> context.getNode("qualifier"));
 		assertNull("1.0", service.getString("qualifier", "foo", null, new IScopeContext[] {context}));
 	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
@@ -14,13 +14,51 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
-import java.io.*;
-import java.util.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.preferences.*;
-import org.eclipse.core.tests.runtime.RuntimeTest;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IExportedPreferences;
+import org.eclipse.core.runtime.preferences.IPreferenceFilter;
+import org.eclipse.core.runtime.preferences.IPreferenceNodeVisitor;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.PreferenceFilterEntry;
+import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
@@ -28,12 +66,11 @@ import org.osgi.service.prefs.Preferences;
  * @since 3.0
  */
 @SuppressWarnings("restriction")
-public class PreferencesServiceTest extends RuntimeTest {
+public class PreferencesServiceTest {
 
 	static class ExportVerifier {
 
 		private final IEclipsePreferences node;
-		private ByteArrayOutputStream output;
 		private final Set<String> expected;
 		private String[] excludes;
 		private IPreferenceFilter[] transfers;
@@ -70,32 +107,19 @@ public class PreferencesServiceTest extends RuntimeTest {
 			expected.add('!' + root.absolutePath());
 		}
 
-		void verify() {
+		void verify() throws Exception {
 			IPreferencesService service = Platform.getPreferencesService();
-			this.output = new ByteArrayOutputStream();
-			try {
+			Properties properties = new Properties();
+			try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 				if (useTransfers) {
 					service.exportPreferences(node, transfers, output);
 				} else {
 					service.exportPreferences(node, output, excludes);
 				}
-			} catch (CoreException e) {
-				fail("0.0", e);
-			}
-			ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
-			Properties properties = new Properties();
-			try {
-				properties.load(input);
-			} catch (IOException e) {
-				fail("1.0", e);
-			} finally {
-				try {
-					input.close();
-				} catch (IOException e) {
-					// ignore
+				try (ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray())) {
+					properties.load(input);
 				}
 			}
-
 			if (properties.isEmpty()) {
 				assertTrue("2.0", expected.isEmpty());
 				return;
@@ -107,11 +131,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 		}
 	}
 
-	public PreferencesServiceTest(String name) {
-		super(name);
-	}
-
-	public void testImportExportBasic() {
+	@Test
+	public void testImportExportBasic() throws Exception {
 		IPreferencesService service = Platform.getPreferencesService();
 
 		// create test node hierarchy
@@ -131,19 +152,11 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertEquals("1.2", value1, actual);
 
 		// export it
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		try {
+		byte[] bytes;
+		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 			service.exportPreferences(test, output, (String[]) null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		} finally {
-			try {
-				output.close();
-			} catch (IOException e1) {
-				// ignore
-			}
+			bytes = output.toByteArray();
 		}
-		byte[] bytes = output.toByteArray();
 
 		// add new values
 		String newKey = getUniqueString() + '3';
@@ -159,17 +172,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertEquals("3.2", newOldValue, actual);
 
 		// import
-		ByteArrayInputStream input = new ByteArrayInputStream(bytes);
-		try {
+		try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
 			service.importPreferences(input);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		} finally {
-			try {
-				input.close();
-			} catch (IOException e) {
-				// ignore
-			}
 		}
 
 		// verify
@@ -185,11 +189,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertTrue("5.4", !((EclipsePreferences) test).isDirty());
 
 		// clear all
-		try {
-			test.clear();
-		} catch (BackingStoreException e) {
-			fail("6.0", e);
-		}
+		test.clear();
 		actual = test.get(key, null);
 		assertNull("6.1", actual);
 		actual = test.get(key1, null);
@@ -198,17 +198,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertNull("6.3", actual);
 
 		// import
-		input = new ByteArrayInputStream(bytes);
-		try {
+		try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
 			service.importPreferences(input);
-		} catch (CoreException e) {
-			fail("7.0", e);
-		} finally {
-			try {
-				input.close();
-			} catch (IOException e) {
-				// ignore
-			}
 		}
 
 		// verify
@@ -221,21 +212,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertNull("8.2", actual);
 	}
 
-	private void assertEquals(String message, String[] one, String[] two) {
-		if (one == null && two == null) {
-			return;
-		}
-		if (one == two) {
-			return;
-		}
-		assertNotNull(message + ".1", one);
-		assertNotNull(message + ".2", two);
-		assertEquals(message + ".3", one.length, two.length);
-		for (int i = 0; i < one.length; i++) {
-			assertEquals(message + ".4." + i, one[i], two[i]);
-		}
-	}
-
+	@Test
 	public void testLookupOrder() {
 		IPreferencesService service = Platform.getPreferencesService();
 		String[] defaultOrder = new String[] {"project", //$NON-NLS-1$
@@ -248,62 +225,53 @@ public class PreferencesServiceTest extends RuntimeTest {
 		String key = getUniqueString();
 
 		// bogus set parms
-		try {
-			service.setDefaultLookupOrder(null, key, fullOrder);
-			fail("0.0");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
-		try {
-			service.setDefaultLookupOrder(qualifier, key, new String[] {"a", null, "b"});
-			fail("0.1");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
+		assertThrows(IllegalArgumentException.class, () -> service.setDefaultLookupOrder(null, key, fullOrder));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.setDefaultLookupOrder(qualifier, key, new String[] { "a", null, "b" }));
 
 		// nothing set
 		String[] order = service.getDefaultLookupOrder(qualifier, key);
 		assertNull("1.0", order);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("1.1", order);
-		assertEquals("1.2", defaultOrder, order);
+		assertArrayEquals("1.2", defaultOrder, order);
 
 		order = service.getDefaultLookupOrder(qualifier, null);
 		assertNull("1.3", order);
 		order = service.getLookupOrder(qualifier, null);
 		assertNotNull("1.4", order);
-		assertEquals("1.5", defaultOrder, order);
+		assertArrayEquals("1.5", defaultOrder, order);
 
 		// set for qualifier/key
 		service.setDefaultLookupOrder(qualifier, key, fullOrder);
 		order = service.getDefaultLookupOrder(qualifier, key);
 		assertNotNull("2.2", order);
-		assertEquals("2.3", fullOrder, order);
+		assertArrayEquals("2.3", fullOrder, order);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("2.4", order);
-		assertEquals("2.5", fullOrder, order);
+		assertArrayEquals("2.5", fullOrder, order);
 
 		// nothing set for qualifier/null
 		order = service.getDefaultLookupOrder(qualifier, null);
 		assertNull("3.0", order);
 		order = service.getLookupOrder(qualifier, null);
 		assertNotNull("3.1", order);
-		assertEquals("3.2", defaultOrder, order);
+		assertArrayEquals("3.2", defaultOrder, order);
 
 		// set for qualifier/null
 		service.setDefaultLookupOrder(qualifier, null, nullKeyOrder);
 		order = service.getDefaultLookupOrder(qualifier, null);
 		assertNotNull("4.0", order);
-		assertEquals("4.1", nullKeyOrder, order);
+		assertArrayEquals("4.1", nullKeyOrder, order);
 		order = service.getLookupOrder(qualifier, null);
 		assertNotNull("4.2", order);
-		assertEquals("4.3", nullKeyOrder, order);
+		assertArrayEquals("4.3", nullKeyOrder, order);
 		order = service.getDefaultLookupOrder(qualifier, key);
 		assertNotNull("4.4", order);
-		assertEquals("4.5", fullOrder, order);
+		assertArrayEquals("4.5", fullOrder, order);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("4.6", order);
-		assertEquals("4.7", fullOrder, order);
+		assertArrayEquals("4.7", fullOrder, order);
 
 		// clear qualifier/key (find qualifier/null)
 		service.setDefaultLookupOrder(qualifier, key, null);
@@ -311,7 +279,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertNull("5.0", order);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("5.1", order);
-		assertEquals("5.2", nullKeyOrder, order);
+		assertArrayEquals("5.2", nullKeyOrder, order);
 
 		// clear qualifier/null (find returns default-default)
 		service.setDefaultLookupOrder(qualifier, null, null);
@@ -319,15 +287,16 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertNull("6.0", order);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("6.1", order);
-		assertEquals("6.2", defaultOrder, order);
+		assertArrayEquals("6.2", defaultOrder, order);
 
 		order = service.getDefaultLookupOrder(qualifier, null);
 		assertNull("6.3", order);
 		order = service.getLookupOrder(qualifier, null);
 		assertNotNull("6.4", order);
-		assertEquals("6.5", defaultOrder, order);
+		assertArrayEquals("6.5", defaultOrder, order);
 	}
 
+	@Test
 	public void testGetWithNodes() {
 		IPreferencesService service = Platform.getPreferencesService();
 		String qualifier = getUniqueString();
@@ -391,6 +360,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertEquals("8.7", defaultValue, actual);
 	}
 
+	@Test
 	public void testSearchingStringBasics() {
 		IPreferencesService service = Platform.getPreferencesService();
 		String qualifier = getUniqueString();
@@ -448,7 +418,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		service.setDefaultLookupOrder(qualifier, null, setOrder);
 		String[] order = service.getLookupOrder(qualifier, null);
 		assertNotNull("6.0", order);
-		assertEquals("6.1", setOrder, order);
+		assertArrayEquals("6.1", setOrder, order);
 
 		// get the value, should be the real one
 		for (int i = 0; i < contexts.length; i++) {
@@ -462,7 +432,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		service.setDefaultLookupOrder(qualifier, key, setOrder);
 		order = service.getLookupOrder(qualifier, key);
 		assertNotNull("8.0", order);
-		assertEquals("8.1", setOrder, order);
+		assertArrayEquals("8.1", setOrder, order);
 
 		// get the value, should be the default one
 		for (int i = 0; i < contexts.length; i++) {
@@ -472,12 +442,12 @@ public class PreferencesServiceTest extends RuntimeTest {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		Platform.getPreferencesService().getRootNode().node(TestScope.SCOPE).removeNode();
 	}
 
+	@Test
 	public void testGet() {
 		IPreferencesService service = Platform.getPreferencesService();
 		String qualifier = getUniqueString();
@@ -519,19 +489,16 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertEquals("10.0", searchPath, service.getString(qualifier, searchPath, null, null));
 	}
 
+	@Test
 	public void testImportExceptions() {
 		// importing an empty file is an error (invalid file format)
 		IPreferencesService service = Platform.getPreferencesService();
 		InputStream input = new BufferedInputStream(new ByteArrayInputStream(new byte[0]));
-		try {
-			service.importPreferences(input);
-			fail("0.0");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> service.importPreferences(input));
 	}
 
-	public void testImportLegacy() {
+	@Test
+	public void testImportLegacy() throws Exception {
 		IPreferencesService service = Platform.getPreferencesService();
 		String[] qualifiers = new String[] {getUniqueString() + 1, getUniqueString() + 2};
 		String[] oldKeys = new String[] {getUniqueString() + 3, getUniqueString() + 4};
@@ -541,11 +508,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 
 		// nodes shouldn't exist
 		for (String qualifier : qualifiers) {
-			try {
-				assertTrue("1.0", !node.nodeExists(qualifier));
-			} catch (BackingStoreException e) {
-				fail("1.99", e);
-			}
+			assertTrue("1.0", !node.nodeExists(qualifier));
 		}
 
 		// store some values
@@ -563,10 +526,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 		}
 
 		// import a legacy file
-		try {
-			service.importPreferences(getLegacyExportFile(qualifiers, newKeys));
-		} catch (CoreException e) {
-			fail("3.0", e);
+		try (InputStream input = getLegacyExportFile(qualifiers, newKeys)) {
+			service.importPreferences(input);
 		}
 
 		// old values shouldn't exist anymore
@@ -582,7 +543,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		}
 	}
 
-	private InputStream getLegacyExportFile(String[] qualifiers, String[] keys) {
+	private InputStream getLegacyExportFile(String[] qualifiers, String[] keys) throws IOException {
 		Properties properties = new Properties();
 		for (String qualifier : qualifiers) {
 			// version id
@@ -591,19 +552,10 @@ public class PreferencesServiceTest extends RuntimeTest {
 				properties.put(qualifier + IPath.SEPARATOR + key, getUniqueString());
 			}
 		}
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		try {
+		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 			properties.store(output, null);
-		} catch (IOException e) {
-			fail("#getLegacyExportFile", e);
-		} finally {
-			try {
-				output.close();
-			} catch (IOException e) {
-				// ignore
-			}
+			return new ByteArrayInputStream(output.toByteArray());
 		}
-		return new ByteArrayInputStream(output.toByteArray());
 	}
 
 	/*
@@ -612,7 +564,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * - export the parent
 	 * - don't expect anything to be exported
 	 */
-	public void testExportExcludes1() {
+	@Test
+	public void testExportExcludes1() throws Exception {
 
 		// add some random key/value pairs
 		String qualifier = getUniqueString();
@@ -641,7 +594,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * - nothing in the excludes list
 	 * - expect that k/v pair to be in the file
 	 */
-	public void testExportExcludes2() {
+	@Test
+	public void testExportExcludes2() throws Exception {
 		String qualifier = getUniqueString();
 		IEclipsePreferences node = new TestScope().getNode(qualifier);
 		String key = getUniqueString();
@@ -661,7 +615,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * - add one of them to the excludes list
 	 * - expect only the other key to exist
 	 */
-	public void testExportExcludes3() {
+	@Test
+	public void testExportExcludes3() throws Exception {
 		String qualifier = getUniqueString();
 		IEclipsePreferences node = new TestScope().getNode(qualifier);
 		String k1 = "a";
@@ -688,7 +643,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * - export containing non-matching string
 	 * - expect all k/v pairs
 	 */
-	public void testExportExcludes4() {
+	@Test
+	public void testExportExcludes4() throws Exception {
 		String qualifier = getUniqueString();
 		IEclipsePreferences node = new TestScope().getNode(qualifier);
 		String k1 = "a";
@@ -710,6 +666,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 	/**
 	 * Tests a default preference value set by a preference initializer extension.
 	 */
+	@Test
 	public void testDefaultFromInitializer() {
 		String value = Platform.getPreferencesService().getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, TestInitializer.DEFAULT_PREF_KEY, null, null);
 		assertEquals("1.0", TestInitializer.DEFAULT_PREF_VALUE, value);
@@ -718,7 +675,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	/*
 	 * - exporting default values shouldn't do anything
 	 */
-	public void testExportDefaults() {
+	@Test
+	public void testExportDefaults() throws Exception {
 		String qualifier = getUniqueString();
 		IEclipsePreferences node = DefaultScope.INSTANCE.getNode(qualifier);
 		for (int i = 0; i < 10; i++) {
@@ -735,6 +693,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * - export parent
 	 * - expect all values to be exported but that one
 	 */
+	@Test
 	public void testExportExcludes5() {
 		String qualifier = getUniqueString();
 		IEclipsePreferences node = new TestScope().getNode(qualifier);
@@ -758,10 +717,13 @@ public class PreferencesServiceTest extends RuntimeTest {
 	}
 
 	/**
-	 * @deprecated this tests deprecated functions, so deprecation added to avoid warnings
+	 * @throws Exception
+	 * @deprecated this tests deprecated functions, so deprecation added to avoid
+	 *             warnings
 	 */
 	@Deprecated
-	public void testValidateVersions() {
+	@Test
+	public void testValidateVersions() throws Exception {
 		final char BUNDLE_VERSION_PREFIX = '@';
 
 		// ensure that there is at least one value in the prefs
@@ -769,56 +731,28 @@ public class PreferencesServiceTest extends RuntimeTest {
 		scopeRoot.node("org.eclipse.core.tests.runtime").put("key", "value");
 
 		// no errors if the file doesn't exist
-		IPath path = getRandomLocation();
+		IPath path = FileSystemHelper.getRandomLocation();
 		IStatus result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
 		assertTrue("1.0", result.isOK());
 
 		// an empty file wasn't written by #export so its an invalid file format
 		// NOTE: this changed from "do nothing" to being an error in Eclipse 3.1
 		Properties properties = new Properties();
-		OutputStream output = null;
-		try {
-			output = new FileOutputStream(path.toFile());
+		try (OutputStream output = new FileOutputStream(path.toFile())) {
 			properties.store(output, null);
-		} catch (IOException e) {
-			fail("2.0", e);
-		} finally {
-			if (output != null) {
-				try {
-					output.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
 		}
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
 		assertTrue("2.0", !result.isOK());
 
 		// no errors for a file which we write out right now
-		try {
-			org.eclipse.core.runtime.Preferences.exportPreferences(path);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		org.eclipse.core.runtime.Preferences.exportPreferences(path);
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
 		assertTrue("3.1", result.isOK());
 
 		// warning for old versions
 		properties = new Properties();
-		InputStream input = null;
-		try {
-			input = new FileInputStream(path.toFile());
+		try (InputStream input = new FileInputStream(path.toFile())) {
 			properties.load(input);
-		} catch (IOException e) {
-			fail("4.0", e);
-		} finally {
-			if (input != null) {
-				try {
-					input.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
 		}
 		// change all version numbers to "0" so the validation will fail
 		for (Enumeration<Object> e = properties.keys(); e.hasMoreElements();) {
@@ -827,37 +761,22 @@ public class PreferencesServiceTest extends RuntimeTest {
 				properties.put(key, "0");
 			}
 		}
-		output = null;
-		try {
-			output = new FileOutputStream(path.toFile());
+		try (OutputStream output = new FileOutputStream(path.toFile())) {
 			properties.store(output, null);
-		} catch (IOException e) {
-			fail("4.1", e);
-		} finally {
-			if (output != null) {
-				try {
-					output.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
 		}
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
 		assertTrue("4.2", !result.isOK());
 
 	}
 
-	public void testMatches() {
+	@Test
+	public void testMatches() throws CoreException {
 		IPreferencesService service = Platform.getPreferencesService();
 		IPreferenceFilter[] matching = null;
 		final String QUALIFIER = getUniqueString();
 
 		// an empty transfer list matches nothing
-		try {
-			matching = service.matches(service.getRootNode(), new IPreferenceFilter[0]);
-		} catch (CoreException e) {
-			fail("1.00", e);
-		}
+		matching = service.matches(service.getRootNode(), new IPreferenceFilter[0]);
 		assertEquals("1.1", 0, matching.length);
 
 		// don't match this filter
@@ -874,44 +793,24 @@ public class PreferencesServiceTest extends RuntimeTest {
 				return new String[] {InstanceScope.SCOPE};
 			}
 		};
-		try {
-			matching = service.matches(service.getRootNode(), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("2.00", e);
-		}
+		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
 		assertEquals("2.1", 0, matching.length);
 
 		// shouldn't match since there are no key/value pairs in the node
-		try {
-			matching = service.matches(service.getRootNode(), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("3.00", e);
-		}
+		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
 		assertEquals("3.0", 0, matching.length);
 
 		// add some values so it does match
 		InstanceScope.INSTANCE.getNode(QUALIFIER).put("key", "value");
-		try {
-			matching = service.matches(service.getRootNode(), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("3.00", e);
-		}
+		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
 		assertEquals("3.1", 1, matching.length);
 
 		// should match on the exact node too
-		try {
-			matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("4.00", e);
-		}
+		matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
 		assertEquals("4.1", 1, matching.length);
 
 		// shouldn't match a different scope
-		try {
-			matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("5.00", e);
-		}
+		matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
 		assertEquals("5.1", 0, matching.length);
 
 		// try matching on the root node for a filter which matches all nodes in the scope
@@ -926,19 +825,11 @@ public class PreferencesServiceTest extends RuntimeTest {
 				return new String[] {InstanceScope.SCOPE};
 			}
 		};
-		try {
-			matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
+		matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
 		assertEquals("6.1", 1, matching.length);
 
 		// shouldn't match
-		try {
-			matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] {filter});
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
 		assertEquals("7.1", 0, matching.length);
 	}
 
@@ -946,7 +837,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * See bug 95608 - A node should match if it has any keys OR has a child node
 	 * with keys.
 	 */
-	public void testMatches2() {
+	@Test
+	public void testMatches2() throws CoreException {
 		IPreferencesService service = Platform.getPreferencesService();
 		final String QUALIFIER = getUniqueString();
 
@@ -965,14 +857,11 @@ public class PreferencesServiceTest extends RuntimeTest {
 				return new String[] {InstanceScope.SCOPE};
 			}
 		}};
-		try {
-			assertEquals("1.0", 1, service.matches(service.getRootNode(), filters).length);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		assertEquals("1.0", 1, service.matches(service.getRootNode(), filters).length);
 	}
 
-	public void testExportWithTransfers1() {
+	@Test
+	public void testExportWithTransfers1() throws Exception {
 
 		final String VALID_QUALIFIER = getUniqueString();
 		IPreferenceFilter transfer = new IPreferenceFilter() {
@@ -1014,7 +903,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * Test exporting with a transfer that returns null for the mapping. This means
 	 * export everything in the scope.
 	 */
-	public void testExportWithTransfers2() {
+	@Test
+	public void testExportWithTransfers2() throws Exception {
 		final String VALID_QUALIFIER = getUniqueString();
 		IPreferenceFilter transfer = new IPreferenceFilter() {
 			@Override
@@ -1044,11 +934,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 			}
 			return true;
 		};
-		try {
-			((IEclipsePreferences) service.getRootNode().node(TestScope.SCOPE)).accept(visitor);
-		} catch (BackingStoreException e) {
-			fail("2.00", e);
-		}
+		((IEclipsePreferences) service.getRootNode().node(TestScope.SCOPE)).accept(visitor);
 		verifier.addVersion();
 		verifier.addExportRoot(service.getRootNode());
 
@@ -1064,7 +950,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * When you specify a transfer with children, you should export it even if the
 	 * parent doesn't have any key/value pairs.
 	 */
-	public void testExportWithTransfers3() {
+	@Test
+	public void testExportWithTransfers3() throws Exception {
 
 		final String QUALIFIER = getUniqueString();
 		IPreferenceFilter transfer = new IPreferenceFilter() {
@@ -1107,7 +994,8 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * Since 3.6 preferenceTransfer allows to define common prefix for group of
 	 * preferences
 	 */
-	public void testExportWithTransfers4() {
+	@Test
+	public void testExportWithTransfers4() throws Exception {
 		final String VALID_QUALIFIER = getUniqueString();
 		final String COMMON_PREFIX = "PREFIX.";
 		IPreferenceFilter transfer = new IPreferenceFilter() {
@@ -1140,11 +1028,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 		node.put(VALID_KEY_3, "value3");
 		node.put(VALID_KEY_4, "value4");
 
-		try {
-			matching = service.matches(service.getRootNode(), new IPreferenceFilter[] {transfer});
-		} catch (CoreException e) {
-			fail("1.00", e);
-		}
+		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { transfer });
 		assertEquals("2.00", 1, matching.length);
 
 		ExportVerifier verifier = new ExportVerifier(service.getRootNode(), new IPreferenceFilter[] {transfer});
@@ -1153,7 +1037,6 @@ public class PreferencesServiceTest extends RuntimeTest {
 		verifier.addExpected(node.absolutePath(), VALID_KEY_1);
 		verifier.addExpected(node.absolutePath(), VALID_KEY_2);
 		verifier.verify();
-
 	}
 
 	/**
@@ -1174,6 +1057,7 @@ public class PreferencesServiceTest extends RuntimeTest {
 	 * For more details see bug 418046:
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=418046
 	 */
+	@Test
 	public void testApplyAndExportedPreferencesNotModified() throws BackingStoreException, CoreException {
 		// create a dummy node and export it to a stream
 		IEclipsePreferences toExport = InstanceScope.INSTANCE.getNode("bug418046");
@@ -1222,7 +1106,13 @@ public class PreferencesServiceTest extends RuntimeTest {
 		assertEquals(debugString, "someValue", node.get("someKey", null));
 	}
 
+	@Test
+	@Ignore("not implemented yet")
 	public void testApplyWithTransfers() {
-		// todo
 	}
+
+	private static String getUniqueString() {
+		return UUID.randomUUID().toString();
+	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLLocalTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLLocalTest.java
@@ -23,85 +23,54 @@ import java.net.URL;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
-import org.eclipse.core.tests.runtime.RuntimeTest;
 import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
+import org.junit.Assert;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
-public class PlatformURLLocalTest extends RuntimeTest {
+public class PlatformURLLocalTest {
 
-	public static void assertEquals(String tag, URL expected, URL actual, boolean external) {
+	public static void assertEquals(String tag, URL expected, URL actual, boolean external)
+			throws MalformedURLException {
 		if (external) {
-			assertEquals(tag, expected, actual);
-			return;
-		}
-		try {
-			assertEquals(tag + ".1", new URL(expected.getProtocol(), expected.getHost(), expected.getPort(), expected.getFile()), new URL(actual.getProtocol(), actual.getHost(), actual.getPort(), actual.getFile()));
-		} catch (MalformedURLException e) {
-			fail(tag + ".2", e);
+			Assert.assertEquals(tag, expected, actual);
+		} else {
+			Assert.assertEquals(tag + ".1",
+				new URL(expected.getProtocol(), expected.getHost(), expected.getPort(), expected.getFile()),
+				new URL(actual.getProtocol(), actual.getHost(), actual.getPort(), actual.getFile()));
 		}
 	}
 
-	public PlatformURLLocalTest(String name) {
-		super(name);
-	}
-
-	public void testPlatformURLConfigResolution() {
-		URL platformURL = null;
-		try {
-			// 	create a fake URL
-			platformURL = new URL("platform:/config/x");
-		} catch (MalformedURLException e) {
-			fail("1.0", e);
-		}
-		URL resolvedURL = null;
-		try {
-			resolvedURL = FileLocator.resolve(platformURL);
-		} catch (IOException e) {
-			fail("2.0", e);
-		}
+	@Test
+	public void testPlatformURLConfigResolution() throws IOException {
+		// create a fake URL
+		URL platformURL = new URL("platform:/config/x");
+		URL resolvedURL = FileLocator.resolve(platformURL);
 		assertNotEquals("3.0", platformURL, resolvedURL);
-		URL expected = null;
-		try {
-			expected = new URL(Platform.getConfigurationLocation().getURL(), "x");
-		} catch (MalformedURLException e) {
-			fail("4.0", e);
-		}
+		URL expected = new URL(Platform.getConfigurationLocation().getURL(), "x");
 		assertEquals("5.0", expected, resolvedURL, false);
 	}
 
-	public void testPlatformURLMetaResolution() {
-		URL platformURL = null;
-		try {
-			// 	create a fake URL
-			platformURL = new URL("platform:/meta/" + PI_RUNTIME_TESTS + "/x");
-		} catch (MalformedURLException e) {
-			fail("1.0", e);
-		}
-		URL resolvedURL = null;
-		try {
-			resolvedURL = FileLocator.resolve(platformURL);
-		} catch (IOException e) {
-			fail("2.0", e);
-		}
+	@Test
+	public void testPlatformURLMetaResolution() throws Exception {
+		// create a fake URL
+		URL platformURL = new URL("platform:/meta/" + RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/x");
+		URL resolvedURL = FileLocator.resolve(platformURL);
 		assertNotEquals("3.0", platformURL, resolvedURL);
-		URL expected = null;
-		try {
-			expected = new URL(RuntimeTestsPlugin.getPlugin().getStateLocation().toFile().toURI().toURL(), "x");
-		} catch (MalformedURLException e) {
-			fail("4.0", e);
-		}
+		URL expected = new URL(RuntimeTestsPlugin.getPlugin().getStateLocation().toFile().toURI().toURL(), "x");
 		assertEquals("5.0", expected, resolvedURL, false);
 	}
 
+	@Test
 	public void testBug155081() throws IOException, BundleException {
 		Bundle bundle = null;
 		try {
 			bundle = BundleTestingHelper.installBundle("0.1", RuntimeTestsPlugin.getContext(), RuntimeTestsPlugin.TEST_FILES_ROOT + "platformURL/platform.test.underscore");
 			BundleTestingHelper.refreshPackages(RuntimeTestsPlugin.getContext(), new Bundle[] {bundle});
 			URL test = new URL("platform:/plugin/platform.test.underscore_1.1.0.r321_v20060816/test.txt");
-			InputStream in = test.openStream();
-			in.close();
+			try (InputStream in = test.openStream()) {
+			}
 		} finally {
 			if (bundle != null) {
 				bundle.uninstall();
@@ -109,14 +78,15 @@ public class PlatformURLLocalTest extends RuntimeTest {
 		}
 	}
 
+	@Test
 	public void testBug300197_01() throws IOException, BundleException {
 		Bundle bundle = null;
 		try {
 			bundle = BundleTestingHelper.installBundle("0.1", RuntimeTestsPlugin.getContext(), RuntimeTestsPlugin.TEST_FILES_ROOT + "platformURL/platform_test_underscore");
 			BundleTestingHelper.refreshPackages(RuntimeTestsPlugin.getContext(), new Bundle[] {bundle});
 			URL test = new URL("platform:/plugin/platform_test_underscore/test.txt");
-			InputStream in = test.openStream();
-			in.close();
+			try (InputStream in = test.openStream()) {
+			}
 		} finally {
 			if (bundle != null) {
 				bundle.uninstall();
@@ -124,14 +94,15 @@ public class PlatformURLLocalTest extends RuntimeTest {
 		}
 	}
 
+	@Test
 	public void testBug300197_02() throws IOException, BundleException {
 		Bundle bundle = null;
 		try {
 			bundle = BundleTestingHelper.installBundle("0.1", RuntimeTestsPlugin.getContext(), RuntimeTestsPlugin.TEST_FILES_ROOT + "platformURL/platform_test_underscore_2.0.0");
 			BundleTestingHelper.refreshPackages(RuntimeTestsPlugin.getContext(), new Bundle[] {bundle});
 			URL test = new URL("platform:/plugin/platform_test_underscore_2.0.0/test.txt");
-			InputStream in = test.openStream();
-			in.close();
+			try (InputStream in = test.openStream()) {
+			}
 		} finally {
 			if (bundle != null) {
 				bundle.uninstall();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceExportTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceExportTest.java
@@ -13,10 +13,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Preferences;
+import org.junit.After;
+import org.junit.Test;
 
 /**
  * Tests the Preferences import/export feature.
@@ -24,24 +29,10 @@ import org.eclipse.core.runtime.Preferences;
  * added to hide deprecation reference warnings.
  */
 @Deprecated
-public class PreferenceExportTest extends RuntimeTest {
+public class PreferenceExportTest {
 
-	public PreferenceExportTest() {
-		super("");
-	}
-
-	/**
-	 * Constructor for PreferenceExportTest.
-	 * @param name
-	 */
-	public PreferenceExportTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
+	@After
+	public void tearDown() throws Exception {
 		//remove properties modified by this test
 		Plugin testPlugin = RuntimeTestsPlugin.getPlugin();
 		Preferences prefs = testPlugin.getPluginPreferences();
@@ -53,10 +44,13 @@ public class PreferenceExportTest extends RuntimeTest {
 	}
 
 	/**
-	 * Tests exporting a preference that is different from the default value, but the same
-	 * as the default-default value.  See bug 31458.
+	 * Tests exporting a preference that is different from the default value, but
+	 * the same as the default-default value. See bug 31458.
+	 *
+	 * @throws CoreException
 	 */
-	public void testExportEmptyPreference() {
+	@Test
+	public void testExportEmptyPreference() throws CoreException {
 		final String key1 = "SomeTestKey";
 		final String key2 = "SomeOtherTestKey";
 		final String default1 = "SomeTestValue";
@@ -76,11 +70,7 @@ public class PreferenceExportTest extends RuntimeTest {
 			testPlugin.savePluginPreferences();
 
 			//export preferences
-			try {
-				Preferences.exportPreferences(exportPath);
-			} catch (CoreException e) {
-				fail("1.1", e);
-			}
+			Preferences.exportPreferences(exportPath);
 
 			//change the property value
 			prefs.setToDefault(key1);
@@ -90,11 +80,7 @@ public class PreferenceExportTest extends RuntimeTest {
 			assertEquals("1.1", default2, prefs.getInt(key2));
 
 			//reimport the property
-			try {
-				Preferences.importPreferences(exportPath);
-			} catch (CoreException e) {
-				fail("1.2", e);
-			}
+			Preferences.importPreferences(exportPath);
 
 			//ensure the imported preference is set
 			assertEquals("2.0", Preferences.STRING_DEFAULT_DEFAULT, prefs.getString(key1));
@@ -106,12 +92,14 @@ public class PreferenceExportTest extends RuntimeTest {
 	}
 
 	/**
-	 * Tests that identity tests on preference keys after
-	 * export/import will still work. This is to safeguard
-	 * against programming errors in property change listeners.
-	 * See bug 20193.
+	 * Tests that identity tests on preference keys after export/import will still
+	 * work. This is to safeguard against programming errors in property change
+	 * listeners. See bug 20193.
+	 *
+	 * @throws CoreException
 	 */
-	public void testKeyIdentityAfterExport() {
+	@Test
+	public void testKeyIdentityAfterExport() throws CoreException {
 		final String key = "SomeTestKey";
 		String initialValue = "SomeTestValue";
 		IPath exportPath = IPath.fromOSString(System.getProperty("java.io.tmpdir")).append(Long.toString(System.currentTimeMillis()));
@@ -132,31 +120,19 @@ public class PreferenceExportTest extends RuntimeTest {
 			testPlugin.savePluginPreferences();
 
 			//export preferences
-			try {
-				Preferences.exportPreferences(exportPath);
-			} catch (CoreException e) {
-				fail("1.1", e);
-			}
+			Preferences.exportPreferences(exportPath);
 
 			//change the property value
 			prefs.setValue(key, "SomeOtherValue");
 
 			//reimport the property
-			try {
-				Preferences.importPreferences(exportPath);
-			} catch (CoreException e) {
-				fail("1.2", e);
-			}
+			Preferences.importPreferences(exportPath);
 
 			//set the property to default
 			prefs.setToDefault(key);
 
 			//reimport the property
-			try {
-				Preferences.importPreferences(exportPath);
-			} catch (CoreException e) {
-				fail("1.3", e);
-			}
+			Preferences.importPreferences(exportPath);
 		} finally {
 			exportPath.toFile().delete();
 			if (prefs != null) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferencesTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferencesTest.java
@@ -13,9 +13,19 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime;
 
-import java.io.*;
-import java.util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.eclipse.core.runtime.Preferences;
+import org.junit.Test;
 
 /**
  * Test suite for API class org.eclipse.core.runtime.Preferences
@@ -23,7 +33,7 @@ import org.eclipse.core.runtime.Preferences;
  * added to hide deprecation reference warnings.
  */
 @Deprecated
-public class PreferencesTest extends RuntimeTest {
+public class PreferencesTest {
 
 	static class Tracer implements Preferences.IPropertyChangeListener {
 		public StringBuilder log = new StringBuilder();
@@ -68,30 +78,18 @@ public class PreferencesTest extends RuntimeTest {
 		}
 	}
 
-	public PreferencesTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() {
-		// do nothing
-	}
-
-	@Override
-	protected void tearDown() {
-		// do nothing
-	}
-
+	@Test
 	public void testConstants() {
 		// make sure that the preference store constants are defined properly
-		assertSame("Different values", Preferences.BOOLEAN_DEFAULT_DEFAULT, false);
-		assertSame("Different values", Preferences.INT_DEFAULT_DEFAULT, 0);
-		assertSame("Different values", Preferences.LONG_DEFAULT_DEFAULT, 0L);
-		assertSame("Different values", Preferences.FLOAT_DEFAULT_DEFAULT, 0.0f);
-		assertSame("Different values", Preferences.DOUBLE_DEFAULT_DEFAULT, 0.0);
+		assertEquals("Different values", Preferences.BOOLEAN_DEFAULT_DEFAULT, false);
+		assertEquals("Different values", Preferences.INT_DEFAULT_DEFAULT, 0);
+		assertEquals("Different values", Preferences.LONG_DEFAULT_DEFAULT, 0L);
+		assertEquals("Different values", Preferences.FLOAT_DEFAULT_DEFAULT, 0.0f, 0.0f);
+		assertEquals("Different values", Preferences.DOUBLE_DEFAULT_DEFAULT, 0.0, 0.0f);
 		assertTrue(Preferences.STRING_DEFAULT_DEFAULT.isEmpty());
 	}
 
+	@Test
 	public void testBasics() {
 
 		Preferences ps = new Preferences();
@@ -106,15 +104,15 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("1.1", ps.getBoolean(k1), Preferences.BOOLEAN_DEFAULT_DEFAULT);
 		assertEquals("1.2", ps.getInt(k1), Preferences.INT_DEFAULT_DEFAULT);
 		assertEquals("1.3", ps.getLong(k1), Preferences.LONG_DEFAULT_DEFAULT);
-		assertEquals("1.4", ps.getFloat(k1), Preferences.FLOAT_DEFAULT_DEFAULT);
-		assertEquals("1.5", ps.getDouble(k1), Preferences.DOUBLE_DEFAULT_DEFAULT);
+		assertEquals("1.4", ps.getFloat(k1), Preferences.FLOAT_DEFAULT_DEFAULT, 0.0f);
+		assertEquals("1.5", ps.getDouble(k1), Preferences.DOUBLE_DEFAULT_DEFAULT, 0.0f);
 		assertTrue("1.6", ps.getString(k1).equals(Preferences.STRING_DEFAULT_DEFAULT));
 
 		assertEquals("1.7", ps.getDefaultBoolean(k1), Preferences.BOOLEAN_DEFAULT_DEFAULT);
 		assertEquals("1.8", ps.getDefaultInt(k1), Preferences.INT_DEFAULT_DEFAULT);
 		assertEquals("1.9", ps.getDefaultLong(k1), Preferences.LONG_DEFAULT_DEFAULT);
-		assertEquals("1.10", ps.getDefaultFloat(k1), Preferences.FLOAT_DEFAULT_DEFAULT);
-		assertEquals("1.11", ps.getDefaultDouble(k1), Preferences.DOUBLE_DEFAULT_DEFAULT);
+		assertEquals("1.10", ps.getDefaultFloat(k1), Preferences.FLOAT_DEFAULT_DEFAULT, 0.0f);
+		assertEquals("1.11", ps.getDefaultDouble(k1), Preferences.DOUBLE_DEFAULT_DEFAULT, 0.0f);
 		assertTrue("1.12", ps.getDefaultString(k1).equals(Preferences.STRING_DEFAULT_DEFAULT));
 
 		// test set/getString
@@ -168,6 +166,7 @@ public class PreferencesTest extends RuntimeTest {
 
 	}
 
+	@Test
 	public void testBoolean() {
 
 		Preferences ps = new Preferences();
@@ -188,6 +187,7 @@ public class PreferencesTest extends RuntimeTest {
 
 	}
 
+	@Test
 	public void testInteger() {
 
 		Preferences ps = new Preferences();
@@ -206,6 +206,7 @@ public class PreferencesTest extends RuntimeTest {
 		}
 	}
 
+	@Test
 	public void testLong() {
 
 		Preferences ps = new Preferences();
@@ -224,6 +225,7 @@ public class PreferencesTest extends RuntimeTest {
 		}
 	}
 
+	@Test
 	public void testFloat() {
 
 		Preferences ps = new Preferences();
@@ -242,15 +244,10 @@ public class PreferencesTest extends RuntimeTest {
 			assertEquals("1.3", v2, ps.getDefaultFloat(k1), tol);
 		}
 
-		try {
-			ps.setValue(k1, Float.NaN);
-			assertTrue("1.4", false);
-		} catch (IllegalArgumentException e) {
-			// NaNs should be rejected
-		}
-
+		assertThrows("NaNs should be rejected", IllegalArgumentException.class, () -> ps.setValue(k1, Float.NaN));
 	}
 
+	@Test
 	public void testDouble() {
 
 		Preferences ps = new Preferences();
@@ -269,15 +266,10 @@ public class PreferencesTest extends RuntimeTest {
 			assertEquals("1.3", v2, ps.getDefaultDouble(k1), tol);
 		}
 
-		try {
-			ps.setValue(k1, Float.NaN);
-			assertTrue("1.4", false);
-		} catch (IllegalArgumentException e) {
-			// NaNs should be rejected
-		}
-
+		assertThrows("NaNs should be rejected", IllegalArgumentException.class, () -> ps.setValue(k1, Float.NaN));
 	}
 
+	@Test
 	public void testString() {
 
 		Preferences ps = new Preferences();
@@ -296,6 +288,7 @@ public class PreferencesTest extends RuntimeTest {
 		}
 	}
 
+	@Test
 	public void testPropertyNames() {
 
 		Preferences ps = new Preferences();
@@ -330,6 +323,7 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("1.5", 0, ps.propertyNames().length);
 	}
 
+	@Test
 	public void testContains() {
 
 		Preferences ps = new Preferences();
@@ -364,6 +358,7 @@ public class PreferencesTest extends RuntimeTest {
 		assertTrue("2.1", ps.contains("c"));
 	}
 
+	@Test
 	public void testDefaultPropertyNames() {
 
 		Preferences ps = new Preferences();
@@ -426,6 +421,7 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("1.7", keys.length, ps.defaultPropertyNames().length);
 	}
 
+	@Test
 	public void testListeners2() {
 
 		final Preferences ps = new Preferences();
@@ -462,6 +458,7 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("1.4", "[a:I2->I0]", tracer.log.toString());
 	}
 
+	@Test
 	public void testListeners() {
 
 		final Preferences ps = new Preferences();
@@ -582,7 +579,8 @@ public class PreferencesTest extends RuntimeTest {
 
 	}
 
-	public void testLoadStore() {
+	@Test
+	public void testLoadStore() throws IOException {
 
 		final Preferences ps = new Preferences();
 
@@ -594,20 +592,15 @@ public class PreferencesTest extends RuntimeTest {
 		ps.setValue("s1", "x");
 		String[] keys = {"b1", "i1", "l1", "f1", "d1", "s1",};
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try {
+		byte[] bytes;
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			ps.store(out, "test header");
-		} catch (IOException e) {
-			assertTrue("0.1", false);
+			bytes = out.toByteArray();
 		}
 
-		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-
 		final Preferences ps2 = new Preferences();
-		try {
+		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
 			ps2.load(in);
-		} catch (IOException e) {
-			assertTrue("0.2", false);
 		}
 
 		assertEquals("1.1", true, ps2.getBoolean("b1"));
@@ -622,22 +615,19 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("1.7", s1, s2);
 
 		// load discards current values
-		in = new ByteArrayInputStream(out.toByteArray());
 		final Preferences ps3 = new Preferences();
 		ps3.setValue("s1", "y");
-		try {
+		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
 			ps3.load(in);
-			assertEquals("1.8", "x", ps3.getString("s1"));
-			Set<String> k1 = new HashSet<>(Arrays.asList(keys));
-			Set<String> k2 = new HashSet<>(Arrays.asList(ps3.propertyNames()));
-			assertEquals("1.9", k1, k2);
-		} catch (IOException e) {
-			assertTrue("1.10", false);
 		}
-
+		assertEquals("1.8", "x", ps3.getString("s1"));
+		Set<String> k1 = new HashSet<>(Arrays.asList(keys));
+		Set<String> k2 = new HashSet<>(Arrays.asList(ps3.propertyNames()));
+		assertEquals("1.9", k1, k2);
 	}
 
-	public void testNeedsSaving() {
+	@Test
+	public void testNeedsSaving() throws IOException {
 
 		Preferences ps = new Preferences();
 
@@ -679,20 +669,19 @@ public class PreferencesTest extends RuntimeTest {
 		assertEquals("7.1", false, ps.needsSaving());
 
 		// setToDefault dirties if value was set
-		try {
-			ps = new Preferences();
-			assertEquals("7.2", false, ps.needsSaving());
-			ps.setValue("any", "x");
-			ByteArrayOutputStream out = new ByteArrayOutputStream();
+		ps = new Preferences();
+		assertEquals("7.2", false, ps.needsSaving());
+		ps.setValue("any", "x");
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			ps.store(out, "test header");
-			ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-			ps.load(in);
-			assertEquals("7.3", false, ps.needsSaving());
-			ps.setToDefault("any");
-			assertEquals("7.4", true, ps.needsSaving());
-		} catch (IOException e) {
-			assertTrue("7.5", false);
+			try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
+				ps.load(in);
+			}
 		}
+		assertEquals("7.3", false, ps.needsSaving());
+		ps.setToDefault("any");
+		assertEquals("7.4", true, ps.needsSaving());
+
 
 		// setDefault, getT, getDefaultT do not dirty
 		ps = new Preferences();
@@ -717,13 +706,11 @@ public class PreferencesTest extends RuntimeTest {
 		ps.getDefaultString("s1");
 		assertEquals("8.1", false, ps.needsSaving());
 
-		try {
-			ps = new Preferences();
-			assertEquals("9.1", false, ps.needsSaving());
-			ps.setValue("b1", true);
-			assertEquals("9.2", true, ps.needsSaving());
-			ByteArrayOutputStream out = new ByteArrayOutputStream();
-
+		ps = new Preferences();
+		assertEquals("9.1", false, ps.needsSaving());
+		ps.setValue("b1", true);
+		assertEquals("9.2", true, ps.needsSaving());
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			// store makes not dirty
 			ps.store(out, "test header");
 			assertEquals("9.3", false, ps.needsSaving());
@@ -731,11 +718,10 @@ public class PreferencesTest extends RuntimeTest {
 			// load comes in not dirty
 			ps.setValue("b1", false);
 			assertEquals("9.4", true, ps.needsSaving());
-			ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-			ps.load(in);
+			try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
+				ps.load(in);
+			}
 			assertEquals("9.5", false, ps.needsSaving());
-		} catch (IOException e) {
-			assertTrue("9.0", false);
 		}
 	}
 


### PR DESCRIPTION
`RuntimeTest` and its sublasses are still based on JUnit 3, as they implement the JUnit 3 `TestCase` and the Eclipse-specific `CoreTest` subclass, respectively. This change migrates those tests in `org.eclipse.core.tests.runtime` to JUnit 4 that are neither job tests, nor session or performance tests.

In total, the change does the following:
- Migrates several tests in `org.eclipse.core.tests.runtime` to JUnit 4
- Replaces all try-catch constructs with either exceptions thrown by the test or `assertThrows`
- Replaces unnecessary custom assert implementations with JUnit 4 asserts or hamcrest matcher calls
- Encapsulates all `AutoClosables` into try-with-resources blocks