### PR TITLE
Move error logging from ResourceTest to specific requiring test case

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -14,13 +14,22 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
 import java.io.ByteArrayInputStream;
 import java.lang.Thread.State;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
-
+import java.util.stream.Collectors;
 import org.eclipse.core.internal.events.ResourceDelta;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IBuildConfiguration;
@@ -31,8 +40,10 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
@@ -48,6 +59,7 @@ import org.eclipse.core.tests.internal.builders.TestBuilder.BuilderRuleCallback;
  * depending on the builder's scheduling rule
  */
 public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
+	private ErrorLogging errorLogging = new ErrorLogging();
 
 	public RelaxedSchedRuleBuilderTest(String name) {
 		super(name);
@@ -56,11 +68,16 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
+		errorLogging.enable();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
-		super.tearDown();
+		try {
+			errorLogging.disable();
+		} finally {
+			super.tearDown();
+		}
 		TestBuilder builder = DeltaVerifierBuilder.getInstance();
 		if (builder != null) {
 			builder.reset();
@@ -378,7 +395,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 			fail("Error observed", error.get());
 		}
 		tb.waitForStatus(TestBarrier2.STATUS_DONE);
-		assertNoErrorsLogged();
+		errorLogging.assertNoErrorsLogged();
 	}
 
 	/**
@@ -549,4 +566,32 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		tb1.waitForStatus(TestBarrier2.STATUS_DONE);
 		tb2.waitForStatus(TestBarrier2.STATUS_DONE);
 	}
+
+	private static class ErrorLogging {
+		private final Queue<IStatus> loggedErrors = new ConcurrentLinkedQueue<>();
+
+		private final ILogListener errorLogListener = (IStatus status, String plugin) -> {
+			if (status.matches(IStatus.ERROR)) {
+				loggedErrors.add(status);
+			}
+		};
+
+		public void enable() {
+			Platform.addLogListener(errorLogListener);
+		}
+
+		public void disable() {
+			Platform.removeLogListener(errorLogListener);
+		}
+
+		public void assertNoErrorsLogged() {
+			List<IStatus> errors = new ArrayList<>();
+			loggedErrors.removeIf(errors::add);
+			List<Throwable> thrownExceptions = errors.stream().map(IStatus::getException).filter(Objects::nonNull)
+					.collect(Collectors.toList());
+			assertThat("Test logged exceptions", thrownExceptions, is(empty()));
+			assertThat("Test logged errors", errors, is(empty()));
+		}
+	}
+
 }


### PR DESCRIPTION
The `ResourceTest` class implements error logging that is enabled for every test case in every sub class. But the generated error log is only used within a single test case, so this general logging is unnecessary.

This change moves the logging down to the test case in `RelaxedSchedRuleBuilderTest`, in which it is actually used. It also improves the assertions defined on the error log.