### PR TITLE
Set a bunch of project encodings to UTF-8

### DIFF
--- a/team/bundles/org.eclipse.compare.core/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.compare.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.compare/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.compare/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.core.net/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.core.net/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.jsch.core/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.jsch.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.jsch.ui/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.jsch.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.team.core/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.team.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.team.genericeditor.diff.extension/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.team.genericeditor.diff.extension/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.team.genericeditor.diff.extension/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.genericeditor.diff.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.genericeditor.diff.extension;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/team/bundles/org.eclipse.team.ui/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.team.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/bundles/org.eclipse.ui.net/.settings/org.eclipse.core.resources.prefs
+++ b/team/bundles/org.eclipse.ui.net/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/examples/org.eclipse.compare.examples.xml/.settings/org.eclipse.core.resources.prefs
+++ b/team/examples/org.eclipse.compare.examples.xml/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/examples/org.eclipse.compare.examples/.settings/org.eclipse.core.resources.prefs
+++ b/team/examples/org.eclipse.compare.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/examples/org.eclipse.compare.examples/META-INF/MANIFEST.MF
+++ b/team/examples/org.eclipse.compare.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.examples; singleton:=true
-Bundle-Version: 3.4.100.qualifier
+Bundle-Version: 3.4.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.compare.examples.structurecreator

--- a/team/examples/org.eclipse.compare.examples/pom.xml
+++ b/team/examples/org.eclipse.compare.examples/pom.xml
@@ -18,6 +18,6 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.compare.examples</artifactId>
-  <version>3.4.100-SNAPSHOT</version>
+  <version>3.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/team/examples/org.eclipse.team.examples.filesystem/.settings/org.eclipse.core.resources.prefs
+++ b/team/examples/org.eclipse.team.examples.filesystem/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/tests/org.eclipse.compare.tests/.settings/org.eclipse.core.resources.prefs
+++ b/team/tests/org.eclipse.compare.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/tests/org.eclipse.core.tests.net/.settings/org.eclipse.core.resources.prefs
+++ b/team/tests/org.eclipse.core.tests.net/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/tests/org.eclipse.jsch.tests/.settings/org.eclipse.core.resources.prefs
+++ b/team/tests/org.eclipse.jsch.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/team/tests/org.eclipse.jsch.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.jsch.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSch Tests Plug-in
 Bundle-SymbolicName: org.eclipse.jsch.tests
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.jsch.tests.Activator
 Bundle-Vendor: Eclipse.org

--- a/team/tests/org.eclipse.jsch.tests/pom.xml
+++ b/team/tests/org.eclipse.jsch.tests/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jsch</groupId>
   <artifactId>org.eclipse.jsch.tests</artifactId>
-  <version>1.6.100-SNAPSHOT</version>
+  <version>1.6.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/team/tests/org.eclipse.team.tests.core/.settings/org.eclipse.core.resources.prefs
+++ b/team/tests/org.eclipse.team.tests.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.help.base/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.help.base/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.help.ui/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.help.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.help.webapp/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.help.webapp/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.help/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.help/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.core/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.examples/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.feature/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.ide/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.json/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.json/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.tests/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.tips.ui/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.tips.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ua.releng/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ua.releng/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ua.tests.doc/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ua.tests.doc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ua.tests/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ua.tests/.settings/org.eclipse.core.resources.prefs
@@ -6,3 +6,4 @@ encoding//data/help/search/testnlUTF8_html5.html=UTF-8
 encoding//data/help/toc/filteredToc/parent8859.html=ISO-8859-1
 encoding//data/help/toc/filteredToc/parentUTF8.html=UTF-8
 encoding//non_junit/test_plan.htm=ISO-8859-1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.cheatsheets/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.cheatsheets/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.intro.quicklinks.examples/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.intro.quicklinks.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.intro.quicklinks/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.intro.quicklinks/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.intro.solstice.examples/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.intro.solstice.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.intro.universal/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.intro.universal/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.ui.intro/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.ui.intro/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
It was done using a "Quick Fix" and the value set (UTF-8) is the same value that any other project in the workspace uses. The objective of this commit is to declutter the "Problems" view.