### PR TITLE
Use centos-8-8gb instance configured to use 8 GB RAM (was 4 GB before)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
-		label "centos-latest"
+		label "centos-8-8gb"
 	}
 	tools {
 		maven 'apache-maven-latest'


### PR DESCRIPTION
Should give us enough memory for the next few days.

See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3896