### PR TITLE
Ensure proper cleanup after WorkspaceSessionTests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -26,7 +26,6 @@ import org.eclipse.core.tests.resources.regression.SimpleBuilder;
 import org.eclipse.core.tests.resources.saveparticipant1.SaveParticipant1Plugin;
 import org.eclipse.core.tests.resources.saveparticipant3.SaveParticipant3Plugin;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleException;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -59,7 +59,7 @@ public class SaveManager2Test extends SaveManagerTest {
 		return suite;
 	}
 
-	public void testBuilder() {
+	public void testBuilder() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.isAccessible());
 
@@ -68,31 +68,19 @@ public class SaveManager2Test extends SaveManagerTest {
 		DeltaVerifierBuilder verifier = DeltaVerifierBuilder.getInstance();
 		verifier.reset();
 		verifier.addExpectedChange(added, project, IResourceDelta.ADDED, 0);
-		try {
-			added.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		added.create(getRandomContents(), true, null);
 		waitForBuild();
 		assertTrue("3.2", verifier.wasAutoBuild());
 		assertTrue("3.3", verifier.isDeltaValid());
 		// remove the file because we don't want it to affect any other delta in the test
-		try {
-			added.delete(true, false, null);
-		} catch (CoreException e) {
-			fail("3.4", e);
-		}
+		added.delete(true, false, null);
 	}
 
-	public void testSaveParticipant() {
+	public void testSaveParticipant() throws Exception {
 		// get plugin
 		Bundle bundle = Platform.getBundle(PI_SAVE_PARTICIPANT_1);
 		assertTrue("0.1", bundle != null);
-		try {
-			bundle.start();
-		} catch (BundleException e) {
-			fail("0.0", e);
-		}
+		bundle.start();
 		SaveParticipant1Plugin plugin1 = SaveParticipant1Plugin.getInstance();
 
 		// prepare plugin to the save operation
@@ -100,38 +88,20 @@ public class SaveManager2Test extends SaveManagerTest {
 		IResource added1 = getWorkspace().getRoot().getFile(IPath.fromOSString(PROJECT_1).append("addedFile"));
 		plugin1.addExpectedChange(added1, IResourceDelta.ADDED, 0);
 		IStatus status;
-		try {
-			status = plugin1.registerAsSaveParticipant();
-			if (!status.isOK()) {
-				System.out.println(status.getMessage());
-				assertTrue("1.0", false);
-			}
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		status = plugin1.registerAsSaveParticipant();
+		assertTrue("Registering save participant failed with message: " + status.getMessage(), status.isOK());
 
 		// SaveParticipant3Plugin
 		bundle = Platform.getBundle(PI_SAVE_PARTICIPANT_3);
 		assertTrue("7.1", bundle != null);
-		try {
-			bundle.start();
-		} catch (BundleException e) {
-			fail("7.0", e);
-		}
+		bundle.start();
 		SaveParticipant3Plugin plugin3 = SaveParticipant3Plugin.getInstance();
 
-		try {
-			status = plugin3.registerAsSaveParticipant();
-			if (!status.isOK()) {
-				System.out.println(status.getMessage());
-				fail("7.2");
-			}
-		} catch (CoreException e) {
-			fail("7.3", e);
-		}
+		status = plugin3.registerAsSaveParticipant();
+		assertTrue("Registering save participant failed with message: " + status.getMessage(), status.isOK());
 	}
 
-	public void testVerifyProject2() {
+	public void testVerifyProject2() throws CoreException {
 		// project2 should be closed
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_2);
 		assertTrue("0.0", project.exists());
@@ -142,36 +112,24 @@ public class SaveManager2Test extends SaveManagerTest {
 		assertExistsInFileSystem("1.0", resources);
 		assertDoesNotExistInWorkspace("1.1", resources);
 
-		try {
-			project.open(null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project.open(null);
 		assertTrue("2.1", project.exists());
 		assertTrue("2.2", project.isOpen());
 		assertExistsInFileSystem("2.3", resources);
 		assertExistsInWorkspace("2.4", resources);
 
 		// verify builder -- cause an incremental build
-		try {
-			touch(project);
-		} catch (CoreException e) {
-			fail("2.5", e);
-		}
+		touch(project);
 		waitForBuild();
 		SimpleBuilder builder = SimpleBuilder.getInstance();
 		assertTrue("2.6", builder.wasAutoBuild());
 
 		// add a file to test save participant delta
 		IFile file = project.getFile("addedFile");
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.create(getRandomContents(), true, null);
 	}
 
-	public void testVerifyRestoredWorkspace() {
+	public void testVerifyRestoredWorkspace() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.exists());
 		assertTrue("0.1", project.isOpen());
@@ -183,10 +141,6 @@ public class SaveManager2Test extends SaveManagerTest {
 
 		// add a file to test save participant delta
 		IFile file = project.getFile("addedFile");
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.create(getRandomContents(), true, null);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManagerTest.java
@@ -58,12 +58,8 @@ public class SaveManagerTest extends WorkspaceSessionTest {
 		return new String[] {"/file110", "/folder110/", "/folder110/file120", "/folder111/", "/folder111/folder120/", "/folder111/file121"};
 	}
 
-	public void saveWorkspace() {
-		try {
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+	public void saveWorkspace() throws CoreException {
+		getWorkspace().save(true, null);
 	}
 
 	/**
@@ -78,7 +74,7 @@ public class SaveManagerTest extends WorkspaceSessionTest {
 		workspace.setDescription(desc);
 	}
 
-	public void test1() {
+	public void test1() throws Exception {
 		SaveManager1Test test = new SaveManager1Test();
 		test.saveWorkspace();
 		test.testCreateMyProject();
@@ -90,7 +86,7 @@ public class SaveManagerTest extends WorkspaceSessionTest {
 
 	}
 
-	public void test2() {
+	public void test2() throws Exception {
 		SaveManager2Test test = new SaveManager2Test();
 		test.testVerifyRestoredWorkspace();
 		test.testBuilder();
@@ -99,11 +95,10 @@ public class SaveManagerTest extends WorkspaceSessionTest {
 		test.saveWorkspace();
 	}
 
-	public void test3() {
+	public void test3() throws Exception {
 		SaveManager3Test test = new SaveManager3Test();
 		test.testSaveParticipant();
 		test.testBuilder();
-		test.cleanUp();
 	}
 
 	protected void touch(IProject project) throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -43,16 +43,14 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		workspace.setDescription(Workspace.defaultWorkspaceDescription());
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	private void setDefaultWorkspaceDescription() throws CoreException {
 		workspace.setDescription(Workspace.defaultWorkspaceDescription());
 	}
 
 	/**
 	 * Tests properties state in a brand new workspace (must match defaults).
 	 */
-	public void testDefaults() {
+	public void testDefaults() throws CoreException {
 		IWorkspaceDescription description = Workspace.defaultWorkspaceDescription();
 
 		assertEquals("1.0", description, preferences);
@@ -66,13 +64,15 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		for (String property : descriptionProperties) {
 			assertTrue("2.0 - Description property is not default: " + property, defaultPropertiesList.contains(property));
 		}
+		
+		setDefaultWorkspaceDescription();
 	}
 
 	/**
 	 * Makes changes in the preferences and ensure they are reflected in the
 	 * workspace description.
 	 */
-	public void testSetPreferences() {
+	public void testSetPreferences() throws CoreException {
 		preferences.setValue(ResourcesPlugin.PREF_AUTO_BUILDING, true);
 		assertTrue("1.0", workspace.getDescription().isAutoBuilding());
 
@@ -110,6 +110,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 
 		preferences.setValue(ResourcesPlugin.PREF_KEEP_DERIVED_STATE, true);
 		assertTrue("4.1", workspace.getDescription().isKeepDerivedState());
+
+		setDefaultWorkspaceDescription();
 	}
 
 	/**
@@ -152,6 +154,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		} finally {
 			preferences.removePropertyChangeListener(listener);
 		}
+
+		setDefaultWorkspaceDescription();
 	}
 
 	/**
@@ -204,6 +208,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 			ensureDoesNotExistInFileSystem(originalPreferencesFile.removeLastSegments(1).toFile());
 			ensureDoesNotExistInFileSystem(modifiedPreferencesFile.removeLastSegments(1).toFile());
 		}
+
+		setDefaultWorkspaceDescription();
 	}
 
 	/**
@@ -234,6 +240,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		// the original value should remain set
 		assertEquals("3.1", 90000, workspace.getDescription().getFileStateLongevity());
 		assertEquals("3.2", 90000, preferences.getLong(ResourcesPlugin.PREF_FILE_STATE_LONGEVITY));
+
+		setDefaultWorkspaceDescription();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceSessionTest.java
@@ -35,8 +35,6 @@ package org.eclipse.core.tests.resources;
  * @see org.eclipse.core.tests.session.WorkspaceSessionTestSuite
  */
 public class WorkspaceSessionTest extends ResourceTest {
-	protected String testName;
-
 	/**
 	 * Constructor for WorkspaceSessionTest.
 	 */
@@ -54,9 +52,27 @@ public class WorkspaceSessionTest extends ResourceTest {
 		super(name);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		// We should not run super.tearDown() on session tests.
-		// If needed, we should call it explicitly.
+	/**
+	 * Executes the cleanup functionality in {@link ResourceTest#tearDown()} after
+	 * the last of the session of this test class (i.e., the last <code>test*</code>
+	 * method) has finished.
+	 * <p>
+	 * The test methods are executed in lexicographic order of their names, e.g.,
+	 * <code>test1</code> before <code>test2</code>. The name of this method is
+	 * chosen so that it comes lexicographically rather safely after all other
+	 * actual test methods.
+	 */
+	public void test___cleanup() throws Exception {
+		super.tearDown();
 	}
+
+	/**
+	 * Cleanup is done after all sessions of this test class in
+	 * {@link #test___cleanup()}. This method is overwritten to do nothing in order
+	 * to not cleanup between the sessions.
+	 */
+	@Override
+	protected final void tearDown() throws Exception {
+	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -17,7 +17,14 @@ package org.eclipse.core.tests.resources.regression;
 import java.io.ByteArrayInputStream;
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
@@ -48,28 +55,25 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 	/**
 	 * Create projects, setup a builder, and do an initial build.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IResource[] resources = {project1, unsorted1, sorted1, unsortedFile1};
 		ensureExistsInWorkspace(resources, true);
 
-		try {
-			//give unsorted files some initial content
-			unsortedFile1.setContents(new ByteArrayInputStream(new byte[] {1, 4, 3}), true, true, null);
+		// give unsorted files some initial content
+		unsortedFile1.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);
 
-			setAutoBuilding(false);
+		setAutoBuilding(false);
 
-			//configure builder for project1
-			IProjectDescription description = project1.getDescription();
-			description.setBuildSpec(new ICommand[] {createCommand(description, "Project1Build1"), createCommand(description, "Project1Build2")});
-			project1.setDescription(description, getMonitor());
+		// configure builder for project1
+		IProjectDescription description = project1.getDescription();
+		description.setBuildSpec(new ICommand[] { createCommand(description, "Project1Build1"),
+				createCommand(description, "Project1Build2") });
+		project1.setDescription(description, getMonitor());
 
-			//initial build -- created sortedFile1
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		// initial build -- created sortedFile1
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	protected ICommand createCommand(IProjectDescription description, String builderId) {
@@ -85,12 +89,8 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 	 * Do another build immediately after restart.  Builder1 should be invoked because it cares
 	 * about changes made by Builder2 during the last build phase.
 	 */
-	public void test2() {
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+	public void test2() throws CoreException {
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 		//Only builder1 should have been built
 		SortBuilder[] builders = SortBuilder.allInstances();
 		assertEquals("1.0", 2, builders.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -17,8 +17,11 @@ package org.eclipse.core.tests.resources.session;
 import java.util.Arrays;
 import java.util.List;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -60,313 +63,257 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		getWorkspace().save(true, getMonitor());
 	}
 
-	public void test1() {
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
+	public void test1() throws Exception {
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.1", 0, df.length);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.1", 0, df.length);
 
 		// test that a deleted file can be found
-		try {
-			// create and delete a file
-			pfile.create(getRandomContents(), true, getMonitor());
-			pfile.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		// create and delete a file
+		pfile.create(getRandomContents(), true, getMonitor());
+		pfile.delete(true, true, getMonitor());
 	}
 
-	public void test2() {
-		try {
-			// the deleted file should show up as a deleted member of project
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.1", 1, df.length);
-			assertEquals("0.2", pfile, df[0]);
+	public void test2() throws Exception {
+		// the deleted file should show up as a deleted member of project
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.1", 1, df.length);
+		assertEquals("0.2", pfile, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.3", 1, df.length);
-			assertEquals("0.4", pfile, df[0]);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.3", 1, df.length);
+		assertEquals("0.4", pfile, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.5", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.5", 0, df.length);
 
-			// the deleted file should show up as a deleted member of workspace root
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.5.1", 0, df.length);
+		// the deleted file should show up as a deleted member of workspace root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.5.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.5.2", 1, df.length);
-			assertEquals("0.5.3", pfile, df[0]);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.5.2", 1, df.length);
+		assertEquals("0.5.3", pfile, df[0]);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.5.4", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.5.4", 0, df.length);
 
-			// recreate the file
-			pfile.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		// recreate the file
+		pfile.create(getRandomContents(), true, getMonitor());
 	}
 
-	public void test3() {
-		try {
-			// the deleted file should no longer show up as a deleted member of project
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.6", 0, df.length);
+	public void test3() throws Exception {
+		// the deleted file should no longer show up as a deleted member of project
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.6", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.7", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.7", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.8", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.8", 0, df.length);
 
-			// the deleted file should no longer show up as a deleted member of ws root
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.8.1", 0, df.length);
+		// the deleted file should no longer show up as a deleted member of ws root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.8.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.8.2", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.8.2", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.8.3", 0, df.length);
-
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.8.3", 0, df.length);
 
 		// scrub the project
-		try {
-			project.delete(true, getMonitor());
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.delete(true, getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.9", 0, df.length);
-		} catch (CoreException e) {
-			fail("0.10", e);
-		}
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.9", 0, df.length);
 
 		// test folder
-		try {
-			// create and delete a file in a folder
-			folder.create(true, true, getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-			file.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// create and delete a file in a folder
+		folder.create(true, true, getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+		file.delete(true, true, getMonitor());
 	}
 
-	public void test4() {
-		try {
-			// the deleted file should show up as a deleted member
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.1", 0, df.length);
+	public void test4() throws Exception {
+		// the deleted file should show up as a deleted member
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.1", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.2", 1, df.length);
-			assertEquals("1.3", file, df[0]);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.2", 1, df.length);
+		assertEquals("1.3", file, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.4", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.4", 0, df.length);
 
-			// recreate the file
-			file.create(getRandomContents(), true, getMonitor());
+		// recreate the file
+		file.create(getRandomContents(), true, getMonitor());
 
-			// the recreated file should no longer show up as a deleted member
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.5", 0, df.length);
+		// the recreated file should no longer show up as a deleted member
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.5", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.6", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.6", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.7", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.7", 0, df.length);
 
-			// deleting the folder should bring it back into history
-			folder.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// deleting the folder should bring it back into history
+		folder.delete(true, true, getMonitor());
 	}
 
-	public void test5() {
-		try {
-			// the deleted file should show up as a deleted member of project
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.8", 0, df.length);
+	public void test5() throws Exception {
+		// the deleted file should show up as a deleted member of project
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.8", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.9", 1, df.length);
-			assertEquals("1.10", file, df[0]);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.9", 1, df.length);
+		assertEquals("1.10", file, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.11", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.11", 0, df.length);
 
-			// create and delete a file where the folder was
-			folderAsFile.create(getRandomContents(), true, getMonitor());
-			folderAsFile.delete(true, true, getMonitor());
-			folder.create(true, true, getMonitor());
+		// create and delete a file where the folder was
+		folderAsFile.create(getRandomContents(), true, getMonitor());
+		folderAsFile.delete(true, true, getMonitor());
+		folder.create(true, true, getMonitor());
 
-			// the deleted file should show up as a deleted member of folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.12", 1, df.length);
-			assertEquals("1.13", folderAsFile, df[0]);
+		// the deleted file should show up as a deleted member of folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.12", 1, df.length);
+		assertEquals("1.13", folderAsFile, df[0]);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.14", 2, df.length);
-			List<IFile> dfList = Arrays.asList(df);
-			assertTrue("1.15", dfList.contains(file));
-			assertTrue("1.16", dfList.contains(folderAsFile));
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.14", 2, df.length);
+		List<IFile> dfList = Arrays.asList(df);
+		assertTrue("1.15", dfList.contains(file));
+		assertTrue("1.16", dfList.contains(folderAsFile));
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.17", 2, df.length);
-			dfList = Arrays.asList(df);
-			assertTrue("1.18", dfList.contains(file));
-			assertTrue("1.19", dfList.contains(folderAsFile));
-
-		} catch (CoreException e) {
-			fail("1.00", e);
-		}
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.17", 2, df.length);
+		dfList = Arrays.asList(df);
+		assertTrue("1.18", dfList.contains(file));
+		assertTrue("1.19", dfList.contains(folderAsFile));
 
 		// scrub the project
-		try {
-			project.delete(true, getMonitor());
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.delete(true, getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.50", 0, df.length);
-		} catch (CoreException e) {
-			fail("1.51", e);
-		}
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.50", 0, df.length);
 
 		// test a bunch of deletes
-		try {
-			// create and delete a file in a folder
-			folder.create(true, true, getMonitor());
-			folder2.create(true, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			file3.create(getRandomContents(), true, getMonitor());
-			folder.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
+		// create and delete a file in a folder
+		folder.create(true, true, getMonitor());
+		folder2.create(true, true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		file3.create(getRandomContents(), true, getMonitor());
+		folder.delete(true, true, getMonitor());
 	}
 
-	public void test6() {
-		try {
-			// under root
-			IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.1", 0, df.length);
+	public void test6() throws Exception {
+		// under root
+		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.2", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.2", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.3", 3, df.length);
-			List<IFile> dfList = Arrays.asList(df);
-			assertTrue("3.3.1", dfList.contains(file1));
-			assertTrue("3.3.2", dfList.contains(file2));
-			assertTrue("3.3.3", dfList.contains(file3));
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.3", 3, df.length);
+		List<IFile> dfList = Arrays.asList(df);
+		assertTrue("3.3.1", dfList.contains(file1));
+		assertTrue("3.3.2", dfList.contains(file2));
+		assertTrue("3.3.3", dfList.contains(file3));
 
-			// under project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.4", 0, df.length);
+		// under project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.4", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.5", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.5", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.6", 3, df.length);
-			dfList = Arrays.asList(df);
-			assertTrue("3.6.1", dfList.contains(file1));
-			assertTrue("3.6.2", dfList.contains(file2));
-			assertTrue("3.6.3", dfList.contains(file3));
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.6", 3, df.length);
+		dfList = Arrays.asList(df);
+		assertTrue("3.6.1", dfList.contains(file1));
+		assertTrue("3.6.2", dfList.contains(file2));
+		assertTrue("3.6.3", dfList.contains(file3));
 
-			// under folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.7", 0, df.length);
+		// under folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.7", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.8", 2, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.8", 2, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.9", 3, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.9", 3, df.length);
 
-			// under folder2
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.10", 0, df.length);
+		// under folder2
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.10", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.11", 1, df.length);
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.11", 1, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.12", 1, df.length);
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.12", 1, df.length);
 
-		} catch (CoreException e) {
-			fail("3.00", e);
-		}
-
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.5", e);
-		}
+		project.delete(true, getMonitor());
 	}
 
-	public void test7() {
+	public void test7() throws Exception {
 		// once the project is gone, so is all the history for that project
-		try {
-			// under root
-			IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.1", 0, df.length);
+		// under root
+		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.2", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.2", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.3", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.3", 0, df.length);
 
-			// under project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.4", 0, df.length);
+		// under project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.4", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.5", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.5", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.6", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.6", 0, df.length);
 
-			// under folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.7", 0, df.length);
+		// under folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.7", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.8", 0, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.8", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.9", 0, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.9", 0, df.length);
 
-			// under folder2
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.10", 0, df.length);
+		// under folder2
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.10", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.11", 0, df.length);
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.11", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.12", 0, df.length);
-
-		} catch (CoreException e) {
-			fail("4.00", e);
-		}
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.12", 0, df.length);
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -22,6 +22,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -58,8 +59,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	private void saveWorkspace() throws CoreException {
 		getWorkspace().save(true, getMonitor());
 	}
 
@@ -74,6 +74,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		// create and delete a file
 		pfile.create(getRandomContents(), true, getMonitor());
 		pfile.delete(true, true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test2() throws Exception {
@@ -102,6 +104,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 		// recreate the file
 		pfile.create(getRandomContents(), true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test3() throws Exception {
@@ -138,6 +142,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		folder.create(true, true, getMonitor());
 		file.create(getRandomContents(), true, getMonitor());
 		file.delete(true, true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test4() throws Exception {
@@ -167,6 +173,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 		// deleting the folder should bring it back into history
 		folder.delete(true, true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test5() throws Exception {
@@ -219,6 +227,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		file2.create(getRandomContents(), true, getMonitor());
 		file3.create(getRandomContents(), true, getMonitor());
 		folder.delete(true, true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test6() throws Exception {
@@ -271,6 +281,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertEquals("3.12", 1, df.length);
 
 		project.delete(true, getMonitor());
+
+		saveWorkspace();
 	}
 
 	public void test7() throws Exception {
@@ -314,6 +326,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
 		assertEquals("4.12", 0, df.length);
+
+		saveWorkspace();
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -37,8 +37,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		//						return new ProjectPreferenceSessionTest("testDeleteFileBeforeLoad2");
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	private void saveWorkspace() throws Exception {
 		getWorkspace().save(true, getMonitor());
 	}
 
@@ -62,6 +61,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		IFile file = project.getFile(IPath.fromOSString(DIR_NAME).append(qualifier).addFileExtension(FILE_EXTENSION));
 		assertTrue("2.0", file.exists());
 		assertTrue("2.1", file.getLocation().toFile().exists());
+		saveWorkspace();
 	}
 
 	public void testDeleteFileBeforeLoad2() throws Exception {
@@ -85,6 +85,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		} finally {
 			Platform.removeLogListener(listener);
 		}
+		saveWorkspace();
 	}
 
 	/*
@@ -98,13 +99,15 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		Preferences node = context.getNode("test.save.load");
 		node.put("key", "value");
 		node.flush();
+		saveWorkspace();
 	}
 
-	public void testSaveLoad2() {
+	public void testSaveLoad2() throws Exception {
 		IProject project = getProject("testSaveLoad");
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode("test.save.load");
 		assertEquals("1.0", "value", node.get("key", null));
+		saveWorkspace();
 	}
 
 	private static IProject getProject(String name) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -18,7 +18,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ProjectScope;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
@@ -51,25 +50,21 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	 * - startup
 	 * - delete the .prefs file from disk
 	 */
-	public void testDeleteFileBeforeLoad1() {
+	public void testDeleteFileBeforeLoad1() throws Exception {
 		IProject project = getProject("testDeleteFileBeforeLoad");
 		String qualifier = "test.delete.file.before.load";
 		ensureExistsInWorkspace(project, true);
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode(qualifier);
 		node.put("key", "value");
-		try {
-			node.flush();
-		} catch (BackingStoreException e) {
-			fail("1.99", e);
-		}
+		node.flush();
 		waitForRefresh();
 		IFile file = project.getFile(IPath.fromOSString(DIR_NAME).append(qualifier).addFileExtension(FILE_EXTENSION));
 		assertTrue("2.0", file.exists());
 		assertTrue("2.1", file.getLocation().toFile().exists());
 	}
 
-	public void testDeleteFileBeforeLoad2() {
+	public void testDeleteFileBeforeLoad2() throws Exception {
 		IProject project = getProject("testDeleteFileBeforeLoad");
 		Platform.getPreferencesService().getRootNode().node(ProjectScope.SCOPE).node(project.getName());
 		ILogListener listener = (status, plugin) -> {
@@ -87,8 +82,6 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		try {
 			Platform.addLogListener(listener);
 			project.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
 		} finally {
 			Platform.removeLogListener(listener);
 		}
@@ -98,17 +91,13 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	 * Test saving a key/value pair in one session and then ensure that they exist
 	 * in the next session.
 	 */
-	public void testSaveLoad1() {
+	public void testSaveLoad1() throws Exception {
 		IProject project = getProject("testSaveLoad");
 		ensureExistsInWorkspace(project, true);
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode("test.save.load");
 		node.put("key", "value");
-		try {
-			node.flush();
-		} catch (BackingStoreException e) {
-			fail("1.99", e);
-		}
+		node.flush();
 	}
 
 	public void testSaveLoad2() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1G1N9GZ.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1G1N9GZ.java
@@ -15,7 +15,9 @@ package org.eclipse.core.tests.resources.session;
 
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
@@ -61,24 +63,19 @@ public class Test1G1N9GZ extends WorkspaceSerializationTest {
 		workspace.save(true, getMonitor());
 	}
 
-	public void test3() {
+	public void test3() throws Exception {
 		/* get new handles */
 		IProject p1 = workspace.getRoot().getProject("p1");
 		IProject p2 = workspace.getRoot().getProject("p2");
 
 		/* try to create other files */
-		try {
-			ByteArrayInputStream source = new ByteArrayInputStream("file's content".getBytes());
+		try (ByteArrayInputStream source = new ByteArrayInputStream("file's content".getBytes())) {
 			p1.getFile("file2").create(source, true, null);
-		} catch (Exception e) {
-			fail("1.0", e);
 		}
-		try {
-			ByteArrayInputStream source = new ByteArrayInputStream("file's content".getBytes());
+		try (ByteArrayInputStream source = new ByteArrayInputStream("file's content".getBytes())) {
 			p2.getFile("file2").create(source, true, null);
-		} catch (Exception e) {
-			fail("1.1", e);
 		}
+
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
@@ -14,7 +14,10 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
@@ -31,45 +34,29 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 	/**
 	 * Prepares the environment.  Create some resources and save the workspace.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IProjectDescription description = getWorkspace().newProjectDescription("MyProject");
 		ICommand command = description.newCommand();
 		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
 		description.setBuildSpec(new ICommand[] {command});
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			project.setDescription(description, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+		project.setDescription(description, getMonitor());
 
 		IFile file = project.getFile("foo.txt");
-		try {
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.create(getRandomContents(), true, getMonitor());
 
-		try {
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**
 	 * Step 2, edit a file then immediately crash.
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("foo.txt");
-		try {
-			file.setContents(getRandomContents(), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.setContents(getRandomContents(), true, true, getMonitor());
 		// crash
 		System.exit(-1);
 	}
@@ -77,20 +64,8 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 	/**
 	 * Now immediately try to save after recovering from crash.
 	 */
-	public void test3() {
-		try {
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-
-		//cleanup
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-		try {
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("99.99", e);
-		}
+	public void test3() throws CoreException {
+		getWorkspace().save(true, getMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
@@ -13,12 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
-import java.io.IOException;
 import junit.framework.Test;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
@@ -36,42 +40,33 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 	/**
 	 * Setup.  Creates a project with a linked resource.
 	 */
-	public void test1() {
+	public void test1() throws Exception {
 		IProject project = workspace.getRoot().getProject("Project1");
 		IFolder link = project.getFolder("link");
 		IFile linkChild = link.getFile("child.txt");
 		ensureExistsInWorkspace(project, true);
-		try {
-			IFileStore parent = EFS.getStore(location.toFile().toURI());
-			IFileStore child = parent.getChild(linkChild.getName());
-			parent.mkdir(EFS.NONE, getMonitor());
-			child.openOutputStream(EFS.NONE, getMonitor()).close();
-			link.createLink(location, IResource.NONE, getMonitor());
+		IFileStore parent = EFS.getStore(location.toFile().toURI());
+		IFileStore child = parent.getChild(linkChild.getName());
+		parent.mkdir(EFS.NONE, getMonitor());
+		child.openOutputStream(EFS.NONE, getMonitor()).close();
+		link.createLink(location, IResource.NONE, getMonitor());
 
-			assertTrue("1.0", link.exists());
-			assertTrue("1.1", linkChild.exists());
+		assertTrue("1.0", link.exists());
+		assertTrue("1.1", linkChild.exists());
 
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException | IOException e) {
-			fail("1.99", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**
 	 * Refresh the linked resource and check that its content is intact
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IProject project = workspace.getRoot().getProject("Project1");
 		IFolder link = project.getFolder("link");
 		IFile linkChild = link.getFile("child.txt");
-		try {
-			link.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		link.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-			assertTrue("1.0", link.exists());
-			assertTrue("1.1", linkChild.exists());
-			cleanup();
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		assertTrue("1.0", link.exists());
+		assertTrue("1.1", linkChild.exists());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
@@ -14,7 +14,10 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -27,40 +30,24 @@ public class TestBug12575 extends WorkspaceSerializationTest {
 	 * Setup.  Create a simple project, delete the .project file, shutdown
 	 * cleanly.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IProject project = workspace.getRoot().getProject(projectName);
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		try {
-			dotProject.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		dotProject.delete(IResource.NONE, getMonitor());
+		workspace.save(true, getMonitor());
 	}
 
 	/**
 	 * Infection.  Modify the .project, cause a snapshot, crash
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IProject project = workspace.getRoot().getProject(projectName);
 		IProject other = workspace.getRoot().getProject("Other");
-		try {
-			IProjectDescription desc = project.getDescription();
-			desc.setReferencedProjects(new IProject[] {other});
-			project.setDescription(desc, IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		desc.setReferencedProjects(new IProject[] { other });
+		project.setDescription(desc, IResource.FORCE, getMonitor());
 		//creating a project will cause a snapshot
 		ensureExistsInWorkspace(other, true);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -16,7 +16,11 @@ package org.eclipse.core.tests.resources.session;
 
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
@@ -32,61 +36,49 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 	 * Setup.  Creates a project with a builder, with a built state,
 	 * autobuild off.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IProject project = workspace.getRoot().getProject("Project1");
 		ensureExistsInWorkspace(project, true);
-		try {
-			setAutoBuilding(false);
+		setAutoBuilding(false);
 
-			//create a project and configure builder
-			IProjectDescription description = project.getDescription();
-			ICommand command = description.newCommand();
-			Map<String, String> args = command.getArguments();
-			args.put(TestBuilder.BUILD_ID, "Project1Build1");
-			command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
-			command.setArguments(args);
-			description.setBuildSpec(new ICommand[] {command});
-			project.setDescription(description, getMonitor());
+		//create a project and configure builder
+		IProjectDescription description = project.getDescription();
+		ICommand command = description.newCommand();
+		Map<String, String> args = command.getArguments();
+		args.put(TestBuilder.BUILD_ID, "Project1Build1");
+		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
+		command.setArguments(args);
+		description.setBuildSpec(new ICommand[] { command });
+		project.setDescription(description, getMonitor());
 
-			//initial build
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		//initial build
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**
 	 * Rename the project without invoking any builds.
 	 */
-	public void test2() {
-		try {
-			IProject project = workspace.getRoot().getProject("Project1");
-			IProjectDescription desc = project.getDescription();
-			desc.setName("MovedProject");
-			project.move(desc, IResource.NONE, getMonitor());
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+	public void test2() throws CoreException {
+		IProject project = workspace.getRoot().getProject("Project1");
+		IProjectDescription desc = project.getDescription();
+		desc.setName("MovedProject");
+		project.move(desc, IResource.NONE, getMonitor());
+		workspace.save(true, getMonitor());
 	}
 
 	/**
 	 * If this session starts correctly then the bug is fixed
 	 */
-	public void test3() {
+	public void test3() throws CoreException {
 		IProject oldLocation = workspace.getRoot().getProject("Project1");
 		IProject newLocation = workspace.getRoot().getProject("MovedProject");
 
 		assertTrue("1.0", !oldLocation.exists());
 		assertTrue("1.0", newLocation.exists());
 		assertTrue("1.1", newLocation.isOpen());
-		try {
-			workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -14,9 +14,13 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.*;
+import org.eclipse.core.tests.resources.AutomatedResourceTests;
+import org.eclipse.core.tests.resources.TestUtil;
+import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
 /**
@@ -24,86 +28,46 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  */
 public class TestBug202384 extends WorkspaceSessionTest {
 
-	public void testInitializeWorkspace() {
+	public void testInitializeWorkspace() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
 		ensureExistsInWorkspace(project, true);
-		try {
-			project.setDefaultCharset("UTF-8", getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-		try {
-			assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-		try {
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		project.setDefaultCharset("UTF-8", getMonitor());
+		assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
+		project.close(getMonitor());
+		workspace.save(true, getMonitor());
 	}
 
-	public void testStartWithClosedProject() {
+	public void testStartWithClosedProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
 		assertFalse("1.0", project.isOpen());
-		try {
-			//project is closed so it is not possible to read correct encoding
-			assertNull("2.0", project.getDefaultCharset(false));
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-		try {
-			//opening the project should initialize ProjectPreferences
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
-		try {
-			//correct values should be available after initialization
-			assertEquals("5.0", "UTF-8", project.getDefaultCharset(false));
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		// project is closed so it is not possible to read correct encoding
+		assertNull("2.0", project.getDefaultCharset(false));
+		// opening the project should initialize ProjectPreferences
+		project.open(getMonitor());
+		// correct values should be available after initialization
+		assertEquals("5.0", "UTF-8", project.getDefaultCharset(false));
+		workspace.save(true, getMonitor());
 	}
 
-	public void testStartWithOpenProject() {
+	public void testStartWithOpenProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
 		assertTrue("1.0", project.isOpen());
-		try {
-			//correct values should be available if ProjectPreferences got
-			//initialized upon creation
-			String expectedEncoding = "UTF-8";
-			// check with a timeout, in case some initialize operation is slow
-			long timeout = 10_000;
-			long start = System.currentTimeMillis();
-			while (!expectedEncoding.equals(project.getDefaultCharset(false))
-					&& System.currentTimeMillis() - start < timeout) {
-				TestUtil.dumpRunnigOrWaitingJobs(getName());
-				TestUtil.waitForJobs(getName(), 500, 1000);
-			}
-			assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));
-		} catch (CoreException e) {
-			fail("3.0", e);
+		// correct values should be available if ProjectPreferences got
+		// initialized upon creation
+		String expectedEncoding = "UTF-8";
+		// check with a timeout, in case some initialize operation is slow
+		long timeout = 10_000;
+		long start = System.currentTimeMillis();
+		while (!expectedEncoding.equals(project.getDefaultCharset(false))
+				&& System.currentTimeMillis() - start < timeout) {
+			TestUtil.dumpRunnigOrWaitingJobs(getName());
+			TestUtil.waitForJobs(getName(), 500, 1000);
 		}
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));
+		workspace.save(true, getMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -15,7 +15,9 @@ package org.eclipse.core.tests.resources.session;
 
 import java.io.File;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
@@ -29,7 +31,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 	/**
 	 * Setup.  Creates a project with a file.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 
 		IProject project = workspace.getRoot().getProject("Project1");
@@ -40,11 +42,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 		ensureExistsInWorkspace(file, getRandomContents());
 
 		// save the workspace
-		try {
-			workspace.save(true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.save(true, null);
 
 		// move the project to another location, before the workbench is started again
 		// to emulate disconnection of a device (e.g. USB key) or a remote file system
@@ -54,7 +52,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 	/**
 	 * Eclipse started again.
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 
 		IProject p1 = workspace.getRoot().getProject("Project1");
@@ -67,11 +65,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 		assertTrue("3.0", new File(p1.getLocation().toFile().getAbsolutePath() + "_temp").renameTo(p1.getLocation().toFile()));
 
 		// now the project should be opened without any problems
-		try {
-			p1.open(null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		p1.open(null);
 
 		// the project should be opened and the file should exist
 		assertTrue("5.0", p1.isOpen());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
@@ -36,31 +36,19 @@ public class TestBug30015 extends WorkspaceSessionTest {
 	/**
 	 * Create and open the project
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		varValue = Platform.getLocation().removeLastSegments(1);
 		rawLocation = IPath.fromOSString(VAR_NAME).append("ProjectLocation");
 		//define the variable
-		try {
-			getWorkspace().getPathVariableManager().setValue(VAR_NAME, varValue);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().getPathVariableManager().setValue(VAR_NAME, varValue);
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_NAME);
 		IProjectDescription description = getWorkspace().newProjectDescription(PROJECT_NAME);
 		description.setLocation(rawLocation);
 		//create the project
-		try {
-			project.create(description, getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("9.99", e);
-		}
+		project.create(description, getMonitor());
+		project.open(getMonitor());
 		//save and shutdown
-		try {
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("9.99", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -16,7 +16,9 @@ package org.eclipse.core.tests.resources.session;
 
 import java.io.File;
 import junit.framework.Test;
-import org.eclipse.core.filesystem.*;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.filesystem.FileCache;
 import org.eclipse.core.internal.filesystem.local.LocalFile;
 import org.eclipse.core.runtime.CoreException;
@@ -29,7 +31,7 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  * Test for bug 323833
  */
 public class TestBug323833 extends WorkspaceSessionTest {
-	public void test1() {
+	public void test1() throws CoreException {
 		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
 			return;
 		}
@@ -40,19 +42,11 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
 		IFileInfo info = fileStore.fetchInfo();
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-		try {
-			fileStore.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
 
 		// create a cached file
 		File cachedFile = null;
-		try {
-			cachedFile = fileStore.toLocalFile(EFS.CACHE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		cachedFile = fileStore.toLocalFile(EFS.CACHE, getMonitor());
 
 		IFileInfo cachedFileInfo = new LocalFile(cachedFile).fetchInfo();
 
@@ -61,16 +55,12 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		assertTrue("4.0", cachedFileInfo.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
 			return;
 		}
 
-		try {
-			FileCache.getCache();
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		FileCache.getCache();
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -16,7 +16,12 @@ package org.eclipse.core.tests.resources.session;
 
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
@@ -40,59 +45,39 @@ public class TestBug6995 extends WorkspaceSessionTest {
 
 		//create a project and configure builder
 		IProject project = workspace.getRoot().getProject("Project");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IProjectDescription description = project.getDescription();
-			ICommand command = description.newCommand();
-			Map<String, String> args = command.getArguments();
-			args.put(TestBuilder.BUILD_ID, "Project1Build1");
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			command.setArguments(args);
-			description.setBuildSpec(new ICommand[] {command});
-			project.setDescription(description, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription description = project.getDescription();
+		ICommand command = description.newCommand();
+		Map<String, String> args = command.getArguments();
+		args.put(TestBuilder.BUILD_ID, "Project1Build1");
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		command.setArguments(args);
+		description.setBuildSpec(new ICommand[] { command });
+		project.setDescription(description, getMonitor());
 
 		//do an initial build
-		try {
-			project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
 		//save the workspace
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		workspace.save(true, getMonitor());
 	}
 
 	/**
 	 * After restarted the workspace, do a snapshot, then try to build.
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("Project");
 		//snapshot
-		try {
-			workspace.save(false, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.save(false, getMonitor());
 
 		//build
-		try {
-			//make a change so build doesn't get short-circuited
-			IFile file = project.getFile("File");
-			file.create(getRandomContents(), true, getMonitor());
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		//make a change so build doesn't get short-circuited
+		IFile file = project.getFile("File");
+		file.create(getRandomContents(), true, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 
 		//make sure an incremental build occurred
 		SortBuilder builder = SortBuilder.getInstance();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -14,8 +14,12 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
@@ -30,26 +34,18 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 	/**
 	 * Create a project at a non-default location, and close it.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IProject project = workspace.getRoot().getProject(PROJECT);
 		IFile file = project.getFile(FILE);
-		try {
-			IProjectDescription desc = workspace.newProjectDescription(PROJECT);
-			desc.setLocation(location);
-			project.create(desc, getMonitor());
-			project.open(getMonitor());
-			ensureExistsInWorkspace(file, true);
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		IProjectDescription desc = workspace.newProjectDescription(PROJECT);
+		desc.setLocation(location);
+		project.create(desc, getMonitor());
+		project.open(getMonitor());
+		ensureExistsInWorkspace(file, true);
+		project.close(getMonitor());
 		assertEquals("1.1", location, project.getLocation());
 
-		try {
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		workspace.save(true, getMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
@@ -15,7 +15,11 @@ package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ProjectDescription;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
@@ -26,33 +30,25 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  */
 public class TestCreateLinkedResourceInHiddenProject extends WorkspaceSerializationTest {
 
-	public void test1() {
+	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		try {
-			IProjectDescription desc = new ProjectDescription();
-			desc.setName(PROJECT);
-			project.create(desc, IResource.HIDDEN, getMonitor());
-			project.open(getMonitor());
+		IProjectDescription desc = new ProjectDescription();
+		desc.setName(PROJECT);
+		project.create(desc, IResource.HIDDEN, getMonitor());
+		project.open(getMonitor());
 
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.save(true, getMonitor());
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		IPath path = getTempDir().addTrailingSeparator().append(getUniqueString());
 		path.toFile().mkdir();
 
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFolder folder = project.getFolder(getUniqueString());
 
-		try {
-			folder.createLink(path, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		folder.createLink(path, IResource.NONE, getMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -17,7 +17,13 @@ package org.eclipse.core.tests.resources.session;
 import java.util.ArrayList;
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
@@ -58,91 +64,79 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 	/**
 	 * Create projects, setup a builder, and do an initial build.
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IResource[] resources = {project1, project2, project3, project4, file1, file2, file3, file4};
 		ensureExistsInWorkspace(resources, true);
-		try {
-			setAutoBuilding(false);
+		setAutoBuilding(false);
 
-			//create a project and configure builder
-			IProjectDescription description = project1.getDescription();
-			ICommand command = description.newCommand();
-			Map<String, String> args = command.getArguments();
-			args.put(TestBuilder.BUILD_ID, "Project1Build1");
-			command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
-			command.setArguments(args);
-			description.setBuildSpec(new ICommand[] {command});
-			project1.setDescription(description, getMonitor());
+		// create a project and configure builder
+		IProjectDescription description = project1.getDescription();
+		ICommand command = description.newCommand();
+		Map<String, String> args = command.getArguments();
+		args.put(TestBuilder.BUILD_ID, "Project1Build1");
+		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
+		command.setArguments(args);
+		description.setBuildSpec(new ICommand[] { command });
+		project1.setDescription(description, getMonitor());
 
-			//initial build requesting no projects
-			project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		// initial build requesting no projects
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**
 	 * Check that "no interesting builders" case suceeded, then ask for more projects.
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
 		builder.requestDeltas(new IProject[] {project1, project2, project4});
-		try {
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			ArrayList<IProject> received = builder.getReceivedDeltas();
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		ArrayList<IProject> received = builder.getReceivedDeltas();
 
-			//should have received only a delta for project1
-			assertEquals("1.0", 1, received.size());
-			assertTrue("1.1", received.contains(project1));
+		// should have received only a delta for project1
+		assertEquals("1.0", 1, received.size());
+		assertTrue("1.1", received.contains(project1));
 
-			//should be no empty deltas
-			ArrayList<IProject> empty = builder.getEmptyDeltas();
-			assertEquals("1.2", 0, empty.size());
+		// should be no empty deltas
+		ArrayList<IProject> empty = builder.getEmptyDeltas();
+		assertEquals("1.2", 0, empty.size());
 
-			//save
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// save
+		getWorkspace().save(true, getMonitor());
 	}
 
 	/**
 	 * Check that interesting projects (1, 2, and 4) were stored and retrieved
 	 */
-	public void test3() {
+	public void test3() throws CoreException {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
-		try {
-			//dirty projects 1, 2, 3
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			file2.setContents(getRandomContents(), true, true, getMonitor());
-			file3.setContents(getRandomContents(), true, true, getMonitor());
+		// dirty projects 1, 2, 3
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file2.setContents(getRandomContents(), true, true, getMonitor());
+		file3.setContents(getRandomContents(), true, true, getMonitor());
 
-			//build
-			project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			ArrayList<IProject> received = builder.getReceivedDeltas();
+		// build
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		ArrayList<IProject> received = builder.getReceivedDeltas();
 
-			//should have received deltas for 1, 2, and 4
-			assertEquals("1.0", 3, received.size());
-			assertTrue("1.1", received.contains(project1));
-			assertTrue("1.2", received.contains(project2));
-			assertTrue("1.3", !received.contains(project3));
-			assertTrue("1.4", received.contains(project4));
+		// should have received deltas for 1, 2, and 4
+		assertEquals("1.0", 3, received.size());
+		assertTrue("1.1", received.contains(project1));
+		assertTrue("1.2", received.contains(project2));
+		assertTrue("1.3", !received.contains(project3));
+		assertTrue("1.4", received.contains(project4));
 
-			//delta for project4 should be empty
-			ArrayList<IProject> empty = builder.getEmptyDeltas();
-			assertEquals("1.2", 1, empty.size());
-			assertTrue("1.3", empty.contains(project4));
+		// delta for project4 should be empty
+		ArrayList<IProject> empty = builder.getEmptyDeltas();
+		assertEquals("1.2", 1, empty.size());
+		assertTrue("1.3", empty.contains(project4));
 
-			//save
-			getWorkspace().save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// save
+		getWorkspace().save(true, getMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
@@ -23,8 +23,8 @@ import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 
 /**
- * This is an internal test that makes sure the workspace master table does
- * not contain any stable entries after restart
+ * This is an internal test that makes sure the workspace master table does not
+ * contain any stale entries after restart
  */
 public class TestMasterTableCleanup extends WorkspaceSerializationTest {
 	private static final String CLOSE_OPEN = "CloseOpen";
@@ -35,24 +35,20 @@ public class TestMasterTableCleanup extends WorkspaceSerializationTest {
 	 *  1) Project that was closed and then opened
 	 *  2) Project that was closed and then deleted
 	 */
-	public void test1() {
+	public void test1() throws CoreException {
 		IProject closeOpen = getWorkspace().getRoot().getProject(CLOSE_OPEN);
-		try {
-			closeOpen.create(null);
-			closeOpen.open(null);
-			closeOpen.close(null);
-			closeOpen.open(null);
+		closeOpen.create(null);
+		closeOpen.open(null);
+		closeOpen.close(null);
+		closeOpen.open(null);
 
-			IProject closeDelete = getWorkspace().getRoot().getProject(CLOSE_DELETE);
-			closeDelete.create(null);
-			closeDelete.open(null);
-			closeDelete.close(null);
-			closeDelete.delete(IResource.NONE, null);
+		IProject closeDelete = getWorkspace().getRoot().getProject(CLOSE_DELETE);
+		closeDelete.create(null);
+		closeDelete.open(null);
+		closeDelete.close(null);
+		closeDelete.delete(IResource.NONE, null);
 
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		getWorkspace().save(true, null);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
@@ -46,7 +46,7 @@ public class TestMasterTableCleanup extends WorkspaceSerializationTest {
 		closeDelete.create(null);
 		closeDelete.open(null);
 		closeDelete.close(null);
-		closeDelete.delete(IResource.NONE, null);
+		closeDelete.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
 		getWorkspace().save(true, null);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
@@ -14,7 +14,10 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -24,32 +27,24 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  */
 public class TestSave extends WorkspaceSerializationTest {
 
-	public void test1() {
+	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.save(true, getMonitor());
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		assertTrue("1.0", root.exists());
-		try {
-			IResource[] children = root.members();
-			assertEquals("1.2", 1, children.length);
-			IProject project = (IProject) children[0];
-			assertTrue("1.3", project.exists());
-			assertTrue("1.4", project.isOpen());
-			assertEquals("1.5", PROJECT, project.getName());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		IResource[] children = root.members();
+		assertEquals("1.2", 1, children.length);
+		IProject project = (IProject) children[0];
+		assertTrue("1.3", project.exists());
+		assertTrue("1.4", project.isOpen());
+		assertEquals("1.5", PROJECT, project.getName());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
@@ -14,7 +14,10 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -23,31 +26,23 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  * Tests recovery after adding a project and not saving
  */
 public class TestSaveCreateProject extends WorkspaceSerializationTest {
-	public void test1() {
+	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		try {
-			workspace.save(true, getMonitor());
+		workspace.save(true, getMonitor());
 
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		assertTrue("1.0", root.exists());
-		try {
-			IResource[] children = root.members();
-			assertEquals("1.2", 1, children.length);
-			IProject project = (IProject) children[0];
-			assertTrue("1.3", project.exists());
-			assertEquals("1.4", PROJECT, project.getName());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		IResource[] children = root.members();
+		assertEquals("1.2", 1, children.length);
+		IProject project = (IProject) children[0];
+		assertTrue("1.3", project.exists());
+		assertEquals("1.4", PROJECT, project.getName());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import java.io.ByteArrayInputStream;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -43,8 +47,9 @@ public class TestSaveSnap extends WorkspaceSerializationTest {
 		/* do even more stuff */
 		IFile file = folder.getFile(FILE);
 		byte[] bytes = "Test bytes".getBytes();
-		java.io.ByteArrayInputStream in = new java.io.ByteArrayInputStream(bytes);
-		file.create(in, true, getMonitor());
+		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
+			file.create(in, true, getMonitor());
+		}
 
 		//snapshot
 		workspace.save(false, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
@@ -14,7 +14,9 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -23,23 +25,19 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  * Create a project, close it, save, crash, recover.  Recovered project should still be closed.
  */
 public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
-	public void test1() {
+	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFile file = project.getFile(FILE);
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), true, null);
-			project.close(getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), true, null);
+		project.close(getMonitor());
 
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		workspace.save(true, getMonitor());
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFile file = project.getFile(FILE);
 
@@ -47,11 +45,7 @@ public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
 		assertTrue("1.1", !project.isOpen());
 		assertTrue("1.2", !file.exists());
 
-		try {
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		project.open(getMonitor());
 
 		assertTrue("2.0", project.isOpen());
 		assertTrue("2.1", file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import java.io.ByteArrayInputStream;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -24,34 +28,31 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  */
 public class TestSnapSaveSnap extends WorkspaceSerializationTest {
 
-	public void test1() {
+	public void test1() throws Exception {
 		/* create some resource handles */
 		IProject project = getWorkspace().getRoot().getProject(PROJECT);
 		IFolder folder = project.getFolder(FOLDER);
 		IFile file = folder.getFile(FILE);
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			//snapshot
-			workspace.save(false, getMonitor());
+		// snapshot
+		workspace.save(false, getMonitor());
 
-			/* do more stuff */
-			folder.create(true, true, getMonitor());
+		/* do more stuff */
+		folder.create(true, true, getMonitor());
 
-			//full save
-			workspace.save(true, getMonitor());
+		// full save
+		workspace.save(true, getMonitor());
 
-			/* do even more stuff */
-			byte[] bytes = "Test bytes".getBytes();
-			java.io.ByteArrayInputStream in = new java.io.ByteArrayInputStream(bytes);
+		/* do even more stuff */
+		byte[] bytes = "Test bytes".getBytes();
+		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
 			file.create(in, true, getMonitor());
-
-			//snapshot
-			workspace.save(false, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
 		}
+
+		// snapshot
+		workspace.save(false, getMonitor());
 		//exit without saving
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
@@ -32,7 +34,7 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 	private static final long MAX_FILE_SIZE = 1024 * 53;
 	private static final long SNAPSHOT_INTERVAL = 4321;
 
-	public void test1() {
+	public void test1() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IWorkspaceDescription desc = workspace.getDescription();
 		desc.setAutoBuilding(false);
@@ -42,12 +44,8 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 		desc.setMaxFileStates(MAX_STATES);
 		desc.setMaxFileStateSize(MAX_FILE_SIZE);
 		desc.setSnapshotInterval(SNAPSHOT_INTERVAL);
-		try {
-			workspace.setDescription(desc);
-			workspace.save(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.setDescription(desc);
+		workspace.save(true, getMonitor());
 	}
 
 	public void test2() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -34,14 +34,10 @@ public class Snapshot1Test extends SnapshotTest {
 	}
 
 	// copy and paste in the scrapbook to run
-	public void testCreateMyProject() {
+	public void testCreateMyProject() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		try {
-			project.create(null);
-			project.open(null);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(null);
+		project.open(null);
 		assertTrue("0.1", project.exists());
 		assertTrue("0.2", project.isOpen());
 
@@ -51,11 +47,7 @@ public class Snapshot1Test extends SnapshotTest {
 		assertExistsInFileSystem("1.1", resources);
 		assertExistsInWorkspace("1.2", resources);
 
-		try {
-			project.close(null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project.close(null);
 		assertTrue("2.1", project.exists());
 		assertTrue("2.2", !project.isOpen());
 	}
@@ -63,14 +55,10 @@ public class Snapshot1Test extends SnapshotTest {
 	/**
 	 * Create another project and leave it closed for next session.
 	 */
-	public void testCreateProject2() {
+	public void testCreateProject2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_2);
-		try {
-			project.create(null);
-			project.open(null);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(null);
+		project.open(null);
 		assertTrue("0.1", project.exists());
 		assertTrue("0.2", project.isOpen());
 
@@ -81,11 +69,7 @@ public class Snapshot1Test extends SnapshotTest {
 		assertExistsInWorkspace("3.2", resources);
 	}
 
-	public void testSnapshotWorkspace() {
-		try {
-			getWorkspace().save(false, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+	public void testSnapshotWorkspace() throws CoreException {
+		getWorkspace().save(false, null);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -57,18 +57,14 @@ public class Snapshot2Test extends SnapshotTest {
 		assertExistsInWorkspace("1.2", resources);
 	}
 
-	public void testChangeProject2() {
+	public void testChangeProject2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project2");
 		assertTrue("0.1", project.exists());
 		assertTrue("0.2", project.isOpen());
 
 		// remove all resources
-		try {
-			IResource[] children = project.members();
-			getWorkspace().delete(children, true, null);
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
+		IResource[] children = project.members();
+		getWorkspace().delete(children, true, null);
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());
@@ -77,25 +73,17 @@ public class Snapshot2Test extends SnapshotTest {
 		assertExistsInWorkspace("1.2", resources);
 	}
 
-	public void testSnapshotWorkspace() {
-		try {
-			getWorkspace().save(false, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+	public void testSnapshotWorkspace() throws CoreException {
+		getWorkspace().save(false, null);
 	}
 
-	public void testVerifyPreviousSession() {
+	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.exists());
 		assertTrue("0.1", !project.isOpen());
 
-		try {
-			project.open(null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.open(null);
 		assertTrue("1.2", project.isOpen());
 
 		// verify existence of children

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -30,15 +32,11 @@ public class Snapshot3Test extends SnapshotTest {
 		return Snapshot2Test.defineHierarchy2();
 	}
 
-	public void testSaveWorkspace() {
-		try {
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+	public void testSaveWorkspace() throws CoreException {
+		getWorkspace().save(true, null);
 	}
 
-	public void testVerifyPreviousSession() {
+	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.exists());
@@ -54,12 +52,8 @@ public class Snapshot3Test extends SnapshotTest {
 		assertTrue("3.0", project.exists());
 		assertTrue("3.1", project.isOpen());
 
-		try {
-			assertEquals("4.0", 4, project.members().length);
-			assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		assertEquals("4.0", 4, project.members().length);
+		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot2Test.defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -44,7 +44,7 @@ public class Snapshot4Test extends SnapshotTest {
 		return new String[0];
 	}
 
-	public void testChangeMyProject() {
+	public void testChangeMyProject() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.1", project.exists());
@@ -52,78 +52,46 @@ public class Snapshot4Test extends SnapshotTest {
 
 		// remove resources
 		IFile file = project.getFile("added file");
-		try {
-			file.delete(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.delete(true, true, null);
 		assertDoesNotExistInFileSystem("1.1", file);
 		assertDoesNotExistInWorkspace("1.2", file);
 
 		// full save
-		try {
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		getWorkspace().save(true, null);
 
 		// remove resources
 		file = project.getFile("yet another file");
-		try {
-			file.delete(true, true, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.delete(true, true, null);
 		assertDoesNotExistInFileSystem("3.1", file);
 		assertDoesNotExistInWorkspace("3.2", file);
 
 		// snapshot
-		try {
-			getWorkspace().save(false, null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		getWorkspace().save(false, null);
 
 		// remove resources
 		IFolder folder = project.getFolder("a folder");
-		try {
-			folder.delete(true, true, null);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		folder.delete(true, true, null);
 		assertDoesNotExistInFileSystem("5.1", folder);
 		assertDoesNotExistInWorkspace("5.2", folder);
 
 		// snapshot
-		try {
-			getWorkspace().save(false, null);
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
+		getWorkspace().save(false, null);
 	}
 
-	public void testChangeProject2() {
+	public void testChangeProject2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_2);
 		assertTrue("0.1", project.exists());
 		assertTrue("0.2", project.isOpen());
 
 		// remove project
-		try {
-			project.delete(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.delete(true, true, null);
 		assertTrue("1.1", !project.exists());
 
 		// snapshot
-		try {
-			getWorkspace().save(false, null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		getWorkspace().save(false, null);
 	}
 
-	public void testVerifyPreviousSession() {
+	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.exists());
@@ -139,12 +107,8 @@ public class Snapshot4Test extends SnapshotTest {
 		assertTrue("3.0", project.exists());
 		assertTrue("3.1", project.isOpen());
 
-		try {
-			assertEquals("4.0", 4, project.members().length);
-			assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		assertEquals("4.0", 4, project.members().length);
+		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot3Test.defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -13,8 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 
 /**
  * Only verifies previous session.
@@ -45,12 +47,4 @@ public class Snapshot5Test extends SnapshotTest {
 		assertTrue("3.0", !project.exists());
 	}
 
-	public void cleanUp() {
-		try {
-			ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
-			getWorkspace().save(true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import junit.framework.Test;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
@@ -43,7 +44,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		return OS.isMac();
 	}
 
-	public void test1() {
+	public void test1() throws CoreException {
 		if (skipTest()) {
 			return;
 		}
@@ -53,7 +54,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		test.testSnapshotWorkspace();
 	}
 
-	public void test2() {
+	public void test2() throws CoreException {
 		if (skipTest()) {
 			return;
 		}
@@ -64,7 +65,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		test.testSnapshotWorkspace();
 	}
 
-	public void test3() {
+	public void test3() throws CoreException {
 		if (skipTest()) {
 			return;
 		}
@@ -73,7 +74,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		test.testSaveWorkspace();
 	}
 
-	public void test4() {
+	public void test4() throws CoreException {
 		if (skipTest()) {
 			return;
 		}
@@ -89,7 +90,6 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		}
 		Snapshot5Test test = new Snapshot5Test();
 		test.testVerifyPreviousSession();
-		test.cleanUp();
 	}
 
 }


### PR DESCRIPTION
`WorkspaceSessionTests` overwrite the `tearDown()` method with an empty implementation to avoid that cleanup is performed after each test method (i.e., session). However, the cleanup functionality is not called after the last of the sessions of a test class has finished, thus potentially leaving the system in an unclean state and not ensuring test isolation.

This change adds a test method to the WorkspaceSessionTest that is supposed to be executed after all actual test methods and executes the `tearDown()` functionality to clean up. Those `WorkspaceSessionTests` implementations that had overwritten the `tearDown()` method are adapted to properly clean up after each of their test methods if required. To this end, the `TestMasterTableCleanup` is adapted to properly remove its generated test project afterwards. In addition, the changes remove unnecessary cleanups and try-catch blocks.

This change also serves as preparatory work for a potential JUnit 4 migration by already replacing overwritten setup/teardown methods. Note that the added `test___cleanup()` method will only exist temporarily and will be removed/replaced after migration to JUnit 4/5.