### PR TITLE
Cleanup and simplify several resource tests 1

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -198,17 +200,13 @@ public class HistoryStoreTest extends ResourceTest {
 	 *      encounter granularity issues).
 	 *  15. Check file states.  There should be none left.
 	 */
-	public void testAddStateAndPolicies() {
+	public void testAddStateAndPolicies() throws Exception {
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("file.txt");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
 
 		/* set local history policies */
 		IWorkspaceDescription description = getWorkspace().getDescription();
@@ -218,39 +216,22 @@ public class HistoryStoreTest extends ResourceTest {
 		description.setMaxFileStates(5);
 		// max size of file = 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
+		getWorkspace().setDescription(description);
 
 		/* test max file states */
 		for (int i = 0; i < 8; i++) {
-			try {
-				ensureOutOfSync(file);
-				file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-				file.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+			ensureOutOfSync(file);
+			file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+			file.setContents(getRandomContents(), true, true, getMonitor());
 		}
-		IFileState[] states = null;
-		try {
-			states = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.01", e);
-		}
+		IFileState[] states = file.getHistory(getMonitor());
 		// Make sure we have 8 states as we haven't trimmed yet.
 		assertEquals("1.02", 8, states.length);
 
 		IFileState[] oldStates = states;
 
-		try {
-			getWorkspace().save(true, null);
-			states = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		getWorkspace().save(true, null);
+		states = file.getHistory(getMonitor());
 		// We added 8 states.  Make sure we only have 5 (the max).
 		assertEquals("1.2", description.getMaxFileStates(), states.length);
 
@@ -270,35 +251,19 @@ public class HistoryStoreTest extends ResourceTest {
 		description.setMaxFileStates(15);
 		// max size of file = 7 bytes
 		description.setMaxFileStateSize(7);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("2.0.0", e);
-		}
+		getWorkspace().setDescription(description);
 		file = project.getFile("file1.txt");
-		try {
-			file.create(new ByteArrayInputStream(new byte[0]), true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.create(new ByteArrayInputStream(new byte[0]), true, getMonitor());
 		// Add 10 bytes to exceed the max file state size.
 		for (int i = 0; i < 10; i++) {
-			try {
-				file.appendContents(getContents("a"), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("2.1", e);
-			}
+			file.appendContents(getContents("a"), true, true, getMonitor());
 		}
-		try {
-			getWorkspace().save(true, null);
-			states = file.getHistory(getMonitor());
-			// #states = size + 1 for the 0 byte length file to begin with.
-			for (int i = 0; i < states.length; i++) {
-				int bytesRead = numBytes(states[i].getContents());
-				assertTrue("2.2." + i, bytesRead <= description.getMaxFileStateSize());
-			}
-		} catch (CoreException e) {
-			fail("2.3", e);
+		getWorkspace().save(true, null);
+		states = file.getHistory(getMonitor());
+		// #states = size + 1 for the 0 byte length file to begin with.
+		for (int i = 0; i < states.length; i++) {
+			int bytesRead = numBytes(states[i].getContents());
+			assertTrue("2.2." + i, bytesRead <= description.getMaxFileStateSize());
 		}
 
 		/* test max file longevity */
@@ -310,44 +275,25 @@ public class HistoryStoreTest extends ResourceTest {
 		// 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
 		// the description should be the same as the first test
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-		try {
-			states = file.getHistory(getMonitor());
-			// Make sure we have 5 states for file file.txt
-			assertEquals("3.1", description.getMaxFileStates(), states.length);
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		getWorkspace().setDescription(description);
+		states = file.getHistory(getMonitor());
+		// Make sure we have 5 states for file file.txt
+		assertEquals("3.1", description.getMaxFileStates(), states.length);
 		// change policies
 		// 10 seconds
 		description.setFileStateLongevity(1000 * 10);
 		// 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("3.3", e);
-		}
-		try {
-			// sleep for more than 10 seconds (the granularity varies on
-			// some machines so we will sleep for 12 seconds)
-			Thread.sleep(1000 * 12);
-		} catch (InterruptedException e) {
-			fail("3.4", e);
-		}
-		try {
-			getWorkspace().save(true, null);
-			states = file.getHistory(getMonitor());
-			// The 5 states for file.txt should have exceeded their longevity
-			// and been removed.  Make sure we have 0 states left.
-			assertEquals("3.5", 0, states.length);
-		} catch (CoreException e) {
-			fail("3.6", e);
-		}
+		getWorkspace().setDescription(description);
+
+		// sleep for more than 10 seconds (the granularity varies on
+		// some machines so we will sleep for 12 seconds)
+		Thread.sleep(1000 * 12);
+		getWorkspace().save(true, null);
+		states = file.getHistory(getMonitor());
+		// The 5 states for file.txt should have exceeded their longevity
+		// and been removed. Make sure we have 0 states left.
+		assertEquals("3.5", 0, states.length);
 	}
 
 	public void testBug28238() {
@@ -379,7 +325,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("3.0", 1, states.length);
 	}
 
-	public void testBug28603() {
+	public void testBug28603() throws CoreException {
 		// paths to mimic files in the workspace
 		IProject project = getWorkspace().getRoot().getProject("myproject28603");
 		IFolder folder1 = project.getFolder("myfolder1");
@@ -389,61 +335,27 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// directly deletes history files if project did already existed:
 		ensureExistsInWorkspace(new IResource[] {project, folder1, folder2}, true);
-		try {
-			file1.create(getRandomContents(), IResource.FORCE, getMonitor());
-			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
-			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
-			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
-			setMaxFileStates(50);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		file1.create(getRandomContents(), IResource.FORCE, getMonitor());
+		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+		setMaxFileStates(50);
 
 		int maxStates = ResourcesPlugin.getWorkspace().getDescription().getMaxFileStates();
 
-		IFileState[] states = null;
-		try {
-			states = file1.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		IFileState[] states = file1.getHistory(getMonitor());
 		assertEquals("1.1", 3, states.length);
 		int currentStates = 3;
-		try {
-			assertEquals("1.2" + " file2 already has history", 0, file2.getHistory(getMonitor()).length);
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		assertEquals("1.2" + " file2 already has history", 0, file2.getHistory(getMonitor()).length);
 		for (int i = 0; i < maxStates + 10; i++) {
-			try {
-				states = file1.getHistory(getMonitor());
-			} catch (CoreException e) {
-				fail("2.0." + i, e);
-			}
+			states = file1.getHistory(getMonitor());
 			assertEquals("2.1." + i + " file1 states", currentStates, states.length);
-			try {
-				file1.move(file2.getFullPath(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("2.2." + i, e);
-			}
-
-			try {
-				states = file2.getHistory(getMonitor());
-			} catch (CoreException e) {
-				fail("2.3." + i, e);
-			}
+			file1.move(file2.getFullPath(), true, true, getMonitor());
+			states = file2.getHistory(getMonitor());
 			currentStates = currentStates < maxStates ? currentStates + 1 : maxStates;
 			assertEquals("2.4." + i + " file2 states", currentStates, states.length);
-			try {
-				file2.move(file1.getFullPath(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("2.5." + i, e);
-			}
-			try {
-				states = file1.getHistory(getMonitor());
-			} catch (CoreException e) {
-				fail("2.6." + i, e);
-			}
+			file2.move(file1.getFullPath(), true, true, getMonitor());
+			states = file1.getHistory(getMonitor());
 			currentStates = currentStates < maxStates ? currentStates + 1 : maxStates;
 			assertEquals("2.7." + i + " file1 states", currentStates, states.length);
 		}
@@ -459,17 +371,13 @@ public class HistoryStoreTest extends ResourceTest {
 	 *   of time and discard stale data
 	 *
 	 */
-	public void testClean() {
+	public void testClean() throws Exception {
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("ProjectClean");
 		IFile file = project.getFile("file.txt");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
 		IHistoryStore store = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 		// get another copy for changes
 		IWorkspaceDescription description = getWorkspace().getDescription();
@@ -481,72 +389,49 @@ public class HistoryStoreTest extends ResourceTest {
 		description.setMaxFileStates(500);
 		// 1Mb max size
 		description.setMaxFileStateSize(1024 * 1024);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
+		getWorkspace().setDescription(description);
 
 		// Set up 8 file states for this file when 500 are allowed
 		for (int i = 0; i < 8; i++) {
-			try {
-				ensureOutOfSync(file);
-				file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-				//			try {
-				//				Thread.sleep(5000); // necessary because of lastmodified granularity in some file systems
-				//			} catch (InterruptedException e) {
-				//			}
-				file.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+			ensureOutOfSync(file);
+			file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+			// try {
+			// Thread.sleep(5000); // necessary because of lastmodified granularity in some
+			// file systems
+			// } catch (InterruptedException e) {
+			// }
+			file.setContents(getRandomContents(), true, true, getMonitor());
 		}
 		// All 8 states should exist.
 		long oldLastModTimes[] = new long[8];
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.1", 8, states.length);
-			for (int i = 0; i < 8; i++) {
-				oldLastModTimes[i] = states[i].getModificationTime();
-			}
-		} catch (CoreException e) {
-			fail("1.2", e);
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.1", 8, states.length);
+		for (int i = 0; i < 8; i++) {
+			oldLastModTimes[i] = states[i].getModificationTime();
 		}
 
 		// Set max. number of file states to be 3
 		description.setMaxFileStates(3);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		getWorkspace().setDescription(description);
 		// Run 'clean' - should cause 5 of 8 states to be removed
 		store.clean(getMonitor());
 		// Restore max. number of states/file to 500
 		description.setMaxFileStates(500);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		getWorkspace().setDescription(description);
 
 		// Check to ensure only 3 states remain.  Make sure these are the 3
 		// newer states.
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("2.3", 3, states.length);
-			// assert that states are in the correct order (newer ones first)
-			long lastModified = states[0].getModificationTime();
-			for (int i = 1; i < states.length; i++) {
-				assertTrue("2.4." + i, lastModified >= states[i].getModificationTime());
-				lastModified = states[i].getModificationTime();
-			}
-			// Make sure we kept the 3 newer states.
-			for (int i = 0; i < states.length; i++) {
-				assertTrue("2.5." + i, oldLastModTimes[i] == states[i].getModificationTime());
-			}
-		} catch (CoreException e) {
-			fail("2.6", e);
+		states = file.getHistory(getMonitor());
+		assertEquals("2.3", 3, states.length);
+		// assert that states are in the correct order (newer ones first)
+		long lastModified = states[0].getModificationTime();
+		for (int i = 1; i < states.length; i++) {
+			assertTrue("2.4." + i, lastModified >= states[i].getModificationTime());
+			lastModified = states[i].getModificationTime();
+		}
+		// Make sure we kept the 3 newer states.
+		for (int i = 0; i < states.length; i++) {
+			assertTrue("2.5." + i, oldLastModTimes[i] == states[i].getModificationTime());
 		}
 
 		/* test max file longevity */
@@ -555,53 +440,32 @@ public class HistoryStoreTest extends ResourceTest {
 		description.setMaxFileStates(500);
 		description.setMaxFileStateSize(1024 * 1024); // 1 Mb
 		// the description should be the same as the first test
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("3.1", 3, states.length);
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		getWorkspace().setDescription(description);
+		states = file.getHistory(getMonitor());
+		assertEquals("3.1", 3, states.length);
 		// change policies
 		// 10 seconds
 		description.setFileStateLongevity(1000 * 10);
 		// 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
-		try {
-			// sleep for 12 seconds (must exceed 10 seconds).  This should
-			// cause all 3 states for file.txt to be considered stale.
-			Thread.sleep(1000 * 12);
-		} catch (InterruptedException e) {
-			fail("4.1", e);
-		}
+		getWorkspace().setDescription(description);
+
+		// sleep for 12 seconds (must exceed 10 seconds). This should
+		// cause all 3 states for file.txt to be considered stale.
+		Thread.sleep(1000 * 12);
+
 		store.clean(getMonitor());
 		// change policies - restore to original values
 		// 1 day
 		description.setFileStateLongevity(1000 * 3600 * 24);
 		// 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
-		try {
-			getWorkspace().setDescription(description);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		getWorkspace().setDescription(description);
+
 		// Ensure we have no state information left.  It should have been
 		// considered stale.
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("5.1", 0, states.length);
-		} catch (CoreException e) {
-			fail("5.2", e);
-		}
+		states = file.getHistory(getMonitor());
+		assertEquals("5.1", 0, states.length);
 	}
 
 	/**
@@ -621,64 +485,52 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testCopyFolder() {
+	public void testCopyFolder() throws CoreException {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("CopyFolderProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		IFile file = project.getFile("file1.txt");
 
 		IFolder folder = project.getFolder("folder1");
 		IFolder folder2 = project.getFolder("folder2");
 		file = folder.getFile("file1.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
-			// Now do the move
-			folder.copy(folder2.getFullPath(), true, getMonitor());
+		// Now do the move
+		folder.copy(folder2.getFullPath(), true, getMonitor());
 
-			// Check to make sure the file has been copied
-			IFile file2 = folder2.getFile("file1.txt");
-			assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
+		// Check to make sure the file has been copied
+		IFile file2 = folder2.getFile("file1.txt");
+		assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
 
-			// Give the new (copied file) some new contents
-			file2.setContents(getContents(contents[3]), true, true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
+		// Give the new (copied file) some new contents
+		file2.setContents(getContents(contents[3]), true, true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
-			// Check the local history of both files
-			states = file.getHistory(getMonitor());
-			assertEquals("2.0", 2, states.length);
-			assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
-			states = file2.getHistory(getMonitor());
-			assertEquals("2.3", 4, states.length);
-			assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		// Check the local history of both files
+		states = file.getHistory(getMonitor());
+		assertEquals("2.0", 2, states.length);
+		assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		states = file2.getHistory(getMonitor());
+		assertEquals("2.3", 4, states.length);
+		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
 
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.delete(true, getMonitor());
 	}
 
 	/*
@@ -690,7 +542,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * - give an invalid source path but a valid destination path
 	 * - give an invalid destination path but a valid source path
 	 */
-	public void testCopyHistoryFile() {
+	public void testCopyHistoryFile() throws Exception {
 		// Create a project, folder and file so we have some history store
 		// Should have a project that appears as follows:
 		// - project name TestCopyHistoryProject
@@ -710,36 +562,23 @@ public class HistoryStoreTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder1");
 		IFile file = folder.getFile("file1.txt");
 		IFile file2 = folder.getFile("file2.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.0", e);
-			}
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.1", e);
-			}
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.2", e);
-			}
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
-			file2.create(getContents(contents[3]), true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		Thread.sleep(1000);
+
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		file2.create(getContents(contents[3]), true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
 		// Run some tests with illegal arguments
 		LogListenerVerifier verifier = new LogListenerVerifier();
@@ -750,39 +589,23 @@ public class HistoryStoreTest extends ResourceTest {
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		verifier.addExpected(IResourceStatus.INTERNAL_ERROR);
 		store.copyHistory(null, null, false);
-		try {
-			verifier.verify();
-		} catch (VerificationFailedException e) {
-			fail("1.4 ", e);
-		}
+		verifier.verify();
 		verifier.reset();
 
 		verifier.addExpected(IResourceStatus.INTERNAL_ERROR);
 		store.copyHistory(null, file2, false);
-		try {
-			verifier.verify();
-		} catch (VerificationFailedException e) {
-			fail("1.5 ", e);
-		}
+		verifier.verify();
 		verifier.reset();
 
 		verifier.addExpected(IResourceStatus.INTERNAL_ERROR);
 		store.copyHistory(file, null, false);
-		try {
-			verifier.verify();
-		} catch (VerificationFailedException e) {
-			fail("1.6 ", e);
-		}
+		verifier.verify();
 		verifier.reset();
 
 		// Try to copy the history store stuff to the same location
 		verifier.addExpected(IResourceStatus.INTERNAL_ERROR);
 		store.copyHistory(file, file, false);
-		try {
-			verifier.verify();
-		} catch (VerificationFailedException e) {
-			fail("1.7 ", e);
-		}
+		verifier.verify();
 		verifier.reset();
 
 		// Remember to remove the log listener now that we are done
@@ -791,23 +614,14 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// Test a valid copy of a file
 		store.copyHistory(file, file2, false);
-		IFileState[] states = null;
-		try {
-			states = file2.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.3");
-		}
+		states = file2.getHistory(getMonitor());
 		assertEquals("2.4", 3, states.length);
-		try {
-			assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
-		} catch (CoreException e) {
-			fail("2.8");
-		}
+		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
 	}
 
-	public void testCopyHistoryFolder() {
+	public void testCopyHistoryFolder() throws Exception {
 		String[] contents = {"content0", "content1", "content2", "content3", "content4"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("TestCopyHistoryProject");
@@ -817,58 +631,36 @@ public class HistoryStoreTest extends ResourceTest {
 		IFolder folder2 = project.getFolder("folder2");
 		IFile file = folder.getFile("file1.txt");
 		IFile file2 = folder2.getFile("file1.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.0", e);
-			}
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.1", e);
-			}
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.2", e);
-			}
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
-			folder2.create(true, true, getMonitor());
-			file2.create(getContents(contents[3]), true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		Thread.sleep(1000);
+
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		folder2.create(true, true, getMonitor());
+		file2.create(getContents(contents[3]), true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
 		// Test a valid copy of a folder
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(folder, folder2, false);
-		IFileState[] states = null;
-		try {
-			states = file2.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.3");
-		}
+		states = file2.getHistory(getMonitor());
 		assertEquals("2.4", 3, states.length);
-		try {
-			assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
-		} catch (CoreException e) {
-			fail("2.8");
-		}
+		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
 	}
 
-	public void testCopyHistoryProject() {
+	public void testCopyHistoryProject() throws Exception {
 		String[] contents = {"content0", "content1", "content2", "content3", "content4"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("TestCopyHistoryProject");
@@ -879,125 +671,86 @@ public class HistoryStoreTest extends ResourceTest {
 		IFolder folder2 = project2.getFolder("folder1");
 		IFile file = folder.getFile("file1.txt");
 		IFile file2 = folder2.getFile("file1.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.0", e);
-			}
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.1", e);
-			}
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				fail("0.2", e);
-			}
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
-			folder2.create(true, true, getMonitor());
-			file2.create(getContents(contents[3]), true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		Thread.sleep(1000);
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		Thread.sleep(1000);
+
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		folder2.create(true, true, getMonitor());
+		file2.create(getContents(contents[3]), true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
 		// Test a valid copy of a folder
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(project, project2, false);
-		IFileState[] states = null;
-		try {
-			states = file2.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.3");
-		}
+		states = file2.getHistory(getMonitor());
 		assertEquals("2.4", 3, states.length);
-		try {
-			assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
-		} catch (CoreException e) {
-			fail("2.8");
-		}
+		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
 	}
 
-	public void testDelete() {
+	public void testDelete() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		// test file
 		IFile file = project.getFile("file.txt");
-		try {
-			file.create(getRandomContents(), true, getMonitor());
-			file.setContents(getRandomContents(), true, true, getMonitor());
-			file.setContents(getRandomContents(), true, true, getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+		file.setContents(getRandomContents(), true, true, getMonitor());
+		file.setContents(getRandomContents(), true, true, getMonitor());
 
-			// Check to see that there are only 2 states before the deletion
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
+		// Check to see that there are only 2 states before the deletion
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
 
-			// Delete the file.  This should add a state to the history store.
-			file.delete(true, true, getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("1.1", 3, states.length);
+		// Delete the file. This should add a state to the history store.
+		file.delete(true, true, getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("1.1", 3, states.length);
 
-			// Re-create the file.  This should not affect the history store.
-			file.create(getRandomContents(), true, getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("1.2", 3, states.length);
-		} catch (CoreException e) {
-			fail("1.20", e);
-		}
+		// Re-create the file. This should not affect the history store.
+		file.create(getRandomContents(), true, getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("1.2", 3, states.length);
 
 		// test folder
 		IFolder folder = project.getFolder("folder");
 		// Make sure this has a different name as the history store information
 		// for the first 'file.txt' is likely still around.
 		file = folder.getFile("file2.txt");
-		try {
-			folder.create(true, true, getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-			file.setContents(getRandomContents(), true, true, getMonitor());
-			file.setContents(getRandomContents(), true, true, getMonitor());
+		folder.create(true, true, getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+		file.setContents(getRandomContents(), true, true, getMonitor());
+		file.setContents(getRandomContents(), true, true, getMonitor());
 
-			// There should only be 2 history store entries.
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("2.0", 2, states.length);
+		// There should only be 2 history store entries.
+		states = file.getHistory(getMonitor());
+		assertEquals("2.0", 2, states.length);
 
-			// Delete the folder.  This should cause one more history store entry.
-			folder.delete(true, true, getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("2.1", 3, states.length);
+		// Delete the folder. This should cause one more history store entry.
+		folder.delete(true, true, getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("2.1", 3, states.length);
 
-			// Re-create the folder.  There should be no new history store entries.
-			folder.create(true, true, getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("2.2", 3, states.length);
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		// Re-create the folder. There should be no new history store entries.
+		folder.create(true, true, getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("2.2", 3, states.length);
 
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
+		project.delete(true, getMonitor());
 	}
 
 	/**
@@ -1008,33 +761,20 @@ public class HistoryStoreTest extends ResourceTest {
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("removeAllStatesFile.txt");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
 
 		// Constant for the number of states we will create
 		final int ITERATIONS = 20;
 
 		/* Add multiple states for one file location. */
 		for (int i = 0; i < ITERATIONS; i++) {
-			try {
-				file.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("3.0." + i, e);
-			}
+			file.setContents(getRandomContents(), true, true, getMonitor());
 		}
 
 		/* Valid Case: Test retrieved values. */
-		IFileState[] states = null;
-		try {
-			states = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		IFileState[] states = file.getHistory(getMonitor());
 		// Make sure we have ITERATIONS number of states
 		assertEquals("5.1", ITERATIONS, states.length);
 		// Make sure that each of these states really exists in the filesystem.
@@ -1043,174 +783,153 @@ public class HistoryStoreTest extends ResourceTest {
 		}
 	}
 
-	public void testFindDeleted() {
+	public void testFindDeleted() throws CoreException {
 		// create common objects
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.1", 0, df.length);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.1", 0, df.length);
 
 		// test that a deleted file can be found
 		IFile pfile = project.getFile("findDeletedFile.txt");
-		try {
-			// create and delete a file
-			pfile.create(getRandomContents(), true, getMonitor());
-			pfile.delete(true, true, getMonitor());
+		// create and delete a file
+		pfile.create(getRandomContents(), true, getMonitor());
+		pfile.delete(true, true, getMonitor());
 
-			// the deleted file should show up as a deleted member of project
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.1", 1, df.length);
-			assertEquals("0.2", pfile, df[0]);
+		// the deleted file should show up as a deleted member of project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.1", 1, df.length);
+		assertEquals("0.2", pfile, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.3", 1, df.length);
-			assertEquals("0.4", pfile, df[0]);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.3", 1, df.length);
+		assertEquals("0.4", pfile, df[0]);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.5", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.5", 0, df.length);
 
-			// the deleted file should show up as a deleted member of workspace root
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.5.1", 0, df.length);
+		// the deleted file should show up as a deleted member of workspace root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.5.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.5.2", 1, df.length);
-			assertEquals("0.5.3", pfile, df[0]);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.5.2", 1, df.length);
+		assertEquals("0.5.3", pfile, df[0]);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.5.4", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.5.4", 0, df.length);
 
-			// recreate the file
-			pfile.create(getRandomContents(), true, getMonitor());
+		// recreate the file
+		pfile.create(getRandomContents(), true, getMonitor());
 
-			// the deleted file should no longer show up as a deleted member of project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.6", 0, df.length);
+		// the deleted file should no longer show up as a deleted member of project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.6", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.7", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.7", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.8", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.8", 0, df.length);
 
-			// the deleted file should no longer show up as a deleted member of ws root
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.8.1", 0, df.length);
+		// the deleted file should no longer show up as a deleted member of ws root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.8.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("0.8.2", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("0.8.2", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("0.8.3", 0, df.length);
-
-		} catch (CoreException e) {
-			fail("0.00", e);
-		}
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("0.8.3", 0, df.length);
 
 		// scrub the project
-		try {
-			project.delete(true, getMonitor());
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.delete(true, getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("0.9", 0, df.length);
-		} catch (CoreException e) {
-			fail("0.10", e);
-		}
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("0.9", 0, df.length);
 
 		// test folder
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("filex.txt");
 		IFile folderAsFile = project.getFile(folder.getProjectRelativePath());
-		try {
-			// create and delete a file in a folder
-			folder.create(true, true, getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-			file.delete(true, true, getMonitor());
 
-			// the deleted file should show up as a deleted member
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.1", 0, df.length);
+		// create and delete a file in a folder
+		folder.create(true, true, getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+		file.delete(true, true, getMonitor());
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.2", 1, df.length);
-			assertEquals("1.3", file, df[0]);
+		// the deleted file should show up as a deleted member
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.1", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.4", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.2", 1, df.length);
+		assertEquals("1.3", file, df[0]);
 
-			// recreate the file
-			file.create(getRandomContents(), true, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.4", 0, df.length);
 
-			// the deleted file should no longer show up as a deleted member
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.5", 0, df.length);
+		// recreate the file
+		file.create(getRandomContents(), true, getMonitor());
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.6", 0, df.length);
+		// the deleted file should no longer show up as a deleted member
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.5", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.7", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.6", 0, df.length);
 
-			// deleting the folder should bring it back
-			folder.delete(true, true, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.7", 0, df.length);
 
-			// the deleted file should show up as a deleted member of project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.8", 0, df.length);
+		// deleting the folder should bring it back
+		folder.delete(true, true, getMonitor());
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.9", 1, df.length);
-			assertEquals("1.10", file, df[0]);
+		// the deleted file should show up as a deleted member of project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.8", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.11", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.9", 1, df.length);
+		assertEquals("1.10", file, df[0]);
 
-			// create and delete a file where the folder was
-			folderAsFile.create(getRandomContents(), true, getMonitor());
-			folderAsFile.delete(true, true, getMonitor());
-			folder.create(true, true, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.11", 0, df.length);
 
-			// the deleted file should show up as a deleted member of folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("1.12", 1, df.length);
-			assertEquals("1.13", folderAsFile, df[0]);
+		// create and delete a file where the folder was
+		folderAsFile.create(getRandomContents(), true, getMonitor());
+		folderAsFile.delete(true, true, getMonitor());
+		folder.create(true, true, getMonitor());
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.14", 2, df.length);
-			List<IFile> dfList = Arrays.asList(df);
-			assertTrue("1.15", dfList.contains(file));
-			assertTrue("1.16", dfList.contains(folderAsFile));
+		// the deleted file should show up as a deleted member of folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("1.12", 1, df.length);
+		assertEquals("1.13", folderAsFile, df[0]);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("1.17", 2, df.length);
-			dfList = Arrays.asList(df);
-			assertTrue("1.18", dfList.contains(file));
-			assertTrue("1.19", dfList.contains(folderAsFile));
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.14", 2, df.length);
+		List<IFile> dfList = Arrays.asList(df);
+		assertTrue("1.15", dfList.contains(file));
+		assertTrue("1.16", dfList.contains(folderAsFile));
 
-		} catch (CoreException e) {
-			fail("1.00", e);
-		}
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("1.17", 2, df.length);
+		dfList = Arrays.asList(df);
+		assertTrue("1.18", dfList.contains(file));
+		assertTrue("1.19", dfList.contains(folderAsFile));
 
 		// scrub the project
-		try {
-			project.delete(true, getMonitor());
-			project.create(getMonitor());
-			project.open(getMonitor());
+		project.delete(true, getMonitor());
+		project.create(getMonitor());
+		project.open(getMonitor());
 
-			IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("1.50", 0, df.length);
-		} catch (CoreException e) {
-			fail("1.51", e);
-		}
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("1.50", 0, df.length);
 
 		// test a bunch of deletes
 		folder = project.getFolder("folder");
@@ -1218,135 +937,117 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file2 = folder.getFile("file2.txt");
 		IFolder folder2 = folder.getFolder("folder2");
 		IFile file3 = folder2.getFile("file3.txt");
-		try {
-			// create and delete a file in a folder
-			folder.create(true, true, getMonitor());
-			folder2.create(true, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			file3.create(getRandomContents(), true, getMonitor());
-			folder.delete(true, true, getMonitor());
 
-			// under root
-			IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.1", 0, df.length);
+		// create and delete a file in a folder
+		folder.create(true, true, getMonitor());
+		folder2.create(true, true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		file3.create(getRandomContents(), true, getMonitor());
+		folder.delete(true, true, getMonitor());
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.2", 0, df.length);
+		// under root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.3", 3, df.length);
-			List<IFile> dfList = Arrays.asList(df);
-			assertTrue("3.3.1", dfList.contains(file1));
-			assertTrue("3.3.2", dfList.contains(file2));
-			assertTrue("3.3.3", dfList.contains(file3));
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.2", 0, df.length);
 
-			// under project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.4", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.3", 3, df.length);
+		dfList = Arrays.asList(df);
+		assertTrue("3.3.1", dfList.contains(file1));
+		assertTrue("3.3.2", dfList.contains(file2));
+		assertTrue("3.3.3", dfList.contains(file3));
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.5", 0, df.length);
+		// under project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.4", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.6", 3, df.length);
-			dfList = Arrays.asList(df);
-			assertTrue("3.6.1", dfList.contains(file1));
-			assertTrue("3.6.2", dfList.contains(file2));
-			assertTrue("3.6.3", dfList.contains(file3));
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.5", 0, df.length);
 
-			// under folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.7", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.6", 3, df.length);
+		dfList = Arrays.asList(df);
+		assertTrue("3.6.1", dfList.contains(file1));
+		assertTrue("3.6.2", dfList.contains(file2));
+		assertTrue("3.6.3", dfList.contains(file3));
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.8", 2, df.length);
+		// under folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.7", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.9", 3, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.8", 2, df.length);
 
-			// under folder2
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("3.10", 0, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.9", 3, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("3.11", 1, df.length);
+		// under folder2
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("3.10", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("3.12", 1, df.length);
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("3.11", 1, df.length);
 
-		} catch (CoreException e) {
-			fail("3.00", e);
-		}
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("3.12", 1, df.length);
 
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.5", e);
-		}
+		project.delete(true, getMonitor());
 
 		// once the project is gone, so is all the history for that project
-		try {
-			// under root
-			IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.1", 0, df.length);
+		// under root
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.1", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.2", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.2", 0, df.length);
 
-			df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.3", 0, df.length);
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.3", 0, df.length);
 
-			// under project
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.4", 0, df.length);
+		// under project
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.4", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.5", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.5", 0, df.length);
 
-			df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.6", 0, df.length);
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.6", 0, df.length);
 
-			// under folder
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.7", 0, df.length);
+		// under folder
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.7", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.8", 0, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.8", 0, df.length);
 
-			df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.9", 0, df.length);
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.9", 0, df.length);
 
-			// under folder2
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
-			assertEquals("4.10", 0, df.length);
+		// under folder2
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		assertEquals("4.10", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
-			assertEquals("4.11", 0, df.length);
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		assertEquals("4.11", 0, df.length);
 
-			df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
-			assertEquals("4.12", 0, df.length);
-
-		} catch (CoreException e) {
-			fail("4.00", e);
-		}
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		assertEquals("4.12", 0, df.length);
 	}
 
 	/**
 	 * Test for retrieving contents of files with states logged in the HistoryStore.
 	 */
 	public void testGetContents() throws Throwable {
-
 		final int ITERATIONS = 20;
 
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		/* Create files. */
 		IFile file = project.getFile("getContentsFile.txt");
@@ -1367,14 +1068,11 @@ public class HistoryStoreTest extends ResourceTest {
 			FileInfo fileInfo = new FileInfo(file.getName());
 			fileInfo.setLastModified(myLong);
 			historyStore.addState(file.getFullPath(), ((Resource) file).getStore(), fileInfo, true);
-			try {
-				contents = "This file has some contents in testGetContents.";
-				InputStream is = new ByteArrayInputStream(contents.getBytes());
+			contents = "This file has some contents in testGetContents.";
+			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
 				createFileInFileSystem(file.getLocation(), is);
-				file.refreshLocal(IResource.DEPTH_INFINITE, null);
-			} catch (CoreException e) {
-				fail("1.1." + i, e);
 			}
+			file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
 
 		/* Add multiple editions for second file location. */
@@ -1382,106 +1080,63 @@ public class HistoryStoreTest extends ResourceTest {
 			FileInfo fileInfo = new FileInfo(file.getName());
 			fileInfo.setLastModified(myLong);
 			historyStore.addState(secondValidFile.getFullPath(), ((Resource) secondValidFile).getStore(), fileInfo, true);
-			try {
-				contents = "A file with some other contents in testGetContents.";
-				InputStream is = new ByteArrayInputStream(contents.getBytes());
+			contents = "A file with some other contents in testGetContents.";
+			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
 				createFileInFileSystem(secondValidFile.getLocation(), is);
-				secondValidFile.refreshLocal(IResource.DEPTH_INFINITE, null);
-			} catch (CoreException e) {
-				fail("2.1." + i, e);
 			}
+			secondValidFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
 
 		/* Ensure contents of file and retrieved resource are identical.
 		 Does not check timestamps. Timestamp checks are performed in a separate test. */
-		DataInputStream inFile = null;
-		DataInputStream inContents = null;
-		IFileState[] stateArray = null;
-		stateArray = historyStore.getStates(file.getFullPath(), getMonitor());
+		IFileState[] stateArray = historyStore.getStates(file.getFullPath(), getMonitor());
 		for (int i = 0; i < stateArray.length; i++, myLong++) {
-			inFile = new DataInputStream(file.getContents(false));
-			try {
-				inContents = new DataInputStream(historyStore.getContents(stateArray[i]));
-			} catch (CoreException e) {
-				fail("3.1." + i, e);
-			}
-			if (!compareContent(inFile, inContents)) {
-				fail("3.2." + i + " No match, files are not identical.");
+			try (DataInputStream inFile = new DataInputStream(file.getContents(false))) {
+				try (DataInputStream inContents = new DataInputStream(historyStore.getContents(stateArray[i]))) {
+					assertTrue(i + " No match, files are not identical.", compareContent(inFile, inContents));
+				}
 			}
 		}
 
 		stateArray = historyStore.getStates(secondValidFile.getFullPath(), getMonitor());
 		for (int i = 0; i < stateArray.length; i++, myLong++) {
-			inFile = new DataInputStream(secondValidFile.getContents(false));
-			try {
-				inContents = new DataInputStream(historyStore.getContents(stateArray[i]));
-			} catch (CoreException e) {
-				fail("4.1." + i, e);
-			}
-			if (!compareContent(inFile, inContents)) {
-				fail("4.2." + i + " No match, files are not identical.");
+			try (DataInputStream inFile = new DataInputStream(secondValidFile.getContents(false))) {
+				try (DataInputStream inContents = new DataInputStream(historyStore.getContents(stateArray[i]))) {
+					assertTrue(i + " No match, files are not identical.", compareContent(inFile, inContents));
+				}
 			}
 		}
 
 		/* Test getting an invalid file state. */
 		for (int i = 0; i < ITERATIONS; i++) {
+			final long immutableValue = myLong;
 			// Create bogus FileState using invalid uuid.
-			try {
-				InputStream in = historyStore
-						.getContents(new FileState(historyStore, IPath.ROOT, myLong, new UniversalUniqueIdentifier()));
-				in.close();
-				fail("6." + i + " Edition should be invalid.");
-			} catch (CoreException e) {
-				// expected
-			}
+			assertThrows(CoreException.class, () -> historyStore.getContents(
+					new FileState(historyStore, IPath.ROOT, immutableValue, new UniversalUniqueIdentifier())));
 		}
 
 		/* Test verification using null file state. */
 		for (int i = 0; i < ITERATIONS; i++) {
-			try {
-				historyStore.getContents(null);
-				fail("7." + i + " Null edition should be invalid.");
-			} catch (RuntimeException e) {
-				// expected
-			}
+			assertThrows(RuntimeException.class, () -> historyStore.getContents(null));
 		}
 	}
 
-	public void testModifiedStamp() {
+	public void testModifiedStamp() throws CoreException {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		IFile file = project.getFile("file");
-		try {
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-		IFileState[] history = null;
-		try {
-			history = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.create(getRandomContents(), true, getMonitor());
+
+		IFileState[] history = file.getHistory(getMonitor());
 		// no history yet
 		assertEquals("1.2", 0, history.length);
 		// save the file's current time stamp - it will be remembered in the file state
 		long fileTimeStamp = file.getLocalTimeStamp();
-		try {
-			file.setContents(getRandomContents(), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		try {
-			history = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		file.setContents(getRandomContents(), true, true, getMonitor());
+		history = file.getHistory(getMonitor());
 		// one state in the history
 		assertEquals("2.2", 1, history.length);
 		// the timestamp in the state should match the previous file's timestamp
@@ -1505,64 +1160,52 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the moved file should have 4 states as it retains the states from
 	 * before the move took place as well.
 	 */
-	public void testMoveFolder() {
+	public void testMoveFolder() throws CoreException {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		IFile file = project.getFile("file1.txt");
 
 		IFolder folder = project.getFolder("folder1");
 		IFolder folder2 = project.getFolder("folder2");
 		file = folder.getFile("file1.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
-			// Now do the move
-			folder.move(folder2.getFullPath(), true, getMonitor());
+		// Now do the move
+		folder.move(folder2.getFullPath(), true, getMonitor());
 
-			// Check to make sure the file has been moved
-			IFile file2 = folder2.getFile("file1.txt");
-			assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
+		// Check to make sure the file has been moved
+		IFile file2 = folder2.getFile("file1.txt");
+		assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
 
-			// Give the new (moved file) some new contents
-			file2.setContents(getContents(contents[3]), true, true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
+		// Give the new (moved file) some new contents
+		file2.setContents(getContents(contents[3]), true, true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
-			// Check the local history of both files
-			states = file.getHistory(getMonitor());
-			assertEquals("2.0", 2, states.length);
-			assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
-			states = file2.getHistory(getMonitor());
-			assertEquals("2.3", 4, states.length);
-			assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		// Check the local history of both files
+		states = file.getHistory(getMonitor());
+		assertEquals("2.0", 2, states.length);
+		assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		states = file2.getHistory(getMonitor());
+		assertEquals("2.3", 4, states.length);
+		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
 
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.delete(true, getMonitor());
 	}
 
 	/**
@@ -1582,191 +1225,131 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testMoveProject() {
+	public void testMoveProject() throws CoreException {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MoveProjectProject");
 		IProject project2 = getWorkspace().getRoot().getProject("SecondMoveProjectProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		IFile file = project.getFile("file1.txt");
 
 		IFolder folder = project.getFolder("folder1");
 		file = folder.getFile("file1.txt");
-		try {
-			// Setup folder1 and file1.txt with some local history
-			folder.create(true, true, getMonitor());
-			file.create(getContents(contents[0]), true, getMonitor());
-			file.setContents(getContents(contents[1]), true, true, getMonitor());
-			file.setContents(getContents(contents[2]), true, true, getMonitor());
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("1.0", 2, states.length);
-			assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		// Setup folder1 and file1.txt with some local history
+		folder.create(true, true, getMonitor());
+		file.create(getContents(contents[0]), true, getMonitor());
+		file.setContents(getContents(contents[1]), true, true, getMonitor());
+		file.setContents(getContents(contents[2]), true, true, getMonitor());
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("1.0", 2, states.length);
+		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
-			// Now do the move
-			project.move(IPath.fromOSString("SecondMoveProjectProject"), true, getMonitor());
+		// Now do the move
+		project.move(IPath.fromOSString("SecondMoveProjectProject"), true, getMonitor());
 
-			// Check to make sure the file has been moved
-			IFile file2 = project2.getFile("folder1/file1.txt");
-			assertTrue("1.3", file2.getFullPath().toString().endsWith("SecondMoveProjectProject/folder1/file1.txt"));
+		// Check to make sure the file has been moved
+		IFile file2 = project2.getFile("folder1/file1.txt");
+		assertTrue("1.3", file2.getFullPath().toString().endsWith("SecondMoveProjectProject/folder1/file1.txt"));
 
-			// Give the new (copied file) some new contents
-			file2.setContents(getContents(contents[3]), true, true, getMonitor());
-			file2.setContents(getContents(contents[4]), true, true, getMonitor());
+		// Give the new (copied file) some new contents
+		file2.setContents(getContents(contents[3]), true, true, getMonitor());
+		file2.setContents(getContents(contents[4]), true, true, getMonitor());
 
-			// Check the local history of both files
-			states = file.getHistory(getMonitor());
+		// Check the local history of both files
+		states = file.getHistory(getMonitor());
 
-			// original file should not remember history when project is moved
-			assertEquals("2.0", 0, states.length);
-			states = file2.getHistory(getMonitor());
-			assertEquals("2.3", 4, states.length);
-			assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
-		} catch (CoreException e) {
-			fail("2.9", e);
-		}
+		// original file should not remember history when project is moved
+		assertEquals("2.0", 0, states.length);
+		states = file2.getHistory(getMonitor());
+		assertEquals("2.3", 4, states.length);
+		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
 
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.delete(true, getMonitor());
 	}
 
-	public void testRemoveAll() {
-
+	public void testRemoveAll() throws CoreException {
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("removeAllStatesFile.txt");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), true, getMonitor());
+
 		final int ITERATIONS = 20;
 
 		/* test remove in a file */
 		for (int i = 0; i < ITERATIONS; i++) {
-			try {
-				file.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("3.0." + i, e);
-			}
+			file.setContents(getRandomContents(), true, true, getMonitor());
 		}
 
 		/* Valid Case: Ensure correct number of states available. */
-		IFileState[] states = null;
-		try {
-			states = file.getHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		IFileState[] states = file.getHistory(getMonitor());
 		assertEquals("4.1", ITERATIONS, states.length);
 
 		/* Remove all states, and verify that no states remain. */
-		try {
-			file.clearHistory(getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("5.0", 0, states.length);
-		} catch (CoreException e) {
-			fail("5.1", e);
-		}
+		file.clearHistory(getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("5.0", 0, states.length);
 
 		/* test remove in a folder -- make sure it does not affect other resources' states*/
 		IFolder folder = project.getFolder("folder");
 		IFile anotherOne = folder.getFile("anotherOne");
-		try {
-			folder.create(true, true, getMonitor());
-			anotherOne.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
+		folder.create(true, true, getMonitor());
+		anotherOne.create(getRandomContents(), true, getMonitor());
 		for (int i = 0; i < ITERATIONS; i++) {
-			try {
-				file.setContents(getRandomContents(), true, true, getMonitor());
-				anotherOne.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("6.1." + i, e);
-			}
+			file.setContents(getRandomContents(), true, true, getMonitor());
+			anotherOne.setContents(getRandomContents(), true, true, getMonitor());
 		}
 
-		try {
-			states = file.getHistory(getMonitor());
-			assertEquals("6.2", ITERATIONS, states.length);
-			states = anotherOne.getHistory(getMonitor());
-			assertEquals("6.3", ITERATIONS, states.length);
-		} catch (CoreException e) {
-			fail("6.4", e);
-		}
+		states = file.getHistory(getMonitor());
+		assertEquals("6.2", ITERATIONS, states.length);
+		states = anotherOne.getHistory(getMonitor());
+		assertEquals("6.3", ITERATIONS, states.length);
 
 		/* Remove all states, and verify that no states remain. */
-		try {
-			project.clearHistory(getMonitor());
-			states = file.getHistory(getMonitor());
-			assertEquals("7.0", 0, states.length);
-			states = anotherOne.getHistory(getMonitor());
-			assertEquals("7.1", 0, states.length);
-		} catch (CoreException e) {
-			fail("7.2", e);
-		}
+		project.clearHistory(getMonitor());
+		states = file.getHistory(getMonitor());
+		assertEquals("7.0", 0, states.length);
+		states = anotherOne.getHistory(getMonitor());
+		assertEquals("7.1", 0, states.length);
 
 		/* test remove in a folder -- make sure it does not affect other resources' states*/
 		IFile aaa = project.getFile("aaa");
 		IFolder bbb = project.getFolder("bbb");
 		anotherOne = bbb.getFile("anotherOne");
 		IFile ccc = project.getFile("ccc");
-		try {
-			bbb.create(true, true, getMonitor());
-			anotherOne.create(getRandomContents(), true, getMonitor());
-			aaa.create(getRandomContents(), true, getMonitor());
-			ccc.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("8.0", e);
-		}
+		bbb.create(true, true, getMonitor());
+		anotherOne.create(getRandomContents(), true, getMonitor());
+		aaa.create(getRandomContents(), true, getMonitor());
+		ccc.create(getRandomContents(), true, getMonitor());
+
 		for (int i = 0; i < ITERATIONS; i++) {
-			try {
-				anotherOne.setContents(getRandomContents(), true, true, getMonitor());
-				aaa.setContents(getRandomContents(), true, true, getMonitor());
-				ccc.setContents(getRandomContents(), true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("8.1." + i, e);
-			}
+			anotherOne.setContents(getRandomContents(), true, true, getMonitor());
+			aaa.setContents(getRandomContents(), true, true, getMonitor());
+			ccc.setContents(getRandomContents(), true, true, getMonitor());
 		}
 
-		try {
-			states = anotherOne.getHistory(getMonitor());
-			assertEquals("8.3", ITERATIONS, states.length);
-			states = aaa.getHistory(getMonitor());
-			assertEquals("8.4", ITERATIONS, states.length);
-			states = ccc.getHistory(getMonitor());
-			assertEquals("8.5", ITERATIONS, states.length);
-		} catch (CoreException e) {
-			fail("8.6", e);
-		}
+		states = anotherOne.getHistory(getMonitor());
+		assertEquals("8.3", ITERATIONS, states.length);
+		states = aaa.getHistory(getMonitor());
+		assertEquals("8.4", ITERATIONS, states.length);
+		states = ccc.getHistory(getMonitor());
+		assertEquals("8.5", ITERATIONS, states.length);
 
 		/* Remove all states, and verify that no states remain. aaa and ccc should not be affected. */
-		try {
-			bbb.clearHistory(getMonitor());
-			states = anotherOne.getHistory(getMonitor());
-			assertEquals("9.1", 0, states.length);
-			states = aaa.getHistory(getMonitor());
-			assertEquals("9.2", ITERATIONS, states.length);
-			states = ccc.getHistory(getMonitor());
-			assertEquals("9.3", ITERATIONS, states.length);
-		} catch (CoreException e) {
-			fail("9.4", e);
-		}
+		bbb.clearHistory(getMonitor());
+		states = anotherOne.getHistory(getMonitor());
+		assertEquals("9.1", 0, states.length);
+		states = aaa.getHistory(getMonitor());
+		assertEquals("9.2", ITERATIONS, states.length);
+		states = ccc.getHistory(getMonitor());
+		assertEquals("9.3", ITERATIONS, states.length);
 	}
 
 	/**
@@ -1785,79 +1368,50 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testSimpleCopy() {
-
+	public void testSimpleCopy() throws CoreException {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("SimpleCopyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		IFile file = project.getFile("simpleCopyFileWithHistoryCopy");
 		IFile copyFile = project.getFile("copyOfSimpleCopyFileWithHistoryCopy");
 
 		/* Create first file. */
-		try {
-			file.create(getContents(contents[0]), true, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.create(getContents(contents[0]), true, null);
 
 		/* Set new contents on first file. Should add two entries to the history store. */
-		try {
-			file.setContents(getContents(contents[1]), true, true, null);
-			file.setContents(getContents(contents[2]), true, true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.setContents(getContents(contents[1]), true, true, null);
+		file.setContents(getContents(contents[2]), true, true, null);
 
 		/* Copy first file to the second. Second file should have no history. */
-		try {
-			file.copy(copyFile.getFullPath(), true, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.copy(copyFile.getFullPath(), true, null);
 
 		/* Check history for both files. */
-		try {
-			IFileState[] states = file.getHistory(null);
-			assertEquals("4.0", 2, states.length);
-			states = copyFile.getHistory(null);
-			assertEquals("4.1", 2, states.length);
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		IFileState[] states = file.getHistory(null);
+		assertEquals("4.0", 2, states.length);
+		states = copyFile.getHistory(null);
+		assertEquals("4.1", 2, states.length);
 
 		/* Set new contents on second file. Should add two entries to the history store. */
-		try {
-			copyFile.setContents(getContents(contents[3]), true, true, null);
-			copyFile.setContents(getContents(contents[4]), true, true, null);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		copyFile.setContents(getContents(contents[3]), true, true, null);
+		copyFile.setContents(getContents(contents[4]), true, true, null);
 
 		/* Check history for both files. */
-		try {
-			// Check log for original file.
-			IFileState[] states = file.getHistory(null);
-			assertEquals("6.0", 2, states.length);
-			assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		// Check log for original file.
+		states = file.getHistory(null);
+		assertEquals("6.0", 2, states.length);
+		assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
-			// Check log for copy.
-			states = copyFile.getHistory(null);
-			assertEquals("6.3", 4, states.length);
-			assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
-
-		} catch (CoreException e) {
-			fail("6.8", e);
-		}
+		// Check log for copy.
+		states = copyFile.getHistory(null);
+		assertEquals("6.3", 4, states.length);
+		assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
 	}
 
 	/**
@@ -1876,81 +1430,52 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the moved file should have 4 states as it retains the states from
 	 * before the move took place as well.
 	 */
-	public void testSimpleMove() {
-
+	public void testSimpleMove() throws CoreException {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("SimpleMoveProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		IFile file = project.getFile("simpleMoveFileWithCopy");
 		IFile moveFile = project.getFile("copyOfSimpleMoveFileWithCopy");
 
 		/* Create first file. */
-		try {
-			file.create(getContents(contents[0]), true, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.create(getContents(contents[0]), true, null);
 
 		/* Set new contents on source file. Should add two entries to the history store. */
-		try {
-			file.setContents(getContents(contents[1]), true, true, null);
-			file.setContents(getContents(contents[2]), true, true, null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.setContents(getContents(contents[1]), true, true, null);
+		file.setContents(getContents(contents[2]), true, true, null);
 
 		/* Move source file to second location.
 		 * Moved files should have the history of the original file.
 		 */
-		try {
-			file.move(moveFile.getFullPath(), true, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.move(moveFile.getFullPath(), true, null);
 
 		/* Check history for both files. */
-		try {
-			IFileState[] states = file.getHistory(null);
-			assertEquals("4.0", 2, states.length);
-			states = moveFile.getHistory(null);
-			assertEquals("4.1", 2, states.length);
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		IFileState[] states = file.getHistory(null);
+		assertEquals("4.0", 2, states.length);
+		states = moveFile.getHistory(null);
+		assertEquals("4.1", 2, states.length);
 
 		/* Set new contents on moved file. Should add two entries to the history store. */
-		try {
-			moveFile.setContents(getContents(contents[3]), true, true, null);
-			moveFile.setContents(getContents(contents[4]), true, true, null);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		moveFile.setContents(getContents(contents[3]), true, true, null);
+		moveFile.setContents(getContents(contents[4]), true, true, null);
 
 		/* Check history for both files. */
-		try {
-			// Check log for original file.
-			IFileState[] states = file.getHistory(null);
-			assertEquals("6.0", 2, states.length);
-			assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		// Check log for original file.
+		states = file.getHistory(null);
+		assertEquals("6.0", 2, states.length);
+		assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
-			// Check log for moved file.
-			states = moveFile.getHistory(null);
-			assertEquals("6.3", 4, states.length);
-			assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
-			assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
-
-		} catch (CoreException e) {
-			fail("6.8", e);
-		}
+		// Check log for moved file.
+		states = moveFile.getHistory(null);
+		assertEquals("6.3", 4, states.length);
+		assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
+		assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
 	}
 
 	/**
@@ -1965,123 +1490,81 @@ public class HistoryStoreTest extends ResourceTest {
 	 *   6. Set new content				"content 2"			4
 	 *   7. Roll back to third version  "content 3"			5
 	 */
-	public void testSimpleUse() {
-
+	public void testSimpleUse() throws CoreException {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		String[] contents = {"content1", "content2", "content3"};
 		IFile file = project.getFile("file");
 
 		/* Create the file. */
-		try {
-			file.create(getContents(contents[0]), true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.create(getContents(contents[0]), true, getMonitor());
 
 		/* Set new contents on the file. Should add two entries to the store. */
-		try {
-			for (int i = 0; i < 2; i++) {
-				file.setContents(getContents(contents[i + 1]), true, true, getMonitor());
-			}
-		} catch (CoreException e) {
-			fail("2.0", e);
+		for (int i = 0; i < 2; i++) {
+			file.setContents(getContents(contents[i + 1]), true, true, getMonitor());
 		}
 
 		/* Ensure two entries are available for the file, and that content matches. */
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("3.0", 2, states.length);
-			assertTrue("3.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("3.1.2", compareContent(getContents(contents[0]), states[1].getContents()));
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		IFileState[] states = file.getHistory(getMonitor());
+		assertEquals("3.0", 2, states.length);
+		assertTrue("3.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("3.1.2", compareContent(getContents(contents[0]), states[1].getContents()));
 
 		/* Delete the file. Should add an entry to the store. */
-		try {
-			file.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		file.delete(true, true, getMonitor());
 
 		/* Ensure three entries are available for the file, and that content matches. */
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("5.0", 3, states.length);
-			assertTrue("5.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-			assertTrue("5.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
-			assertTrue("5.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
-		} catch (CoreException e) {
-			fail("5.2", e);
-		}
+		states = file.getHistory(getMonitor());
+		assertEquals("5.0", 3, states.length);
+		assertTrue("5.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
+		assertTrue("5.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
+		assertTrue("5.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
 
 		/* Roll file back to first version, and ensure that content matches. */
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			// Create the file with the contents from one of the states.
-			// Won't add another entry to the store.
-			file.create(states[0].getContents(), false, getMonitor());
+		states = file.getHistory(getMonitor());
+		// Create the file with the contents from one of the states.
+		// Won't add another entry to the store.
+		file.create(states[0].getContents(), false, getMonitor());
 
-			// Check history store.
-			states = file.getHistory(getMonitor());
-			assertEquals("6.0", 3, states.length);
-			assertTrue("6.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-			assertTrue("6.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
-			assertTrue("6.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
+		// Check history store.
+		states = file.getHistory(getMonitor());
+		assertEquals("6.0", 3, states.length);
+		assertTrue("6.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
+		assertTrue("6.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
+		assertTrue("6.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
 
-			// Check file contents.
-			assertTrue("6.2", compareContent(getContents(contents[2]), file.getContents(false)));
-
-		} catch (CoreException e) {
-			fail("6.3", e);
-		}
+		// Check file contents.
+		assertTrue("6.2", compareContent(getContents(contents[2]), file.getContents(false)));
 
 		/* Set new contents on the file. Should add an entry to the history store. */
-		try {
-			file.setContents(getContents(contents[1]), true, true, null);
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		file.setContents(getContents(contents[1]), true, true, null);
 
 		/* Ensure four entries are available for the file, and that entries match. */
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			assertEquals("8.0", 4, states.length);
-			assertTrue("8.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-			assertTrue("8.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("8.1.3", compareContent(getContents(contents[1]), states[2].getContents()));
-			assertTrue("8.1.4", compareContent(getContents(contents[0]), states[3].getContents()));
-		} catch (CoreException e) {
-			fail("8.2", e);
-		}
+		states = file.getHistory(getMonitor());
+		assertEquals("8.0", 4, states.length);
+		assertTrue("8.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
+		assertTrue("8.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("8.1.3", compareContent(getContents(contents[1]), states[2].getContents()));
+		assertTrue("8.1.4", compareContent(getContents(contents[0]), states[3].getContents()));
 
 		/* Roll file back to third version, and ensure that content matches. */
-		try {
-			IFileState[] states = file.getHistory(getMonitor());
-			// Will add another entry to log.
-			file.setContents(states[2], true, true, getMonitor());
+		states = file.getHistory(getMonitor());
+		// Will add another entry to log.
+		file.setContents(states[2], true, true, getMonitor());
 
-			// Check history log.
-			states = file.getHistory(getMonitor());
-			assertEquals("9.0", 5, states.length);
-			assertTrue("9.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-			assertTrue("9.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
-			assertTrue("9.1.3", compareContent(getContents(contents[2]), states[2].getContents()));
-			assertTrue("9.1.4", compareContent(getContents(contents[1]), states[3].getContents()));
-			assertTrue("9.1.5", compareContent(getContents(contents[0]), states[4].getContents()));
+		// Check history log.
+		states = file.getHistory(getMonitor());
+		assertEquals("9.0", 5, states.length);
+		assertTrue("9.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
+		assertTrue("9.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
+		assertTrue("9.1.3", compareContent(getContents(contents[2]), states[2].getContents()));
+		assertTrue("9.1.4", compareContent(getContents(contents[1]), states[3].getContents()));
+		assertTrue("9.1.5", compareContent(getContents(contents[0]), states[4].getContents()));
 
-			// Check file contents.
-			assertTrue("9.2", compareContent(getContents(contents[1]), file.getContents(false)));
-
-		} catch (CoreException e) {
-			fail("9.3", e);
-		}
+		// Check file contents.
+		assertTrue("9.2", compareContent(getContents(contents[1]), file.getContents(false)));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -13,11 +13,27 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import org.eclipse.core.internal.resources.*;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.internal.resources.ICoreConstants;
+import org.eclipse.core.internal.resources.ProjectDescriptionReader;
+import org.eclipse.core.internal.resources.RegexFileInfoMatcher;
+import org.eclipse.core.internal.resources.Resource;
+import org.eclipse.core.internal.resources.ResourceInfo;
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.FileInfoMatcherDescription;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceFilterDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 
@@ -100,38 +116,24 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of a simple filter on a folder.
 	 */
-	public void testCreateFilterOnFolder() {
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+	public void testCreateFilterOnFolder() throws CoreException {
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo");
 		IFile bar = existingFolderInExistingProject.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
+
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
@@ -139,12 +141,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS);
 		assertEquals("1.8", filters[0].getResource(), existingFolderInExistingProject);
 
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingProject.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingProject.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "foo");
@@ -157,38 +154,22 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of a simple filter on a project.
 	 */
-	public void testCreateFilterOnProject() {
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-			existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FOLDERS, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+	public void testCreateFilterOnProject() throws CoreException {
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
+		existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FOLDERS,
+				matcherDescription, 0, getMonitor());
 
 		IFolder foo = existingProject.getFolder("foo");
 		IFolder bar = existingProject.getFolder("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
+		IResourceFilterDescription[] filters = existingProject.getFilters();
 
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
@@ -196,12 +177,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FOLDERS);
 		assertEquals("1.8", filters[0].getResource(), existingProject);
 
-		IResource members[] = null;
-		try {
-			members = existingProject.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingProject.members();
 		assertEquals("2.0", members.length, 3);
 		for (IResource member : members) {
 			if (member.getType() == IResource.FOLDER) {
@@ -218,49 +194,29 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of a simple filter on a linked folder.
 	 */
-	public void testCreateFilterOnLinkedFolder() {
-
+	public void testCreateFilterOnLinkedFolder() throws CoreException {
 		IPath location = getRandomLocation();
 		IFolder folder = nonExistingFolderInExistingProject;
 
 		//try to create without the flag (should fail)
-		try {
-			folder.createLink(location, IResource.NONE, getMonitor());
-			fail("1.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> folder.createLink(location, IResource.NONE, getMonitor()));
 
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-			folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
+		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
+				matcherDescription, 0, getMonitor());
+
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = folder.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
+
+		IResourceFilterDescription[] filters = folder.getFilters();
 
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
@@ -268,12 +224,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES);
 		assertEquals("1.8", filters[0].getResource(), folder);
 
-		IResource members[] = null;
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = folder.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "foo");
@@ -287,155 +238,75 @@ public class FilteredResourceTest extends ResourceTest {
 	 * Tests the creation of two different filters on a linked folder and the original.
 	 * Regression for bug 267201
 	 */
-	public void testCreateFilterOnLinkedFolderAndTarget() {
-
+	public void testCreateFilterOnLinkedFolderAndTarget() throws Exception {
 		IPath location = existingFolderInExistingFolder.getLocation();
 		IFolder folder = nonExistingFolderInExistingProject;
 
-		try {
-			folder.createLink(location, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.5");
-		}
+		folder.createLink(location, IResource.NONE, getMonitor());
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.cpp");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.h");
 
-		IResourceFilterDescription filterDescription2 = null;
+		folder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES,
+				matcherDescription1, 0, getMonitor());
+		IResourceFilterDescription filterDescription2 = existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0,
+				getMonitor());
 
-		try {
-			folder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-			filterDescription2 = existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
-
-		IResource members[] = null;
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		IResource members[] = folder.members();
 		assertEquals("1.2", members.length, 0);
 
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		members = existingFolderInExistingFolder.members();
 		assertEquals("1.4", members.length, 0);
 
 		IFile newFile = existingFolderInExistingFolder.getFile("foo.cpp");
-		try {
-			assertTrue("1.5", newFile.getLocation().toFile().createNewFile());
-		} catch (IOException e1) {
-			fail("1.6", e1);
-		}
+		assertTrue("1.5", newFile.getLocation().toFile().createNewFile());
 
-		try {
-			existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.7", e);
-		}
-
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.8", e);
-		}
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("1.9", members.length, 1);
 		assertEquals("2.0", members[0].getType(), IResource.FILE);
 		assertEquals("2.1", members[0].getName(), "foo.cpp");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		members = folder.members();
 		assertEquals("2.3", members.length, 0);
 
 		newFile = existingFolderInExistingFolder.getFile("foo.h");
-		try {
-			assertTrue("2.5", newFile.getLocation().toFile().createNewFile());
-		} catch (IOException e1) {
-			fail("2.6", e1);
-		}
+		assertTrue("2.5", newFile.getLocation().toFile().createNewFile());
 
-		try {
-			existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.7", e);
-		}
-
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", members.length, 1);
 		assertEquals("3.0", members[0].getType(), IResource.FILE);
 		assertEquals("3.1", members[0].getName(), "foo.cpp");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		members = folder.members();
 		assertEquals("3.3", members.length, 0);
 
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.4", e);
-		}
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("3.8", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("3.9", members.length, 1);
 		assertEquals("4.0", members[0].getType(), IResource.FILE);
 		assertEquals("4.1", members[0].getName(), "foo.cpp");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		members = folder.members();
 		assertEquals("4.3", members.length, 1);
 		assertEquals("4.4", members[0].getType(), IResource.FILE);
 		assertEquals("4.5", members[0].getName(), "foo.h");
 
 		// create a file that shows under both
 		newFile = existingFolderInExistingFolder.getFile("foo.text");
-		try {
-			assertTrue("5.5", newFile.getLocation().toFile().createNewFile());
-		} catch (IOException e1) {
-			fail("5.6", e1);
-		}
+		assertTrue("5.5", newFile.getLocation().toFile().createNewFile());
 
-		try {
-			existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.7", e);
-		}
-
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("5.8", e);
-		}
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("5.9", members.length, 2);
 		assertEquals("6.0", members[0].getType(), IResource.FILE);
 		assertEquals("6.1", members[0].getName(), "foo.cpp");
 		assertEquals("6.2", members[1].getType(), IResource.FILE);
 		assertEquals("6.3", members[1].getName(), "foo.text");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("6.4", e);
-		}
+		members = folder.members();
 		assertEquals("6.5", members.length, 2);
 		assertEquals("6.6", members[0].getType(), IResource.FILE);
 		assertEquals("6.7", members[0].getName(), "foo.h");
@@ -443,102 +314,56 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("6.9", members[1].getName(), "foo.text");
 
 		// delete the common file
-		try {
-			newFile.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("7.1", e);
-		}
+		newFile.delete(true, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("7.2", members.length, 1);
 		assertEquals("7.3", members[0].getType(), IResource.FILE);
 		assertEquals("7.4", members[0].getName(), "foo.cpp");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("7.5", e);
-		}
+		members = folder.members();
 		assertEquals("7.6", members.length, 1);
 		assertEquals("7.7", members[0].getType(), IResource.FILE);
 		assertEquals("7.8", members[0].getName(), "foo.h");
 
 		// remove the first filter
-		try {
-			filterDescription2.delete(0, getMonitor());
-		} catch (CoreException e) {
-			fail("8.0");
-		}
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("8.1", e);
-		}
+		filterDescription2.delete(0, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("8.2", members.length, 2);
 		assertEquals("8.3", members[0].getType(), IResource.FILE);
 		assertEquals("8.4", members[0].getName(), "foo.cpp");
 		assertEquals("8.4.1", members[1].getType(), IResource.FILE);
 		assertEquals("8.4.2", members[1].getName(), "foo.h");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("8.5", e);
-		}
+		members = folder.members();
 		assertEquals("8.6", members.length, 1);
 		assertEquals("8.7", members[0].getType(), IResource.FILE);
 		assertEquals("8.8", members[0].getName(), "foo.h");
 
 		// add the filter again
-		try {
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("9.0");
-		}
-
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("9.1", e);
-		}
+		existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0,
+				getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("9.2", members.length, 1);
 		assertEquals("9.3", members[0].getType(), IResource.FILE);
 		assertEquals("9.4", members[0].getName(), "foo.cpp");
 
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("9.5", e);
-		}
+		members = folder.members();
 		assertEquals("9.6", members.length, 1);
 		assertEquals("9.7", members[0].getType(), IResource.FILE);
 		assertEquals("9.8", members[0].getName(), "foo.h");
 	}
 
-	public void testIResource_isFiltered() {
+	public void testIResource_isFiltered() throws CoreException {
 		IFolder folder = existingFolderInExistingProject.getFolder("virtual_folder.txt");
 		IFile file = existingFolderInExistingProject.getFile("linked_file.txt");
 
-		try {
-			folder.create(IResource.VIRTUAL, true, getMonitor());
-		} catch (CoreException e1) {
-			fail("0.79", e1);
-		}
-		try {
-			file.createLink(existingFileInExistingProject.getLocation(), 0, getMonitor());
-		} catch (CoreException e1) {
-			fail("0.89", e1);
-		}
+		folder.create(IResource.VIRTUAL, true, getMonitor());
+		file.createLink(existingFileInExistingProject.getLocation(), 0, getMonitor());
 
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.txt");
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL, matcherDescription, 0,
+				getMonitor());
 
 		IWorkspace workspace = existingProject.getWorkspace();
 		assertTrue("1.0", workspace.validateFiltered(folder).isOK());
@@ -551,89 +376,59 @@ public class FilteredResourceTest extends ResourceTest {
 	 * excluded locations.
 	 * Regression for bug 267201
 	 */
-	public void testCreateFilterOnLinkedFolderAndTarget2() {
-
+	public void testCreateFilterOnLinkedFolderAndTarget2() throws CoreException {
 		final IPath location = existingFolderInExistingFolder.getLocation();
 		final IFolder folder = nonExistingFolderInExistingProject;
 
-		try {
-			folder.createLink(location, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.5");
-		}
+		folder.createLink(location, IResource.NONE, getMonitor());
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.h");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.cpp");
 
-		try {
-			folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
+				matcherDescription1, 0, getMonitor());
+		existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0,
+				getMonitor());
 
-		IResource members[] = null;
 
 		// Create 'foo.cpp' in existingFolder...
 		IFile newFile = existingFolderInExistingFolder.getFile("foo.cpp");
-		try {
-			create(newFile, true);
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e1) {
-			fail("1.6", e1);
-		}
+		create(newFile, true);
+		IResource[] members = existingFolderInExistingFolder.members();
 		assertEquals("1.9", 1, members.length);
 		assertEquals("2.0", IResource.FILE, members[0].getType());
 		assertEquals("2.1", "foo.cpp", members[0].getName());
 
 		// Create a 'foo.h' under folder
 		newFile = folder.getFile("foo.h");
-		try {
-			create(newFile, true);
-		} catch (CoreException e1) {
-			fail("2.6", e1);
-		}
+		create(newFile, true);
 		// Check that foo.h has appeared in 'folder'
-		try {
-			//			// Refreshing restores sanity (hides the .cpp files)...
-			//			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
+		// // Refreshing restores sanity (hides the .cpp files)...
+		// folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = folder.members();
 		assertEquals("4.3", 1, members.length);
 		assertEquals("4.4", IResource.FILE, members[0].getType());
 		assertEquals("4.5", "foo.h", members[0].getName());
 
 		// Check it hasn't appeared in existingFolder...
-		try {
-			//			// Refresh restores sanity...
-			//			existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		// // Refresh restores sanity...
+		// existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE,
+		// getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", 1, members.length);
 		assertEquals("3.0", IResource.FILE, members[0].getType());
 		assertEquals("3.1", "foo.cpp", members[0].getName());
 		// And refreshing doesn't change things
-		try {
-			existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", 1, members.length);
 		assertEquals("3.0", IResource.FILE, members[0].getType());
 		assertEquals("3.1", "foo.cpp", members[0].getName());
 
 		// Check modifying foo.h doesn't make it appear
-		try {
-			modifyInWorkspace(folder.getFile("foo.h"));
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("2.8", e);
-		}
+		modifyInWorkspace(folder.getFile("foo.h"));
+		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", 1, members.length);
 		assertEquals("3.0", IResource.FILE, members[0].getType());
 		assertEquals("3.1", "foo.cpp", members[0].getName());
@@ -650,7 +445,7 @@ public class FilteredResourceTest extends ResourceTest {
 	 * otherExistingProject/nonExistingFolder2InOtherExistingProject =&gt; existingProject/existingFolderInExsitingProject/existingFolderInExistingFolder
 	 * This is a regression test for Bug 268518.
 	 */
-	public void testCreateFilterOnLinkedFolderWithAlias() {
+	public void testCreateFilterOnLinkedFolderWithAlias() throws Exception {
 		final IProject project = otherExistingProject;
 		final IPath parentLoc = existingFolderInExistingProject.getLocation();
 		final IPath childLoc = existingFolderInExistingFolder.getLocation();
@@ -662,126 +457,88 @@ public class FilteredResourceTest extends ResourceTest {
 		assertTrue("0.3", parentLoc.isPrefixOf(childLoc));
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
-		IResourceFilterDescription filterDescription1 = null;
 
-		try {
-			// Filter out all children from existingFolderInExistingProject
-			filterDescription1 = folder1.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
+		// Filter out all children from existingFolderInExistingProject
+		IResourceFilterDescription filterDescription1 = folder1.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
 
-		try {
-			folder1.createLink(parentLoc, IResource.NONE, getMonitor());
-			folder2.createLink(childLoc, IResource.NONE, getMonitor());
-			existingProject.close(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder1.createLink(parentLoc, IResource.NONE, getMonitor());
+		folder2.createLink(childLoc, IResource.NONE, getMonitor());
+		existingProject.close(getMonitor());
 
-		try {
-			assertTrue("12.0", folder1.exists());
-			assertTrue("12.2", folder2.exists());
-			assertTrue("12.4", folder1.isLinked());
-			assertTrue("12.6", folder2.isLinked());
-			assertTrue("12.8", folder1.getLocation().equals(parentLoc));
-			assertTrue("12.10", folder2.getLocation().equals(childLoc));
-			assertTrue("12.12", folder1.members().length == 0);
-			assertTrue("12.14", folder2.members().length == 0);
-		} catch (CoreException e) {
-			fail("12.20", e);
-		}
+		assertTrue("12.0", folder1.exists());
+		assertTrue("12.2", folder2.exists());
+		assertTrue("12.4", folder1.isLinked());
+		assertTrue("12.6", folder2.isLinked());
+		assertTrue("12.8", folder1.getLocation().equals(parentLoc));
+		assertTrue("12.10", folder2.getLocation().equals(childLoc));
+		assertTrue("12.12", folder1.members().length == 0);
+		assertTrue("12.14", folder2.members().length == 0);
 
 		// Need to unset M_USED on the project's resource info, or
 		// reconcileLinks will never be called...
 		Workspace workspace = ((Workspace) ResourcesPlugin.getWorkspace());
 		try {
-			try {
-				workspace.prepareOperation(project, getMonitor());
-				workspace.beginOperation(true);
+			workspace.prepareOperation(project, getMonitor());
+			workspace.beginOperation(true);
 
-				ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
-				ri.clear(ICoreConstants.M_USED);
-			} finally {
-				workspace.endOperation(project, true);
-			}
-		} catch (CoreException e) {
-			fail("2.90", e);
+			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
+			ri.clear(ICoreConstants.M_USED);
+		} finally {
+			workspace.endOperation(project, true);
 		}
 
-		try {
-			project.close(getMonitor());
-			assertTrue("3.1", !project.isOpen());
-			// Create a file under existingFolderInExistingFolder
-			createFileInFileSystem(childLoc.append("foo"));
-			// Reopen the project
-			project.open(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.close(getMonitor());
+		assertTrue("3.1", !project.isOpen());
+		// Create a file under existingFolderInExistingFolder
+		createFileInFileSystem(childLoc.append("foo"));
+		// Reopen the project
+		project.open(IResource.NONE, getMonitor());
 
-		try {
-			assertTrue("22.0", folder1.exists());
-			assertTrue("22.2", folder2.exists());
-			assertTrue("22.4", folder1.isLinked());
-			assertTrue("22.6", folder2.isLinked());
-			assertTrue("22.8", folder1.getLocation().equals(parentLoc));
-			assertTrue("22.10", folder2.getLocation().equals(childLoc));
-			assertTrue("22.12", folder1.members().length == 0);
-			assertTrue("22.12", folder2.members().length == 1);
-		} catch (CoreException e) {
-			fail("22.20", e);
-		}
+		assertTrue("22.0", folder1.exists());
+		assertTrue("22.2", folder2.exists());
+		assertTrue("22.4", folder1.isLinked());
+		assertTrue("22.6", folder2.isLinked());
+		assertTrue("22.8", folder1.getLocation().equals(parentLoc));
+		assertTrue("22.10", folder2.getLocation().equals(childLoc));
+		assertTrue("22.12", folder1.members().length == 0);
+		assertTrue("22.12", folder2.members().length == 1);
 
 		// Swap the links around, loading may be order independent...
-		try {
-			folder2.createLink(parentLoc, IResource.REPLACE, getMonitor());
-			folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
+		folder2.createLink(parentLoc, IResource.REPLACE, getMonitor());
+		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
 
-			// Filter out all children from existingFolderInExistingProject
-			folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-			filterDescription1.delete(0, getMonitor());
-			assertTrue(folder1.getFilters().length == 0);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// Filter out all children from existingFolderInExistingProject
+		folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
+				matcherDescription1, 0, getMonitor());
+		filterDescription1.delete(0, getMonitor());
+		assertTrue(folder1.getFilters().length == 0);
 
 		// Need to unset M_USED on the project's resource info, or
 		// reconcileLinks will never be called...
 		try {
-			try {
-				workspace.prepareOperation(project, getMonitor());
-				workspace.beginOperation(true);
+			workspace.prepareOperation(project, getMonitor());
+			workspace.beginOperation(true);
 
-				ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
-				ri.clear(ICoreConstants.M_USED);
-			} finally {
-				workspace.endOperation(project, true);
-			}
-		} catch (CoreException e) {
-			fail("4.5", e);
+			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
+			ri.clear(ICoreConstants.M_USED);
+		} finally {
+			workspace.endOperation(project, true);
 		}
 
-		try {
-			project.close(getMonitor());
-			assertTrue("3.1", !project.isOpen());
-			project.open(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		project.close(getMonitor());
+		assertTrue("3.1", !project.isOpen());
+		project.open(IResource.NONE, getMonitor());
 
-		try {
-			assertTrue("32.0", folder1.exists());
-			assertTrue("32.2", folder2.exists());
-			assertTrue("32.4", folder1.isLinked());
-			assertTrue("32.6", folder2.isLinked());
-			assertTrue("32.8", folder2.getLocation().equals(parentLoc));
-			assertTrue("32.10", folder1.getLocation().equals(childLoc));
-			assertTrue("32.12", folder1.members().length == 1);
-			assertTrue("32.12", folder2.members().length == 0);
-		} catch (CoreException e) {
-			fail("32.20", e);
-		}
+		assertTrue("32.0", folder1.exists());
+		assertTrue("32.2", folder2.exists());
+		assertTrue("32.4", folder1.isLinked());
+		assertTrue("32.6", folder2.isLinked());
+		assertTrue("32.8", folder2.getLocation().equals(parentLoc));
+		assertTrue("32.10", folder1.getLocation().equals(childLoc));
+		assertTrue("32.12", folder1.members().length == 1);
+		assertTrue("32.12", folder2.members().length == 0);
 	}
 
 	/**
@@ -795,7 +552,7 @@ public class FilteredResourceTest extends ResourceTest {
 	 * otherExistingProject/nonExistingFolder2InOtherExistingProject =&gt; existingProject/existingFolderInExsitingProject/existingFolderInExistingFolder
 	 * This is a regression test for Bug 268518.
 	 */
-	public void testCreateFilterOnLinkedFolderWithAlias2() {
+	public void testCreateFilterOnLinkedFolderWithAlias2() throws CoreException {
 		final IProject project = otherExistingProject;
 		final IPath parentLoc = existingFolderInExistingProject.getLocation();
 		final IPath childLoc = existingFolderInExistingFolder.getLocation();
@@ -807,105 +564,74 @@ public class FilteredResourceTest extends ResourceTest {
 		assertTrue("0.3", parentLoc.isPrefixOf(childLoc));
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
-		IResourceFilterDescription filterDescription1 = null;
 
-		try {
-			// Filter out all children from existingFolderInExistingProject
-			filterDescription1 = folder1.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
+		// Filter out all children from existingFolderInExistingProject
+		IResourceFilterDescription filterDescription1 = folder1.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
 
-		try {
-			folder1.createLink(parentLoc, IResource.NONE, getMonitor());
-			folder2.createLink(childLoc, IResource.NONE, getMonitor());
-			existingProject.close(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder1.createLink(parentLoc, IResource.NONE, getMonitor());
+		folder2.createLink(childLoc, IResource.NONE, getMonitor());
+		existingProject.close(getMonitor());
 
-		try {
-			assertTrue("12.0", folder1.exists());
-			assertTrue("12.2", folder2.exists());
-			assertTrue("12.4", folder1.isLinked());
-			assertTrue("12.6", folder2.isLinked());
-			assertTrue("12.8", folder1.getLocation().equals(parentLoc));
-			assertTrue("12.10", folder2.getLocation().equals(childLoc));
-			assertTrue("12.12", folder1.members().length == 0);
-			assertTrue("12.14", folder2.members().length == 0);
-		} catch (CoreException e) {
-			fail("12.20", e);
-		}
+		assertTrue("12.0", folder1.exists());
+		assertTrue("12.2", folder2.exists());
+		assertTrue("12.4", folder1.isLinked());
+		assertTrue("12.6", folder2.isLinked());
+		assertTrue("12.8", folder1.getLocation().equals(parentLoc));
+		assertTrue("12.10", folder2.getLocation().equals(childLoc));
+		assertTrue("12.12", folder1.members().length == 0);
+		assertTrue("12.14", folder2.members().length == 0);
 
 		// Need to unset M_USED on the project's resource info, or
 		// reconcileLinks will never be called...
 		Workspace workspace = ((Workspace) ResourcesPlugin.getWorkspace());
 		try {
-			try {
-				workspace.prepareOperation(project, getMonitor());
-				workspace.beginOperation(true);
+			workspace.prepareOperation(project, getMonitor());
+			workspace.beginOperation(true);
 
-				ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
-				ri.clear(ICoreConstants.M_USED);
-			} finally {
-				workspace.endOperation(project, true);
-			}
-		} catch (CoreException e) {
-			fail("2.90", e);
+			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
+			ri.clear(ICoreConstants.M_USED);
+		} finally {
+			workspace.endOperation(project, true);
 		}
 
-		try {
-			// Create a file under existingFolderInExistingFolder
-			create(folder2.getFile("foo"), true);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// Create a file under existingFolderInExistingFolder
+		create(folder2.getFile("foo"), true);
 
-		try {
-			assertTrue("22.0", folder1.exists());
-			assertTrue("22.2", folder2.exists());
-			assertTrue("22.4", folder1.isLinked());
-			assertTrue("22.6", folder2.isLinked());
-			assertTrue("22.8", folder1.getLocation().equals(parentLoc));
-			assertTrue("22.10", folder2.getLocation().equals(childLoc));
-			assertTrue("22.12", folder1.members().length == 0);
-			assertTrue("22.12", folder2.members().length == 1);
-		} catch (CoreException e) {
-			fail("22.20", e);
-		}
+		assertTrue("22.0", folder1.exists());
+		assertTrue("22.2", folder2.exists());
+		assertTrue("22.4", folder1.isLinked());
+		assertTrue("22.6", folder2.isLinked());
+		assertTrue("22.8", folder1.getLocation().equals(parentLoc));
+		assertTrue("22.10", folder2.getLocation().equals(childLoc));
+		assertTrue("22.12", folder1.members().length == 0);
+		assertTrue("22.12", folder2.members().length == 1);
 
 		// Swap the links around, loading may be order independent...
-		try {
-			folder2.createLink(parentLoc, IResource.REPLACE | IResource.NONE, getMonitor());
-			folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
+		folder2.createLink(parentLoc, IResource.REPLACE | IResource.NONE, getMonitor());
+		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
 
-			// Filter out all children from existingFolderInExistingProject
-			folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-			filterDescription1.delete(0, getMonitor());
-			assertTrue(folder1.getFilters().length == 0);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		// Filter out all children from existingFolderInExistingProject
+		folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
+				matcherDescription1, 0, getMonitor());
+		filterDescription1.delete(0, getMonitor());
+		assertTrue(folder1.getFilters().length == 0);
 
-		try {
-			assertTrue("32.0", folder1.exists());
-			assertTrue("32.2", folder2.exists());
-			assertTrue("32.4", folder1.isLinked());
-			assertTrue("32.6", folder2.isLinked());
-			assertTrue("32.8", folder2.getLocation().equals(parentLoc));
-			assertTrue("32.10", folder1.getLocation().equals(childLoc));
-			assertTrue("32.12", folder1.members().length == 1);
-			assertTrue("32.12", folder2.members().length == 0);
-		} catch (CoreException e) {
-			fail("32.20", e);
-		}
+		assertTrue("32.0", folder1.exists());
+		assertTrue("32.2", folder2.exists());
+		assertTrue("32.4", folder1.isLinked());
+		assertTrue("32.6", folder2.isLinked());
+		assertTrue("32.8", folder2.getLocation().equals(parentLoc));
+		assertTrue("32.10", folder1.getLocation().equals(childLoc));
+		assertTrue("32.12", folder1.members().length == 1);
+		assertTrue("32.12", folder2.members().length == 0);
 	}
 
 	/**
 	 * Tests the creation of a simple filter on a linked folder before the resource creation.
 	 */
-	public void testCreateFilterOnLinkedFolderBeforeCreation() {
-
+	public void testCreateFilterOnLinkedFolderBeforeCreation() throws CoreException {
 		IPath location = existingFolderInExistingFolder.getLocation();
 		IFolder folder = nonExistingFolderInExistingProject;
 
@@ -913,42 +639,22 @@ public class FilteredResourceTest extends ResourceTest {
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 
-		try {
-			folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("0.5");
-		}
-
-		try {
-			folder.createLink(location, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
+				matcherDescription1, 0, getMonitor());
+		folder.createLink(location, IResource.NONE, getMonitor());
 
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = folder.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
+
+		IResourceFilterDescription[] filters = folder.getFilters();
 
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
@@ -956,12 +662,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES);
 		assertEquals("1.8", filters[0].getResource(), folder);
 
-		IResource members[] = null;
-		try {
-			members = folder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = folder.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "foo");
@@ -970,64 +671,34 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation and removal of a simple filter on a folder.
 	 */
-	public void testCreateAndRemoveFilterOnFolder() {
+	public void testCreateAndRemoveFilterOnFolder() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-		IResourceFilterDescription filterDescription = null;
-
-		try {
-			filterDescription = existingFolderInExistingFolder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		IResourceFilterDescription filterDescription = existingFolderInExistingFolder
+				.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES
+						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
 
-		try {
-			filterDescription.delete(0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		filterDescription.delete(0, getMonitor());
 
 		//close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.4", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
 
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingFolder.getFilters();
-		} catch (CoreException e) {
-			fail("1.5", e);
-		}
+		IResourceFilterDescription[] filters = existingFolderInExistingFolder.getFilters();
 
 		assertEquals("1.6", filters.length, 0);
 
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.7", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("1.8", members.length, 2);
 		assertEquals("1.9", members[0].getType(), IResource.FILE);
 		assertEquals("2.0", members[0].getName(), "bar");
@@ -1038,48 +709,24 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation and removal of a simple filter on a folder.
 	 */
-	public void testCreateAndRemoveFilterOnFolderWithoutClosingProject() {
+	public void testCreateAndRemoveFilterOnFolderWithoutClosingProject() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-		IResourceFilterDescription filterDescription = null;
-
-		try {
-			filterDescription = existingFolderInExistingFolder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		IResourceFilterDescription filterDescription = existingFolderInExistingFolder
+				.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES
+						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		filterDescription.delete(0, getMonitor());
 
-		try {
-			filterDescription.delete(0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingFolder.getFilters();
-		} catch (CoreException e) {
-			fail("1.5", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingFolder.getFilters();
 		assertEquals("1.6", filters.length, 0);
 
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.7", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("1.8", members.length, 2);
 		assertEquals("1.9", members[0].getType(), IResource.FILE);
 		assertEquals("2.0", members[0].getName(), "bar");
@@ -1090,33 +737,21 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of the include-only filter.
 	 */
-	public void testIncludeOnlyFilter() {
+	public void testIncludeOnlyFilter() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFile file = existingFolderInExistingProject.getFile("file.c");
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingProject.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingProject.members();
 		assertEquals("2.0", members.length, 2);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "file.c");
@@ -1124,25 +759,12 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("2.4", members[1].getName(), "foo.c");
 
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
+				getMonitor());
 
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0");
-		}
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
-
-		members = null;
-		try {
-			members = existingFolderInExistingProject.members();
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingFolderInExistingProject.members();
 		assertEquals("3.3", members.length, 2);
 		assertEquals("3.4", members[0].getType(), IResource.FILE);
 		assertEquals("3.5", members[0].getName(), "file.c");
@@ -1153,14 +775,12 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of the exclude-all filter.
 	 */
-	public void testExcludeAllFilter() {
+	public void testExcludeAllFilter() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 
-		try {
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFile file = existingFolderInExistingFolder.getFile("file.c");
@@ -1168,19 +788,9 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 2);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "bar.h");
@@ -1188,25 +798,12 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("2.4", members[1].getName(), "foo.h");
 
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
+		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
+				getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0");
-		}
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
-
-		members = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		members = existingFolderInExistingFolder.members();
 		assertEquals("3.3", members.length, 1);
 		assertEquals("3.4", members[0].getType(), IResource.FILE);
 		assertEquals("3.5", members[0].getName(), "bar.h");
@@ -1215,16 +812,16 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of the mixed include-only exclude-all filter.
 	 */
-	public void testMixedFilter() {
+	public void testMixedFilter() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFile file = existingFolderInExistingProject.getFile("file.c");
@@ -1232,19 +829,9 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingProject.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingProject.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "file.c");
@@ -1253,16 +840,15 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of inheritable filter.
 	 */
-	public void testInheritedFilter() {
+	public void testInheritedFilter() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 
-		try {
-			existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.INHERITABLE | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.INHERITABLE
+				| IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
+		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFile file = existingFolderInExistingFolder.getFile("file.c");
@@ -1270,19 +856,9 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "file.c");
@@ -1291,32 +867,19 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of FOLDER filter.
 	 */
-	public void testFolderOnlyFilters() {
+	public void testFolderOnlyFilters() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FILE);
 		assertEquals("2.2", members[0].getName(), "foo.c");
@@ -1325,32 +888,19 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests the creation of FILE filter.
 	 */
-	public void testFileOnlyFilters() {
+	public void testFileOnlyFilters() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingFolderInExistingFolder.members();
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
 		assertEquals("2.1", members[0].getType(), IResource.FOLDER);
 		assertEquals("2.2", members[0].getName(), "foo.d");
@@ -1359,49 +909,25 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests moving a folder with filters.
 	 */
-	public void testMoveFolderWithFilterToAnotherProject() {
+	public void testMoveFolderWithFilterToAnotherProject() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
-		try {
-			existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
+		existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
 
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
 
-		filters = null;
-		try {
-			filters = destination.getFilters();
-		} catch (CoreException e) {
-			fail("1.5", e);
-		}
-
+		filters = destination.getFilters();
 		assertEquals("1.6", filters.length, 1);
 		assertEquals("1.7", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("1.8", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
@@ -1412,53 +938,29 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests copying a folder with filters.
 	 */
-	public void testCopyFolderWithFilterToAnotherProject() {
+	public void testCopyFolderWithFilterToAnotherProject() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
-		try {
-			existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
+		existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
 
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("1.6", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES);
 		assertEquals("1.8", filters[0].getResource(), existingFolderInExistingProject);
 
-		filters = null;
-		try {
-			filters = destination.getFilters();
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-
+		filters = destination.getFilters();
 		assertEquals("2.1", filters.length, 1);
 		assertEquals("2.2", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("2.3", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
@@ -1469,55 +971,30 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests copying a folder with filters to another folder.
 	 */
-	public void testCopyFolderWithFilterToAnotherFolder() {
+	public void testCopyFolderWithFilterToAnotherFolder() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
-
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
-		try {
-			existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
+		existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
 
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 1);
 		assertEquals("1.5", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("1.6", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
 		assertEquals("1.7", filters[0].getType(), IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES);
 		assertEquals("1.8", filters[0].getResource(), existingFolderInExistingProject);
 
-		filters = null;
-		try {
-			filters = destination.getFilters();
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-
+		filters = destination.getFilters();
 		assertEquals("2.1", filters.length, 1);
 		assertEquals("2.2", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("2.3", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
@@ -1528,51 +1005,26 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests moving a folder with filters to another folder.
 	 */
-	public void testMoveFolderWithFilterToAnotherFolder() {
+	public void testMoveFolderWithFilterToAnotherFolder() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
-
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
-
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
-		try {
-			existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
+		existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
 
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
 
-		filters = null;
-		try {
-			filters = destination.getFilters();
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-
+		filters = destination.getFilters();
 		assertEquals("2.1", filters.length, 1);
 		assertEquals("2.2", filters[0].getFileInfoMatcherDescription().getId(), REGEX_FILTER_PROVIDER);
 		assertEquals("2.3", filters[0].getFileInfoMatcherDescription().getArguments(), "foo.*");
@@ -1583,89 +1035,52 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Tests deleting a folder with filters.
 	 */
-	public void testDeleteFolderWithFilterToAnotherFolder() {
+	public void testDeleteFolderWithFilterToAnotherFolder() throws CoreException {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 
-		try {
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
-			existingFolderInExistingFolder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+		existingFolderInExistingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
+				getMonitor());
+		existingFolderInExistingFolder.createFilter(
+				IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0,
+				getMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
+		existingFolderInExistingProject.delete(0, getMonitor());
 
-		try {
-			existingFolderInExistingProject.delete(0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
-
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
 
-		filters = null;
-		try {
-			filters = existingFolderInExistingFolder.getFilters();
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-
+		filters = existingFolderInExistingFolder.getFilters();
 		assertEquals("2.1", filters.length, 0);
 	}
 
 	/* Regression test for Bug 304276 */
 	public void testInvalidCharactersInRegExFilter() {
 		RegexFileInfoMatcher matcher = new RegexFileInfoMatcher();
-		try {
-			matcher.initialize(existingProject, "*:*");
-			fail("1.0");
-		} catch (CoreException e) {
-		}
+		assertThrows(CoreException.class, () -> matcher.initialize(existingProject, "*:*"));
 	}
 
 	/**
 	 * Regression test for Bug 302146
 	 */
-	public void testBug302146() {
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
-			existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0");
-		}
+	public void testBug302146() throws Exception {
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
+		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
+				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0,
+				getMonitor());
 
 		// close and reopen the project
-		try {
-			existingProject.close(getMonitor());
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		IResourceFilterDescription[] filters = null;
-		try {
-			filters = existingFolderInExistingProject.getFilters();
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		existingProject.close(getMonitor());
+		existingProject.open(getMonitor());
+		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 
 		// check that filters are recreated when the project is reopened
 		// it means that .project was updated with filter details
@@ -1675,11 +1090,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("4.3", filters[0].getType(), IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS);
 		assertEquals("4.4", filters[0].getResource(), existingFolderInExistingProject);
 
-		try {
-			new ProjectDescriptionReader(existingProject).read(existingProject.getFile(".project").getLocation());
-		} catch (IOException e) {
-			fail("5.0", e);
-		}
+		new ProjectDescriptionReader(existingProject).read(existingProject.getFile(".project").getLocation());
 	}
 
 	/**
@@ -1689,145 +1100,82 @@ public class FilteredResourceTest extends ResourceTest {
 	 * appear in the workspace, along with all its children, in spite of active resource filters to the
 	 * contrary.
 	 */
-	public void test317783() {
+	public void test317783() throws CoreException {
 		IFolder folder = existingProject.getFolder("foo");
 		ensureExistsInWorkspace(folder, true);
 
 		IFile file = folder.getFile("bar.txt");
 		ensureExistsInWorkspace(file, "content");
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
+		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
+				matcherDescription, 0, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
-			existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
-		IResource members[] = null;
-		try {
-			members = existingProject.members();
-		} catch (CoreException e) {
-			fail("1.4", e);
-		}
+		IResource members[] = existingProject.members();
 		assertEquals("1.5", 2, members.length);
 		assertEquals("1.6", ".project", members[0].getName());
 		assertEquals("1.7", existingFileInExistingProject.getName(), members[1].getName());
 
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-
-		try {
-			members = existingProject.members();
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		members = existingProject.members();
 		assertEquals("2.2", 2, members.length);
 		assertEquals("2.3", ".project", members[0].getName());
 		assertEquals("2.4", existingFileInExistingProject.getName(), members[1].getName());
 
 		assertEquals("2.5", false, folder.exists());
 		assertEquals("2.6", false, file.exists());
-
 	}
 
 	/**
 	 * Regression for  Bug 317824 -  Renaming a project that contains resource filters fails,
 	 * and copying a project that contains resource filters removes the resource filters.
 	 */
-	public void test317824() {
+	public void test317824() throws CoreException {
 		IFolder folder = existingProject.getFolder("foo");
 		ensureExistsInWorkspace(folder, true);
 
 		IFile file = folder.getFile("bar.txt");
 		ensureExistsInWorkspace(file, "content");
 
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
+		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
+				matcherDescription, 0, getMonitor());
+		assertEquals(1, existingProject.getFilters().length);
 
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
-			existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2");
-		}
-
-		try {
-			assertEquals(1, existingProject.getFilters().length);
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
-
-		try {
-			existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.4", e);
-		}
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		IPath newPath = existingProject.getFullPath().removeLastSegments(1).append(existingProject.getName() + "_moved");
-		try {
-			existingProject.move(newPath, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.5", e);
-		}
+		existingProject.move(newPath, true, getMonitor());
 
 		IProject newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(existingProject.getName() + "_moved");
-		try {
-			assertTrue(newProject.exists());
-			assertEquals(1, newProject.getFilters().length);
-		} catch (CoreException e) {
-			fail("1.6", e);
-		}
+		assertTrue(newProject.exists());
+		assertEquals(1, newProject.getFilters().length);
 
 		newPath = newProject.getFullPath().removeLastSegments(1).append(newProject.getName() + "_copy");
-		try {
-			newProject.copy(newPath, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.7", e);
-		}
+		newProject.copy(newPath, true, getMonitor());
 
 		newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(newProject.getName() + "_copy");
-		try {
-			assertTrue(newProject.exists());
-			assertEquals(1, newProject.getFilters().length);
-		} catch (CoreException e) {
-			fail("1.8", e);
-		}
+		assertTrue(newProject.exists());
+		assertEquals(1, newProject.getFilters().length);
 	}
 
 	/**
 	 * Regression test for bug 328464
 	 */
-	public void test328464() {
+	public void test328464() throws CoreException {
 		IFolder folder = existingProject.getFolder(getUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
 		IFile file_a_txt = folder.getFile("a.txt");
 		ensureExistsInWorkspace(file_a_txt, true);
 
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "a\\.txt");
-			existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES | IResourceFilterDescription.INHERITABLE, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER,
+				"a\\.txt");
+		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES
+				| IResourceFilterDescription.INHERITABLE, matcherDescription, 0, getMonitor());
 
 		assertFalse("2.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
 
@@ -1838,11 +1186,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 		assertFalse("4.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
 
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		assertFalse("6.0", file_a_txt.exists());
 		assertFalse("7.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
@@ -1855,16 +1199,16 @@ public class FilteredResourceTest extends ResourceTest {
 	/**
 	 * Regression test for bug 343914
 	 */
-	public void test343914() {
+	public void test343914() throws CoreException {
 		String subProjectName = "subProject";
 		IPath subProjectLocation = existingProject.getLocation().append(subProjectName);
 
-		try {
-			FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, subProjectName);
-			existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS | IResourceFilterDescription.FILES | IResourceFilterDescription.INHERITABLE, matcherDescription, 0, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER,
+				subProjectName);
+		existingProject.createFilter(
+				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS
+						| IResourceFilterDescription.FILES | IResourceFilterDescription.INHERITABLE,
+				matcherDescription, 0, getMonitor());
 
 		IPath fileLocation = subProjectLocation.append("file.txt");
 
@@ -1891,11 +1235,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IProjectDescription newProjectDescription = getWorkspace().newProjectDescription(subProjectName);
 		newProjectDescription.setLocation(subProjectLocation);
 
-		try {
-			subProject.create(newProjectDescription, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		subProject.create(newProjectDescription, getMonitor());
 		result = root.getFileForLocation(fileLocation);
 
 		assertTrue("3.0", result != null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -33,7 +33,7 @@ public class HiddenResourceTest extends ResourceTest {
 		listener.addExpectedChange(subFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		addResourceChangeListener(listener);
 		try {
-			setHidden("3.0", folder, true, IResource.DEPTH_ZERO);
+			setHidden(folder, true, IResource.DEPTH_ZERO);
 			ensureOutOfSync(subFile);
 			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
@@ -45,7 +45,7 @@ public class HiddenResourceTest extends ResourceTest {
 	/**
 	 * Resources which are marked as hidden resources should always be found.
 	 */
-	public void testFindMember() {
+	public void testFindMember() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(getUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -61,14 +61,14 @@ public class HiddenResourceTest extends ResourceTest {
 		assertEquals("1.3", subFile, root.findMember(subFile.getFullPath()));
 
 		// the folder is hidden
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		assertEquals("2.1", project, root.findMember(project.getFullPath()));
 		assertEquals("2.2", folder, root.findMember(folder.getFullPath()));
 		assertEquals("2.3", file, root.findMember(file.getFullPath()));
 		assertEquals("2.4", subFile, root.findMember(subFile.getFullPath()));
 
 		// all are hidden
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		assertEquals("3.1", project, root.findMember(project.getFullPath()));
 		assertEquals("3.2", folder, root.findMember(folder.getFullPath()));
 		assertEquals("3.3", file, root.findMember(file.getFullPath()));
@@ -89,7 +89,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 
 		// Initial values should be false.
-		assertHidden("1.0", project, false, IResource.DEPTH_INFINITE);
+		assertHidden(project, false, IResource.DEPTH_INFINITE);
 
 		// Check the calls to #members
 		members = project.members();
@@ -100,11 +100,11 @@ public class HiddenResourceTest extends ResourceTest {
 		assertEquals("2.3", 1, members.length);
 
 		// Set the values.
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
-		assertHidden("3.1", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
+		assertHidden(project, true, IResource.DEPTH_INFINITE);
 
 		// Check the values
-		assertHidden("4.0", project, true, IResource.DEPTH_INFINITE);
+		assertHidden(project, true, IResource.DEPTH_INFINITE);
 
 		// Check the calls to #members
 		members = project.members();
@@ -115,8 +115,8 @@ public class HiddenResourceTest extends ResourceTest {
 		// FIXME: add the tests for #members(int)
 
 		// reset to false
-		setHidden("6.0", project, false, IResource.DEPTH_INFINITE);
-		assertHidden("6.1", project, false, IResource.DEPTH_INFINITE);
+		setHidden(project, false, IResource.DEPTH_INFINITE);
+		assertHidden(project, false, IResource.DEPTH_INFINITE);
 
 		// Check the calls to members(IResource.NONE);
 		members = project.members(IResource.NONE);
@@ -129,7 +129,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertEquals("7.5", 1, members.length);
 
 		// Set one of the children to be HIDDEN and try again
-		setHidden("8.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		members = project.members();
 
 		// +1 for project description, -1 for hidden folder
@@ -148,8 +148,8 @@ public class HiddenResourceTest extends ResourceTest {
 		assertEquals("8.12", 1, members.length);
 
 		// Set all the resources to be hidden
-		setHidden("9.0", project, true, IResource.DEPTH_INFINITE);
-		assertHidden("9.1", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
+		assertHidden(project, true, IResource.DEPTH_INFINITE);
 		members = project.members(IResource.NONE);
 		assertEquals("9.3", 0, members.length);
 		members = folder.members(IResource.NONE);
@@ -181,24 +181,24 @@ public class HiddenResourceTest extends ResourceTest {
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor);
-		assertTrue("1.1." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue("1.3." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
 
-		assertTrue("1.5." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		// set the folder to be hidden. It and its children should
 		// be ignored by the visitor
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		visitor.reset();
 		visitor.addExpected(project);
 		visitor.addExpected(file);
@@ -206,7 +206,7 @@ public class HiddenResourceTest extends ResourceTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor);
-		assertTrue("2.2." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		visitor.reset();
 		visitor.addExpected(project);
@@ -215,27 +215,27 @@ public class HiddenResourceTest extends ResourceTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue("2.4." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 		// should see all resources if we include the flag
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
-		assertTrue("2.6." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 		// should NOT visit the folder and its members if we call accept on it directly
 		visitor.reset();
 		folder.accept(visitor);
-		assertTrue("2.8." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		visitor.reset();
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue("2.10." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 
 		visitor.reset();
 		visitor.addExpected(folder);
 		visitor.addExpected(subFile);
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
-		assertTrue("2.11." + visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.getMessage(), visitor.isValid());
 	}
 
 	public void testCopy() throws CoreException {
@@ -256,7 +256,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 
 		// set a folder to be hidden
-		setHidden("1.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// copy the project
 		int flags = IResource.FORCE;
 		project.copy(destProject.getFullPath(), flags, getMonitor());
@@ -267,7 +267,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.copy(destFolder.getFullPath(), flags, getMonitor());
 		assertExistsInWorkspace("2.2", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("2.3", new IResource[] {destFolder, destSubFile});
@@ -276,7 +276,7 @@ public class HiddenResourceTest extends ResourceTest {
 		// copy the project
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, getMonitor());
 		assertExistsInWorkspace("3.2", resources);
 		assertExistsInWorkspace("3.3", destResources);
@@ -285,7 +285,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
-		setHidden("4.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.copy(destFolder.getFullPath(), flags, getMonitor());
 		assertExistsInWorkspace("4.2", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("4.3", new IResource[] {destFolder, destSubFile});
@@ -309,7 +309,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 
 		// set a folder to be hidden
-		setHidden("1.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// move the project
 		int flags = IResource.FORCE;
 		project.move(destProject.getFullPath(), flags, getMonitor());
@@ -320,7 +320,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.move(destFolder.getFullPath(), flags, getMonitor());
 		assertDoesNotExistInWorkspace("2.2", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("2.3", new IResource[] {destFolder, destSubFile});
@@ -329,7 +329,7 @@ public class HiddenResourceTest extends ResourceTest {
 		// move the project
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, getMonitor());
 		assertDoesNotExistInWorkspace("3.2", resources);
 		assertExistsInWorkspace("3.3", destResources);
@@ -338,7 +338,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
-		setHidden("4.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.move(destFolder.getFullPath(), flags, getMonitor());
 		assertDoesNotExistInWorkspace("4.2", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("4.3", new IResource[] {destFolder, destSubFile});
@@ -371,32 +371,32 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// set one child to be hidden
 		ensureExistsInWorkspace(resources, true);
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
 		project.delete(flags, getMonitor());
 		assertDoesNotExistInWorkspace("2.2", resources);
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
-		setHidden("2.3", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.delete(flags, getMonitor());
 		assertDoesNotExistInWorkspace("2.5", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("2.6", new IResource[] {project, file});
 
 		// set all resources to be hidden
 		ensureExistsInWorkspace(resources, true);
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
 		project.delete(flags, getMonitor());
 		assertDoesNotExistInWorkspace("3.2", resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
-		setHidden("3.3", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		file.delete(flags, getMonitor());
 		assertDoesNotExistInWorkspace("3.5", file);
 		assertExistsInWorkspace("3.6", new IResource[] {project, folder, subFile});
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
-		setHidden("3.7", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.delete(flags, getMonitor());
 		assertDoesNotExistInWorkspace("3.9", new IResource[] {folder, subFile});
 		assertExistsInWorkspace("3.10", new IResource[] {project, file});
@@ -424,7 +424,7 @@ public class HiddenResourceTest extends ResourceTest {
 			waitForEncodingRelatedJobs();
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
-			assertTrue("1.0." + listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.getMessage(), listener.isDeltaValid());
 			ensureDoesNotExistInWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
@@ -433,7 +433,7 @@ public class HiddenResourceTest extends ResourceTest {
 		try {
 			IWorkspaceRunnable body = monitor -> {
 				ensureExistsInWorkspace(resources, true);
-				setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
+				setHidden(folder, true, IResource.DEPTH_ZERO);
 			};
 			listener.reset();
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
@@ -443,7 +443,7 @@ public class HiddenResourceTest extends ResourceTest {
 			getWorkspace().run(body, getMonitor());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
-			assertTrue("2.1." + listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.getMessage(), listener.isDeltaValid());
 			ensureDoesNotExistInWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
@@ -452,7 +452,7 @@ public class HiddenResourceTest extends ResourceTest {
 		try {
 			IWorkspaceRunnable body = monitor -> {
 				ensureExistsInWorkspace(resources, true);
-				setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
+				setHidden(project, true, IResource.DEPTH_INFINITE);
 			};
 			listener.reset();
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
@@ -492,7 +492,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * Resources which are marked as hidden resources return TRUE
 	 * in all calls to #exists.
 	 */
-	public void testExists() {
+	public void testExists() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
@@ -504,20 +504,20 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace("1.0", resources);
 
 		// set a folder to be hidden
-		setHidden("2.0", folder, true, IResource.DEPTH_ZERO);
-		assertHidden("2.1", folder, true, IResource.DEPTH_ZERO);
+		setHidden(folder, true, IResource.DEPTH_ZERO);
+		assertHidden(folder, true, IResource.DEPTH_ZERO);
 		assertExistsInWorkspace("2.2", resources);
 
 		// set all resources to be hidden
-		setHidden("3.0", project, true, IResource.DEPTH_INFINITE);
-		assertHidden("3.1", project, true, IResource.DEPTH_INFINITE);
+		setHidden(project, true, IResource.DEPTH_INFINITE);
+		assertHidden(project, true, IResource.DEPTH_INFINITE);
 		assertExistsInWorkspace("3.2", resources);
 	}
 
 	/**
 	 * Test the set and get methods for hidden resources.
 	 */
-	public void testSetGet() {
+	public void testSetGet() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
@@ -540,11 +540,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// now set the values
 		for (IResource resource : resources) {
-			try {
-				resource.setHidden(true);
-			} catch (CoreException e) {
-				fail("2.0: " + resource.getFullPath(), e);
-			}
+			resource.setHidden(true);
 		}
 
 		// the values should be true for projects only
@@ -564,11 +560,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// clear the values
 		for (IResource resource : resources) {
-			try {
-				resource.setHidden(false);
-			} catch (CoreException e) {
-				fail("4.0: " + resource.getFullPath(), e);
-			}
+			resource.setHidden(false);
 		}
 
 		// values should be false again
@@ -593,47 +585,37 @@ public class HiddenResourceTest extends ResourceTest {
 		folder.create(IResource.HIDDEN, true, getMonitor());
 		file.create(getRandomContents(), IResource.HIDDEN, getMonitor());
 
-		assertHidden("2.0", project, false, IResource.DEPTH_ZERO);
-		assertHidden("3.0", folder, true, IResource.DEPTH_ZERO);
-		assertHidden("4.0", file, true, IResource.DEPTH_ZERO);
+		assertHidden(project, false, IResource.DEPTH_ZERO);
+		assertHidden(folder, true, IResource.DEPTH_ZERO);
+		assertHidden(file, true, IResource.DEPTH_ZERO);
 
 		IProject project2 = getWorkspace().getRoot().getProject(getUniqueString());
 
 		project2.create(null, IResource.HIDDEN, getMonitor());
 		project2.open(getMonitor());
 
-		assertHidden("6.0", project2, true, IResource.DEPTH_ZERO);
+		assertHidden(project2, true, IResource.DEPTH_ZERO);
 	}
 
-	protected void assertHidden(final String message, IResource root, final boolean value, int depth) {
+	protected void assertHidden(IResource root, final boolean value, int depth)
+			throws CoreException {
 		IResourceVisitor visitor = resource -> {
 			boolean expected = false;
 			if (resource.getType() == IResource.PROJECT || resource.getType() == IResource.FILE || resource.getType() == IResource.FOLDER) {
 				expected = value;
 			}
-			assertEquals(message + resource.getFullPath(), expected, resource.isHidden());
+			assertEquals(resource.getFullPath() + "", expected, resource.isHidden());
 			return true;
 		};
-		try {
-			root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);
-		} catch (CoreException e) {
-			fail(message + "resource.accept", e);
-		}
+		root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);
 	}
 
-	protected void setHidden(final String message, IResource root, final boolean value, int depth) {
+	protected void setHidden(IResource root, final boolean value, int depth)
+			throws CoreException {
 		IResourceVisitor visitor = resource -> {
-			try {
-				resource.setHidden(value);
-			} catch (CoreException e) {
-				fail(message + resource.getFullPath(), e);
-			}
+			resource.setHidden(value);
 			return true;
 		};
-		try {
-			root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);
-		} catch (CoreException e) {
-			fail(message + "resource.accept", e);
-		}
+		root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -31,7 +33,7 @@ public class IFolderTest extends ResourceTest {
 		super.tearDown();
 	}
 
-	public void testChangeCase() {
+	public void testChangeCase() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder before = project.getFolder("folder");
 		IFolder after = project.getFolder("Folder");
@@ -40,22 +42,14 @@ public class IFolderTest extends ResourceTest {
 
 		// create the resources and set some content in a file that will be moved.
 		ensureExistsInWorkspace(before, true);
-		try {
-			beforeFile.create(getRandomContents(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		beforeFile.create(getRandomContents(), false, getMonitor());
 
 		// Be sure the resources exist and then move them.
 		assertExistsInWorkspace("1.0", before);
 		assertExistsInWorkspace("1.1", beforeFile);
 		assertDoesNotExistInWorkspace("1.2", after);
 		assertDoesNotExistInWorkspace("1.3", afterFile);
-		try {
-			before.move(after.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		before.move(after.getFullPath(), IResource.NONE, getMonitor());
 
 		assertDoesNotExistInWorkspace("1.2", before);
 		assertDoesNotExistInWorkspace("1.3", beforeFile);
@@ -72,42 +66,30 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(before, true);
 		ensureDoesNotExistInFileSystem(before);
 
-		try {
-			//should fail because 'before' does not exist in the filesystem
-			before.copy(after.getFullPath(), IResource.FORCE, getMonitor());
-			fail("1.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		// should fail because 'before' does not exist in the filesystem
+		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, getMonitor()));
+
 		//the destination should not exist, because the source does not exist
 		assertTrue("1.1", !before.exists());
 		assertTrue("1.2", !after.exists());
 	}
 
-	public void testCreateDerived() {
+	public void testCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(derived);
 
-		try {
-			derived.create(IResource.DERIVED, true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		derived.create(IResource.DERIVED, true, getMonitor());
 		assertTrue("1.0", derived.isDerived());
 		assertTrue("1.1", !derived.isTeamPrivateMember());
-		try {
-			derived.delete(false, getMonitor());
-			derived.create(IResource.NONE, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		derived.delete(false, getMonitor());
+		derived.create(IResource.NONE, true, getMonitor());
 		assertTrue("2.0", !derived.isDerived());
 		assertTrue("2.1", !derived.isTeamPrivateMember());
 	}
 
-	public void testDeltaOnCreateDerived() {
+	public void testDeltaOnCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
 		ensureExistsInWorkspace(project, true);
@@ -117,57 +99,39 @@ public class IFolderTest extends ResourceTest {
 
 		verifier.addExpectedChange(derived, IResourceDelta.ADDED, IResource.NONE);
 
-		try {
-			derived.create(IResource.FORCE | IResource.DERIVED, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		derived.create(IResource.FORCE | IResource.DERIVED, true, getMonitor());
 
 		assertTrue("2.0", verifier.isDeltaValid());
 	}
 
-	public void testCreateDerivedTeamPrivate() {
+	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
-		try {
-			teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, getMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
 		assertTrue("1.1", teamPrivate.isDerived());
-		try {
-			teamPrivate.delete(false, getMonitor());
-			teamPrivate.create(IResource.NONE, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		teamPrivate.delete(false, getMonitor());
+		teamPrivate.create(IResource.NONE, true, getMonitor());
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
 
-	public void testCreateTeamPrivate() {
+	public void testCreateTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
-		try {
-			teamPrivate.create(IResource.TEAM_PRIVATE, true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		teamPrivate.create(IResource.TEAM_PRIVATE, true, getMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
 		assertTrue("1.1", !teamPrivate.isDerived());
-		try {
-			teamPrivate.delete(false, getMonitor());
-			teamPrivate.create(IResource.NONE, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		teamPrivate.delete(false, getMonitor());
+		teamPrivate.create(IResource.NONE, true, getMonitor());
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
@@ -178,88 +142,56 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 
 		IFolder target = project.getFolder("Folder1");
-		try {
-			assertTrue("1.0", !target.exists());
-			target.create(true, true, getMonitor());
-			assertTrue("1.1", target.exists());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		assertTrue("1.0", !target.exists());
+		target.create(true, true, getMonitor());
+		assertTrue("1.1", target.exists());
 
 		// nested folder creation
 		IFolder nestedTarget = target.getFolder("Folder2");
-		try {
-			assertTrue("2.0", !nestedTarget.exists());
-			nestedTarget.create(true, true, getMonitor());
-			assertTrue("2.1", nestedTarget.exists());
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		assertTrue("2.0", !nestedTarget.exists());
+		nestedTarget.create(true, true, getMonitor());
+		assertTrue("2.1", nestedTarget.exists());
 
 		// try to create a folder that already exists
-		try {
-			assertTrue("3.0", target.exists());
-			target.create(true, true, getMonitor());
-			fail("3.1");
-		} catch (CoreException e) {
-			assertTrue("3.2", target.exists());
-		}
+		assertTrue("3.0", target.exists());
+		IFolder folderTarget = target;
+		assertThrows(CoreException.class, () -> folderTarget.create(true, true, getMonitor()));
+		assertTrue("3.2", target.exists());
 
 		// try to create a folder over a file that exists
 		IFile file = target.getFile("File1");
 		target = target.getFolder("File1");
-		try {
-			file.create(getRandomContents(), true, getMonitor());
-			assertTrue("4.0", file.exists());
-		} catch (CoreException e) {
-			fail("4.1", e);
-		}
+		file.create(getRandomContents(), true, getMonitor());
+		assertTrue("4.0", file.exists());
 
-		try {
-			target.create(true, true, getMonitor());
-			fail("5.0");
-		} catch (CoreException e) {
-			assertTrue("5.1", file.exists());
-			assertTrue("5.2", !target.exists());
-		}
+		IFolder subfolderTarget = target;
+		assertThrows(CoreException.class, () -> subfolderTarget.create(true, true, getMonitor()));
+		assertTrue("5.1", file.exists());
+		assertTrue("5.2", !target.exists());
 
 		// try to create a folder on a project (one segment) path
-		try {
-			target = getWorkspace().getRoot().getFolder(IPath.fromOSString("/Folder3"));
-			fail("6.0");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
+		assertThrows(IllegalArgumentException.class,
+				() -> getWorkspace().getRoot().getFolder(IPath.fromOSString("/Folder3")));
 
 		// try to create a folder as a child of a file
 		file = project.getFile("File2");
-		try {
-			file.create(null, true, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		file.create(null, true, getMonitor());
 
 		target = project.getFolder("File2/Folder4");
-		try {
-			assertTrue("7.1", !target.exists());
-			target.create(true, true, getMonitor());
-			fail("7.2");
-		} catch (CoreException e) {
-			assertTrue("7.3", file.exists());
-			assertTrue("7.4", !target.exists());
-		}
+		assertTrue("7.1", !target.exists());
+		IFolder nonexistentSubfolderTarget = target;
+		assertThrows(CoreException.class, () -> nonexistentSubfolderTarget.create(true, true, getMonitor()));
+		assertTrue("7.3", file.exists());
+		assertTrue("7.4", !target.exists());
 
 		// try to create a folder under a non-existant parent
 		IFolder folder = project.getFolder("Folder5");
 		target = folder.getFolder("Folder6");
-		try {
-			assertTrue("8.0", !folder.exists());
-			target.create(true, true, getMonitor());
-			fail("8.1");
-		} catch (CoreException e) {
-			assertTrue("8.2", !folder.exists());
-			assertTrue("8.3", !target.exists());
-		}
+		assertTrue("8.0", !folder.exists());
+		IFolder nonexistentFolderTarget = target;
+		assertThrows(CoreException.class, () -> nonexistentFolderTarget.create(true, true, getMonitor()));
+		assertTrue("8.2", !folder.exists());
+		assertTrue("8.3", !target.exists());
 	}
 
 	public void testFolderDeletion() throws Throwable {
@@ -299,18 +231,15 @@ public class IFolderTest extends ResourceTest {
 		IFile existing = getWorkspace().getRoot().getFile(path);
 		ensureExistsInWorkspace(existing, true);
 		IFolder target = getWorkspace().getRoot().getFolder(path);
-		try {
-			target.create(true, true, getMonitor());
-			fail("1.0 Should not be able to create folder over a file");
-		} catch (CoreException e) {
-			assertTrue("2.0", existing.exists());
-		}
+		assertThrows("Should not be able to create folder over a file", CoreException.class,
+				() -> target.create(true, true, getMonitor()));
+		assertTrue("2.0", existing.exists());
 	}
 
 	/**
 	 * Tests creation and manipulation of folder names that are reserved on some platforms.
 	 */
-	public void testInvalidFolderNames() {
+	public void testInvalidFolderNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		ensureExistsInWorkspace(project, true);
 
@@ -327,12 +256,7 @@ public class IFolderTest extends ResourceTest {
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
 			assertTrue("1.0 " + name, !folder.exists());
-			try {
-				folder.create(true, true, getMonitor());
-				fail("1.1 " + name);
-			} catch (CoreException e) {
-				// expected
-			}
+			assertThrows(CoreException.class, () -> folder.create(true, true, getMonitor()));
 			assertTrue("1.2 " + name, !folder.exists());
 		}
 
@@ -347,11 +271,7 @@ public class IFolderTest extends ResourceTest {
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
 			assertTrue("2.0 " + name, !folder.exists());
-			try {
-				folder.create(true, true, getMonitor());
-			} catch (CoreException e) {
-				fail("2.1 " + name, e);
-			}
+			folder.create(true, true, getMonitor());
 			assertTrue("2.2 " + name, folder.exists());
 		}
 	}
@@ -393,25 +313,15 @@ public class IFolderTest extends ResourceTest {
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		// getting/setting persistent properties on non-existent resources should throw an exception
 		ensureDoesNotExistInWorkspace(target);
-		try {
-			target.getPersistentProperty(name);
-			fail("1.0");
-		} catch (CoreException e) {
-			//this should happen
-		}
-		try {
-			target.setPersistentProperty(name, value);
-			fail("1.1");
-		} catch (CoreException e) {
-			//this should happen
-		}
+		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
+		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 
 		ensureExistsInWorkspace(target, true);
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
 		assertTrue("2.0", target.getPersistentProperty(name).equals(value));
 		// see what happens if we get a non-existant property
-		name = new QualifiedName("itp-test", "testNonProperty");
-		assertNull("2.1", target.getPersistentProperty(name));
+		QualifiedName nonExistentPropertyName = new QualifiedName("itp-test", "testNonProperty");
+		assertNull("2.1", target.getPersistentProperty(nonExistentPropertyName));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -14,9 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,12 +49,8 @@ public class IPathVariableTest extends ResourceTest {
 	protected void setUp() throws Exception {
 		super.setUp();
 		project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.3", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 		assertTrue("1.4", project.exists());
 		manager = project.getPathVariableManager();
 	}
@@ -170,47 +167,31 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Test IPathVariableManager#getPathVariableNames
 	 */
-	public void testGetPathVariableNames() {
+	public void testGetPathVariableNames() throws CoreException {
 		String[] names = null;
 
 		// add one
-		try {
-			manager.setValue("one", getRandomLocation());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		manager.setValue("one", getRandomLocation());
 		names = manager.getPathVariableNames();
 		List<String> list = Arrays.asList(names);
 		assertTrue("1.2", list.contains("one"));
 
 		// add another
-		try {
-			manager.setValue("two", IPath.ROOT);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		manager.setValue("two", IPath.ROOT);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
 		assertTrue("2.2", list.contains("one"));
 		assertTrue("2.3", list.contains("two"));
 
 		// remove one
-		try {
-			manager.setValue("one", (IPath) null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue("one", (IPath) null);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
 		assertTrue("3.2", list.contains("two"));
 		assertTrue("3.3", !list.contains("one"));
 
 		// remove the last one
-		try {
-			manager.setValue("two", (IPath) null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		manager.setValue("two", (IPath) null);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
 		assertTrue("4.2", !list.contains("two"));
@@ -220,7 +201,7 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Test IPathVariableManager#getValue and IPathVariableManager#setValue
 	 */
-	public void testGetSetValue() {
+	public void testGetSetValue() throws CoreException {
 		boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("C:\\testGetSetValue") : IPath.fromOSString("/testGetSetValue");
 		IPath pathTwo = IPath.fromOSString("/blort/backup");
@@ -232,57 +213,33 @@ public class IPathVariableTest extends ResourceTest {
 		assertNull("0.0", manager.getValue("one"));
 
 		// add a value to the table
-		try {
-			manager.setValue("one", pathOne);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		manager.setValue("one", pathOne);
 		IPath value = manager.getValue("one");
 		assertNotNull("1.1", value);
 		assertEquals("1.2", pathOne, value);
 
 		// add another value
-		try {
-			manager.setValue("two", pathTwo);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		manager.setValue("two", pathTwo);
 		value = manager.getValue("two");
 		assertNotNull("2.1", value);
 		assertEquals("2.2", pathTwo, value);
 
 		// edit the first value
-		try {
-			manager.setValue("one", pathOneEdit);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue("one", pathOneEdit);
 		value = manager.getValue("one");
 		assertNotNull("3.1", value);
 		assertTrue("3.2", pathOneEdit.equals(value));
 
 		// setting with value == null will remove
-		try {
-			manager.setValue("one", (IPath) null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		manager.setValue("one", (IPath) null);
 		assertNull("4.1", manager.getValue("one"));
 
 		// set values with bogus names
-		try {
-			manager.setValue("ECLIPSE$HOME", IPath.ROOT);
-			fail("5.0 Accepted invalid variable name in setValue()");
-		} catch (CoreException ce) {
-			// success
-		}
+		assertThrows("Accepted invalid variable name in setValue()", CoreException.class,
+				() -> manager.setValue("ECLIPSE$HOME", IPath.ROOT));
 
 		// set value with relative path
-		try {
-			manager.setValue("one", IPath.fromOSString("foo/bar"));
-		} catch (CoreException ce) {
-			fail("5.0 Did not Accepted invalid variable value in setValue()");
-		}
+		manager.setValue("one", IPath.fromOSString("foo/bar"));
 
 		// set invalid value (with invalid segment)
 		if (WINDOWS) {
@@ -291,11 +248,7 @@ public class IPathVariableTest extends ResourceTest {
 			assertTrue("6.0", invalidPath.isAbsolute());
 			assertTrue("6.1", !IPath.EMPTY.isValidPath(invalidPathString));
 			assertTrue("6.2", manager.validateValue(invalidPath).isOK());
-			try {
-				manager.setValue("one", invalidPath);
-			} catch (CoreException ce) {
-				fail("6.3 Fail to accept invalid variable value in setValue()");
-			}
+			manager.setValue("one", invalidPath);
 		}
 
 	}
@@ -303,48 +256,27 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Test IPathVariableManager#isDefined
 	 */
-	public void testIsDefined() {
+	public void testIsDefined() throws CoreException {
 		assertTrue("0.0", !manager.isDefined("one"));
-		try {
-			manager.setValue("one", IPath.ROOT);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		manager.setValue("one", IPath.ROOT);
 		assertTrue("1.1", manager.isDefined("one"));
-		try {
-			manager.setValue("one", (IPath) null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		manager.setValue("one", (IPath) null);
 		assertTrue("2.1", !manager.isDefined("one"));
 	}
 
 	/**
 	 * Test IPathVariableManager#resolvePath
 	 */
-	public void testResolvePathWithMacro() {
+	public void testResolvePathWithMacro() throws CoreException {
 		final boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("c:/testGetSetValue/foo") : IPath.fromOSString("/testGetSetValue/foo");
 		IPath pathTwo = WINDOWS ? IPath.fromOSString("c:/tmp/backup") : IPath.fromOSString("/tmp/backup");
 		// add device if neccessary
 		pathTwo = IPath.fromOSString(pathTwo.toFile().getAbsolutePath());
 
-		try {
-			manager.setValue("one", pathOne);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
-		try {
-			manager.setValue("two", pathTwo);
-		} catch (CoreException e) {
-			fail("0.2", e);
-		}
-
-		try {
-			manager.setValue("three", IPath.fromOSString("${two}/extra"));
-		} catch (CoreException e) {
-			fail("0.3", e);
-		}
+		manager.setValue("one", pathOne);
+		manager.setValue("two", pathTwo);
+		manager.setValue("three", IPath.fromOSString("${two}/extra"));
 
 		IPath path = IPath.fromOSString("three/bar");
 		IPath expected = IPath.fromOSString("/tmp/backup/extra/bar").setDevice(WINDOWS ? "c:" : null);
@@ -419,25 +351,17 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Test IPathVariableManager#resolvePath
 	 */
-	public void testResolvePath() {
+	public void testResolvePath() throws CoreException {
 		final boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("C:/testGetSetValue/foo") : IPath.fromOSString("/testGetSetValue/foo");
 		IPath pathTwo = IPath.fromOSString("/blort/backup");
 		//add device if necessary
 		pathTwo = IPath.fromOSString(pathTwo.toFile().getAbsolutePath());
 
-		try {
-			// for WINDOWS - the device id for windows will be changed to upper case
-			// in the variable stored in the manager
-			manager.setValue("one", pathOne);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
-		try {
-			manager.setValue("two", pathTwo);
-		} catch (CoreException e) {
-			fail("0.2", e);
-		}
+		// for WINDOWS - the device id for windows will be changed to upper case
+		// in the variable stored in the manager
+		manager.setValue("one", pathOne);
+		manager.setValue("two", pathTwo);
 
 		// one substitution
 		IPath path = IPath.fromOSString("one/bar");
@@ -500,113 +424,60 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Test IPathVariableManager#convertToRelative()
 	 */
-	public void testConvertToRelative() {
+	public void testConvertToRelative() throws CoreException {
 		final boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("c:/foo/bar") : IPath.fromOSString("/foo/bar");
 		IPath pathTwo = WINDOWS ? IPath.fromOSString("c:/foo/other") : IPath.fromOSString("/foo/other");
 		IPath pathThree = WINDOWS ? IPath.fromOSString("c:/random/other/subpath") : IPath.fromOSString("/random/other/subpath");
 		IPath file = WINDOWS ? IPath.fromOSString("c:/foo/other/file.txt") : IPath.fromOSString("/foo/other/file.txt");
 
-		try {
-			manager.setValue("ONE", pathOne);
-			manager.setValue("THREE", pathThree);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
+		manager.setValue("ONE", pathOne);
+		manager.setValue("THREE", pathThree);
 
-		IPath actual = null;
-		try {
-			actual = convertToRelative(manager, file, false, "ONE");
-		} catch (CoreException e) {
-			fail("0.2", e);
-		}
+		IPath actual = convertToRelative(manager, file, false, "ONE");
 		IPath expected = file;
 		assertEquals("1.0", expected, actual);
 
-		try {
-			manager.setValue("TWO", pathTwo);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		manager.setValue("TWO", pathTwo);
+		actual = convertToRelative(manager, file, false, "ONE");
 
-		try {
-			actual = convertToRelative(manager, file, false, "ONE");
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
 		expected = file;
 		assertEquals("2.0", expected, actual);
 
-		try {
-			actual = convertToRelative(manager, file, false, "TWO");
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		actual = convertToRelative(manager, file, false, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
 		assertEquals("3.0", expected, actual);
 
 		// force the path to be relative to "ONE"
-		try {
-			actual = convertToRelative(manager, file, true, "ONE");
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		actual = convertToRelative(manager, file, true, "ONE");
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
 		assertEquals("4.0", expected, actual);
 
 		// the second time should be re-using "FOO"
-		try {
-			actual = convertToRelative(manager, file, true, "ONE");
-		} catch (CoreException e) {
-			fail("4.3", e);
-		}
+		actual = convertToRelative(manager, file, true, "ONE");
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
 		assertEquals("5.0", expected, actual);
 
-		try {
-			actual = convertToRelative(manager, file, true, "TWO");
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		actual = convertToRelative(manager, file, true, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
 		assertEquals("6.0", expected, actual);
 
-		try {
-			actual = convertToRelative(manager, file, true, "TWO");
-		} catch (CoreException e) {
-			fail("6.1", e);
-		}
+		actual = convertToRelative(manager, file, true, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
 		assertEquals("7.0", expected, actual);
 
-		try {
-			actual = convertToRelative(manager, file, false, null);
-		} catch (CoreException e) {
-			fail("7.1", e);
-		}
+		actual = convertToRelative(manager, file, false, null);
 		expected = IPath.fromOSString("TWO/file.txt");
 		assertEquals("8.0", expected, actual);
 
-		try {
-			manager.setValue("TWO", (IPath) null);
-		} catch (CoreException e) {
-			fail("8.1", e);
-		}
+		manager.setValue("TWO", (IPath) null);
 
 		// now without any direct reference
-		try {
-			actual = convertToRelative(manager, file, false, null);
-		} catch (CoreException e) {
-			fail("8.2", e);
-		}
+		actual = convertToRelative(manager, file, false, null);
 		expected = file;
 		assertEquals("9.0", expected, actual);
 
-		try {
-			actual = convertToRelative(manager, file, true, null);
-		} catch (CoreException e) {
-			fail("9.1", e);
-		}
+		actual = convertToRelative(manager, file, true, null);
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
 		assertEquals("10.0", expected, actual);
 	}
@@ -637,22 +508,14 @@ public class IPathVariableTest extends ResourceTest {
 	public void testEmptyURIResolution() {
 		IPath path = IPath.fromOSString(new String());
 		URI uri = URIUtil.toURI(path);
-		try {
-			manager.resolveURI(uri);
-		} catch (Throwable e) {
-			fail("1.2", e);
-		}
-		try {
-			getWorkspace().getPathVariableManager().resolveURI(uri);
-		} catch (Throwable e) {
-			fail("1.2", e);
-		}
+		manager.resolveURI(uri);
+		getWorkspace().getPathVariableManager().resolveURI(uri);
 	}
 
 	/**
 	 * Test IPathVariableManager#addChangeListener and IPathVariableManager#removeChangeListener
 	 */
-	public void testListeners() {
+	public void testListeners() throws Exception {
 		PathVariableChangeVerifier listener = new PathVariableChangeVerifier();
 		manager.addChangeListener(listener);
 		IPath pathOne = IPath.fromOSString("/blort/foobar");
@@ -661,48 +524,22 @@ public class IPathVariableTest extends ResourceTest {
 		IPath pathOneEdit = pathOne.append("myworld");
 
 		try {
-
 			// add a variable
-			try {
-				manager.setValue("one", pathOne);
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+			manager.setValue("one", pathOne);
 			listener.addExpectedEvent(IPathVariableChangeEvent.VARIABLE_CREATED, "one", pathOne);
-			try {
-				listener.verify();
-			} catch (PathVariableChangeVerifier.VerificationFailedException e) {
-				fail("1.1", e);
-			}
+			listener.verify();
 
 			// change a variable
 			listener.reset();
-			try {
-				manager.setValue("one", pathOneEdit);
-			} catch (CoreException e) {
-				fail("2.0", e);
-			}
+			manager.setValue("one", pathOneEdit);
 			listener.addExpectedEvent(IPathVariableChangeEvent.VARIABLE_CHANGED, "one", pathOneEdit);
-			try {
-				listener.verify();
-			} catch (PathVariableChangeVerifier.VerificationFailedException e) {
-				fail("2.1", e);
-			}
+			listener.verify();
 
 			// remove a variable
 			listener.reset();
-			try {
-				manager.setValue("one", (IPath) null);
-			} catch (CoreException e) {
-				fail("3.0", e);
-			}
+			manager.setValue("one", (IPath) null);
 			listener.addExpectedEvent(IPathVariableChangeEvent.VARIABLE_DELETED, "one", null);
-			try {
-				listener.verify();
-			} catch (PathVariableChangeVerifier.VerificationFailedException e) {
-				fail("3.1", e);
-			}
-
+			listener.verify();
 		} finally {
 			manager.removeChangeListener(listener);
 		}
@@ -732,7 +569,7 @@ public class IPathVariableTest extends ResourceTest {
 	/**
 	 * Regression for Bug 308975 - Can't recover from 'invalid' path variable
 	 */
-	public void testLinkExistInProjectDescriptionButNotInWorkspace() {
+	public void testLinkExistInProjectDescriptionButNotInWorkspace() throws Exception {
 		String dorProjectContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + //
 				"<projectDescription>" + //
 				"<name>ExistingProject</name>" + //
@@ -755,29 +592,21 @@ public class IPathVariableTest extends ResourceTest {
 
 		ensureExistsInWorkspace(new IResource[] {existingProject}, true);
 
-		try {
-			existingProject.close(getMonitor());
-			ProjectInfo info = (ProjectInfo) ((Project) existingProject).getResourceInfo(false, false);
-			info.clear(ICoreConstants.M_USED);
-			String dotProjectPath = existingProject.getLocation().append(".project").toOSString();
-			FileWriter fstream = new FileWriter(dotProjectPath);
-			try (BufferedWriter out = new BufferedWriter(fstream)) {
-				out.write(dorProjectContent);
-			}
-			existingProject.open(getMonitor());
-		} catch (CoreException | IOException e) {
-			fail("1.99", e);
+		existingProject.close(getMonitor());
+		ProjectInfo info = (ProjectInfo) ((Project) existingProject).getResourceInfo(false, false);
+		info.clear(ICoreConstants.M_USED);
+		String dotProjectPath = existingProject.getLocation().append(".project").toOSString();
+		FileWriter fstream = new FileWriter(dotProjectPath);
+		try (BufferedWriter out = new BufferedWriter(fstream)) {
+			out.write(dorProjectContent);
 		}
+		existingProject.open(getMonitor());
 
 		IPathVariableManager pathVariableManager = existingProject.getPathVariableManager();
 		String[] varNames = pathVariableManager.getPathVariableNames();
 
 		for (String varName : varNames) {
-			try {
-				pathVariableManager.getURIValue(varName);
-			} catch (Exception e) {
-				fail("3.99", e);
-			}
+			pathVariableManager.getURIValue(varName);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -17,8 +17,6 @@ package org.eclipse.core.tests.resources;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
-import java.util.HashSet;
-import java.util.Set;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
@@ -51,7 +49,8 @@ import org.osgi.service.prefs.Preferences;
 public class IProjectTest extends ResourceTest {
 	private final FussyProgressMonitor monitor = new FussyProgressMonitor();
 
-	public void ensureExistsInWorkspace(final IProject project, final IProjectDescription description) {
+	public void ensureExistsInWorkspace(final IProject project, final IProjectDescription description)
+			throws CoreException {
 		if (project == null) {
 			return;
 		}
@@ -59,13 +58,9 @@ public class IProjectTest extends ResourceTest {
 			project.create(description, mon);
 			project.open(mon);
 		};
-		try {
-			monitor.prepare();
-			getWorkspace().run(body, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("#ensureExistsInWorkspace(IProject, IProjectDescription): " + project.getFullPath(), e);
-		}
+		monitor.prepare();
+		getWorkspace().run(body, monitor);
+		monitor.assertUsedUp();
 	}
 
 	public void setGetPersistentProperty(IResource target) throws CoreException {
@@ -190,7 +185,7 @@ public class IProjectTest extends ResourceTest {
 	/**
 	 * Tests creation and manipulation of projects names that are reserved on some platforms.
 	 */
-	public void testInvalidProjectNames() {
+	public void testInvalidProjectNames() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 
 		//should not be able to create a project with invalid path on any platform
@@ -207,17 +202,14 @@ public class IProjectTest extends ResourceTest {
 		for (String name : names) {
 			IProject project = root.getProject(name);
 			assertFalse("1.0 " + name, project.exists());
-			try {
+			assertThrows(CoreException.class, () -> {
 				monitor.prepare();
 				project.create(monitor);
 				monitor.assertUsedUp();
 				monitor.prepare();
 				project.open(monitor);
 				monitor.assertUsedUp();
-				fail("1.1 " + name);
-			} catch (CoreException e) {
-				// expected
-			}
+			});
 			assertFalse("1.2 " + name, project.exists());
 			assertFalse("1.3 " + name, project.isOpen());
 		}
@@ -233,16 +225,12 @@ public class IProjectTest extends ResourceTest {
 		for (String name : names) {
 			IProject project = root.getProject(name);
 			assertFalse("2.0 " + name, project.exists());
-			try {
-				monitor.prepare();
-				project.create(monitor);
-				monitor.assertUsedUp();
-				monitor.prepare();
-				project.open(monitor);
-				monitor.assertUsedUp();
-			} catch (CoreException e) {
-				fail("2.1 " + name, e);
-			}
+			monitor.prepare();
+			project.create(monitor);
+			monitor.assertUsedUp();
+			monitor.prepare();
+			project.open(monitor);
+			monitor.assertUsedUp();
 			assertTrue("2.2 " + name, project.exists());
 			assertTrue("2.3 " + name, project.isOpen());
 		}
@@ -410,14 +398,11 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(new IResource[] {project, destProject}, true);
 		ensureExistsInWorkspace(resources, true);
 		assertDoesNotExistInWorkspace("3.0", destination);
-		try {
-			monitor.prepare();
-			source.copy(destination.getFullPath(), true, monitor);
-			monitor.assertUsedUp();
-			fail("3.1");
-		} catch (CoreException e) {
-			// expected
-		}
+
+		monitor.prepare();
+		IResource projectToCopy = source;
+		IResource destinationFolder = destination;
+		assertThrows(CoreException.class, () -> projectToCopy.copy(destinationFolder.getFullPath(), true, monitor));
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);
 		monitor.assertUsedUp();
@@ -432,14 +417,12 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(resources, true);
 		assertDoesNotExistInWorkspace("4.0", destination);
-		try {
-			monitor.prepare();
-			source.copy(destination.getFullPath(), true, monitor);
-			monitor.assertUsedUp();
-			fail("4.1");
-		} catch (CoreException e) {
-			// expected
-		}
+
+		monitor.prepare();
+		IResource folderToCopy = source;
+		IResource destinationProject = destination;
+		assertThrows(CoreException.class, () -> folderToCopy.copy(destinationProject.getFullPath(), true, monitor));
+
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(true, monitor);
@@ -616,44 +599,35 @@ public class IProjectTest extends ResourceTest {
 	/**
 	 * Tests creating a project whose location already exists with different case
 	 */
-	public void testProjectCreationLocationExistsWithDifferentCase() {
-		if (OS.isWindows()) {
-			String projectName = getUniqueString() + "a";
-			IProject project = getWorkspace().getRoot().getProject(projectName);
-
-			try {
-				project.create(monitor);
-				monitor.assertUsedUp();
-				monitor.prepare();
-				project.delete(false, true, monitor);
-				monitor.assertUsedUp();
-			} catch (CoreException ex) {
-				fail("1.0");
-			}
-
-			// the attempt to create a project in an already existing location with different case
-			project = getWorkspace().getRoot().getProject(projectName.toUpperCase());
-
-			try {
-				monitor.prepare();
-				project.create(monitor);
-				monitor.assertUsedUp();
-				fail("2.0");
-			} catch (CoreException e) {
-				//expected
-			}
-
-			// the attempt to create a project in an already existing location with the same case
-			project = getWorkspace().getRoot().getProject(projectName);
-
-			try {
-				monitor.prepare();
-				project.create(monitor);
-				monitor.assertUsedUp();
-			} catch (CoreException e) {
-				fail("3.0", e);
-			}
+	public void testProjectCreationLocationExistsWithDifferentCase() throws CoreException {
+		if (!OS.isWindows()) {
+			return;
 		}
+
+		String projectName = getUniqueString() + "a";
+		IProject project = getWorkspace().getRoot().getProject(projectName);
+
+		project.create(monitor);
+		monitor.assertUsedUp();
+		monitor.prepare();
+		project.delete(false, true, monitor);
+		monitor.assertUsedUp();
+
+		// the attempt to create a project in an already existing location with
+		// different case
+		IProject uppercaseProject = getWorkspace().getRoot().getProject(projectName.toUpperCase());
+
+		monitor.prepare();
+		assertThrows(CoreException.class, () -> uppercaseProject.create(monitor));
+		monitor.assertUsedUp();
+
+		// the attempt to create a project in an already existing location with the same
+		// case
+		project = getWorkspace().getRoot().getProject(projectName);
+
+		monitor.prepare();
+		project.create(monitor);
+		monitor.assertUsedUp();
 	}
 
 	/**
@@ -2106,22 +2080,19 @@ public class IProjectTest extends ResourceTest {
 		IPath location = root.append("%20foo bar");
 		IProjectDescription desc = getWorkspace().newProjectDescription(project1.getName());
 		desc.setLocation(location);
-		try {
-			project1.create(desc, monitor);
-			monitor.assertUsedUp();
-			project1.open(null);
+		project1.create(desc, monitor);
+		deleteOnTearDown(location);
+		monitor.assertUsedUp();
+		project1.open(null);
 
-			assertTrue("1.0", project1.exists());
-			assertTrue("1.1", project1.isAccessible());
-			assertEquals("1.2", location, project1.getLocation());
-			assertEquals("1.3", location, project1.getRawLocation());
+		assertTrue("1.0", project1.exists());
+		assertTrue("1.1", project1.isAccessible());
+		assertEquals("1.2", location, project1.getLocation());
+		assertEquals("1.3", location, project1.getRawLocation());
 
-			monitor.prepare();
-			project1.delete(IResource.FORCE, monitor);
-			monitor.assertUsedUp();
-		} finally {
-			Workspace.clear(location.toFile());
-		}
+		monitor.prepare();
+		project1.delete(IResource.FORCE, monitor);
+		monitor.assertUsedUp();
 	}
 
 	public void testProjectMoveContent() throws CoreException {
@@ -2130,35 +2101,28 @@ public class IProjectTest extends ResourceTest {
 		IResource[] resources = buildResources(project, children);
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(resources, true);
-		Set<IPath> pathsToDelete = new HashSet<>(5);
 
-		try {
-			// move the project content
-			IProjectDescription destination = project.getDescription();
-			IPath oldPath = project.getLocation();
-			IPath newPath = getTempDir().append(Long.toString(System.currentTimeMillis()));
-			pathsToDelete.add(newPath);
-			destination.setLocation(newPath);
-			monitor.prepare();
-			project.move(destination, false, monitor);
-			monitor.assertUsedUp();
-			newPath = project.getLocation();
+		// move the project content
+		IProjectDescription destination = project.getDescription();
+		IPath oldPath = project.getLocation();
+		IPath newPath = getTempDir().append(Long.toString(System.currentTimeMillis()));
+		deleteOnTearDown(newPath);
+		destination.setLocation(newPath);
+		monitor.prepare();
+		project.move(destination, false, monitor);
+		monitor.assertUsedUp();
+		newPath = project.getLocation();
 
-			// ensure that the new description was set correctly and the locations
-			// aren't the same
-			assertFalse("2.0", oldPath.equals(newPath));
+		// ensure that the new description was set correctly and the locations
+		// aren't the same
+		assertFalse("2.0", oldPath.equals(newPath));
 
-			// make sure all the resources still exist.
-			IResourceVisitor visitor = resource -> {
-				assertExistsInWorkspace("2.1." + resource.getFullPath(), resource);
-				return true;
-			};
-			getWorkspace().getRoot().accept(visitor);
-		} finally {
-			for (IPath path : pathsToDelete) {
-				Workspace.clear(path.toFile());
-			}
-		}
+		// make sure all the resources still exist.
+		IResourceVisitor visitor = resource -> {
+			assertExistsInWorkspace("2.1." + resource.getFullPath(), resource);
+			return true;
+		};
+		getWorkspace().getRoot().accept(visitor);
 	}
 
 	public void testProjectMoveVariations() throws CoreException {
@@ -2269,63 +2233,56 @@ public class IProjectTest extends ResourceTest {
 
 	public void testProjectMoveVariations_bug307140() throws CoreException {
 		// Test moving project to its subfolder
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
-		IProjectDescription description;
-		project.create(monitor);
+		IProject originalProject = getWorkspace().getRoot().getProject(getUniqueString());
+		originalProject.create(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		project.open(monitor);
+		originalProject.open(monitor);
 		monitor.assertUsedUp();
 
-		IPath originalLocation = project.getLocation();
-		IFolder subFolder = project.getFolder(getUniqueString());
+		IPath originalLocation = originalProject.getLocation();
+		IFolder originalProjectSubFolder = originalProject.getFolder(getUniqueString());
 
-		try {
-			description = project.getDescription();
-			description.setLocation(subFolder.getLocation());
+		assertThrows(CoreException.class, () -> {
+			IProjectDescription originalDescription = originalProject.getDescription();
+			originalDescription.setLocation(originalProjectSubFolder.getLocation());
 			monitor.prepare();
-			project.move(description, true, monitor);
+			originalProject.move(originalDescription, true, monitor);
 			monitor.assertUsedUp();
-			fail("2.0");
-		} catch (CoreException e) {
-			//should be thrown
-		}
+		});
 
-		assertEquals("3.0", originalLocation, project.getLocation());
+		assertEquals("3.0", originalLocation, originalProject.getLocation());
 
 		//cleanup
-			monitor.prepare();
-			getWorkspace().getRoot().delete(false, monitor);
-			monitor.assertUsedUp();
+		monitor.prepare();
+		getWorkspace().getRoot().delete(false, monitor);
+		monitor.assertUsedUp();
 
 		// Test moving project to its subfolder - project at non-default location
-		project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject destinationProject = getWorkspace().getRoot().getProject(getUniqueString());
 
 		//location outside the workspace
-		description = getWorkspace().newProjectDescription(project.getName());
-		description.setLocation(getRandomLocation());
+		IProjectDescription newDescription = getWorkspace().newProjectDescription(destinationProject.getName());
+		newDescription.setLocation(getRandomLocation());
 		monitor.prepare();
-		project.create(description, monitor);
+		destinationProject.create(newDescription, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		project.open(monitor);
+		destinationProject.open(monitor);
 		monitor.assertUsedUp();
 
-		originalLocation = project.getLocation();
-		subFolder = project.getFolder(getUniqueString());
+		IPath destinationLocation = destinationProject.getLocation();
+		IFolder destinationProjectSubFolder = destinationProject.getFolder(getUniqueString());
 
-		try {
-			description = project.getDescription();
-			description.setLocation(subFolder.getLocation());
+		assertThrows(CoreException.class, () ->  {
+			IProjectDescription destinationDescription = destinationProject.getDescription();
+			destinationDescription.setLocation(destinationProjectSubFolder.getLocation());
 			monitor.prepare();
-			project.move(description, true, monitor);
+			destinationProject.move(destinationDescription, true, monitor);
 			monitor.assertUsedUp();
-			fail("6.0");
-		} catch (CoreException e) {
-			//should be thrown
-		}
+		});
 
-		assertEquals("7.0", originalLocation, project.getLocation());
+		assertEquals("7.0", destinationLocation, destinationProject.getLocation());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -13,7 +13,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IMarkerDelta;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -60,17 +68,13 @@ public class IResourceChangeEventTest extends ResourceTest {
 			marker2 = file2.createMarker(IMarker.BOOKMARK);
 			marker3 = file3.createMarker(IMarker.BOOKMARK);
 		};
-		try {
-			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().run(body, getMonitor());
 	}
 
 	/**
 	 * Tests the IResourceChangeEvent#findMarkerDeltas method.
 	 */
-	public void testFindMarkerDeltas() {
+	public void testFindMarkerDeltas() throws CoreException {
 		/*
 		 * The following changes will occur:
 		 * - add marker1
@@ -118,14 +122,12 @@ public class IResourceChangeEventTest extends ResourceTest {
 		};
 		try {
 			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("Exception1", e);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
 	}
 
-	public void testFindMarkerDeltasInEmptyDelta() {
+	public void testFindMarkerDeltasInEmptyDelta() throws CoreException {
 		/*
 		 * The following changes will occur:
 		 * - change file1
@@ -171,8 +173,6 @@ public class IResourceChangeEventTest extends ResourceTest {
 		//do the work
 		try {
 			file1.setContents(getRandomContents(), true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("Exception2", e);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}


### PR DESCRIPTION
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Adds missing try-with-resources blocks

This PR includes the following classes:
* `HistoryStoreTest`
* `ContentDescriptionManagerTest`
* `FilteredResourceTest`
* `HiddenResourceTest`
* `IFolderTest`
* `IPathVariableTest`
* `IProjectDescriptionTest`
* `IProjectTest`
* `IResourceChangeEvenTest`

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.