### PR TITLE
Refactor FileStoreTest and remove unnecessary method in ResourceTest

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -1040,17 +1040,6 @@ public abstract class ResourceTest extends CoreTest {
 		return new String(readBytesInWorkspace(file), StandardCharsets.UTF_8);
 	}
 
-	protected void setAttribute(IFileStore target, int attribute, boolean value) {
-		assertTrue("setAttribute.1", isAttributeSupported(attribute));
-		IFileInfo fileInfo = target.fetchInfo();
-		fileInfo.setAttribute(attribute, value);
-		try {
-			target.putInfo(fileInfo, EFS.SET_ATTRIBUTES, null);
-		} catch (CoreException e) {
-			fail("ResourceTest#setAttribute", e);
-		}
-	}
-
 	protected void setReadOnly(IFileStore target, boolean value) {
 		assertTrue("setReadOnly.1", isReadOnlySupported());
 		IFileInfo fileInfo = target.fetchInfo();


### PR DESCRIPTION
* Refactors the `FileStoreTest` by removing or replacing try-catch blocks
* Pushes down a utility method from `ResourceTest` to `FileStoreTest` as it is the only consumer