### PR TITLE
Cleanup and simplify several resource tests 2

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.IFileSystem;
@@ -31,40 +33,18 @@ import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
  * the local file system.
  */
 public class NonLocalLinkedResourceTest extends ResourceTest {
-	private int nextFolder = 0;
-
 	/**
 	 * Creates a folder in the test file system with the given name
 	 */
-	protected IFileStore createFolderStore(String name) {
+	protected IFileStore createFolderStore(String name) throws CoreException {
 		IFileSystem system = getFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
-		try {
-			store.mkdir(EFS.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("createFolderStore", e);
-		}
+		store.mkdir(EFS.NONE, getMonitor());
 		return store;
 	}
 
-	protected IFileSystem getFileSystem() {
-		try {
-			return EFS.getFileSystem(MemoryFileSystem.SCHEME_MEMORY);
-		} catch (CoreException e) {
-			fail("Test file system missing", e);
-		}
-		//can't get here
-		return null;
-	}
-
-	@Override
-	protected IFileStore getTempStore() {
-		IFileSystem system = getFileSystem();
-		IFileStore store;
-		do {
-			store = system.getStore(IPath.ROOT.append(Integer.toString(nextFolder++)));
-		} while (store.fetchInfo().exists());
-		return store;
+	protected IFileSystem getFileSystem() throws CoreException {
+		return EFS.getFileSystem(MemoryFileSystem.SCHEME_MEMORY);
 	}
 
 	@Override
@@ -73,7 +53,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		super.tearDown();
 	}
 
-	public void testCopyFile() {
+	public void testCopyFile() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IFileStore destinationStore = createFolderStore("destination");
 		IProject project = getWorkspace().getRoot().getProject("project");
@@ -85,45 +65,24 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		try {
-			source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-			destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-			sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
 
 		//copy to linked destination should succeed
-		try {
-			sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
 		//copy to local destination should succeed
-		try {
-			sourceFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		sourceFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
 		//copy from local to non local
 		ensureDoesNotExistInWorkspace(destinationFile);
 		//copy from local to non local
-		try {
-			localFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		localFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
 
 		//copy to self should fail
-		try {
-			localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
-			fail("4.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor()));
 	}
 
-	public void testCopyFolder() {
+	public void testCopyFolder() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IProject project = getWorkspace().getRoot().getProject("project");
 		IFolder parentFolder = project.getFolder("parent");
@@ -132,48 +91,26 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		try {
-			parentFolder.create(IResource.NONE, true, getMonitor());
-			source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		parentFolder.create(IResource.NONE, true, getMonitor());
+		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
 
 		//shallow copy to destination should succeed
-		try {
-			source.copy(destination.getFullPath(), IResource.SHALLOW, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		source.copy(destination.getFullPath(), IResource.SHALLOW, getMonitor());
 		assertTrue("1.1", destination.exists());
 
 		//deep copy to destination should succeed
-		try {
-			destination.delete(IResource.NONE, getMonitor());
-			source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		destination.delete(IResource.NONE, getMonitor());
+		source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
 		assertTrue("2.1", destination.exists());
 
 		//should fail when destination is occupied
-		try {
-			source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
-			fail("3.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> source.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
 
 		//copy to self should fail
-		try {
-			source.copy(source.getFullPath(), IResource.NONE, getMonitor());
-			fail("4.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> source.copy(source.getFullPath(), IResource.NONE, getMonitor()));
 	}
 
-	public void testMoveFile() {
+	public void testMoveFile() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IFileStore destinationStore = createFolderStore("destination");
 		IProject project = getWorkspace().getRoot().getProject("project");
@@ -185,52 +122,28 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		try {
-			source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-			destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-			sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
 
 		//move to linked destination should succeed
-		try {
-			sourceFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		sourceFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
 		//move back to source location
 		//move to linked destination should succeed
-		try {
-			destinationFile.move(sourceFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		destinationFile.move(sourceFile.getFullPath(), IResource.NONE, getMonitor());
 
 		//move to local destination should succeed
-		try {
-			sourceFile.move(localFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		sourceFile.move(localFile.getFullPath(), IResource.NONE, getMonitor());
+
 		//movefrom local to non local
-		try {
-			localFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		localFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
 
 		//copy to self should fail
-		try {
-			localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
-			fail("4.0");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor()));
 	}
 
 	// Test for Bug 342060 - Renaming a project failing with custom EFS
-	public void test342060() {
+	public void test342060() throws CoreException {
 		IFileStore sourceStore = createBogusFolderStore("source");
 		IFileStore destinationStore = createBogusFolderStore("destination");
 		IProject project = getWorkspace().getRoot().getProject("project");
@@ -239,42 +152,24 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFile sourceFile = source.getFile("file.txt");
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		try {
-			source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-			destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-			sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
 
 		//move to linked destination should succeed
-		try {
-			project.move(IPath.fromPortableString("movedProject"), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.move(IPath.fromPortableString("movedProject"), IResource.NONE, getMonitor());
 	}
 
-	protected IFileStore createBogusFolderStore(String name) {
+	protected IFileStore createBogusFolderStore(String name) throws CoreException {
 		IFileSystem system = getBogusFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
-		try {
-			deleteOnTearDown(
+		deleteOnTearDown(
 					IPath.fromOSString(system.getStore(IPath.ROOT).toLocalFile(EFS.NONE, getMonitor()).getPath()));
-			store.mkdir(EFS.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("createFolderStore", e);
-		}
+		store.mkdir(EFS.NONE, getMonitor());
 		return store;
 	}
 
-	protected IFileSystem getBogusFileSystem() {
-		try {
-			return EFS.getFileSystem(BogusFileSystem.SCHEME_BOGUS);
-		} catch (CoreException e) {
-			fail("Test file system missing", e);
-		}
-		//can't get here
-		return null;
+	protected IFileSystem getBogusFileSystem() throws CoreException {
+		return EFS.getFileSystem(BogusFileSystem.SCHEME_BOGUS);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
@@ -14,8 +14,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import java.util.*;
-import org.eclipse.core.resources.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -34,26 +41,22 @@ public class ProjectOrderTest extends ResourceTest {
 	 * @param source the source project; must be accessible
 	 * @param target the target project; need not be accessible
 	 */
-	void addProjectReference(IProject source, IProject target) {
-		try {
-			IProjectDescription pd = source.getDescription();
-			IProject[] a = pd.getReferencedProjects();
-			Set<IProject> x = new HashSet<>();
-			x.addAll(Arrays.asList(a));
-			x.add(target);
-			IProject[] r = new IProject[x.size()];
-			x.toArray(r);
-			pd.setReferencedProjects(r);
-			source.setDescription(pd, null);
-		} catch (CoreException e) {
-			assertTrue("", false);
-		}
+	void addProjectReference(IProject source, IProject target) throws CoreException {
+		IProjectDescription pd = source.getDescription();
+		IProject[] a = pd.getReferencedProjects();
+		Set<IProject> x = new HashSet<>();
+		x.addAll(Arrays.asList(a));
+		x.add(target);
+		IProject[] r = new IProject[x.size()];
+		x.toArray(r);
+		pd.setReferencedProjects(r);
+		source.setDescription(pd, null);
 	}
 
 	/**
 	 * P0, P1&lt;-P2&lt;-P3&lt;-P4, P5
 	 */
-	public void test0() {
+	public void test0() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();
 		IProject p0 = root.getProject("p0");
@@ -63,52 +66,48 @@ public class ProjectOrderTest extends ResourceTest {
 		IProject p4 = root.getProject("p4");
 		IProject p5 = root.getProject("p5");
 
-		try {
-			p0.create(null);
-			p0.open(null);
-			p1.create(null);
-			p1.open(null);
-			p2.create(null);
-			p2.open(null);
-			p3.create(null);
-			p3.open(null);
-			p4.create(null);
-			p4.open(null);
-			p5.create(null);
-			p5.open(null);
+		p0.create(null);
+		p0.open(null);
+		p1.create(null);
+		p1.open(null);
+		p2.create(null);
+		p2.open(null);
+		p3.create(null);
+		p3.open(null);
+		p4.create(null);
+		p4.open(null);
+		p5.create(null);
+		p5.open(null);
 
-			addProjectReference(p2, p1);
-			addProjectReference(p3, p2);
-			addProjectReference(p4, p3);
+		addProjectReference(p2, p1);
+		addProjectReference(p3, p2);
+		addProjectReference(p4, p3);
 
-			IProject[] projects = new IProject[] {p4, p3, p2, p5, p1, p0};
-			IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
-			assertTrue("0.1", oldOrder[1].length == 0);
-			List<IProject> x = Arrays.asList(oldOrder[0]);
-			assertTrue("0.2", x.size() == 6);
-			assertTrue("0.3", x.indexOf(p0) >= 0);
-			assertTrue("0.4", x.indexOf(p1) >= 0);
-			assertTrue("0.5", x.indexOf(p5) >= 0);
-			assertTrue("0.6", x.indexOf(p2) > x.indexOf(p1));
-			assertTrue("0.7", x.indexOf(p3) > x.indexOf(p2));
-			assertTrue("0.8", x.indexOf(p4) > x.indexOf(p3));
+		IProject[] projects = new IProject[] { p4, p3, p2, p5, p1, p0 };
+		IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
+		assertTrue("0.1", oldOrder[1].length == 0);
+		List<IProject> x = Arrays.asList(oldOrder[0]);
+		assertTrue("0.2", x.size() == 6);
+		assertTrue("0.3", x.indexOf(p0) >= 0);
+		assertTrue("0.4", x.indexOf(p1) >= 0);
+		assertTrue("0.5", x.indexOf(p5) >= 0);
+		assertTrue("0.6", x.indexOf(p2) > x.indexOf(p1));
+		assertTrue("0.7", x.indexOf(p3) > x.indexOf(p2));
+		assertTrue("0.8", x.indexOf(p4) > x.indexOf(p3));
 
-			IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("0.9", !order.hasCycles);
-			assertTrue("0.10", order.knots.length == 0);
-			assertTrue("0.11", x.size() == 6);
-			assertTrue("0.12", x.indexOf(p0) < x.indexOf(p1)); //alpha
-			assertTrue("0.13", x.indexOf(p2) > x.indexOf(p1)); //ref
-			assertTrue("0.14", x.indexOf(p3) > x.indexOf(p2)); //ref
-			assertTrue("0.15", x.indexOf(p4) > x.indexOf(p3)); //ref
-			assertTrue("0.16", x.indexOf(p5) > x.indexOf(p4)); //alpha
-		} catch (CoreException e) {
-			assertTrue("0.0", false);
-		}
+		IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("0.9", !order.hasCycles);
+		assertTrue("0.10", order.knots.length == 0);
+		assertTrue("0.11", x.size() == 6);
+		assertTrue("0.12", x.indexOf(p0) < x.indexOf(p1)); // alpha
+		assertTrue("0.13", x.indexOf(p2) > x.indexOf(p1)); // ref
+		assertTrue("0.14", x.indexOf(p3) > x.indexOf(p2)); // ref
+		assertTrue("0.15", x.indexOf(p4) > x.indexOf(p3)); // ref
+		assertTrue("0.16", x.indexOf(p5) > x.indexOf(p4)); // alpha
 	}
 
-	public void test1() {
+	public void test1() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();
 		IProject p0 = root.getProject("p0");
@@ -128,277 +127,257 @@ public class ProjectOrderTest extends ResourceTest {
 		assertTrue("1.5", x.isEmpty());
 
 		// 1 project
-		try {
-			// open projects show up
-			p0.create(null);
-			p0.open(null);
-			projects = new IProject[] {p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.6.1", oldOrder[1].length == 0);
-			assertTrue("1.6.2", x.size() == 1);
-			assertTrue("1.6.3", x.indexOf(p0) >= 0);
+		// open projects show up
+		p0.create(null);
+		p0.open(null);
+		projects = new IProject[] { p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.6.1", oldOrder[1].length == 0);
+		assertTrue("1.6.2", x.size() == 1);
+		assertTrue("1.6.3", x.indexOf(p0) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.6.4", !order.hasCycles);
-			assertTrue("1.6.5", order.knots.length == 0);
-			assertTrue("1.6.6", x.size() == 1);
-			assertTrue("1.6.7", x.indexOf(p0) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.6.4", !order.hasCycles);
+		assertTrue("1.6.5", order.knots.length == 0);
+		assertTrue("1.6.6", x.size() == 1);
+		assertTrue("1.6.7", x.indexOf(p0) >= 0);
 
-			// closed projects do not show up
-			p0.close(null);
-			projects = new IProject[] {p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.6,8", oldOrder[1].length == 0);
-			assertTrue("1.6.9", x.isEmpty());
+		// closed projects do not show up
+		p0.close(null);
+		projects = new IProject[] { p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.6,8", oldOrder[1].length == 0);
+		assertTrue("1.6.9", x.isEmpty());
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.6.10", !order.hasCycles);
-			assertTrue("1.6.11", order.knots.length == 0);
-			assertTrue("1.6.12", x.isEmpty());
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.6.10", !order.hasCycles);
+		assertTrue("1.6.11", order.knots.length == 0);
+		assertTrue("1.6.12", x.isEmpty());
 
-			// non-existent projects do not show up either
-			projects = new IProject[] {p0, p1};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.6.13", oldOrder[1].length == 0);
-			assertTrue("1.6.14", x.isEmpty());
+		// non-existent projects do not show up either
+		projects = new IProject[] { p0, p1 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.6.13", oldOrder[1].length == 0);
+		assertTrue("1.6.14", x.isEmpty());
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.6.15", !order.hasCycles);
-			assertTrue("1.6.16", order.knots.length == 0);
-			assertTrue("1.6.17", x.isEmpty());
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.6.15", !order.hasCycles);
+		assertTrue("1.6.16", order.knots.length == 0);
+		assertTrue("1.6.17", x.isEmpty());
 
-			p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-		} catch (CoreException e) {
-			assertTrue("1.6.0", false);
-		}
+		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
 		// 2 projects no references
-		try {
-			// open projects show up
-			p0.create(null);
-			p0.open(null);
-			p1.create(null);
-			p1.open(null);
+		// open projects show up
+		p0.create(null);
+		p0.open(null);
+		p1.create(null);
+		p1.open(null);
 
-			projects = new IProject[] {p1, p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.7.1", oldOrder[1].length == 0);
-			assertTrue("1.7.2", x.size() == 2);
-			assertTrue("1.7.3", x.indexOf(p0) >= 0);
-			assertTrue("1.7.4", x.indexOf(p1) >= 0);
+		projects = new IProject[] { p1, p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.7.1", oldOrder[1].length == 0);
+		assertTrue("1.7.2", x.size() == 2);
+		assertTrue("1.7.3", x.indexOf(p0) >= 0);
+		assertTrue("1.7.4", x.indexOf(p1) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.7.5", x.size() == 2);
-			assertTrue("1.7.6", x.indexOf(p0) >= 0);
-			assertTrue("1.7.7", x.indexOf(p1) >= 0);
-			// alpha order
-			assertTrue("1.7.8", x.indexOf(p0) < x.indexOf(p1));
-			assertTrue("1.7.9", !order.hasCycles);
-			assertTrue("1.7.10", order.knots.length == 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.7.5", x.size() == 2);
+		assertTrue("1.7.6", x.indexOf(p0) >= 0);
+		assertTrue("1.7.7", x.indexOf(p1) >= 0);
+		// alpha order
+		assertTrue("1.7.8", x.indexOf(p0) < x.indexOf(p1));
+		assertTrue("1.7.9", !order.hasCycles);
+		assertTrue("1.7.10", order.knots.length == 0);
 
-			// closed projects do not show up
-			p0.close(null);
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.7.11", oldOrder[1].length == 0);
-			assertTrue("1.7.12", x.size() == 1);
-			assertTrue("1.7.13", x.indexOf(p0) < 0);
-			assertTrue("1.7.14", x.indexOf(p1) >= 0);
+		// closed projects do not show up
+		p0.close(null);
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.7.11", oldOrder[1].length == 0);
+		assertTrue("1.7.12", x.size() == 1);
+		assertTrue("1.7.13", x.indexOf(p0) < 0);
+		assertTrue("1.7.14", x.indexOf(p1) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.7.15", !order.hasCycles);
-			assertTrue("1.7.16", order.knots.length == 0);
-			assertTrue("1.7.17", x.size() == 1);
-			assertTrue("1.7.18", x.indexOf(p0) < 0);
-			assertTrue("1.7.19", x.indexOf(p1) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.7.15", !order.hasCycles);
+		assertTrue("1.7.16", order.knots.length == 0);
+		assertTrue("1.7.17", x.size() == 1);
+		assertTrue("1.7.18", x.indexOf(p0) < 0);
+		assertTrue("1.7.19", x.indexOf(p1) >= 0);
 
-			p0.open(null);
-			p1.close(null);
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.7.20", oldOrder[1].length == 0);
-			assertTrue("1.7.21", x.size() == 1);
-			assertTrue("1.7.22", x.indexOf(p0) >= 0);
-			assertTrue("1.7.23", x.indexOf(p1) < 0);
+		p0.open(null);
+		p1.close(null);
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.7.20", oldOrder[1].length == 0);
+		assertTrue("1.7.21", x.size() == 1);
+		assertTrue("1.7.22", x.indexOf(p0) >= 0);
+		assertTrue("1.7.23", x.indexOf(p1) < 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.7.24", !order.hasCycles);
-			assertTrue("1.7.25", order.knots.length == 0);
-			assertTrue("1.7.26", x.size() == 1);
-			assertTrue("1.7.27", x.indexOf(p0) >= 0);
-			assertTrue("1.7.28", x.indexOf(p1) < 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.7.24", !order.hasCycles);
+		assertTrue("1.7.25", order.knots.length == 0);
+		assertTrue("1.7.26", x.size() == 1);
+		assertTrue("1.7.27", x.indexOf(p0) >= 0);
+		assertTrue("1.7.28", x.indexOf(p1) < 0);
 
-			p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-			p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-		} catch (CoreException e) {
-			assertTrue("1.7.0", false);
-		}
+		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
+		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
 		// 2 projects: "p0" refs "p1"
-		try {
-			p0.create(null);
-			p0.open(null);
-			p1.create(null);
-			p1.open(null);
-			addProjectReference(p0, p1);
+		p0.create(null);
+		p0.open(null);
+		p1.create(null);
+		p1.open(null);
+		addProjectReference(p0, p1);
 
-			projects = new IProject[] {p1, p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.8.1", oldOrder[1].length == 0);
-			assertTrue("1.8.2", x.size() == 2);
-			assertTrue("1.8.3", x.indexOf(p0) >= 0);
-			assertTrue("1.8.4", x.indexOf(p1) >= 0);
-			assertTrue("1.8.5", x.indexOf(p0) > x.indexOf(p1));
+		projects = new IProject[] { p1, p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.8.1", oldOrder[1].length == 0);
+		assertTrue("1.8.2", x.size() == 2);
+		assertTrue("1.8.3", x.indexOf(p0) >= 0);
+		assertTrue("1.8.4", x.indexOf(p1) >= 0);
+		assertTrue("1.8.5", x.indexOf(p0) > x.indexOf(p1));
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.8.6", x.size() == 2);
-			assertTrue("1.8.7", x.indexOf(p0) >= 0);
-			assertTrue("1.8.8", x.indexOf(p1) >= 0);
-			assertTrue("1.8.9", x.indexOf(p0) > x.indexOf(p1));
-			assertTrue("1.8.10", !order.hasCycles);
-			assertTrue("1.8.11", order.knots.length == 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.8.6", x.size() == 2);
+		assertTrue("1.8.7", x.indexOf(p0) >= 0);
+		assertTrue("1.8.8", x.indexOf(p1) >= 0);
+		assertTrue("1.8.9", x.indexOf(p0) > x.indexOf(p1));
+		assertTrue("1.8.10", !order.hasCycles);
+		assertTrue("1.8.11", order.knots.length == 0);
 
-			p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-			p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-		} catch (CoreException e) {
-			assertTrue("1.8.0", false);
-		}
+		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
+		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
 		// 2 projects: "p1" refs "p0"
-		try {
-			p0.create(null);
-			p0.open(null);
-			p1.create(null);
-			p1.open(null);
-			addProjectReference(p1, p0);
+		p0.create(null);
+		p0.open(null);
+		p1.create(null);
+		p1.open(null);
+		addProjectReference(p1, p0);
 
-			projects = new IProject[] {p1, p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.9.1", oldOrder[1].length == 0);
-			assertTrue("1.9.2", x.size() == 2);
-			assertTrue("1.9.3", x.indexOf(p0) >= 0);
-			assertTrue("1.9.4", x.indexOf(p1) >= 0);
-			assertTrue("1.9.5", x.indexOf(p1) > x.indexOf(p0));
+		projects = new IProject[] { p1, p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.9.1", oldOrder[1].length == 0);
+		assertTrue("1.9.2", x.size() == 2);
+		assertTrue("1.9.3", x.indexOf(p0) >= 0);
+		assertTrue("1.9.4", x.indexOf(p1) >= 0);
+		assertTrue("1.9.5", x.indexOf(p1) > x.indexOf(p0));
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.9.6", !order.hasCycles);
-			assertTrue("1.9.7", order.knots.length == 0);
-			assertTrue("1.9.8", x.size() == 2);
-			assertTrue("1.9.9", x.indexOf(p0) >= 0);
-			assertTrue("1.9.10", x.indexOf(p1) >= 0);
-			assertTrue("1.9.11", x.indexOf(p1) > x.indexOf(p0));
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.9.6", !order.hasCycles);
+		assertTrue("1.9.7", order.knots.length == 0);
+		assertTrue("1.9.8", x.size() == 2);
+		assertTrue("1.9.9", x.indexOf(p0) >= 0);
+		assertTrue("1.9.10", x.indexOf(p1) >= 0);
+		assertTrue("1.9.11", x.indexOf(p1) > x.indexOf(p0));
 
-			p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-			p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-		} catch (CoreException e) {
-			assertTrue("1.9.0", false);
-		}
+		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
+		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
 		// 2 projects: "p0" refs "p1" and "p1" refs "p0"
-		try {
-			// open projects show up
-			p0.create(null);
-			p0.open(null);
-			p1.create(null);
-			p1.open(null);
-			addProjectReference(p1, p0);
-			addProjectReference(p0, p1);
+		// open projects show up
+		p0.create(null);
+		p0.open(null);
+		p1.create(null);
+		p1.open(null);
+		addProjectReference(p1, p0);
+		addProjectReference(p0, p1);
 
-			projects = new IProject[] {p1, p0};
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			List<IProject> unordered = Arrays.asList(oldOrder[1]);
-			assertTrue("1.10.1", oldOrder[1].length == 2);
-			assertTrue("1.10.2", x.isEmpty());
-			assertTrue("1.10.3", unordered.size() == 2);
-			assertTrue("1.10.4", unordered.indexOf(p0) >= 0);
-			assertTrue("1.10.5", unordered.indexOf(p1) >= 0);
+		projects = new IProject[] { p1, p0 };
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		List<IProject> unordered = Arrays.asList(oldOrder[1]);
+		assertTrue("1.10.1", oldOrder[1].length == 2);
+		assertTrue("1.10.2", x.isEmpty());
+		assertTrue("1.10.3", unordered.size() == 2);
+		assertTrue("1.10.4", unordered.indexOf(p0) >= 0);
+		assertTrue("1.10.5", unordered.indexOf(p1) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.10.6", order.hasCycles);
-			assertTrue("1.10.7", order.knots.length == 1);
-			assertTrue("1.10.8", x.size() == 2);
-			assertTrue("1.10.9", x.indexOf(p0) >= 0);
-			assertTrue("1.10.10", x.indexOf(p1) >= 0);
-			List<IProject> knot = Arrays.asList(order.knots[0]);
-			assertTrue("1.10.11", knot.size() == 2);
-			assertTrue("1.10.12", knot.indexOf(p0) >= 0);
-			assertTrue("1.10.13", knot.indexOf(p1) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.10.6", order.hasCycles);
+		assertTrue("1.10.7", order.knots.length == 1);
+		assertTrue("1.10.8", x.size() == 2);
+		assertTrue("1.10.9", x.indexOf(p0) >= 0);
+		assertTrue("1.10.10", x.indexOf(p1) >= 0);
+		List<IProject> knot = Arrays.asList(order.knots[0]);
+		assertTrue("1.10.11", knot.size() == 2);
+		assertTrue("1.10.12", knot.indexOf(p0) >= 0);
+		assertTrue("1.10.13", knot.indexOf(p1) >= 0);
 
-			// closing one breaks the cycle
-			p0.close(null);
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.10.14", oldOrder[1].length == 0);
-			assertTrue("1.10.15", x.size() == 1);
-			assertTrue("1.10.16", x.indexOf(p1) >= 0);
+		// closing one breaks the cycle
+		p0.close(null);
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.10.14", oldOrder[1].length == 0);
+		assertTrue("1.10.15", x.size() == 1);
+		assertTrue("1.10.16", x.indexOf(p1) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.10.17", !order.hasCycles);
-			assertTrue("1.10.18", order.knots.length == 0);
-			assertTrue("1.10.19", x.size() == 1);
-			assertTrue("1.10.20", x.indexOf(p1) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.10.17", !order.hasCycles);
+		assertTrue("1.10.18", order.knots.length == 0);
+		assertTrue("1.10.19", x.size() == 1);
+		assertTrue("1.10.20", x.indexOf(p1) >= 0);
 
-			// closing other instead breaks the cycle
-			p0.open(null);
-			p1.close(null);
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			assertTrue("1.10.21", oldOrder[1].length == 0);
-			assertTrue("1.10.22", x.size() == 1);
-			assertTrue("1.10.23", x.indexOf(p0) >= 0);
+		// closing other instead breaks the cycle
+		p0.open(null);
+		p1.close(null);
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		assertTrue("1.10.21", oldOrder[1].length == 0);
+		assertTrue("1.10.22", x.size() == 1);
+		assertTrue("1.10.23", x.indexOf(p0) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.10.24", !order.hasCycles);
-			assertTrue("1.10.25", order.knots.length == 0);
-			assertTrue("1.10.26", x.size() == 1);
-			assertTrue("1.10.27", x.indexOf(p0) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.10.24", !order.hasCycles);
+		assertTrue("1.10.25", order.knots.length == 0);
+		assertTrue("1.10.26", x.size() == 1);
+		assertTrue("1.10.27", x.indexOf(p0) >= 0);
 
-			// reopening both brings back the cycle
-			p1.open(null);
-			oldOrder = ws.computePrerequisiteOrder(projects);
-			x = Arrays.asList(oldOrder[0]);
-			unordered = Arrays.asList(oldOrder[1]);
-			assertTrue("1.10.28", oldOrder[1].length == 2);
-			assertTrue("1.10.29", x.isEmpty());
-			assertTrue("1.10.30", unordered.size() == 2);
-			assertTrue("1.10.31", unordered.indexOf(p0) >= 0);
-			assertTrue("1.10.32", unordered.indexOf(p1) >= 0);
+		// reopening both brings back the cycle
+		p1.open(null);
+		oldOrder = ws.computePrerequisiteOrder(projects);
+		x = Arrays.asList(oldOrder[0]);
+		unordered = Arrays.asList(oldOrder[1]);
+		assertTrue("1.10.28", oldOrder[1].length == 2);
+		assertTrue("1.10.29", x.isEmpty());
+		assertTrue("1.10.30", unordered.size() == 2);
+		assertTrue("1.10.31", unordered.indexOf(p0) >= 0);
+		assertTrue("1.10.32", unordered.indexOf(p1) >= 0);
 
-			order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("1.10.33", order.hasCycles);
-			assertTrue("1.10.34", order.knots.length == 1);
-			assertTrue("1.10.35", x.size() == 2);
-			assertTrue("1.10.36", x.indexOf(p0) >= 0);
-			assertTrue("1.10.37", x.indexOf(p1) >= 0);
-			knot = Arrays.asList(order.knots[0]);
-			assertTrue("1.10.38", knot.size() == 2);
-			assertTrue("1.10.39", knot.indexOf(p0) >= 0);
-			assertTrue("1.10.40", knot.indexOf(p1) >= 0);
+		order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("1.10.33", order.hasCycles);
+		assertTrue("1.10.34", order.knots.length == 1);
+		assertTrue("1.10.35", x.size() == 2);
+		assertTrue("1.10.36", x.indexOf(p0) >= 0);
+		assertTrue("1.10.37", x.indexOf(p1) >= 0);
+		knot = Arrays.asList(order.knots[0]);
+		assertTrue("1.10.38", knot.size() == 2);
+		assertTrue("1.10.39", knot.indexOf(p0) >= 0);
+		assertTrue("1.10.40", knot.indexOf(p1) >= 0);
 
-			p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-			p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
-		} catch (CoreException e) {
-			assertTrue("1.10.41", false);
-		}
+		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
+		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 	}
 
 	/**
@@ -406,7 +385,7 @@ public class ProjectOrderTest extends ResourceTest {
 	 * Cormen, Leiserson, Rivest
 	 * Figure 23.9(b)
 	 */
-	public void test2() {
+	public void test2() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();
 		IProject a = root.getProject("a");
@@ -418,122 +397,118 @@ public class ProjectOrderTest extends ResourceTest {
 		IProject g = root.getProject("g");
 		IProject h = root.getProject("h");
 
-		try {
-			a.create(null);
-			a.open(null);
-			b.create(null);
-			b.open(null);
-			c.create(null);
-			c.open(null);
-			d.create(null);
-			d.open(null);
-			e.create(null);
-			e.open(null);
-			f.create(null);
-			f.open(null);
-			g.create(null);
-			g.open(null);
-			h.create(null);
-			h.open(null);
+		a.create(null);
+		a.open(null);
+		b.create(null);
+		b.open(null);
+		c.create(null);
+		c.open(null);
+		d.create(null);
+		d.open(null);
+		e.create(null);
+		e.open(null);
+		f.create(null);
+		f.open(null);
+		g.create(null);
+		g.open(null);
+		h.create(null);
+		h.open(null);
 
-			// knot 1
-			addProjectReference(b, a);
-			addProjectReference(a, e);
-			addProjectReference(e, b);
+		// knot 1
+		addProjectReference(b, a);
+		addProjectReference(a, e);
+		addProjectReference(e, b);
 
-			// knot 2
-			addProjectReference(c, d);
-			addProjectReference(d, c);
+		// knot 2
+		addProjectReference(c, d);
+		addProjectReference(d, c);
 
-			// knot 3
-			addProjectReference(f, g);
-			addProjectReference(g, f);
+		// knot 3
+		addProjectReference(f, g);
+		addProjectReference(g, f);
 
-			// self-reference
-			addProjectReference(h, h);
+		// self-reference
+		addProjectReference(h, h);
 
-			// inter-knot references
-			addProjectReference(c, b);
-			addProjectReference(f, b);
-			addProjectReference(g, c);
-			addProjectReference(h, d);
-			addProjectReference(h, g);
+		// inter-knot references
+		addProjectReference(c, b);
+		addProjectReference(f, b);
+		addProjectReference(g, c);
+		addProjectReference(h, d);
+		addProjectReference(h, g);
 
-			IProject[] projects = new IProject[] {a, b, c, d, e, f, g, h};
-			IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
-			List<IProject> x = Arrays.asList(oldOrder[0]);
-			List<IProject> unordered = Arrays.asList(oldOrder[1]);
-			assertTrue("2.1", x.size() == 1);
-			assertTrue("2.2", x.indexOf(h) >= 0);
-			assertTrue("2.3", unordered.size() == 7);
-			assertTrue("2.4", unordered.indexOf(a) >= 0);
-			assertTrue("2.5", unordered.indexOf(b) >= 0);
-			assertTrue("2.6", unordered.indexOf(c) >= 0);
-			assertTrue("2.7", unordered.indexOf(d) >= 0);
-			assertTrue("2.8", unordered.indexOf(e) >= 0);
-			assertTrue("2.9", unordered.indexOf(f) >= 0);
-			assertTrue("2.10", unordered.indexOf(g) >= 0);
+		IProject[] projects = new IProject[] { a, b, c, d, e, f, g, h };
+		IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
+		List<IProject> x = Arrays.asList(oldOrder[0]);
+		List<IProject> unordered = Arrays.asList(oldOrder[1]);
+		assertTrue("2.1", x.size() == 1);
+		assertTrue("2.2", x.indexOf(h) >= 0);
+		assertTrue("2.3", unordered.size() == 7);
+		assertTrue("2.4", unordered.indexOf(a) >= 0);
+		assertTrue("2.5", unordered.indexOf(b) >= 0);
+		assertTrue("2.6", unordered.indexOf(c) >= 0);
+		assertTrue("2.7", unordered.indexOf(d) >= 0);
+		assertTrue("2.8", unordered.indexOf(e) >= 0);
+		assertTrue("2.9", unordered.indexOf(f) >= 0);
+		assertTrue("2.10", unordered.indexOf(g) >= 0);
 
-			IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
-			x = Arrays.asList(order.projects);
-			assertTrue("2.11", x.size() == 8);
-			assertTrue("2.12", x.indexOf(a) >= 0);
-			assertTrue("2.13", x.indexOf(b) >= 0);
-			assertTrue("2.14", x.indexOf(c) >= 0);
-			assertTrue("2.15", x.indexOf(d) >= 0);
-			assertTrue("2.16", x.indexOf(e) >= 0);
-			assertTrue("2.17", x.indexOf(f) >= 0);
-			assertTrue("2.18", x.indexOf(g) >= 0);
-			assertTrue("2.19", x.indexOf(h) >= 0);
-			// {a, b, e} < {c,d} < {f, g} < {h}
-			assertTrue("2.20", x.indexOf(b) < x.indexOf(c));
-			assertTrue("2.21", x.indexOf(b) < x.indexOf(d));
-			assertTrue("2.22", x.indexOf(a) < x.indexOf(c));
-			assertTrue("2.23", x.indexOf(a) < x.indexOf(d));
-			assertTrue("2.24", x.indexOf(e) < x.indexOf(c));
-			assertTrue("2.25", x.indexOf(e) < x.indexOf(d));
-			assertTrue("2.26", x.indexOf(c) < x.indexOf(f));
-			assertTrue("2.27", x.indexOf(c) < x.indexOf(g));
-			assertTrue("2.28", x.indexOf(d) < x.indexOf(f));
-			assertTrue("2.29", x.indexOf(d) < x.indexOf(g));
-			assertTrue("2.30", x.indexOf(f) < x.indexOf(h));
-			assertTrue("2.31", x.indexOf(g) < x.indexOf(h));
-			assertTrue("2.32", order.hasCycles);
-			assertTrue("2.33", order.knots.length == 3);
-			List<IProject> k1 = Arrays.asList(order.knots[0]);
-			List<IProject> k2 = Arrays.asList(order.knots[1]);
-			List<IProject> k3 = Arrays.asList(order.knots[2]);
-			// sort 3 groups
-			if (k2.indexOf(b) >= 0) {
-				List<IProject> temp = k1;
-				k1 = k2;
-				k2 = temp;
-			} else if (k3.indexOf(b) >= 0) {
-				List<IProject> temp = k1;
-				k1 = k3;
-				k3 = temp;
-			}
-			if (k3.indexOf(c) >= 0) {
-				List<IProject> temp = k2;
-				k2 = k3;
-				k3 = temp;
-			}
-			// knot 1
-			assertTrue("2.34", k1.size() == 3);
-			assertTrue("2.35", k1.indexOf(a) >= 0);
-			assertTrue("2.36", k1.indexOf(b) >= 0);
-			assertTrue("2.37", k1.indexOf(e) >= 0);
-			// knot 2
-			assertTrue("2.38", k2.size() == 2);
-			assertTrue("2.39", k2.indexOf(c) >= 0);
-			assertTrue("2.40", k2.indexOf(d) >= 0);
-			// knot 3
-			assertTrue("2.41", k3.size() == 2);
-			assertTrue("2.42", k3.indexOf(f) >= 0);
-			assertTrue("2.43", k3.indexOf(g) >= 0);
-		} catch (CoreException ex) {
-			assertTrue("2.4.0", false);
+		IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
+		x = Arrays.asList(order.projects);
+		assertTrue("2.11", x.size() == 8);
+		assertTrue("2.12", x.indexOf(a) >= 0);
+		assertTrue("2.13", x.indexOf(b) >= 0);
+		assertTrue("2.14", x.indexOf(c) >= 0);
+		assertTrue("2.15", x.indexOf(d) >= 0);
+		assertTrue("2.16", x.indexOf(e) >= 0);
+		assertTrue("2.17", x.indexOf(f) >= 0);
+		assertTrue("2.18", x.indexOf(g) >= 0);
+		assertTrue("2.19", x.indexOf(h) >= 0);
+		// {a, b, e} < {c,d} < {f, g} < {h}
+		assertTrue("2.20", x.indexOf(b) < x.indexOf(c));
+		assertTrue("2.21", x.indexOf(b) < x.indexOf(d));
+		assertTrue("2.22", x.indexOf(a) < x.indexOf(c));
+		assertTrue("2.23", x.indexOf(a) < x.indexOf(d));
+		assertTrue("2.24", x.indexOf(e) < x.indexOf(c));
+		assertTrue("2.25", x.indexOf(e) < x.indexOf(d));
+		assertTrue("2.26", x.indexOf(c) < x.indexOf(f));
+		assertTrue("2.27", x.indexOf(c) < x.indexOf(g));
+		assertTrue("2.28", x.indexOf(d) < x.indexOf(f));
+		assertTrue("2.29", x.indexOf(d) < x.indexOf(g));
+		assertTrue("2.30", x.indexOf(f) < x.indexOf(h));
+		assertTrue("2.31", x.indexOf(g) < x.indexOf(h));
+		assertTrue("2.32", order.hasCycles);
+		assertTrue("2.33", order.knots.length == 3);
+		List<IProject> k1 = Arrays.asList(order.knots[0]);
+		List<IProject> k2 = Arrays.asList(order.knots[1]);
+		List<IProject> k3 = Arrays.asList(order.knots[2]);
+		// sort 3 groups
+		if (k2.indexOf(b) >= 0) {
+			List<IProject> temp = k1;
+			k1 = k2;
+			k2 = temp;
+		} else if (k3.indexOf(b) >= 0) {
+			List<IProject> temp = k1;
+			k1 = k3;
+			k3 = temp;
 		}
+		if (k3.indexOf(c) >= 0) {
+			List<IProject> temp = k2;
+			k2 = k3;
+			k3 = temp;
+		}
+		// knot 1
+		assertTrue("2.34", k1.size() == 3);
+		assertTrue("2.35", k1.indexOf(a) >= 0);
+		assertTrue("2.36", k1.indexOf(b) >= 0);
+		assertTrue("2.37", k1.indexOf(e) >= 0);
+		// knot 2
+		assertTrue("2.38", k2.size() == 2);
+		assertTrue("2.39", k2.indexOf(c) >= 0);
+		assertTrue("2.40", k2.indexOf(d) >= 0);
+		// knot 3
+		assertTrue("2.41", k3.size() == 2);
+		assertTrue("2.42", k3.indexOf(f) >= 0);
+		assertTrue("2.43", k3.indexOf(g) >= 0);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.InputStream;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
@@ -79,13 +81,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 	 * Trying to save a null Snapshot throws CoreException.
 	 */
 	public void testSaveNullSnapshot() throws Throwable {
-		boolean exceptionThrown = false;
-		try {
-			projects[0].saveSnapshot(IProject.SNAPSHOT_TREE, null, null);
-		} catch (CoreException ce) {
-			exceptionThrown = true;
-		}
-		assertTrue("1.0", exceptionThrown);
+		assertThrows(CoreException.class, () -> projects[0].saveSnapshot(IProject.SNAPSHOT_TREE, null, null));
 	}
 
 	/*
@@ -264,13 +260,8 @@ public class ProjectSnapshotTest extends ResourceTest {
 		project.open(null);
 		assertTrue("1.1", project.isOpen());
 		assertTrue("1.2", project.getFolder("foo").exists());
-		boolean errorReported = false;
-		try {
-			project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, URI.create("NON_EXISTING/foo/bar.zip"), null);
-		} catch (CoreException ce) {
-			errorReported = true;
-		}
-		assertTrue("1.4", errorReported);
+		assertThrows(CoreException.class, () -> project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD,
+				URI.create("NON_EXISTING/foo/bar.zip"), null));
 	}
 
 	public void testAutoLoadMissingSnapshot() throws Throwable {
@@ -370,13 +361,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 
 		// setting snapshot while project is closed is forbidden
 		project.close(null);
-		boolean exceptionThrown = false;
-		try {
-			project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, tempURI, null);
-		} catch (CoreException e) {
-			exceptionThrown = true;
-		}
-		assertTrue("4.0", exceptionThrown);
+		assertThrows(CoreException.class, () -> project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, tempURI, null));
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -16,9 +16,12 @@
 package org.eclipse.core.tests.resources;
 
 import java.io.File;
-import java.io.IOException;
 import org.eclipse.core.filesystem.EFS;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -54,7 +57,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		resource.setResourceAttributes(attributes);
 	}
 
-	public void testAttributeArchive() {
+	public void testAttributeArchive() throws CoreException {
 		// only activate this test on platforms that support it
 		if (!isAttributeSupported(EFS.ATTRIBUTE_ARCHIVE)) {
 			return;
@@ -63,33 +66,22 @@ public class ResourceAttributeTest extends ResourceTest {
 		IFile file = project.getFile("target");
 		ensureExistsInWorkspace(file, getRandomContents());
 
-		try {
-			// file bit is set already for a new file
-			assertTrue("1.0", file.getResourceAttributes().isArchive());
-			setArchive(file, false);
-			assertTrue("1.2", !file.getResourceAttributes().isArchive());
-			setArchive(file, true);
-			assertTrue("1.4", file.getResourceAttributes().isArchive());
+		// file bit is set already for a new file
+		assertTrue("1.0", file.getResourceAttributes().isArchive());
+		setArchive(file, false);
+		assertTrue("1.2", !file.getResourceAttributes().isArchive());
+		setArchive(file, true);
+		assertTrue("1.4", file.getResourceAttributes().isArchive());
 
-			// folder bit is not set already for a new folder
-			assertTrue("2.0", !project.getResourceAttributes().isArchive());
-			setArchive(project, true);
-			assertTrue("2.2", project.getResourceAttributes().isArchive());
-			setArchive(project, false);
-			assertTrue("2.4", !project.getResourceAttributes().isArchive());
-		} catch (CoreException e1) {
-			fail("2.99", e1);
-		}
-
-		// remove trash
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// folder bit is not set already for a new folder
+		assertTrue("2.0", !project.getResourceAttributes().isArchive());
+		setArchive(project, true);
+		assertTrue("2.2", project.getResourceAttributes().isArchive());
+		setArchive(project, false);
+		assertTrue("2.4", !project.getResourceAttributes().isArchive());
 	}
 
-	public void testAttributeExecutable() {
+	public void testAttributeExecutable() throws CoreException {
 		// only activate this test on platforms that support it
 		if (!isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE)) {
 			return;
@@ -98,34 +90,23 @@ public class ResourceAttributeTest extends ResourceTest {
 		IFile file = project.getFile("target");
 		ensureExistsInWorkspace(file, getRandomContents());
 
-		try {
-			// file
-			assertTrue("1.0", !file.getResourceAttributes().isExecutable());
-			setExecutable(file, true);
-			assertTrue("1.2", file.getResourceAttributes().isExecutable());
-			setExecutable(file, false);
-			assertTrue("1.4", !file.getResourceAttributes().isExecutable());
+		// file
+		assertTrue("1.0", !file.getResourceAttributes().isExecutable());
+		setExecutable(file, true);
+		assertTrue("1.2", file.getResourceAttributes().isExecutable());
+		setExecutable(file, false);
+		assertTrue("1.4", !file.getResourceAttributes().isExecutable());
 
-			// folder
-			//folder is executable initially
-			assertTrue("2.0", project.getResourceAttributes().isExecutable());
-			setExecutable(project, false);
-			assertTrue("2.2", !project.getResourceAttributes().isExecutable());
-			setExecutable(project, true);
-			assertTrue("2.4", project.getResourceAttributes().isExecutable());
-		} catch (CoreException e1) {
-			fail("2.99", e1);
-		}
-
-		// remove trash
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// folder
+		// folder is executable initially
+		assertTrue("2.0", project.getResourceAttributes().isExecutable());
+		setExecutable(project, false);
+		assertTrue("2.2", !project.getResourceAttributes().isExecutable());
+		setExecutable(project, true);
+		assertTrue("2.4", project.getResourceAttributes().isExecutable());
 	}
 
-	public void testAttributeHidden() {
+	public void testAttributeHidden() throws CoreException {
 		// only activate this test on platforms that support it
 		if (!isAttributeSupported(EFS.ATTRIBUTE_HIDDEN)) {
 			return;
@@ -134,30 +115,19 @@ public class ResourceAttributeTest extends ResourceTest {
 		IFile file = project.getFile("target");
 		ensureExistsInWorkspace(file, getRandomContents());
 
-		try {
-			// file
-			assertTrue("1.0", !file.getResourceAttributes().isHidden());
-			setHidden(file, true);
-			assertTrue("1.2", file.getResourceAttributes().isHidden());
-			setHidden(file, false);
-			assertTrue("1.4", !file.getResourceAttributes().isHidden());
+		// file
+		assertTrue("1.0", !file.getResourceAttributes().isHidden());
+		setHidden(file, true);
+		assertTrue("1.2", file.getResourceAttributes().isHidden());
+		setHidden(file, false);
+		assertTrue("1.4", !file.getResourceAttributes().isHidden());
 
-			// folder
-			assertTrue("2.0", !project.getResourceAttributes().isHidden());
-			setHidden(project, true);
-			assertTrue("2.2", project.getResourceAttributes().isHidden());
-			setHidden(project, false);
-			assertTrue("2.4", !project.getResourceAttributes().isHidden());
-		} catch (CoreException e1) {
-			fail("2.99", e1);
-		}
-
-		/* remove trash */
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// folder
+		assertTrue("2.0", !project.getResourceAttributes().isHidden());
+		setHidden(project, true);
+		assertTrue("2.2", project.getResourceAttributes().isHidden());
+		setHidden(project, false);
+		assertTrue("2.4", !project.getResourceAttributes().isHidden());
 	}
 
 	public void testAttributeReadOnly() {
@@ -182,26 +152,15 @@ public class ResourceAttributeTest extends ResourceTest {
 		assertTrue("2.2", project.getResourceAttributes().isReadOnly());
 		setReadOnly(project, false);
 		assertTrue("2.4", !project.getResourceAttributes().isReadOnly());
-
-		/* remove trash */
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
 	}
 
 	/**
 	 * Attributes of a closed project should be null.
 	 */
-	public void testClosedProject() {
+	public void testClosedProject() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		ensureExistsInWorkspace(project, true);
-		try {
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+		project.close(getMonitor());
 		assertNull("1.0", project.getResourceAttributes());
 	}
 
@@ -234,7 +193,7 @@ public class ResourceAttributeTest extends ResourceTest {
 	 * Test commented out because current failing on Hudson.
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=397353
 	 */
-	public void _testRefreshExecutableOnFolder() {
+	public void _testRefreshExecutableOnFolder() throws CoreException {
 		// only test on platforms that implement the executable bit
 		if ((EFS.getLocalFileSystem().attributes() & EFS.ATTRIBUTE_EXECUTABLE) == 0) {
 			return;
@@ -244,36 +203,25 @@ public class ResourceAttributeTest extends ResourceTest {
 		IFile file = folder.getFile("file");
 		ensureExistsInWorkspace(file, getRandomContents());
 
-		try {
-			//folder is executable initially and the file should exist
-			assertTrue("1.0", project.getResourceAttributes().isExecutable());
-			assertTrue("1.1", file.exists());
+		// folder is executable initially and the file should exist
+		assertTrue("1.0", project.getResourceAttributes().isExecutable());
+		assertTrue("1.1", file.exists());
 
-			setExecutable(folder, false);
-			waitForRefresh();
+		setExecutable(folder, false);
+		waitForRefresh();
 
-			boolean wasExecutable = folder.getResourceAttributes().isExecutable();
-			boolean fileExists = file.exists();
+		boolean wasExecutable = folder.getResourceAttributes().isExecutable();
+		boolean fileExists = file.exists();
 
-			//set the folder executable before asserting anything, otherwise cleanup will fail
-			setExecutable(folder, true);
+		// set the folder executable before asserting anything, otherwise cleanup will
+		// fail
+		setExecutable(folder, true);
 
-			assertTrue("2.1", !wasExecutable);
-			assertTrue("2.2", !fileExists);
-
-		} catch (CoreException e1) {
-			fail("2.99", e1);
-		}
-
-		/* remove trash */
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		assertTrue("2.1", !wasExecutable);
+		assertTrue("2.2", !fileExists);
 	}
 
-	public void testAttributeSymlink() {
+	public void testAttributeSymlink() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
 		if (!canCreateSymLinks()) {
 			return;
@@ -282,17 +230,13 @@ public class ResourceAttributeTest extends ResourceTest {
 		IFile link = project.getFile("link");
 		ensureExistsInWorkspace(link, getRandomContents());
 
-		try {
-			// attempts to set the symbolic link attribute wont't affect
-			// the resource and the underlying file
-			assertTrue("1.0", !link.getResourceAttributes().isSymbolicLink());
-			setSymlink(link, true);
-			assertTrue("2.0", !link.getResourceAttributes().isSymbolicLink());
-			setSymlink(link, false);
-			assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
-		} catch (CoreException e1) {
-			fail("4.0", e1);
-		}
+		// attempts to set the symbolic link attribute wont't affect
+		// the resource and the underlying file
+		assertTrue("1.0", !link.getResourceAttributes().isSymbolicLink());
+		setSymlink(link, true);
+		assertTrue("2.0", !link.getResourceAttributes().isSymbolicLink());
+		setSymlink(link, false);
+		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
 
 		ensureDoesNotExistInWorkspace(link);
 
@@ -308,12 +252,8 @@ public class ResourceAttributeTest extends ResourceTest {
 
 		// attempts to clear the symbolic link attribute shouldn't affect
 		// the resource and the underlying file
-		try {
-			setSymlink(link, false);
-			assertTrue("3.0", link.getResourceAttributes().isSymbolicLink());
-		} catch (CoreException e1) {
-			fail("4.0", e1);
-		}
+		setSymlink(link, false);
+		assertTrue("3.0", link.getResourceAttributes().isSymbolicLink());
 
 		// remove the underlying file and add it again as a local file,
 		// the resource in the workspace should have the symbolic link attribute
@@ -321,57 +261,42 @@ public class ResourceAttributeTest extends ResourceTest {
 		String s = link.getLocation().toOSString();
 
 		link.getLocation().toFile().delete();
-		try {
-			new File(s).createNewFile();
-			assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
-		} catch (IOException e) {
-			fail("4.99", e);
-		}
-
-		/* remove trash */
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		new File(s).createNewFile();
+		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
 	}
 
-	public void testAttributes() {
+	public void testAttributes() throws CoreException {
 		int[] attributes = new int[] {EFS.ATTRIBUTE_GROUP_READ, EFS.ATTRIBUTE_GROUP_WRITE, EFS.ATTRIBUTE_GROUP_EXECUTE, EFS.ATTRIBUTE_OTHER_READ, EFS.ATTRIBUTE_OTHER_WRITE, EFS.ATTRIBUTE_OTHER_EXECUTE};
 
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
 		IFile file = project.getFile(getUniqueString());
 		ensureExistsInWorkspace(file, getRandomContents());
 
-		try {
-			for (int attribute : attributes) {
-				// only activate this test on platforms that support it
-				if (!isAttributeSupported(attribute)) {
-					continue;
-				}
-
-				// file
-				ResourceAttributes resAttr = file.getResourceAttributes();
-				resAttr.set(attribute, true);
-				file.setResourceAttributes(resAttr);
-				assertTrue("1.0", file.getResourceAttributes().isSet(attribute));
-
-				resAttr.set(attribute, false);
-				file.setResourceAttributes(resAttr);
-				assertFalse("2.0", file.getResourceAttributes().isSet(attribute));
-
-				// folder
-				resAttr = project.getResourceAttributes();
-				resAttr.set(attribute, true);
-				project.setResourceAttributes(resAttr);
-				assertTrue("3.0", project.getResourceAttributes().isSet(attribute));
-
-				resAttr.set(attribute, false);
-				project.setResourceAttributes(resAttr);
-				assertFalse("4.0", project.getResourceAttributes().isSet(attribute));
+		for (int attribute : attributes) {
+			// only activate this test on platforms that support it
+			if (!isAttributeSupported(attribute)) {
+				continue;
 			}
-		} catch (CoreException e) {
-			fail("5.0", e);
+
+			// file
+			ResourceAttributes resAttr = file.getResourceAttributes();
+			resAttr.set(attribute, true);
+			file.setResourceAttributes(resAttr);
+			assertTrue("1.0", file.getResourceAttributes().isSet(attribute));
+
+			resAttr.set(attribute, false);
+			file.setResourceAttributes(resAttr);
+			assertFalse("2.0", file.getResourceAttributes().isSet(attribute));
+
+			// folder
+			resAttr = project.getResourceAttributes();
+			resAttr.set(attribute, true);
+			project.setResourceAttributes(resAttr);
+			assertTrue("3.0", project.getResourceAttributes().isSet(attribute));
+
+			resAttr.set(attribute, false);
+			project.setResourceAttributes(resAttr);
+			assertFalse("4.0", project.getResourceAttributes().isSet(attribute));
 		}
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -14,9 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import org.eclipse.core.internal.resources.PlatformURLResourceConnection;
 import org.eclipse.core.resources.IFile;
@@ -107,31 +108,20 @@ public class ResourceURLTest extends ResourceTest {
 	public void testNonExistantURLs() throws Throwable {
 		IResource[] resources = buildResources();
 		for (int i = 1; i < resources.length; i++) {
-			try {
-				checkURL(resources[i]);
-				fail("1.0");
-			} catch (IOException e) {
-				// expected
-			}
+			final int index = i;
+			assertThrows(IOException.class, () -> checkURL(resources[index]));
 		}
 	}
 
 	/**
 	 * Tests decoding of normalized URLs containing spaces
 	 */
-	public void testSpaces() {
+	public void testSpaces() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("My Project");
 		IFile file = project.getFile("a.txt");
 		ensureExistsInWorkspace(file, CONTENT);
-		try {
-			URL url = new URL(PlatformURLResourceConnection.RESOURCE_URL_STRING + "My%20Project/a.txt");
-			InputStream stream = url.openStream();
-			assertTrue("1.0", compareContent(stream, getContents(CONTENT)));
-		} catch (MalformedURLException e) {
-			fail("0.99", e);
-		} catch (IOException e) {
-			fail("1.99", e);
-		}
-
+		URL url = new URL(PlatformURLResourceConnection.RESOURCE_URL_STRING + "My%20Project/a.txt");
+		InputStream stream = url.openStream();
+		assertTrue("1.0", compareContent(stream, getContents(CONTENT)));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -15,9 +15,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import org.eclipse.core.filesystem.*;
-import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import static org.junit.Assert.assertThrows;
+
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 
@@ -28,40 +35,28 @@ public class VirtualFolderTest extends ResourceTest {
 	protected IProject existingProject;
 	protected IFolder existingVirtualFolderInExistingProject;
 
-	protected void doCleanup() throws Exception {
-		ensureExistsInWorkspace(new IResource[] {existingProject}, true);
-		existingVirtualFolderInExistingProject.create(IResource.VIRTUAL, true, getMonitor());
-	}
-
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingVirtualFolderInExistingProject = existingProject.getFolder("existingVirtualFolderInExistingProject");
-		doCleanup();
+		ensureExistsInWorkspace(new IResource[] { existingProject }, true);
+		existingVirtualFolderInExistingProject.create(IResource.VIRTUAL, true, getMonitor());
 	}
 
 	/**
 	 * Tests creating a virtual folder
 	 */
-	public void testCreateVirtualFolder() {
+	public void testCreateVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
 
-		try {
-			virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
 
 		assertTrue("2.0", virtualFolder.exists());
 		assertTrue("3.0", virtualFolder.isVirtual());
 
 		// delete should succeed
-		try {
-			virtualFolder.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		virtualFolder.delete(IResource.NONE, getMonitor());
 	}
 
 	/**
@@ -69,16 +64,8 @@ public class VirtualFolderTest extends ResourceTest {
 	 */
 	public void testCreateFileUnderVirtualFolder() {
 		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
-		boolean failed = false;
-		try {
-			create(file, true);
-			fail("1.0");
-		} catch (CoreException e) {
-			failed = true;
-		}
-
+		assertThrows(CoreException.class, () -> create(file, true));
 		assertTrue("2.0", !file.exists());
-		assertTrue("3.0", failed);
 	}
 
 	/**
@@ -86,343 +73,222 @@ public class VirtualFolderTest extends ResourceTest {
 	 */
 	public void testCreateFolderUnderVirtualFolder() {
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
-		boolean failed = false;
-		try {
-			create(folder, true);
-			fail("1.0");
-		} catch (CoreException e) {
-			failed = true;
-		}
-
+		assertThrows(CoreException.class, () -> create(folder, true));
 		assertTrue("2.0", !folder.exists());
-		assertTrue("3.0", failed);
 	}
 
 	/**
 	 * Tests creating a virtual folder under a virtual folder
 	 */
-	public void testCreateVirtualFolderUnderVirtualFolder() {
+	public void testCreateVirtualFolderUnderVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
-		try {
-			virtualFolder.create(IResource.VIRTUAL, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		virtualFolder.create(IResource.VIRTUAL, true, null);
 
 		assertTrue("2.0", virtualFolder.exists());
 		assertTrue("3.0", virtualFolder.isVirtual());
 
 		// delete should succeed
-		try {
-			virtualFolder.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		virtualFolder.delete(IResource.NONE, getMonitor());
 	}
 
 	/**
 	 * Tests creating a linked folder under a virtual folder
 	 */
-	public void testCreateLinkedFolderUnderVirtualFolder() {
+	public void testCreateLinkedFolderUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		try {
-			linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 
 		assertTrue("2.0", linkedFolder.exists());
 		assertEquals("3.0", location, linkedFolder.getLocation());
 		assertTrue("4.0", !location.toFile().exists());
 
 		// getting children should succeed (and be empty)
-		try {
-			assertEquals("5.0", 0, linkedFolder.members().length);
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
+		assertEquals("5.0", 0, linkedFolder.members().length);
 
 		// delete should succeed
-		try {
-			linkedFolder.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		linkedFolder.delete(IResource.NONE, getMonitor());
 	}
 
 	/**
 	 * Tests creating a linked file under a virtual folder
 	 */
-	public void testCreateLinkedFileUnderVirtualFolder() {
+	public void testCreateLinkedFileUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
 		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
 
-		try {
-			file.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 
 		assertTrue("2.0", file.exists());
 		assertEquals("3.0", location, file.getLocation());
 		assertTrue("4.0", !location.toFile().exists());
 
 		// delete should succeed
-		try {
-			file.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		file.delete(IResource.NONE, getMonitor());
 	}
 
-	public void testCopyProjectWithVirtualFolder() {
+	public void testCopyProjectWithVirtualFolder() throws CoreException {
 		IPath fileLocation = getRandomLocation();
+		deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
+		deleteOnTearDown(folderLocation);
 
 		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(getUniqueString());
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		try {
-			try {
-				createFileInFileSystem(fileLocation, getRandomContents());
-				folderLocation.toFile().mkdir();
+		createFileInFileSystem(fileLocation, getRandomContents());
+		folderLocation.toFile().mkdir();
 
-				linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-				linkedFile.createLink(fileLocation, IResource.NONE, getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+		linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
+		linkedFile.createLink(fileLocation, IResource.NONE, getMonitor());
 
-			// copy the project
-			IProject destinationProject = getWorkspace().getRoot().getProject("CopyTargetProject");
-			try {
-				existingProject.copy(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
-			} catch (CoreException e) {
-				fail("2.0", e);
-			}
+		// copy the project
+		IProject destinationProject = getWorkspace().getRoot().getProject("CopyTargetProject");
+		existingProject.copy(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
 
-			IFile newFile = destinationProject.getFile(linkedFile.getProjectRelativePath());
-			assertTrue("3.0", newFile.isLinked());
-			assertEquals("3.1", linkedFile.getLocation(), newFile.getLocation());
-			assertTrue("3.2", newFile.getParent().isVirtual());
+		IFile newFile = destinationProject.getFile(linkedFile.getProjectRelativePath());
+		assertTrue("3.0", newFile.isLinked());
+		assertEquals("3.1", linkedFile.getLocation(), newFile.getLocation());
+		assertTrue("3.2", newFile.getParent().isVirtual());
 
-			IFolder newFolder = destinationProject.getFolder(linkedFolder.getProjectRelativePath());
-			assertTrue("4.0", newFolder.isLinked());
-			assertEquals("4.1", linkedFolder.getLocation(), newFolder.getLocation());
-			assertTrue("4.2", newFolder.getParent().isVirtual());
+		IFolder newFolder = destinationProject.getFolder(linkedFolder.getProjectRelativePath());
+		assertTrue("4.0", newFolder.isLinked());
+		assertEquals("4.1", linkedFolder.getLocation(), newFolder.getLocation());
+		assertTrue("4.2", newFolder.getParent().isVirtual());
 
-			// test project deep copy
-			try {
-				destinationProject.delete(IResource.NONE, getMonitor());
-				existingProject.copy(destinationProject.getFullPath(), IResource.NONE, getMonitor());
-			} catch (CoreException e) {
-				fail("5.0", e);
-			}
+		// test project deep copy
+		destinationProject.delete(IResource.NONE, getMonitor());
+		existingProject.copy(destinationProject.getFullPath(), IResource.NONE, getMonitor());
 
-			assertTrue("5.1", newFile.isLinked());
-			assertEquals("5.2", linkedFile.getLocation(), newFile.getLocation());
-			assertTrue("5.3", newFile.getParent().isVirtual());
-			assertTrue("5.4", newFolder.isLinked());
-			assertEquals("5.5", linkedFolder.getLocation(), newFolder.getLocation());
-			assertTrue("5.6", newFolder.getParent().isVirtual());
+		assertTrue("5.1", newFile.isLinked());
+		assertEquals("5.2", linkedFile.getLocation(), newFile.getLocation());
+		assertTrue("5.3", newFile.getParent().isVirtual());
+		assertTrue("5.4", newFolder.isLinked());
+		assertEquals("5.5", linkedFolder.getLocation(), newFolder.getLocation());
+		assertTrue("5.6", newFolder.getParent().isVirtual());
 
-			try {
-				destinationProject.delete(IResource.NONE, getMonitor());
-			} catch (CoreException e) {
-				fail("6.0", e);
-			}
-		} finally {
-			Workspace.clear(fileLocation.toFile());
-			Workspace.clear(folderLocation.toFile());
-		}
+		destinationProject.delete(IResource.NONE, getMonitor());
 	}
 
-	public void testMoveProjectWithVirtualFolder() {
+	public void testMoveProjectWithVirtualFolder() throws CoreException {
 		IPath fileLocation = getRandomLocation();
+		deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
+		deleteOnTearDown(folderLocation);
 
 		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 		IFile childFile = folder.getFile(getUniqueString());
 		IResource[] oldResources = new IResource[] {existingProject, file, folder, childFile};
 
-		try {
-			assertDoesNotExistInWorkspace("1.0", new IResource[] {folder, file, childFile});
+		assertDoesNotExistInWorkspace("1.0", new IResource[] { folder, file, childFile });
 
-			try {
-				createFileInFileSystem(fileLocation);
-				folderLocation.toFile().mkdir();
+		createFileInFileSystem(fileLocation);
+		folderLocation.toFile().mkdir();
 
-				folder.createLink(folderLocation, IResource.NONE, getMonitor());
-				file.createLink(fileLocation, IResource.NONE, getMonitor());
+		folder.createLink(folderLocation, IResource.NONE, getMonitor());
+		file.createLink(fileLocation, IResource.NONE, getMonitor());
 
-				childFile.create(getRandomContents(), true, getMonitor());
-			} catch (CoreException e) {
-				fail("2.0", e);
-			}
+		childFile.create(getRandomContents(), true, getMonitor());
 
-			// move the project
-			IProject destinationProject = getWorkspace().getRoot().getProject("MoveTargetProject");
-			assertDoesNotExistInWorkspace("3.0", destinationProject);
+		// move the project
+		IProject destinationProject = getWorkspace().getRoot().getProject("MoveTargetProject");
+		assertDoesNotExistInWorkspace("3.0", destinationProject);
 
-			try {
-				existingProject.move(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
-			} catch (CoreException e) {
-				fail("4.0", e);
-			}
+		existingProject.move(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
 
-			IFile newFile = destinationProject.getFile(file.getProjectRelativePath());
-			IFolder newFolder = destinationProject.getFolder(folder.getProjectRelativePath());
-			IFile newChildFile = newFolder.getFile(childFile.getName());
-			IResource[] newResources = new IResource[] {destinationProject, newFile, newFolder, newChildFile};
+		IFile newFile = destinationProject.getFile(file.getProjectRelativePath());
+		IFolder newFolder = destinationProject.getFolder(folder.getProjectRelativePath());
+		IFile newChildFile = newFolder.getFile(childFile.getName());
+		IResource[] newResources = new IResource[] { destinationProject, newFile, newFolder, newChildFile };
 
-			assertExistsInWorkspace("5.0", newResources);
-			assertDoesNotExistInWorkspace("6.1", oldResources);
-			assertTrue("7.0", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
-			assertTrue("8.0", destinationProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertExistsInWorkspace("5.0", newResources);
+		assertDoesNotExistInWorkspace("6.1", oldResources);
+		assertTrue("7.0", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue("8.0", destinationProject.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertTrue("9.0", newFile.getParent().isVirtual());
-			assertTrue("10.0", newFile.isLinked());
+		assertTrue("9.0", newFile.getParent().isVirtual());
+		assertTrue("10.0", newFile.isLinked());
 
-			assertTrue("11.0", newFolder.isLinked());
-			assertTrue("12.0", newFolder.getParent().isVirtual());
-		} finally {
-			Workspace.clear(fileLocation.toFile());
-			Workspace.clear(folderLocation.toFile());
-		}
+		assertTrue("11.0", newFolder.isLinked());
+		assertTrue("12.0", newFolder.getParent().isVirtual());
 	}
 
-	public void testDeleteProjectWithVirtualFolder() {
+	public void testDeleteProjectWithVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
 
-		try {
-			virtualFolder.create(IResource.VIRTUAL, true, null);
-			existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
-			existingProject.create(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		virtualFolder.create(IResource.VIRTUAL, true, null);
+		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+		existingProject.create(getMonitor());
 
 		// virtual folder should not exist until the project is open
 		assertTrue("2.0", !virtualFolder.exists());
 
-		try {
-			existingProject.open(getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		existingProject.open(getMonitor());
 
 		// virtual folder should now exist
 		assertTrue("4.0", virtualFolder.exists());
 		assertTrue("5.0", virtualFolder.isVirtual());
 	}
 
-	public void testDeleteProjectWithVirtualFolderAndLink() {
+	public void testDeleteProjectWithVirtualFolderAndLink() throws CoreException {
 		IPath folderLocation = getRandomLocation();
+		deleteOnTearDown(folderLocation);
 
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
 		IFolder linkedFolder = virtualFolder.getFolder("a_link");
 
-		try {
-			try {
-				folderLocation.toFile().mkdir();
-				virtualFolder.create(IResource.VIRTUAL, true, null);
-				linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-				existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
-				existingProject.create(getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+		folderLocation.toFile().mkdir();
+		virtualFolder.create(IResource.VIRTUAL, true, null);
+		linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
+		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+		existingProject.create(getMonitor());
 
-			// virtual folder should not exist until the project is open
-			assertTrue("2.0", !virtualFolder.exists());
-			assertTrue("3.0", !linkedFolder.exists());
+		// virtual folder should not exist until the project is open
+		assertTrue("2.0", !virtualFolder.exists());
+		assertTrue("3.0", !linkedFolder.exists());
 
-			try {
-				existingProject.open(getMonitor());
-			} catch (CoreException e) {
-				fail("4.0", e);
-			}
+		existingProject.open(getMonitor());
 
-			// virtual folder should now exist
-			assertTrue("5.0", virtualFolder.exists());
-			assertTrue("6.0", virtualFolder.isVirtual());
+		// virtual folder should now exist
+		assertTrue("5.0", virtualFolder.exists());
+		assertTrue("6.0", virtualFolder.isVirtual());
 
-			// link should now exist
-			assertTrue("7.0", linkedFolder.exists());
-			assertTrue("8.0", linkedFolder.isLinked());
+		// link should now exist
+		assertTrue("7.0", linkedFolder.exists());
+		assertTrue("8.0", linkedFolder.isLinked());
 
-			assertEquals("9.0", folderLocation, linkedFolder.getLocation());
-		} finally {
-			Workspace.clear(folderLocation.toFile());
-		}
+		assertEquals("9.0", folderLocation, linkedFolder.getLocation());
 	}
 
-	public void testLinkedFolderInVirtualFolder_FileStoreURI() {
+	public void testLinkedFolderInVirtualFolder_FileStoreURI() throws CoreException {
 		IPath folderLocation = getRandomLocation();
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		try {
-			folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 
 		assertTrue("2.0", folder.exists());
 		assertEquals("3.0", folderLocation, folder.getLocation());
 		assertTrue("4.0", !folderLocation.toFile().exists());
 
 		// Check file store URI for the linked resource
-		try {
-			IFileStore fs = EFS.getStore(existingVirtualFolderInExistingProject.getLocationURI());
-			fs = fs.getChild(folder.getName());
-			assertNotNull("5.0", fs);
-			assertNotNull("6.0", fs.toURI());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		IFileStore fs = EFS.getStore(existingVirtualFolderInExistingProject.getLocationURI());
+		fs = fs.getChild(folder.getName());
+		assertNotNull("5.0", fs);
+		assertNotNull("6.0", fs.toURI());
 	}
 
-	public void testIsVirtual() {
+	public void testIsVirtual() throws CoreException {
 		// create a virtual folder
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
-		try {
-			virtualFolder.create(IResource.VIRTUAL, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		virtualFolder.create(IResource.VIRTUAL, true, null);
 		assertTrue("2.0", virtualFolder.isVirtual());
 	}
 
-	//	We should decide what is the proper value returned for Virtual Folders
-	//
-	//	public void testIsLocal() {
-	//		// create a virtual folder
-	//		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
-	//		try {
-	//			virtualFolder.createGroup(IResource.NONE, null);
-	//		} catch (CoreException e) {
-	//			fail("1.0", e);
-	//		}
-	//		assertTrue("2.0", virtualFolder.isLocal(IResource.DEPTH_INFINITE));
-	//	}
-	//
-	//	public void testIsSynchronizedforVirtualFolder() {
-	//		// create a virtual folder
-	//		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
-	//		try {
-	//			virtualFolder.createGroup(IResource.NONE, null);
-	//		} catch (CoreException e) {
-	//			fail("1.0", e);
-	//		}
-	//		assertTrue("2.0", virtualFolder.isSynchronized(IResource.DEPTH_INFINITE));
-	//	}
-
-	public void testVirtualFolderInLinkedFolder() {
+	public void testVirtualFolderInLinkedFolder() throws CoreException {
 		// setup handles
 		IFolder topFolder = existingProject.getFolder("topFolder");
 		IFolder linkedFolder = topFolder.getFolder("linkedFolder");
@@ -430,36 +296,29 @@ public class VirtualFolderTest extends ResourceTest {
 		IFolder virtualFolder = subFolder.getFolder("virtualFolder");
 
 		IPath linkedFolderLocation = getRandomLocation();
+		deleteOnTearDown(linkedFolderLocation);
 		IPath subFolderLocation = linkedFolderLocation.append(subFolder.getName());
+		deleteOnTearDown(subFolderLocation);
 
-		try {
-			try {
-				// create the structure on disk
-				linkedFolderLocation.toFile().mkdir();
-				subFolderLocation.toFile().mkdir();
+		// create the structure on disk
+		linkedFolderLocation.toFile().mkdir();
+		subFolderLocation.toFile().mkdir();
 
-				// create the structure in the workspace
-				ensureExistsInWorkspace(topFolder, true);
-				linkedFolder.createLink(linkedFolderLocation, IResource.NONE, getMonitor());
-				virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+		// create the structure in the workspace
+		ensureExistsInWorkspace(topFolder, true);
+		linkedFolder.createLink(linkedFolderLocation, IResource.NONE, getMonitor());
+		virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
 
-			// assert locations
-			assertEquals("2.0", linkedFolderLocation, linkedFolder.getLocation());
-			assertEquals("3.0", linkedFolderLocation.append(subFolder.getName()), subFolder.getLocation());
-			assertTrue("4.0", virtualFolder.isVirtual());
-			assertTrue("5.0", virtualFolder.getLocation() == null);
+		// assert locations
+		assertEquals("2.0", linkedFolderLocation, linkedFolder.getLocation());
+		assertEquals("3.0", linkedFolderLocation.append(subFolder.getName()), subFolder.getLocation());
+		assertTrue("4.0", virtualFolder.isVirtual());
+		assertTrue("5.0", virtualFolder.getLocation() == null);
 
-			// assert URIs
-			assertEquals("6.0", URIUtil.toURI(linkedFolderLocation), linkedFolder.getLocationURI());
-			assertEquals("7.0", URIUtil.toURI(subFolderLocation), subFolder.getLocationURI());
-			// assertTrue("8.0", virtualFolder.getLocationURI() == null);
-		} finally {
-			Workspace.clear(subFolderLocation.toFile());
-			Workspace.clear(linkedFolderLocation.toFile());
-		}
+		// assert URIs
+		assertEquals("6.0", URIUtil.toURI(linkedFolderLocation), linkedFolder.getLocationURI());
+		assertEquals("7.0", URIUtil.toURI(subFolderLocation), subFolder.getLocationURI());
+		// assertTrue("8.0", virtualFolder.getLocationURI() == null);
 	}
 
 	/* Regression for Bug 296470 */


### PR DESCRIPTION
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Adds missing try-with-resources blocks

This PR includes the following classes:
* `NatureTest`
* `NonLocalLinkedResourceTest`
* `ProjectOrderTest`
* `ProjectSnapshotTest`
* `ResourceAttributeTest`
* `ResourceURLTest`
* `VirtualFolderTest`
* `WorkspaceTest`

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.