### PR TITLE
Fix inconsistent Javadoc in org.eclipse.ant.tests.ui

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
@@ -147,8 +147,6 @@ public abstract class AbstractAntDebugTest extends AbstractAntUIBuildTest {
 	 * @param waiter
 	 *            the event waiter to use
 	 * @return Object the source of the event
-	 * @exception Exception
-	 *                if the event is never received.
 	 */
 	@Override
 	protected Object launchAndWait(ILaunchConfiguration configuration, DebugEventWaiter waiter) throws CoreException {
@@ -166,8 +164,6 @@ public abstract class AbstractAntDebugTest extends AbstractAntUIBuildTest {
 	 * @param register
 	 *            whether to register the launch
 	 * @return Object the source of the event
-	 * @exception Exception
-	 *                if the event is never received.
 	 */
 	protected Object launchAndWait(ILaunchConfiguration configuration, DebugEventWaiter waiter, boolean register) throws CoreException {
 		ILaunch launch = configuration.launch(ILaunchManager.DEBUG_MODE, null, false, register);

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
@@ -227,9 +227,8 @@ public class AntEditorTests extends AbstractAntUITest {
 
 	/**
 	 * Tests that the augment task can open in the Ant editor
-	 * 
-	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
-	 * @throws Exception
+	 *
+	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
 	public void testAugmentOpenInEditor() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
@@ -239,9 +238,8 @@ public class AntEditorTests extends AbstractAntUITest {
 
 	/**
 	 * Tests that the augment task can be shown and has the correct additions
-	 * 
-	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
-	 * @throws Exception
+	 *
+	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
 	public void testAugmentOpenAndSelect() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
@@ -256,9 +254,8 @@ public class AntEditorTests extends AbstractAntUITest {
 
 	/**
 	 * Tests that the element augmented by the augment task properly displays the augmented elements when hovering
-	 * 
-	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
-	 * @throws Exception
+	 *
+	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
 	 */
 	public void testAugmentOpenSelectHover() throws Exception {
 		IFile file = getIFile("bug377075.ent"); //$NON-NLS-1$
@@ -279,9 +276,8 @@ public class AntEditorTests extends AbstractAntUITest {
 
 	/**
 	 * Tests that the Ant editor is resilient to using an Augment task that references an unknown id
-	 * 
-	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=396219
-	 * @throws Exception
+	 *
+	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=396219
 	 */
 	public void testAugmentMissingId() throws Exception {
 		IFile file = getIFile("bug396219.ent"); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java
@@ -99,7 +99,7 @@ public class AbstractAntUIBuildPerformanceTest extends AbstractAntUIBuildTest {
 
 	/**
 	 * Called from within a test case immediately before the code to measure is run. It starts capturing of performance data. Must be followed by a
-	 * call to {@link PerformanceTestCase#stopMeasuring()} before subsequent calls to this method or {@link PerformanceTestCase#commitMeasurements()}.
+	 * call to {@link #stopMeasuring()} before subsequent calls to this method or {@link #commitMeasurements()}.
 	 */
 	protected void startMeasuring() {
 		fPerformanceMeter.start();

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
@@ -68,7 +68,6 @@ public abstract class AbstractAntUIBuildTest extends AbstractAntUITest {
 	 * to the console.
 	 *
 	 * @param config the config to execute
-	 * @return thread in which the first suspend event occurred
 	 */
 	protected void launch(ILaunchConfiguration config) throws CoreException {
 		launchAndTerminate(config, 20000);

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
@@ -384,7 +384,6 @@ public abstract class AbstractAntUITest extends TestCase {
 	 *
 	 * @param buildFileName
 	 *            build file to launch
-	 * @return thread in which the first suspend event occurred
 	 */
 	protected void launchWithDebug(String buildFileName) throws CoreException {
 		ILaunchConfiguration config = getLaunchConfiguration(buildFileName);
@@ -483,8 +482,6 @@ public abstract class AbstractAntUITest extends TestCase {
 	 * @param waiter
 	 *            the event waiter to use
 	 * @return Object the source of the event
-	 * @exception Exception
-	 *                if the event is never received.
 	 */
 	protected Object launchAndWait(ILaunchConfiguration configuration, DebugEventWaiter waiter) throws CoreException {
 		ILaunch launch = configuration.launch(ILaunchManager.RUN_MODE, null);


### PR DESCRIPTION
See Javadoc checks in this build: https://ci.eclipse.org/platform/job/eclipse.platform/job/PR-785/4/console

```
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java:387: error: invalid use of @return
	 * @return thread in which the first suspend event occurred
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java:486: error: exception not thrown: java.lang.Exception
	 * @exception Exception
	              ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java:71: error: invalid use of @return
	 * @return thread in which the first suspend event occurred
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java:150: error: exception not thrown: java.lang.Exception
	 * @exception Exception
	              ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java:169: error: exception not thrown: java.lang.Exception
	 * @exception Exception
	              ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java:102: error: reference not found
	 * call to {@link PerformanceTestCase#stopMeasuring()} before subsequent calls to this method or {@link PerformanceTestCase#commitMeasurements()}.
	                  ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildPerformanceTest.java:102: error: reference not found
	 * call to {@link PerformanceTestCase#stopMeasuring()} before subsequent calls to this method or {@link PerformanceTestCase#commitMeasurements()}.
	                                                                                                        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java:231: error: unexpected text
	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java:243: error: unexpected text
	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java:260: error: unexpected text
	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=377075
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-785/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java:283: error: unexpected text
	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=396219
	   ^
```