### PR TITLE
Deduplicate launch configs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 40, unit: 'MINUTES')
+		timeout(time: 60, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
 	}

--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.18.300.qualifier
+Bundle-Version: 3.18.400.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
@@ -15,11 +15,13 @@ package org.eclipse.debug.ui.actions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.IEvaluationContext;
@@ -280,9 +282,12 @@ public abstract class ContextualLaunchAction implements IObjectActionDelegate, I
 			}
 		}
 		// now add collected launches
+		Set<ILaunchConfiguration> added = new HashSet<>();
 		for (Entry<LaunchShortcutExtension, ILaunchConfiguration[]> entry : launchConfigurations.entrySet()) {
 			for (ILaunchConfiguration configuration : entry.getValue()) {
-				populateMenuItem(fMode, entry.getKey(), menu, configuration, accelerator++, null);
+				if (added.add(configuration)) {
+					populateMenuItem(fMode, entry.getKey(), menu, configuration, accelerator++, null);
+				}
 			}
 		}
 


### PR DESCRIPTION
The same launch config might be returned by multiple LaunchShortcutExtension and is then shown twice.

This simply filter items that where already seen to deduplicate such entries.

Fix https://github.com/eclipse-platform/eclipse.platform/issues/527