### PR TITLE
Fix several Javadoc errors in org.eclipse.core.tests.resources

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -51,8 +51,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void assertDelta() {
 		if (!verifier.isDeltaValid()) {
@@ -134,8 +132,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddAndRemoveFile() {
 		try {
@@ -155,8 +151,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddAndRemoveFolder() {
 		try {
@@ -175,8 +169,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddFile() {
 		try {
@@ -192,8 +184,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddFileAndFolder() {
 		try {
@@ -211,8 +201,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddFolder() {
 		try {
@@ -227,8 +215,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testAddProject() {
 		try {
@@ -244,8 +230,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testChangeFile() {
 		try {
@@ -262,8 +246,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testChangeFileToFolder() {
 		try {
@@ -281,8 +263,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testChangeFolderToFile() {
 		try {
@@ -305,8 +285,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testCloseOpenReplaceFile() {
 		try {
@@ -331,8 +309,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testMoveFile() {
 		try {
@@ -351,8 +327,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testRemoveFile() {
 		try {
@@ -367,8 +341,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testRemoveFileAndFolder() {
 		try {
@@ -384,8 +356,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testReplaceFile() {
 		try {
@@ -403,8 +373,6 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void testTwoFileChanges() {
 		try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java
@@ -94,9 +94,6 @@ public class DeltaVerifierBuilder extends TestBuilder {
 	 *                  the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags
 	 *                  the type of change (CONTENT, SYNC, etc)
-	 * @param movedPath
-	 *                  or null
-	 * @see IResourceConstants
 	 */
 	public void addExpectedChange(IResource resource, IResource topLevelParent, int status, int changeFlags) {
 		verifier.addExpectedChange(resource, topLevelParent, status, changeFlags, null, null);
@@ -115,7 +112,9 @@ public class DeltaVerifierBuilder extends TestBuilder {
 	 *                  the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags
 	 *                  the type of change (CONTENT, SYNC, etc)
-	 * @param movedPath
+	 * @param movedFromPath
+	 *                  or null
+	 * @param movedToPath
 	 *                  or null
 	 * @see IResourceConstants
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SnowBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SnowBuilder.java
@@ -51,9 +51,6 @@ public class SnowBuilder extends TestBuilder {
 		return singleton;
 	}
 
-	/**
-	 * @see InternalBuilder#build(int, Map, IProgressMonitor)
-	 */
 	@Override
 	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
 		wasDeltaNull = getDelta(getProject()) == null;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SortBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SortBuilder.java
@@ -130,11 +130,6 @@ public class SortBuilder extends TestBuilder {
 		sortedFile.setContents(bis, true, false, null);
 	}
 
-	/**
-	 * Implements the inherited abstract method in
-	 * <code>BaseBuilder</code>.
-	 * @see BaseBuilder#build(IResourceDelta,int,IProgressMonitor)
-	 */
 	@Override
 	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
 		arguments = args;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
@@ -393,7 +393,7 @@ public class DeltaDataTreeTest {
 	/**
 	 * Delete the child with the specified local name from the specified
 	 * node.  Note: this method requires both parentKey and localName,
-	 * making it impossible to delete the root node.<p>
+	 * making it impossible to delete the root node.
 	 *
 	 * @exception ObjectNotFoundException
 	 *	a child of parentKey with name localName does not exist in the receiver
@@ -612,9 +612,6 @@ public class DeltaDataTreeTest {
 	/**
 	 * Answer the key of the child with the given index of the
 	 * specified node.<p>
-	 *
-	 * @param NodeKey, int
-	 * @return NodeKey
 	 *
 	 * @exception ObjectNotFoundException
 	 * 	parentKey does not exist in the receiver

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestModelProvider.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestModelProvider.java
@@ -31,7 +31,7 @@ public class TestModelProvider extends ModelProvider {
 	/**
 	 * Flag to check if the given delta proposes contents deletion. If set to
 	 * {@code true}, the {@link #validateChange(IResourceDelta, IProgressMonitor)}
-	 * will add {@link IStatus.ERROR} to the change description to indicate contents
+	 * will add {@link IStatus#ERROR} to the change description to indicate contents
 	 * deletion proposal.
 	 */
 	public static boolean checkContentsDeletion;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -29,9 +29,6 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 	private IWorkspace workspace;
 	private Preferences preferences;
 
-	/**
-	 * @see TestCase#setUp()
-	 */
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
@@ -40,9 +37,6 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		workspace.setDescription(Workspace.defaultWorkspaceDescription());
 	}
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -134,9 +134,6 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
-	 *
-	 * @see SortBuilderPlugin
-	 * @see SortBuilder
 	 */
 	public void assertDelta() {
 		assertTrue(verifier.getMessage(), verifier.isDeltaValid());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -1070,11 +1070,6 @@ public class LinkedResourceTest extends ResourceTest {
 
 	}
 
-	/**
-	 * Tests the
-	 * {@link org.eclipse.core.resources.IResource#setLinkLocation(URI , int , IProgressMonitor )}
-	 * method.
-	 */
 	public void testsetLinkLocation() {
 		// initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
@@ -1152,11 +1147,6 @@ public class LinkedResourceTest extends ResourceTest {
 		}
 	}
 
-	/**
-	 * Tests the
-	 * {@link org.eclipse.core.resources.IResource#setLinkLocation(IPath, int , IProgressMonitor )}
-	 * method.
-	 */
 	public void testsetLinkLocationPath() {
 		//initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -131,9 +131,6 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		}
 	}
 
-	/**
-	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
-	 */
 	@Override
 	public IPath getRandomLocation() {
 		IPathVariableManager pathVars = getWorkspace().getPathVariableManager();
@@ -152,9 +149,6 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		return path;
 	}
 
-	/**
-	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
-	 */
 	public IPath getRandomProjectLocation() {
 		IPathVariableManager pathVars = getWorkspace().getPathVariableManager();
 		// low order bits are current time, high order bits are static counter
@@ -172,9 +166,6 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		return path;
 	}
 
-	/**
-	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
-	 */
 	public IPath getRandomRelativeProjectLocation() {
 		IPathVariableManager pathVars = getWorkspace().getPathVariableManager();
 		// low order bits are current time, high order bits are static counter
@@ -192,17 +183,11 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		return path;
 	}
 
-	/**
-	 * @see LinkedResourceTest#resolve(org.eclipse.core.runtime.IPath)
-	 */
 	@Override
 	protected IPath resolve(IPath path) {
 		return getWorkspace().getPathVariableManager().resolvePath(path);
 	}
 
-	/**
-	 * @see LinkedResourceTest#resolve(java.net.URI)
-	 */
 	@Override
 	protected URI resolve(URI uri) {
 		return getWorkspace().getPathVariableManager().resolveURI(uri);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
@@ -163,7 +163,6 @@ public class ResourceDeltaVerifier extends Assert implements IResourceChangeList
 	 * @param resource the resource that is expected to change
 	 * @param status the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags the type of change (CONTENT, SYNC, etc)
-	 * @see IResourceConstants
 	 */
 	public void addExpectedChange(IResource resource, int status, int changeFlags) {
 		addExpectedChange(resource, null, status, changeFlags, null, null);
@@ -176,8 +175,8 @@ public class ResourceDeltaVerifier extends Assert implements IResourceChangeList
 	 * @param resource the resource that is expected to change
 	 * @param status the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags the type of change (CONTENT, SYNC, etc)
-	 * @param movedPath or null
-	 * @see IResourceConstants
+	 * @param movedFromPath or null
+	 * @param movedToPath or null
 	 */
 	public void addExpectedChange(IResource resource, int status, int changeFlags, IPath movedFromPath, IPath movedToPath) {
 		addExpectedChange(resource, null, status, changeFlags, movedFromPath, movedToPath);
@@ -191,8 +190,6 @@ public class ResourceDeltaVerifier extends Assert implements IResourceChangeList
 	 * @param topLevelParent Do not added expected changes above this parent
 	 * @param status the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags the type of change (CONTENT, SYNC, etc)
-	 * @param movedPath or null
-	 * @see IResourceConstants
 	 */
 	public void addExpectedChange(IResource resource, IResource topLevelParent, int status, int changeFlags) {
 		addExpectedChange(resource, topLevelParent, status, changeFlags, null, null);
@@ -206,8 +203,8 @@ public class ResourceDeltaVerifier extends Assert implements IResourceChangeList
 	 * @param topLevelParent Do not added expected changes above this parent
 	 * @param status the type of change (ADDED, REMOVED, CHANGED)
 	 * @param changeFlags the type of change (CONTENT, SYNC, etc)
-	 * @param movedPath or null
-	 * @see IResourceConstants
+	 * @param movedFromPath or null
+	 * @param movedToPath or null
 	 */
 	public void addExpectedChange(IResource resource, IResource topLevelParent, int status, int changeFlags, IPath movedFromPath, IPath movedToPath) {
 		resetIfNecessary();
@@ -800,7 +797,6 @@ public class ResourceDeltaVerifier extends Assert implements IResourceChangeList
 
 	/**
 	 * Part of the <code>IResourceChangedListener</code> interface.
-	 * @see IResourceChangedListener
 	 */
 	@Override
 	public void resourceChanged(IResourceChangeEvent e) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrentOperation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrentOperation.java
@@ -106,9 +106,6 @@ public abstract class ConcurrentOperation implements Runnable, IWorkspaceRunnabl
 		}
 	}
 
-	/**
-	 * @see #waitNotification
-	 */
 	public synchronized void proceed() {
 		go = true;
 		notify();


### PR DESCRIPTION
See for example the log in https://ci.eclipse.org/platform/job/eclipse.platform/job/PR-805/6:
```
20:27:09.992 [ERROR] MavenReportException: Error while generating Javadoc: 
Exit code: 1
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceSessionTest.java:71: error: reference not found
	 * {@link #test___tearDown()}. This method is overwritten to do nothing in order
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:54: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:137: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:158: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:178: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:195: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:214: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:230: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:247: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:265: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:284: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:308: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:334: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:354: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:370: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:387: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java:406: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:166: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:179: error: @param name not found
	 * @param movedPath or null
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:180: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:194: error: @param name not found
	 * @param movedPath or null
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:195: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:209: error: @param name not found
	 * @param movedPath or null
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:210: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java:803: error: reference not found
	 * @see IResourceChangedListener
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrentOperation.java:110: error: reference not found
	 * @see #waitNotification
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java:396: warning: empty <p> tag
	 * making it impossible to delete the root node.<p>
	                                                ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java:614: warning: empty <p> tag
	 * specified node.<p>
	                  ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java:616: error: @param name not found
	 * @param NodeKey, int
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java:617: error: invalid use of @return
	 * @return NodeKey
	   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java:97: error: @param name not found
	 * @param movedPath
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java:99: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java:118: error: @param name not found
	 * @param movedPath
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/DeltaVerifierBuilder.java:120: error: reference not found
	 * @see IResourceConstants
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java:138: error: reference not found
	 * @see SortBuilderPlugin
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java:139: error: reference not found
	 * @see SortBuilder
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java:1075: error: reference not found
	 * {@link org.eclipse.core.resources.IResource#setLinkLocation(URI , int , IProgressMonitor )}
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java:1157: error: reference not found
	 * {@link org.eclipse.core.resources.IResource#setLinkLocation(IPath, int , IProgressMonitor )}
	          ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java:135: error: reference not found
	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java:156: error: reference not found
	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java:176: error: reference not found
	 * @see org.eclipse.core.tests.harness.ResourceTest#getRandomLocation()
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SnowBuilder.java:55: error: reference not found
	 * @see InternalBuilder#build(int, Map, IProgressMonitor)
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SortBuilder.java:136: error: reference not found
	 * @see BaseBuilder#build(IResourceDelta,int,IProgressMonitor)
	        ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestModelProvider.java:34: error: reference not found
	 * will add {@link IStatus.ERROR} to the change description to indicate contents
	                   ^
/home/jenkins/agent/workspace/eclipse.platform_PR-805/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java:39: error: reference not found
	 * @see TestCase#setUp()
	        ^
43 errors
2 warnings
Command line was: /opt/tools/java/openjdk/jdk-17/17.0.2+8/bin/javadoc @options @packages
```