### PR TITLE
Fix random failing ServiceSupplierTestCase.testOptionalReferences #488

### DIFF
--- a/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/ServiceSupplierTestCase.java
+++ b/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/ServiceSupplierTestCase.java
@@ -73,11 +73,11 @@ public class ServiceSupplierTestCase {
 		@Inject
 		@Optional
 		@Service(filterExpression = "(component=disabled)")
-		TestService disabledService;
+		volatile TestService disabledService;
 
 		@Inject
 		@Service(filterExpression = "(component=disabled)")
-		List<TestService> services;
+		volatile List<TestService> services;
 	}
 
 	private final List<ServiceRegistration<?>> registrations = new ArrayList<>();
@@ -250,7 +250,7 @@ public class ServiceSupplierTestCase {
 		try {
 			enabler.enableDisabledServiceA();
 			// wait for asynchronous service registry and injection to finish
-			waitForCondition(() -> bean.services.size() == 1, timeoutInMillis);
+			waitForCondition(() -> bean.services.size() == 1 && bean.disabledService != null, timeoutInMillis);
 			assertNotNull(bean.disabledService);
 			assertEquals(1, bean.services.size());
 			assertSame(DisabledServiceA.class, bean.disabledService.getClass());
@@ -271,7 +271,7 @@ public class ServiceSupplierTestCase {
 
 			enabler.disableDisabledServiceA();
 			// wait for asynchronous service registry and injection to finish
-			waitForCondition(() -> bean.services.size() == 0, timeoutInMillis);
+			waitForCondition(() -> bean.services.size() == 0 && bean.disabledService == null, timeoutInMillis);
 			assertNull(bean.disabledService);
 			assertEquals(0, bean.services.size());
 		} finally {


### PR DESCRIPTION
The `ServiceSupplierTestCase.testOptionalReferences` test case randomly fails. The test aims to wait for services to be enabled or disabled, but it only waits until a single value is changed although it asserts that multiple values are changed afterwards. This is a race condition, as the order in which the values are changed or in which the changes are visible is non-deterministic, also due to missing memory barriers.

This change addresses this issue via two means:
1. it makes the fields of the asserted values volatile to ensure that changed values eventually become visible to the UI thread
2. it waits for all values to be changed before asserting their values to allow different orders of value changes