### PR TITLE
Fix several Javadoc errors

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
@@ -68,8 +68,6 @@ public class AbstractDebugTest {
 	/**
 	 * Ensure the welcome screen is closed because in 4.x the debug perspective
 	 * opens a giant fast-view causing issues
-	 *
-	 * @throws Exception
 	 */
 	protected final void assertWelcomeScreenClosed() throws Exception {
 		if (!welcomeClosed && PlatformUI.isWorkbenchRunning()) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -778,7 +778,8 @@ public final class IOConsoleTestUtil {
 	}
 
 	/**
-	 * Get identifier for output {@code IOConsolePartition}s.
+	 * Get identifier for output
+	 * {@code org.eclipse.ui.internal.console.IOConsolePartition}s.
 	 *
 	 * @return output partition identifier
 	 */
@@ -788,7 +789,8 @@ public final class IOConsoleTestUtil {
 	}
 
 	/**
-	 * Get identifier for input {@code IOConsolePartition}s.
+	 * Get identifier for input
+	 * {@code org.eclipse.ui.internal.console.IOConsolePartition}s.
 	 *
 	 * @return input partition identifier
 	 */

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -1388,7 +1388,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 * Tests that a launch is properly registered for notifications before a
 	 * process is spawned and may already propagate a termination event.
 	 *
-	 * see <a href="https://github.com/eclipse-platform/eclipse.platform/issues/598">598</a>
+	 * @see <a href="https://github.com/eclipse-platform/eclipse.platform/issues/598">598</a>
 	 */
 	@Test
 	public void testTerminateLaunchListener_Issue598() throws Exception {
@@ -1453,8 +1453,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that attributes in a nested map are persisted in alphabetical
 	 * order.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testMapAttributePersistence() throws CoreException, IOException {
@@ -1536,8 +1534,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that attributes in a nested set are persisted in alphabetical
 	 * order.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testSetAttributePersistence() throws CoreException, IOException {
@@ -1662,8 +1658,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Test that moving and renaming a shared configuration at the same time
 	 * works.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testRenameAndMoveShared() throws CoreException {
@@ -1691,8 +1685,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 *
 	 * Bug 381175 - [patch] launchConfigurationTypeImage to support platform:
 	 * style icons
-	 *
-	 * @throws Exception
 	 */
 	@Test
 	public void testGetTypeImageFromURI() throws Exception {
@@ -1703,8 +1695,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Test support for a declared launch configuration type image
-	 *
-	 * @throws Exception
 	 */
 	@Test
 	public void testGetTyeImage() throws Exception {
@@ -1716,10 +1706,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that we can get a project handle from a project name
 	 *
-	 * see
-	 * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
-	 *
-	 * @throws Exception
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
 	 * @since 3.9.0
 	 */
 	@Test
@@ -1741,10 +1728,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that we cannot get a project handle from a bogus project name
 	 *
-	 * see
-	 * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
-	 *
-	 * @throws Exception
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
 	 * @since 3.9.0
 	 */
 	@Test
@@ -1765,10 +1749,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that we cannot get a project handle from a bogus project name
 	 *
-	 * see
-	 * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
-	 *
-	 * @throws Exception
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
 	 * @since 3.9.0
 	 */
 	@Test
@@ -1794,10 +1775,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that we can get a project handle from an absolute project name
 	 *
-	 * see
-	 * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
-	 *
-	 * @throws Exception
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=395441">395441</a>
 	 * @since 3.9.0
 	 */
 	@Test
@@ -1819,10 +1797,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	 * Tests that a launch created without a backing
 	 * {@link ILaunchConfiguration} does not cause {@link NullPointerException}s
 	 *
-	 * see
-	 * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=416691">416691</a>
-	 *
-	 * @throws Exception
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=416691">416691</a>
 	 * @since 3.9.0
 	 */
 	@Test
@@ -1865,8 +1840,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Test copying attributes from one configuration to another.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testCopyAttributes() throws CoreException {
@@ -1881,8 +1854,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Tests that creation from a prototype works.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testCreationFromPrototype() throws CoreException {
@@ -1899,8 +1870,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Tests setting the 'isPrototype' attribute.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testIsPrototype() throws CoreException {
@@ -1916,8 +1885,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Tests finding references to a prototype.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testPrototypeChildren() throws CoreException {
@@ -1946,8 +1913,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that when an attribute is removed from a working copy, it does not
 	 * get inherited from its prototype.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testPrototypeRemoveBehavior() throws CoreException {
@@ -1971,8 +1936,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	/**
 	 * Tests that setting a configuration's prototype to null cleans its
 	 * prototype association.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testUnPrototype() throws CoreException {
@@ -1995,8 +1958,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Tests that nested prototypes are not allowed.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testNestedPrototypes() throws CoreException {
@@ -2013,8 +1974,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Test that you cannot set a config's prototype to be a non-prototype.
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testIllegalPrototype() throws CoreException {
@@ -2032,8 +1991,6 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 	/**
 	 * Test that a prototype can be duplicated (and results in a prototype).
-	 *
-	 * @throws CoreException
 	 */
 	@Test
 	public void testCopyPrototype() throws CoreException {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
@@ -294,8 +294,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #preLaunchCheck is cancelled
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
 	 * @since 3.9.100
 	 */
 	@Test
@@ -319,8 +318,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #finalLaunchCheck is cancelled
 	 *
-	 * @throws Exception see <a
-	 *             href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
 	 * @since 3.9.100
 	 */
 	@Test
@@ -344,8 +342,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #buildFoLaunch is cancelled
 	 *
-	 * @throws Exception see <a
-	 *             href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=437122">437122</a>
 	 * @since 3.9.100
 	 */
 	@Test
@@ -444,8 +441,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * <i>throwingEnum</i> method throws exception
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
 	 */
 	private void testThrowingLaunchDelegateMethod(ThrowingEnum throwingEnum) throws Exception {
 		ILaunchConfiguration config = getThrowingConfiguration(throwingEnum);
@@ -468,8 +464,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #preLaunchCheck throws exception
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
 	 */
 	@Test
 	public void testThrowingPreLaunchCheck() throws Exception {
@@ -480,8 +475,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #finalLaunchCheck throws exception
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
 	 */
 	@Test
 	public void testThrowingFinalLaunchCheck() throws Exception {
@@ -492,8 +486,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #buildFoLaunch throws exception
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
 	 */
 	@Test
 	public void testThrowingBuildForLaunch() throws Exception {
@@ -504,8 +497,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	 * Tests if a launch is properly removed from the launch manager when
 	 * #buildFoLaunch throws exception
 	 *
-	 * @throws Exception see <a href=
-	 *             "https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578302">578302</a>
 	 */
 	@Test
 	public void testThrowingLaunch() throws Exception {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
@@ -326,8 +326,6 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 	/**
 	 * This test forces the viewer to reschedule pending content updates due to
 	 * a remove event from the model.
-	 *
-	 * see org.eclipse.debug.internal.ui.viewers.model.TreeModelContentProvider#rescheduleUpdates
 	 */
 	@Test
 	public void testRescheduleUpdates() throws Exception {
@@ -537,8 +535,6 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 	 * <p>
 	 * See Bug 373790 - Debug view stays busy after Resume
 	 * </p>
-	 *
-	 * see org.eclipse.debug.internal.ui.viewers.model.TreeModelContentProvider#rescheduleUpdates
 	 */
 	@Test
 	public void testCancelUpdatesOnRemoveElementWhileUpdatingSubTree() throws Exception {

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroPage.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroPage.java
@@ -412,8 +412,6 @@ public abstract class AbstractIntroPage extends AbstractIntroContainer {
 	/**
 	 * Override parent behavior to add support for HEAD &amp; Title element in pages
 	 * only, and not in divs.
-	 *
-	 * @see org.eclipse.ui.internal.intro.impl.model.AbstractIntroContainer#getModelChild(Element, Bundle, String)
 	 */
 	@Override
 	protected AbstractIntroElement getModelChild(Element childElement,


### PR DESCRIPTION
* Remove invalid @return statements
* Replace or remove invalid @see annotations
* Fix faulty method references
* Fix missing qualification of type references
* Remove obsolete exception specification in test documentations

According Javadoc generation errors can, e.g., be found in the log of https://ci.eclipse.org/platform/job/eclipse.platform/job/PR-812/4