### PR TITLE
Cleanup and simplify resources.regression tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -13,9 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -49,13 +56,9 @@ public class IFolderTest extends ResourceTest {
 
 		try {
 			parentFolder.setReadOnly(true);
-			assertTrue("0.0", parentFolder.isReadOnly());
-			try {
-				folder.create(true, true, getMonitor());
-				fail("0.1");
-			} catch (CoreException e) {
-				assertEquals("0.2", IResourceStatus.PARENT_READ_ONLY, e.getStatus().getCode());
-			}
+			assertTrue(parentFolder.isReadOnly());
+			CoreException exception = assertThrows(CoreException.class, () -> folder.create(true, true, getMonitor()));
+			assertEquals(IResourceStatus.PARENT_READ_ONLY, exception.getStatus().getCode());
 		} finally {
 			parentFolder.setReadOnly(false);
 		}
@@ -65,7 +68,7 @@ public class IFolderTest extends ResourceTest {
 	 * Bug 11510 [resources] Non-local folders do not become local when directory is created.
 	 */
 	@Test
-	public void testBug11510() {
+	public void testBug11510() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("TestProject");
 		IFolder folder = project.getFolder("fold1");
@@ -80,31 +83,19 @@ public class IFolderTest extends ResourceTest {
 
 		// now create the resources in the local file system and refresh
 		ensureExistsInFileSystem(file);
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertTrue("2.1", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("2.2", !folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("2.3", !subFile.isLocal(IResource.DEPTH_ZERO));
 
 		folder.getLocation().toFile().mkdir();
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertTrue("3.1", folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.2", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.3", !subFile.isLocal(IResource.DEPTH_ZERO));
 
 		ensureExistsInFileSystem(subFile);
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertTrue("4.1", subFile.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("4.2", folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("4.3", file.isLocal(IResource.DEPTH_ZERO));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -14,8 +14,15 @@
 package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFileState;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 public class IWorkspaceTest extends ResourceTest {
@@ -23,174 +30,115 @@ public class IWorkspaceTest extends ResourceTest {
 	/**
 	 * 1GDKIHD: ITPCORE:WINNT - API - IWorkspace.move needs to keep history
 	 */
-	public void testMultiMove_1GDKIHD() {
+	public void testMultiMove_1GDKIHD() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		// test file (force = true)
 		IFile file1 = project.getFile("file.txt");
 		IFolder folder = project.getFolder("folder");
 		IResource[] allResources = new IResource[] {file1, folder};
-		try {
-			folder.create(true, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().move(new IFile[] {file1}, folder.getFullPath(), true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file1.getHistory(getMonitor());
-			assertEquals("1.0", 3, states.length);
-			getWorkspace().delete(allResources, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.20", e);
-		}
+		folder.create(true, true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		IFileState[] states = file1.getHistory(getMonitor());
+		assertEquals("1.0", 3, states.length);
+		getWorkspace().delete(allResources, true, getMonitor());
+		project.clearHistory(getMonitor());
 
 		// test file (force = false)
-		try {
-			folder.create(true, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().move(new IFile[] {file1}, folder.getFullPath(), false, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file1.getHistory(getMonitor());
-			assertEquals("2.0", 3, states.length);
-			getWorkspace().delete(allResources, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.20", e);
-		}
-
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
+		folder.create(true, true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), false, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		states = file1.getHistory(getMonitor());
+		assertEquals("2.0", 3, states.length);
+		getWorkspace().delete(allResources, true, getMonitor());
+		project.clearHistory(getMonitor());
 	}
 
 	/**
 	 * 1GDGRIZ: ITPCORE:WINNT - API - IWorkspace.delete needs to keep history
 	 */
-	public void testMultiDelete_1GDGRIZ() {
+	public void testMultiDelete_1GDGRIZ() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		// test file (force = true)
 		IFile file1 = project.getFile("file.txt");
-		try {
-			file1.create(getRandomContents(), true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().delete(new IFile[] {file1}, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file1.getHistory(getMonitor());
-			assertEquals("1.0", 3, states.length);
-			getWorkspace().delete(new IResource[] {file1}, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("1.20", e);
-		}
+		file1.create(getRandomContents(), true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().delete(new IFile[] { file1 }, true, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		IFileState[] states = file1.getHistory(getMonitor());
+		assertEquals("1.0", 3, states.length);
+		getWorkspace().delete(new IResource[] { file1 }, true, getMonitor());
+		project.clearHistory(getMonitor());
 
 		// test file (force = false)
-		try {
-			file1.create(getRandomContents(), true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().delete(new IFile[] {file1}, false, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file1.getHistory(getMonitor());
-			assertEquals("2.0", 3, states.length);
-			getWorkspace().delete(new IResource[] {file1}, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("2.20", e);
-		}
+		file1.create(getRandomContents(), true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().delete(new IFile[] { file1 }, false, getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		states = file1.getHistory(getMonitor());
+		assertEquals("2.0", 3, states.length);
+		getWorkspace().delete(new IResource[] { file1 }, true, getMonitor());
+		project.clearHistory(getMonitor());
 
 		// test folder (force = true)
 		IFolder folder = project.getFolder("folder");
 		IFile file2 = folder.getFile("file2.txt");
-		try {
-			folder.create(true, true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			file2.setContents(getRandomContents(), true, true, getMonitor());
-			file2.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().delete(new IResource[] {folder}, true, getMonitor());
-			folder.create(true, true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file2.getHistory(getMonitor());
-			assertEquals("3.0", 3, states.length);
-			getWorkspace().delete(new IResource[] {folder, file1, file2}, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("3.20", e);
-		}
+		folder.create(true, true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		file2.setContents(getRandomContents(), true, true, getMonitor());
+		file2.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().delete(new IResource[] { folder }, true, getMonitor());
+		folder.create(true, true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		states = file2.getHistory(getMonitor());
+		assertEquals("3.0", 3, states.length);
+		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, getMonitor());
+		project.clearHistory(getMonitor());
 
 		// test folder (force = false)
-		try {
-			folder.create(true, true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			file2.setContents(getRandomContents(), true, true, getMonitor());
-			file2.setContents(getRandomContents(), true, true, getMonitor());
-			getWorkspace().delete(new IResource[] {folder}, false, getMonitor());
-			folder.create(true, true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			IFileState[] states = file2.getHistory(getMonitor());
-			assertEquals("4.0", 3, states.length);
-			getWorkspace().delete(new IResource[] {folder, file1, file2}, true, getMonitor());
-			project.clearHistory(getMonitor());
-		} catch (CoreException e) {
-			fail("4.20", e);
-		}
-
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
+		folder.create(true, true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		file2.setContents(getRandomContents(), true, true, getMonitor());
+		file2.setContents(getRandomContents(), true, true, getMonitor());
+		getWorkspace().delete(new IResource[] { folder }, false, getMonitor());
+		folder.create(true, true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		states = file2.getHistory(getMonitor());
+		assertEquals("4.0", 3, states.length);
+		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, getMonitor());
+		project.clearHistory(getMonitor());
 	}
 
-	public void test_8974() {
+	public void test_8974() throws CoreException {
 		IProject one = getWorkspace().getRoot().getProject("One");
 		IPath oneLocation = getRandomLocation().append(one.getName());
 		oneLocation.toFile().mkdirs();
+		deleteOnTearDown(oneLocation.removeLastSegments(1));
 		IProjectDescription oneDescription = getWorkspace().newProjectDescription(one.getName());
 		oneDescription.setLocation(oneLocation);
 
-		try {
-			one.create(oneDescription, getMonitor());
-		} catch (CoreException e) {
-			Workspace.clear(oneLocation.removeLastSegments(1).toFile());
-			fail("0.0", e);
-		}
+		one.create(oneDescription, getMonitor());
 
-		try {
-			IProject two = getWorkspace().getRoot().getProject("Two");
-			IPath twoLocation = oneLocation.removeLastSegments(1).append(oneLocation.lastSegment().toLowerCase());
+		IProject two = getWorkspace().getRoot().getProject("Two");
+		IPath twoLocation = oneLocation.removeLastSegments(1).append(oneLocation.lastSegment().toLowerCase());
 
-			IStatus result = getWorkspace().validateProjectLocation(two, twoLocation);
-			if (Workspace.caseSensitive) {
-				assertTrue("1.0", result.isOK());
-			} else {
-				assertTrue("1.1", !result.isOK());
-			}
-			// cleanup
-			ensureDoesNotExistInWorkspace(one);
-		} finally {
-			// ensure that the project directory is cleaned up.
-			Workspace.clear(oneLocation.removeLastSegments(1).toFile());
-		}
+		IStatus result = getWorkspace().validateProjectLocation(two, twoLocation);
+		assertEquals(Workspace.caseSensitive, result.isOK());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -13,12 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
 import org.eclipse.core.internal.localstore.SafeChunkyOutputStream;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.internal.localstore.LocalStoreTest;
 
@@ -57,7 +63,7 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 	/**
 	 * The PR reported a problem with longs, but we are testing more types here.
 	 */
-	public void test_1G65KR1() {
+	public void test_1G65KR1() throws IOException {
 		/* evaluate test environment */
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
 		deleteOnTearDown(root);
@@ -73,16 +79,12 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 				DataOutputStream dos = new DataOutputStream(output)) {
 			dos.writeLong(1234567890l);
 			output.succeed();
-		} catch (IOException e) {
-			fail("2.0", e);
 		}
 
 		// read chunks
 		try (SafeChunkyInputStream input = new SafeChunkyInputStream(target);
 				DataInputStream dis = new DataInputStream(input)) {
 				assertEquals("3.0", dis.readLong(), 1234567890l);
-		} catch (IOException e) {
-			fail("3.10", e);
 		}
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -14,7 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -69,23 +71,15 @@ public class NLTest extends ResourceTest {
 		return names.toArray(new String[names.size()]);
 	}
 
-	public void testFileNames() {
+	public void testFileNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("project");
-		try {
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.create(getMonitor());
+		project.open(getMonitor());
 
 		String[] files = getFileNames(Locale.ENGLISH.getLanguage());
 		IResource[] resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInFileSystem("2.1", resources);
 		assertExistsInWorkspace("2.2", resources);
 		ensureDoesNotExistInWorkspace(resources);
@@ -93,20 +87,9 @@ public class NLTest extends ResourceTest {
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInFileSystem("3.1", resources);
 		assertExistsInWorkspace("3.2", resources);
-
-		// remove garbage
-		try {
-			project.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
@@ -14,7 +14,13 @@
 package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.tests.resources.ResourceDeltaVerifier;
@@ -64,7 +70,7 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 	 * Ensure that we get ADDED and OPEN in the delta when we create and open
 	 * a project in a workspace runnable.
 	 */
-	public void test_1GEAB3C() {
+	public void test_1GEAB3C() throws CoreException {
 		verifier.reset();
 		final IProject project = getWorkspace().getRoot().getProject("MyAddedAndOpenedProject");
 		IFile prefs = project.getFolder(EclipsePreferences.DEFAULT_PREFERENCES_DIRNAME)
@@ -82,11 +88,7 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 				monitor.done();
 			}
 		};
-		try {
-			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		getWorkspace().run(body, getMonitor());
 		assertDelta();
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
@@ -15,37 +15,27 @@ package org.eclipse.core.tests.resources.regression;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 public class PR_1GH2B0N_Test extends ResourceTest {
 
-	public void test_1GH2B0N() {
+	public void test_1GH2B0N() throws CoreException {
 		IPath path = getTempDir().append("1GH2B0N");
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IProjectDescription description = getWorkspace().newProjectDescription("MyProject");
 		IPath projectLocation = path.append(project.getName());
+		deleteOnTearDown(projectLocation);
 		description.setLocation(projectLocation);
-		try {
-			try {
-				project.create(description, getMonitor());
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
-			try {
-				project.open(getMonitor());
-			} catch (CoreException e) {
-				fail("1.1", e);
-			}
+		project.create(description, getMonitor());
+		project.open(getMonitor());
 
-			IProject project2 = getWorkspace().getRoot().getProject("MyProject2");
-			IStatus status = getWorkspace().validateProjectLocation(project2, project.getLocation().append(project2.getName()));
-			//Note this is not the original error case -
-			//since Eclipse 3.2 a project is allowed to be nested in another project
-			assertTrue("2.0", status.isOK());
-		} finally {
-			ensureDoesNotExistInWorkspace(project);
-			ensureDoesNotExistInFileSystem(projectLocation.toFile());
-		}
+		IProject project2 = getWorkspace().getRoot().getProject("MyProject2");
+		IStatus status = getWorkspace().validateProjectLocation(project2, project.getLocation().append(project2.getName()));
+		//Note this is not the original error case -
+		//since Eclipse 3.2 a project is allowed to be nested in another project
+		assertTrue("2.0", status.isOK());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
@@ -13,7 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -23,28 +28,15 @@ public class PR_1GHOM0N_Test extends ResourceTest {
 	 * Ensure that we get ADDED and OPEN in the delta when we create and open
 	 * a project in a workspace runnable.
 	 */
-	public void test_1GEAB3C() {
-		// turn off auto-build
-		//	try {
-		//		IWorkspaceDescription wd = getWorkspace().getDescription();
-		//		wd.setAutoBuilding(false);
-		//		getWorkspace().setDescription(wd);
-		//	} catch (CoreException e) {
-		//		fail("1.0", e);
-		//	}
-
+	public void test_1GEAB3C() throws CoreException {
 		// setup the project
 		final IProject project = getWorkspace().getRoot().getProject("MyProject");
-		try {
-			IProjectDescription description = getWorkspace().newProjectDescription(project.getName());
-			ICommand command = description.newCommand();
-			command.setBuilderName(SimpleBuilder.BUILDER_ID);
-			description.setBuildSpec(new ICommand[] {command});
-			project.create(description, getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription description = getWorkspace().newProjectDescription(project.getName());
+		ICommand command = description.newCommand();
+		command.setBuilderName(SimpleBuilder.BUILDER_ID);
+		description.setBuildSpec(new ICommand[] { command });
+		project.create(description, getMonitor());
+		project.open(getMonitor());
 
 		// try and reproduce the error (there are problems when calling an incremental
 		// build from within an operation...it leaves the tree immutable)
@@ -53,10 +45,6 @@ public class PR_1GHOM0N_Test extends ResourceTest {
 			IFile file = project.getFile("test.txt");
 			file.create(getRandomContents(), true, getMonitor());
 		};
-		try {
-			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		getWorkspace().run(body, getMonitor());
 	}
 }


### PR DESCRIPTION
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Adds missing try-with-resources blocks
* Replaces some fail() operations called in other threads with properly evaluated callback

This affects all classes in `org.eclipse.core.tests.resources.regression` _not_ starting with `Bug_*` , so this complements #830 for the `resources.regression` test package.

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.
