### PR TITLE
"Element Tree Spy" view can't be opened on Java 21

### DIFF
--- a/resources/bundles/org.eclipse.core.tools.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.tools.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core Resources Tools
 Bundle-SymbolicName: org.eclipse.core.tools.resources;singleton:=true
-Bundle-Version: 1.7.0.qualifier
+Bundle-Version: 1.7.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tools.resources,
  org.eclipse.core.tools.resources.markers

--- a/resources/bundles/org.eclipse.core.tools.resources/pom.xml
+++ b/resources/bundles/org.eclipse.core.tools.resources/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.tools.resources</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.7.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>


### PR DESCRIPTION
Make sure tooling doesn't fail on new Java runtime reflections restrictions relating to "module borders" etc.

Note, the object size calculations here are an approximation anyway, so ignoring some of them is "OK". We only want a rough estimation here.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/793