### PR TITLE
Fix faulty tags and references in Javadoc

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupExtension.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupExtension.java
@@ -62,7 +62,7 @@ public class LaunchConfigurationTabGroupExtension {
 	 *
 	 * @param element the configuration element defining the attributes of this
 	 *                launch configuration tab extension
-	 * @returns a new launch configuration tab extension
+	 * @return a new launch configuration tab extension
 	 */
 	public LaunchConfigurationTabGroupExtension(IConfigurationElement element) {
 		setConfigurationElement(element);

--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
@@ -126,7 +126,7 @@ public class SystemProxyTest {
 	}
 
 	/**
-	 * This test needs system env set. See {@link #initializeTestProxyData()} for
+	 * This test needs system env set. See {@link #initializeTestProxyData(String)} for
 	 * values.
 	 */
 	@Test
@@ -136,7 +136,7 @@ public class SystemProxyTest {
 	}
 
 	/**
-	 * This test needs system env set. See {@link #initializeTestProxyData()} for
+	 * This test needs system env set. See {@link #initializeTestProxyData(String)} for
 	 * values.
 	 */
 	@Test
@@ -146,7 +146,7 @@ public class SystemProxyTest {
 	}
 
 	/**
-	 * This test needs Gnome settings set. See {@link #initializeTestProxyData()}
+	 * This test needs Gnome settings set. See {@link #initializeTestProxyData(String)}
 	 * for values.
 	 */
 	@Test
@@ -156,7 +156,7 @@ public class SystemProxyTest {
 	}
 
 	/**
-	 * This test needs Gnome settings set. See {@link #initializeTestProxyData()}
+	 * This test needs Gnome settings set. See {@link #initializeTestProxyData(String)}
 	 * for values.
 	 */
 	@Test
@@ -167,7 +167,7 @@ public class SystemProxyTest {
 
 	/**
 	 * This test needs Windows IE settings manually set. See
-	 * {@link #initializeTestProxyData()} for values.
+	 * {@link #initializeTestProxyData(String)} for values.
 	 */
 	@Test
 	public void testGetProxyDataForHost_WindowsIEManualSettings() {
@@ -177,7 +177,7 @@ public class SystemProxyTest {
 
 	/**
 	 * This test needs Windows IE settings manually set. See
-	 * {@link #initializeTestProxyData()} for values.
+	 * {@link #initializeTestProxyData(String)} for values.
 	 */
 	@Test
 	public void testProxySelector_WindowsIEManualSettings() {
@@ -187,7 +187,7 @@ public class SystemProxyTest {
 
 	/**
 	 * This test needs Windows IE settings manually set. See
-	 * {@link #initializeTestProxyData()} for values. Additionally set
+	 * {@link #initializeTestProxyData(String)} for values. Additionally set
 	 * <code>"eclipse.*;nonexisting.com;*.eclipse.org;www.*.com;*.test.*"</code> as
 	 * proxy bypass in the IE settings.
 	 *


### PR DESCRIPTION
For faulty references see, e.g., https://ci.eclipse.org/platform/job/eclipse.platform/job/PR-785/5/console

Faulty tag is a regression (typo) introduced here: https://github.com/eclipse-platform/eclipse.platform/pull/764