### PR TITLE
Fix OutputStreamMonitorTests and InputStreamMonitorTests #834

### DIFF
--- a/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.tests;singleton:=true
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",


### PR DESCRIPTION
The `OutputStreamMonitorTests.testUnbufferedOutputStreamMonitor` randomly fails. A potential reason is that the calls of `waitWhile()` wait for one listener to be updated, but an assertion on another listener is validated afterwards. Thus it may happen that one listener was already notified and the program proceeds while the other has not been notified but is then validated. In addition, the `InputStreamMonitorTests` rely on simply sleep-based timing behavior for asynchronous monitors to receive their data.

This change correct the waiting conditions in `OutputStreamMonitorTest`. In addition, it refactors the test class to not overwrite setup logic and to properly assign functionality to listeners instead of the containing test class. In `InputStreamMonitorTests`, it replaces the sleep operations with proper wait operations on conditions.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/834