### PR TITLE
Cleanup and simplify localstore tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
@@ -13,11 +13,25 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.events;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import org.eclipse.core.internal.events.BuildCommand;
 import org.eclipse.core.internal.resources.Project;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.internal.builders.ConfigurationBuilder;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
@@ -51,14 +65,6 @@ public class BuildProjectFromMultipleJobsTest extends ResourceTest {
 
 		Platform.removeLogListener(logListener);
 		logListener.clear();
-
-		try {
-			IProject testProject = getTestProject();
-			if (testProject.exists()) {
-				testProject.delete(true, null);
-			}
-		} finally {
-		}
 
 		super.tearDown();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.InputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -25,132 +27,76 @@ import org.eclipse.core.runtime.IPath;
 //
 public class BlobStoreTest extends LocalStoreTest {
 
-	public void testConstructor() {
+	public void testConstructor() throws CoreException {
 		/* build scenario */
 		IFileStore root = createStore();
 
 		/* null location */
-		boolean ok = false;
-		try {
-			new BlobStore(null, 0);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("1.1", ok);
+		assertThrows(RuntimeException.class, () -> new BlobStore(null, 0));
 
 		/* nonexistent location */
-		ok = false;
-		try {
-			new BlobStore(EFS.getLocalFileSystem().getStore(IPath.fromOSString("../this/path/should/not/be/a/folder")), 128);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("3.1", ok);
+		assertThrows(RuntimeException.class, () -> new BlobStore(
+						EFS.getLocalFileSystem().getStore(IPath.fromOSString("../this/path/should/not/be/a/folder")),
+						128));
 
 		/* invalid limit values */
-		ok = false;
-		try {
-			new BlobStore(root, 0);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("4.1", ok);
-		ok = false;
-		try {
-			new BlobStore(root, -1);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("4.2", ok);
-		ok = false;
-		try {
-			new BlobStore(root, 35);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("4.3", ok);
-		ok = false;
-		try {
-			new BlobStore(root, 512);
-		} catch (RuntimeException e) {
-			ok = true;
-		}
-		assertTrue("4.4", ok);
+		assertThrows(RuntimeException.class, () -> new BlobStore(root, 0));
+
+		assertThrows(RuntimeException.class, () -> new BlobStore(root, -1));
+
+		assertThrows(RuntimeException.class, () -> new BlobStore(root, 35));
+
+		assertThrows(RuntimeException.class, () -> new BlobStore(root, 512));
 	}
 
-	private IFileStore createStore() {
+	private IFileStore createStore() throws CoreException {
 		IFileStore root = getTempStore();
-		try {
-			root.mkdir(EFS.NONE, null);
-		} catch (CoreException e1) {
-			fail("createStore.99", e1);
-		}
+		root.mkdir(EFS.NONE, null);
 		IFileInfo info = root.fetchInfo();
 		assertTrue("createStore.1", info.exists());
 		assertTrue("createStore.2", info.isDirectory());
 		return root;
 	}
 
-	public void testDeleteBlob() {
+	public void testDeleteBlob() throws CoreException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);
 
 		/* delete blob that does not exist */
 		UniversalUniqueIdentifier uuid = new UniversalUniqueIdentifier();
-		assertTrue("2.1", !store.fileFor(uuid).fetchInfo().exists());
+		assertTrue(!store.fileFor(uuid).fetchInfo().exists());
 		store.deleteBlob(uuid);
-		assertTrue("2.2", !store.fileFor(uuid).fetchInfo().exists());
+		assertTrue(!store.fileFor(uuid).fetchInfo().exists());
 
 		/* delete existing blob */
 		IFileStore target = root.getChild("target");
-		try {
-			createFile(target, "bla bla bla");
-			uuid = store.addBlob(target, true);
-		} catch (CoreException e) {
-			fail("4.1", e);
-		}
-		assertTrue("4.2", store.fileFor(uuid).fetchInfo().exists());
+		createFile(target, "bla bla bla");
+		uuid = store.addBlob(target, true);
+		assertTrue(store.fileFor(uuid).fetchInfo().exists());
 		store.deleteBlob(uuid);
-		assertTrue("4.3", !store.fileFor(uuid).fetchInfo().exists());
+		assertFalse(store.fileFor(uuid).fetchInfo().exists());
 	}
 
-	public void testGetBlob() {
+	public void testGetBlob() throws CoreException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);
 
 		/* null UUID */
-		boolean ok = false;
-		try {
-			store.getBlob(null);
-		} catch (RuntimeException e) {
-			ok = true;
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		assertTrue("2.1", ok);
+		assertThrows(RuntimeException.class, () -> store.getBlob(null));
 
 		/* get existing blob */
 		IFileStore target = root.getChild("target");
 		UniversalUniqueIdentifier uuid = null;
 		String content = "nothing important........tnatropmi gnihton";
-		try {
-			createFile(target, content);
-			uuid = store.addBlob(target, true);
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
-		InputStream input = null;
-		try {
-			input = store.getBlob(uuid);
-		} catch (CoreException e) {
-			fail("3.4", e);
-		}
-		assertTrue("4.1", compareContent(getContents(content), input));
+		createFile(target, content);
+		uuid = store.addBlob(target, true);
+		InputStream input = store.getBlob(uuid);
+		assertTrue(compareContent(getContents(content), input));
 	}
 
-	public void testSetBlob() {
+	public void testSetBlob() throws CoreException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);
@@ -159,18 +105,9 @@ public class BlobStoreTest extends LocalStoreTest {
 		IFileStore target = root.getChild("target");
 		UniversalUniqueIdentifier uuid = null;
 		String content = "nothing important........tnatropmi gnihton";
-		try {
-			createFile(target, content);
-			uuid = store.addBlob(target, true);
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
-		InputStream input = null;
-		try {
-			input = store.getBlob(uuid);
-		} catch (CoreException e) {
-			fail("2.4", e);
-		}
-		assertTrue("2.5", compareContent(getContents(content), input));
+		createFile(target, content);
+		uuid = store.addBlob(target, true);
+		InputStream input = store.getBlob(uuid);
+		assertTrue(compareContent(getContents(content), input));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
@@ -133,62 +133,66 @@ public class BucketTreeTests extends ResourceTest {
 		}
 	}
 
-	public void testVisitor() {
+	public void testVisitor() throws CoreException {
 		IPath baseLocation = getRandomLocation();
-		try {
-			// keep the reference around - it is the same returned by tree.getCurrent()
-			SimpleBucket bucket = new SimpleBucket();
-			BucketTree tree = new BucketTree((Workspace) getWorkspace(), bucket);
-			IProject proj1 = getWorkspace().getRoot().getProject("proj1");
-			IProject proj2 = getWorkspace().getRoot().getProject("proj2");
-			IFile file1 = proj1.getFile("file1.txt");
-			IFolder folder1 = proj1.getFolder("folder1");
-			IFile file2 = folder1.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2, proj2}, true);
-			IPath[] paths = { IPath.ROOT, proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(),
-					file2.getFullPath(), proj2.getFullPath() };
-			for (int i = 0; i < paths.length; i++) {
-				try {
-					tree.loadBucketFor(paths[i]);
-				} catch (CoreException e) {
-					fail("0.1." + i, e);
-				}
-				bucket.set(paths[i], "path", paths[i].toString());
-				bucket.set(paths[i], "segments", Integer.toString(paths[i].segmentCount()));
-			}
-			try {
-				bucket.save();
-			} catch (CoreException e) {
-				fail("0.2", e);
-			}
-			verify(tree, "1.1", IPath.ROOT, BucketTree.DEPTH_ZERO, Set.of(IPath.ROOT));
-			verify(tree, "1.2", IPath.ROOT, BucketTree.DEPTH_ONE,
-					Set.of(IPath.ROOT, proj1.getFullPath(), proj2.getFullPath()));
-			verify(tree, "1.3", IPath.ROOT, BucketTree.DEPTH_INFINITE, Set.of(IPath.ROOT, proj1.getFullPath(),
-					file1.getFullPath(), folder1.getFullPath(),
-							file2.getFullPath(), proj2.getFullPath()));
-			verify(tree, "2.1", proj1.getFullPath(), BucketTree.DEPTH_ZERO, Arrays.asList(new IPath[] {proj1.getFullPath()}));
-			verify(tree, "2.2", proj1.getFullPath(), BucketTree.DEPTH_ONE, Arrays.asList(new IPath[] {proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath()}));
-			verify(tree, "2.3", proj1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(new IPath[] {proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(), file2.getFullPath()}));
-			verify(tree, "3.1", file1.getFullPath(), BucketTree.DEPTH_ZERO, Arrays.asList(new IPath[] {file1.getFullPath()}));
-			verify(tree, "3.2", file1.getFullPath(), BucketTree.DEPTH_ONE, Arrays.asList(new IPath[] {file1.getFullPath()}));
-			verify(tree, "3.3", file1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(new IPath[] {file1.getFullPath()}));
-			verify(tree, "4.1", folder1.getFullPath(), BucketTree.DEPTH_ZERO, Arrays.asList(new IPath[] {folder1.getFullPath()}));
-			verify(tree, "4.2", folder1.getFullPath(), BucketTree.DEPTH_ONE, Arrays.asList(new IPath[] {folder1.getFullPath(), file2.getFullPath()}));
-			verify(tree, "4.3", folder1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(new IPath[] {folder1.getFullPath(), file2.getFullPath()}));
-			verify(tree, "5.1", file2.getFullPath(), BucketTree.DEPTH_ZERO, Arrays.asList(new IPath[] {file2.getFullPath()}));
-			verify(tree, "5.2", file2.getFullPath(), BucketTree.DEPTH_ONE, Arrays.asList(new IPath[] {file2.getFullPath()}));
-			verify(tree, "5.3", file2.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(new IPath[] {file2.getFullPath()}));
-			verify(tree, "6.1", proj2.getFullPath(), BucketTree.DEPTH_ZERO, Arrays.asList(new IPath[] {proj2.getFullPath()}));
-			verify(tree, "6.2", proj2.getFullPath(), BucketTree.DEPTH_ONE, Arrays.asList(new IPath[] {proj2.getFullPath()}));
-			verify(tree, "6.3", proj2.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(new IPath[] {proj2.getFullPath()}));
+		deleteOnTearDown(baseLocation);
 
-		} finally {
-			ensureDoesNotExistInFileSystem(baseLocation.toFile());
+		// keep the reference around - it is the same returned by tree.getCurrent()
+		SimpleBucket bucket = new SimpleBucket();
+		BucketTree tree = new BucketTree((Workspace) getWorkspace(), bucket);
+		IProject proj1 = getWorkspace().getRoot().getProject("proj1");
+		IProject proj2 = getWorkspace().getRoot().getProject("proj2");
+		IFile file1 = proj1.getFile("file1.txt");
+		IFolder folder1 = proj1.getFolder("folder1");
+		IFile file2 = folder1.getFile("file2.txt");
+		ensureExistsInWorkspace(new IResource[] { file1, file2, proj2 }, true);
+		IPath[] paths = { IPath.ROOT, proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(),
+				file2.getFullPath(), proj2.getFullPath() };
+		for (IPath path : paths) {
+			tree.loadBucketFor(path);
+			bucket.set(path, "path", path.toString());
+			bucket.set(path, "segments", Integer.toString(path.segmentCount()));
 		}
+		bucket.save();
+		verify(tree, "1.1", IPath.ROOT, BucketTree.DEPTH_ZERO, Set.of(IPath.ROOT));
+		verify(tree, "1.2", IPath.ROOT, BucketTree.DEPTH_ONE,
+				Set.of(IPath.ROOT, proj1.getFullPath(), proj2.getFullPath()));
+		verify(tree, "1.3", IPath.ROOT, BucketTree.DEPTH_INFINITE, Set.of(IPath.ROOT, proj1.getFullPath(),
+				file1.getFullPath(), folder1.getFullPath(), file2.getFullPath(), proj2.getFullPath()));
+		verify(tree, "2.1", proj1.getFullPath(), BucketTree.DEPTH_ZERO,
+				Arrays.asList(new IPath[] { proj1.getFullPath() }));
+		verify(tree, "2.2", proj1.getFullPath(), BucketTree.DEPTH_ONE,
+				Arrays.asList(new IPath[] { proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath() }));
+		verify(tree, "2.3", proj1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(
+				new IPath[] { proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(), file2.getFullPath() }));
+		verify(tree, "3.1", file1.getFullPath(), BucketTree.DEPTH_ZERO,
+				Arrays.asList(new IPath[] { file1.getFullPath() }));
+		verify(tree, "3.2", file1.getFullPath(), BucketTree.DEPTH_ONE,
+				Arrays.asList(new IPath[] { file1.getFullPath() }));
+		verify(tree, "3.3", file1.getFullPath(), BucketTree.DEPTH_INFINITE,
+				Arrays.asList(new IPath[] { file1.getFullPath() }));
+		verify(tree, "4.1", folder1.getFullPath(), BucketTree.DEPTH_ZERO,
+				Arrays.asList(new IPath[] { folder1.getFullPath() }));
+		verify(tree, "4.2", folder1.getFullPath(), BucketTree.DEPTH_ONE,
+				Arrays.asList(new IPath[] { folder1.getFullPath(), file2.getFullPath() }));
+		verify(tree, "4.3", folder1.getFullPath(), BucketTree.DEPTH_INFINITE,
+				Arrays.asList(new IPath[] { folder1.getFullPath(), file2.getFullPath() }));
+		verify(tree, "5.1", file2.getFullPath(), BucketTree.DEPTH_ZERO,
+				Arrays.asList(new IPath[] { file2.getFullPath() }));
+		verify(tree, "5.2", file2.getFullPath(), BucketTree.DEPTH_ONE,
+				Arrays.asList(new IPath[] { file2.getFullPath() }));
+		verify(tree, "5.3", file2.getFullPath(), BucketTree.DEPTH_INFINITE,
+				Arrays.asList(new IPath[] { file2.getFullPath() }));
+		verify(tree, "6.1", proj2.getFullPath(), BucketTree.DEPTH_ZERO,
+				Arrays.asList(new IPath[] { proj2.getFullPath() }));
+		verify(tree, "6.2", proj2.getFullPath(), BucketTree.DEPTH_ONE,
+				Arrays.asList(new IPath[] { proj2.getFullPath() }));
+		verify(tree, "6.3", proj2.getFullPath(), BucketTree.DEPTH_INFINITE,
+				Arrays.asList(new IPath[] { proj2.getFullPath() }));
 	}
 
-	public void verify(BucketTree tree, final String tag, IPath root, int depth, final Collection<IPath> expected) {
+	public void verify(BucketTree tree, final String tag, IPath root, int depth, final Collection<IPath> expected)
+			throws CoreException {
 		final Set<IPath> visited = new HashSet<>();
 		SimpleBucket.Visitor verifier = new SimpleBucket.Visitor() {
 			@Override
@@ -202,11 +206,7 @@ public class BucketTreeTests extends ResourceTest {
 				return CONTINUE;
 			}
 		};
-		try {
-			tree.accept(verifier, root, depth);
-		} catch (CoreException e) {
-			fail(tag + ".3", e);
-		}
+		tree.accept(verifier, root, depth);
 		assertEquals(tag + ".4", expected.size(), visited.size());
 		for (IPath path : expected) {
 			assertTrue(tag + ".5 " + path, visited.contains(path));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.IOException;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -21,428 +23,298 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.junit.function.ThrowingRunnable;
 
 public class CaseSensitivityTest extends LocalStoreTest {
 	private final boolean isCaseSensitive = Workspace.caseSensitive;
 
-	public void testCreateProjects() {
+	public void testCreateProjects() throws Throwable {
 		String projectName = "testProject31415";
 
 		// create a project, should be fine
 		IProject project1 = getWorkspace().getRoot().getProject(projectName);
-		try {
-			project1.create(null);
-			project1.open(null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project1.create(null);
+		project1.open(null);
 
 		// create a second project; should fail because has same name with different casing
 		IProject project2 = getWorkspace().getRoot().getProject(projectName.toUpperCase());
-		try {
+		ThrowingRunnable projectCreation = () -> {
 			project2.create(null);
 			project2.open(null);
-			assertTrue("2.0", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("2.1", e);
-			}
+		};
+		if (isCaseSensitive) {
+			projectCreation.run();
+		} else {
+			assertThrows(CoreException.class, projectCreation);
 		}
 	}
 
-	public void testCreateFolders() {
+	public void testCreateFolders() throws Throwable {
 		String folderName = "testFolder31415";
 		IProject aProject = getWorkspace().getRoot().getProjects()[0];
 
 		// create a folder, should be fine
 		IFolder folder1 = aProject.getFolder(folderName);
-		try {
-			folder1.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder1.create(true, true, null);
 
 		// create a second folder; should fail because has same name with different casing
 		IFolder folder2 = aProject.getFolder(folderName.toUpperCase());
-		try {
-			folder2.create(true, true, null);
-			assertTrue("2.0", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("2.1", e);
-			}
+		ThrowingRunnable folderCreation = () -> folder2.create(true, true, null);
+		if (isCaseSensitive) {
+			folderCreation.run();
+		} else {
+			assertThrows(CoreException.class, folderCreation);
 		}
 
 		// create a file; should fail because has same name with different casing
 		IFile file = aProject.getFile(folderName.toUpperCase());
-		try {
-			file.create(getRandomContents(), true, null);
-			fail("3.0");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> file.create(getRandomContents(), true, null));
 	}
 
-	public void testCreateFiles() {
+	public void testCreateFiles() throws Throwable {
 		String fileName = "testFile31415";
 		IProject aProject = getWorkspace().getRoot().getProjects()[0];
 
 		// create a file, should be fine
 		IFile file1 = aProject.getFile(fileName);
-		try {
-			file1.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file1.create(getRandomContents(), true, null);
 
 		// create a second file; should fail because has same name with different casing
 		IFile file2 = aProject.getFile(fileName.toUpperCase());
-		try {
-			file2.create(getRandomContents(), true, null);
-			assertTrue("2.0", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("2.1", e);
-			}
+		ThrowingRunnable fileCreation = () -> file2.create(getRandomContents(), true, null);
+		if (isCaseSensitive) {
+			fileCreation.run();
+		} else {
+			assertThrows(CoreException.class, fileCreation);
 		}
 
 		// create a folder; should fail because has same name with different casing
 		IFolder folder = aProject.getFolder(fileName.toUpperCase());
-		try {
-			folder.create(true, true, null);
-			fail("3.0");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> folder.create(true, true, null));
 	}
 
-	public void testRenameProject() {
+	public void testRenameProject() throws Throwable {
 		String project1name = "project1test31415";
 		String project2name = "project2test31415";
 
 		// create 2 projects with different names
 		IProject project1 = getWorkspace().getRoot().getProject(project1name);
-		try {
-			project1.create(null);
-			project1.open(null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project1.create(null);
+		project1.open(null);
 
 		IProject project2 = getWorkspace().getRoot().getProject(project2name);
-		try {
-			project2.create(null);
-			project2.open(null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project2.create(null);
+		project2.open(null);
 
 		// try to rename project 1 to the uppercase name of project 2, should fail
-		try {
-			project1.move(IPath.ROOT.append(project2.getName().toUpperCase()), true, null);
-			assertTrue("3.0", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("3.99", e);
-			}
+		ThrowingRunnable projectMovement = () -> project1.move(IPath.ROOT.append(project2.getName().toUpperCase()),
+				true, null);
+		if (isCaseSensitive) {
+			projectMovement.run();
+		} else {
+			assertThrows(CoreException.class, projectMovement);
 		}
 	}
 
-	public void testRenameFolder() {
+	public void testRenameFolder() throws Throwable {
 		String folder1name = "folder1test31415";
 		String folder2name = "folder2test31415";
 		IProject aProject = getWorkspace().getRoot().getProjects()[0];
 
 		// create 2 folders with different names
 		IFolder folder1 = aProject.getFolder(folder1name);
-		try {
-			folder1.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		folder1.create(true, true, null);
 
 		IFolder folder2 = aProject.getFolder(folder2name);
-		try {
-			folder2.create(true, true, null);
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		folder2.create(true, true, null);
 
 		// try to rename folder 1 to the uppercase name of folder 2, should fail
 		IFolder folder3 = aProject.getFolder(folder2name.toUpperCase());
-		try {
-			folder1.move(folder3.getFullPath(), true, null);
-			assertTrue("3.1", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("3.2", e);
-			}
+		ThrowingRunnable folderMovement = () -> folder1.move(folder3.getFullPath(), true, null);
+		if (isCaseSensitive) {
+			folderMovement.run();
+		} else {
+			assertThrows(CoreException.class, folderMovement);
 		}
 	}
 
-	public void testRenameFile() {
+	public void testRenameFile() throws Throwable {
 		String file1name = "file1test31415";
 		String file2name = "file2test31415";
 		IProject aProject = getWorkspace().getRoot().getProjects()[0];
 
 		// create 2 files with different names
 		IFile file1 = aProject.getFile(file1name);
-		try {
-			file1.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file1.create(getRandomContents(), true, null);
 
 		IFile file2 = aProject.getFile(file2name);
-		try {
-			file2.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		file2.create(getRandomContents(), true, null);
 
 		// try to rename folder 1 to the uppercase name of folder 2, should fail
 		IFile file3 = aProject.getFile(file2name.toUpperCase());
-		try {
-			file1.move(file3.getFullPath(), true, null);
-			assertTrue("3.1", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("3.2", e);
-			}
+		ThrowingRunnable fileMovement = () -> file1.move(file3.getFullPath(), true, null);
+		if (isCaseSensitive) {
+			fileMovement.run();
+		} else {
+			assertThrows(CoreException.class, fileMovement);
 		}
 	}
 
-	public void testCopyAndMoveFolder() {
+	public void testCopyAndMoveFolder() throws Throwable {
 		String folderName = "folderTest31415";
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject destinationProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create 2 folders, one in each project, with case-different names
 		IFolder folder1 = sourceProject.getFolder(folderName);
-		try {
-			folder1.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder1.create(true, true, null);
 
 		IFolder folder2 = destinationProject.getFolder(folderName.toUpperCase());
-		try {
-			folder2.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		folder2.create(true, true, null);
 
 		// try to copy the folder from source project to destination project.
 		// should fail due to conflict
-		try {
-			folder1.copy(destinationProject.getFullPath().append(folder1.getName()), true, null);
-			assertTrue("1.2.1", isCaseSensitive);
-		} catch (CoreException e) {
-			assertTrue("1.2.2." + e.getMessage(), !isCaseSensitive);
+		ThrowingRunnable folderCopy = () -> folder1.copy(destinationProject.getFullPath().append(folder1.getName()),
+				true, null);
+		if (isCaseSensitive) {
+			folderCopy.run();
+		} else {
+			assertThrows(CoreException.class, folderCopy);
 		}
 
 		// try to move the folder from source project to destination project.
 		// should fail due to conflict
-		try {
-			folder1.move(destinationProject.getFullPath().append(folder1.getName()), true, null);
-			fail("1.3");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> folder1.move(destinationProject.getFullPath().append(folder1.getName()), true, null));
 	}
 
-	public void testCopyAndMoveFile() {
+	public void testCopyAndMoveFile() throws Throwable {
 		String fileName = "fileTest31415";
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject destinationProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create 2 files, one in each project, with case-different names
 		IFile file1 = sourceProject.getFile(fileName);
-		try {
-			file1.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file1.create(getRandomContents(), true, null);
 
 		IFile file2 = destinationProject.getFile(fileName.toUpperCase());
-		try {
-			file2.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file2.create(getRandomContents(), true, null);
 
 		// try to copy the file from source project to destination project.
 		// should fail due to conflict
-		try {
-			file1.copy(destinationProject.getFullPath().append(file1.getName()), true, null);
-			assertTrue("1.2.1", isCaseSensitive);
-		} catch (CoreException e) {
-			if (isCaseSensitive) {
-				fail("1.2.2", e);
-			}
+		ThrowingRunnable fileCopy = () -> file1.copy(destinationProject.getFullPath().append(file1.getName()), true,
+				null);
+		if (isCaseSensitive) {
+			fileCopy.run();
+		} else {
+			assertThrows(CoreException.class, fileCopy);
 		}
 
 		// try to move the file from source project to destination project.
 		// should fail due to conflict
-		try {
-			file1.move(destinationProject.getFullPath().append(file1.getName()), true, null);
-			fail("1.3");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> file1.move(destinationProject.getFullPath().append(file1.getName()), true, null));
 	}
 
-	public void testCopyAndMoveFolderOverFile() {
+	public void testCopyAndMoveFolderOverFile() throws Throwable {
 		String name = "test31415";
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject destinationProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create 2 resources, one in each project, with case-different names
 		IFolder folder = sourceProject.getFolder(name);
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder.create(true, true, null);
 
 		IFile file = destinationProject.getFile(name.toUpperCase());
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		// try to copy the folder from source project to destination project.
 		// should fail due to conflict with existing file with case-different name
-		try {
-			folder.copy(destinationProject.getFullPath().append(folder.getName()), true, null);
-			assertTrue("1.2.1", isCaseSensitive);
-		} catch (CoreException e) {
-			assertTrue("1.2.2." + e.getMessage(), !isCaseSensitive);
+		ThrowingRunnable folderCopy = () -> folder.copy(destinationProject.getFullPath().append(folder.getName()), true,
+				null);
+		if (isCaseSensitive) {
+			folderCopy.run();
+		} else {
+			assertThrows(CoreException.class, folderCopy);
 		}
 
 		// try to move the folder from source project to destination project.
 		// should fail due to conflict with existing file with case-different name
-		try {
-			folder.move(destinationProject.getFullPath().append(folder.getName()), true, null);
-			fail("1.3");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> folder.move(destinationProject.getFullPath().append(folder.getName()), true, null));
 	}
 
-	public void testCopyAndMoveFileOverFolder() {
+	public void testCopyAndMoveFileOverFolder() throws Throwable {
 		String name = "test31415";
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject destinationProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create 2 resources, one in each project, with case-different names
 		IFile file = sourceProject.getFile(name);
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		IFolder folder = destinationProject.getFolder(name.toUpperCase());
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		folder.create(true, true, null);
 
 		// try to copy the file from source project to destination project.
 		// should fail due to conflict with existing folder with case-different name
-		try {
-			file.copy(destinationProject.getFullPath().append(file.getName()), true, null);
-			assertTrue("1.2.1", isCaseSensitive);
-		} catch (CoreException e) {
-			assertTrue("1.2.2." + e.getMessage(), !isCaseSensitive);
+		ThrowingRunnable fileCopy = () -> file.copy(destinationProject.getFullPath().append(file.getName()), true,
+				null);
+		if (isCaseSensitive) {
+			fileCopy.run();
+		} else {
+			assertThrows(CoreException.class, fileCopy);
 		}
 
 		// try to move the file from source project to destination project.
 		// should fail due to conflict with existing folder with case-different name
-		try {
-			file.move(destinationProject.getFullPath().append(file.getName()), true, null);
-			assertTrue("1.3", false);
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> file.move(destinationProject.getFullPath().append(file.getName()), true, null));
 	}
 
-	public void testCopyAndMoveFolderBecomeProject() {
+	public void testCopyAndMoveFolderBecomeProject() throws CoreException {
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject blockingProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create a folder in the source project with a case-different name to the second project
 		IFolder folder = sourceProject.getFolder(blockingProject.getName().toUpperCase());
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		folder.create(true, true, null);
 
 		// try to move the folder from source project to the root, which makes it a project.
 		// should always fails since we aren't allowed to move a folder to be a project.
-		try {
-			folder.move(IPath.ROOT.append(folder.getName()), true, null);
-			fail("1.1");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> folder.move(IPath.ROOT.append(folder.getName()), true, null));
 
 		// try to copy the folder from source project to the root, which makes it a project.
 		// should always fail since we aren't allowed to copy a folder to be a project
-		try {
-			folder.copy(IPath.ROOT.append(folder.getName()), true, null);
-			fail("1.2");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> folder.copy(IPath.ROOT.append(folder.getName()), true, null));
 	}
 
-	public void testCopyAndMoveProjectBecomeFolder() {
+	public void testCopyAndMoveProjectBecomeFolder() throws CoreException {
 		IProject sourceProject = getWorkspace().getRoot().getProjects()[0];
 		IProject destinationProject = getWorkspace().getRoot().getProjects()[1];
 
 		// create a file in the destination project with a case-different name of the source project
 		IFile file = destinationProject.getFile(sourceProject.getName().toUpperCase());
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		// try to move the source project to the destination project, which makes it a folder.
 		// should fail because we aren't allowed to move a project to be a folder
-		try {
-			sourceProject.move(destinationProject.getFullPath().append(sourceProject.getName()), true, null);
-			fail("1.1");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> sourceProject.move(destinationProject.getFullPath().append(sourceProject.getName()), true, null));
 
 		// try to copy the source project to the destination project, which makes it a folder.
 		// should fail because we aren't allowed to copy a project to be a folder
-		try {
-			sourceProject.copy(destinationProject.getFullPath().append(sourceProject.getName()), true, null);
-			fail("1.2");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> sourceProject.copy(destinationProject.getFullPath().append(sourceProject.getName()), true, null));
 	}
 
-	public void testRefreshLocalFolder1() {
+	public void testRefreshLocalFolder1() throws CoreException {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
 		// create a Folder, which should be fine
 		IFolder folder = project.getFolder(name.toUpperCase());
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		folder.create(true, true, null);
 
 		// get a Folder handle with the same name but different casing
 		// in order to determine file system location
@@ -454,27 +326,19 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		dir.mkdir();
 
 		// do a refresh, which should cause a problem
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
-		assertTrue("2.0", !folder.exists());
-		assertTrue("2.1", herringRouge.exists());
+		assertFalse(folder.exists());
+		assertTrue(herringRouge.exists());
 	}
 
-	public void testRefreshLocalFile1() {
+	public void testRefreshLocalFile1() throws CoreException {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
 		// create a File, which should be fine
 		IFile file = project.getFile(name.toUpperCase());
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		// get a File handle with the same name but different casing
 		// in order to determine file system location
@@ -485,27 +349,19 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		ensureExistsInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
-		assertTrue("4.0", !file.exists());
-		assertTrue("4.1", herringRouge.exists());
+		assertFalse(file.exists());
+		assertTrue(herringRouge.exists());
 	}
 
-	public void testRefreshLocalFolder2() {
+	public void testRefreshLocalFolder2() throws CoreException {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
 		// create a Folder, which should be fine
 		IFolder folder = project.getFolder(name.toUpperCase());
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		folder.create(true, true, null);
 
 		// get a File handle with the same name but different casing
 		// in order to determine file system location
@@ -516,27 +372,19 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		ensureExistsInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
-		assertTrue("4.0", !folder.exists());
-		assertTrue("4.1", herringRouge.exists());
+		assertFalse(folder.exists());
+		assertTrue(herringRouge.exists());
 	}
 
-	public void testRefreshLocalFile2() {
+	public void testRefreshLocalFile2() throws CoreException {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
 		// create a File, which should be fine
 		IFile file = project.getFile(name.toUpperCase());
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		// get a Folder handle with the same name but different casing
 		// in order to determine file system location
@@ -545,83 +393,55 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		// create a directory with the folder's name
 		java.io.File localFile = file.getLocation().toFile();
 		localFile.delete();
-		assertTrue("2.0", !localFile.exists());
+		assertFalse(localFile.exists());
 		java.io.File dir = herringRouge.getLocation().toFile();
 		dir.mkdir();
-		assertTrue("2.1", dir.exists());
+		assertTrue(dir.exists());
 
 		// do a refresh, which should cause a problem
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
-		assertTrue("4.0", !file.exists());
-		assertTrue("4.1", herringRouge.exists());
+		assertFalse(file.exists());
+		assertTrue(herringRouge.exists());
 	}
 
-	public void testDeleteResources() {
+	public void testDeleteResources() throws CoreException, IOException {
 		String name = "test31415";
 
 		// create a project, should be fine
 		IProject project = getWorkspace().getRoot().getProject(name);
-		try {
-			project.create(null);
-			project.open(null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		project.create(null);
+		project.open(null);
 
 		// create a Folder, which should be fine
 		IFolder folder = project.getFolder(name);
-		try {
-			folder.create(true, true, null);
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		folder.create(true, true, null);
 
 		// create a File, which should be fine
 		IFile file = folder.getFile(name);
-		try {
-			file.create(getRandomContents(), true, null);
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		file.create(getRandomContents(), true, null);
 
 		// replace the File's filesystem rep. with a case-different name
 		java.io.File localFile = file.getLocation().toFile();
 		localFile.delete();
-		assertTrue("4.0", !localFile.exists());
+		assertTrue(!localFile.exists());
 		localFile = new java.io.File(file.getLocation().removeLastSegments(1).toString(), name.toUpperCase());
-		try {
-			localFile.createNewFile();
-		} catch (IOException e) {
-			fail("4.1", e);
-		}
-		assertTrue("4.2", localFile.exists());
+		localFile.createNewFile();
+		assertTrue(localFile.exists());
 
-		try {
-			file.delete(true, null);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		file.delete(true, null);
 
 		localFile.delete(); // so that we can change its parent folder
-		assertTrue("6.0", !localFile.exists());
+		assertFalse(localFile.exists());
 
 		// replace the Folder's filesystem rep. with a case-different name
 		java.io.File localFolder = folder.getLocation().toFile();
 		localFolder.delete();
-		assertTrue("7.0", !localFolder.exists());
+		assertFalse(localFolder.exists());
 		localFolder = new java.io.File(folder.getLocation().removeLastSegments(1).toString(), name.toUpperCase());
 		localFolder.mkdir();
-		assertTrue("7.1", localFolder.exists());
+		assertTrue(localFolder.exists());
 
-		try {
-			folder.delete(true, null);
-		} catch (CoreException e) {
-			fail("8.0", e);
-		}
+		folder.delete(true, null);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -13,14 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 
 public class DeleteTest extends LocalStoreTest {
 
-	public void testDeleteOpenProject() {
+	public void testDeleteOpenProject() throws CoreException {
 		IProject project = projects[0];
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
@@ -36,20 +42,16 @@ public class DeleteTest extends LocalStoreTest {
 		IPath projectLocation = project.getLocation();
 
 		/* delete */
-		try {
-			project.delete(false, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		project.delete(false, true, getMonitor());
 
 		/* assert project does not exist anymore in the workspace*/
-		assertTrue("1.1", !project.exists());
-		assertTrue("1.2", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("1.3", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources still exist */
-		assertTrue("1.4", folderPath.toFile().isDirectory());
-		assertTrue("1.5", filePath.toFile().isFile());
+		assertTrue(folderPath.toFile().isDirectory());
+		assertTrue(filePath.toFile().isFile());
 
 		/* remove trash */
 		Workspace.clear(projectLocation.toFile());
@@ -66,21 +68,17 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		try {
-			project.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		project.delete(true, true, getMonitor());
 
 		/* assert project does not exist anymore in the workspace */
-		assertTrue("2.1", !project.exists());
-		assertTrue("2.2", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("2.3", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not exist anymore */
-		assertTrue("2.4", !projectLocation.toFile().exists());
-		assertTrue("2.5", !folderPath.toFile().exists());
-		assertTrue("2.6", !filePath.toFile().exists());
+		assertFalse(projectLocation.toFile().exists());
+		assertFalse(folderPath.toFile().exists());
+		assertFalse(filePath.toFile().exists());
 
 		/* ===========================================================
 		 * project is OPEN, deleteContents=TRUE, force=TRUE
@@ -96,20 +94,16 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		try {
-			project.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		project.delete(true, true, getMonitor());
 
 		/* assert project does not exist anymore */
-		assertTrue("3.1", !project.exists());
-		assertTrue("3.2", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("3.3", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not exist anymore */
-		assertTrue("3.4", !folderPath.toFile().isDirectory());
-		assertTrue("3.5", !filePath.toFile().isFile());
+		assertFalse(folderPath.toFile().isDirectory());
+		assertFalse(filePath.toFile().isFile());
 
 		/* ===========================================================
 		 * project is OPEN, deleteContents=TRUE, force=true
@@ -123,20 +117,16 @@ public class DeleteTest extends LocalStoreTest {
 		filePath = file.getLocation();
 
 		/* delete */
-		try {
-			project.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		project.delete(true, true, getMonitor());
 
 		/* assert project does not exist anymore */
-		assertTrue("6.1", !project.exists());
-		assertTrue("6.2", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("6.3", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not still exist at default default area */
-		assertTrue("6.4", !folderPath.toFile().exists());
-		assertTrue("6.5", !filePath.toFile().exists());
+		assertFalse(folderPath.toFile().exists());
+		assertFalse(filePath.toFile().exists());
 
 		/* remove trash */
 		Workspace.clear(folderPath.toFile());
@@ -155,25 +145,20 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		try {
-			project.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		project.delete(true, true, getMonitor());
 
 		/* assert project does not exist anymore */
-		assertTrue("7.1", !project.exists());
-		assertTrue("7.2", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("7.3", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not exist anymore */
-		assertTrue("7.4", !folderPath.toFile().isDirectory());
-		assertTrue("7.5", !filePath.toFile().isFile());
+		assertFalse(folderPath.toFile().isDirectory());
+		assertFalse(filePath.toFile().isFile());
 
 	}
 
 	public void testDeleteClosedProject() throws Throwable {
-
 		IProject project = projects[0];
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
@@ -191,25 +176,17 @@ public class DeleteTest extends LocalStoreTest {
 		IPath projectLocation = project.getLocation();
 
 		/* close and delete */
-		try {
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-		try {
-			project.delete(false, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		project.close(getMonitor());
+		project.delete(false, true, getMonitor());
 
 		/* assert project does not exist anymore in the workspace */
-		assertTrue("1.2", !project.exists());
-		assertTrue("1.3", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("1.4", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources still exist (if appropriate) */
-		assertTrue("1.5", folderPath.toFile().exists());
-		assertTrue("1.6", !filePath.toFile().exists());
+		assertTrue(folderPath.toFile().exists());
+		assertFalse(filePath.toFile().exists());
 
 		/* remove trash */
 		Workspace.clear(projectLocation.toFile());
@@ -225,25 +202,17 @@ public class DeleteTest extends LocalStoreTest {
 		filePath = file.getLocation();
 
 		/* close and delete */
-		try {
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		try {
-			project.delete(true, true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		project.close(getMonitor());
+		project.delete(true, true, getMonitor());
 
 		/* assert project does not exist anymore */
-		assertTrue("2.2", !project.exists());
-		assertTrue("2.3", !((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
-		assertNull("2.4", project.getLocation());
+		assertFalse(project.exists());
+		assertFalse(((Workspace) getWorkspace()).getMetaArea().locationFor(project).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not exist anymore */
-		assertTrue("2.5", !folderPath.toFile().isDirectory());
-		assertTrue("2.6", !filePath.toFile().isFile());
+		assertFalse(folderPath.toFile().isDirectory());
+		assertFalse(filePath.toFile().isFile());
 
 		/* ===========================================================
 		 * project is CLOSED, deleteContents=TRUE, force = FALSE
@@ -258,28 +227,20 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* close and delete */
-		try {
-			projects[0].close(getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
-		try {
-			projects[0].delete(true, false, getMonitor());
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		projects[0].close(getMonitor());
+		projects[0].delete(true, false, getMonitor());
 
 		/* assert project was deleted */
-		assertTrue("3.2", !project.exists());
+		assertFalse(project.exists());
 		IPath metaAreaLocation = ((Workspace) getWorkspace()).getMetaArea().locationFor(project);
-		assertTrue("3.3", !metaAreaLocation.toFile().exists());
-		assertTrue("3.4", !metaAreaLocation.append(".properties").toFile().exists());
-		assertTrue("3.5", !projectLocation.append(IProjectDescription.DESCRIPTION_FILE_NAME).toFile().exists());
-		assertNull("3.6", project.getLocation());
+		assertFalse(metaAreaLocation.toFile().exists());
+		assertFalse(metaAreaLocation.append(".properties").toFile().exists());
+		assertFalse(projectLocation.append(IProjectDescription.DESCRIPTION_FILE_NAME).toFile().exists());
+		assertNull(project.getLocation());
 
 		/* assert resources do not exist anymore */
-		assertTrue("3.7", !folderPath.toFile().exists());
-		assertTrue("3.8", !filePath.toFile().exists());
+		assertFalse(folderPath.toFile().exists());
+		assertFalse(filePath.toFile().exists());
 	}
 
 	public void testDeleteResource() throws Throwable {
@@ -344,32 +305,32 @@ public class DeleteTest extends LocalStoreTest {
 		folder.delete(true, null);
 
 		/* assert resources do not exist anymore */
-		assertTrue("1.1", !folder.getLocation().toFile().exists());
+		assertFalse(folder.getLocation().toFile().exists());
 
 		/* =================== */
 		/* (2) force = FALSE   */
 		/* =================== */
 
 		/* create some resources */
-		folder = projects[0].getFolder("folder");
-		ensureExistsInWorkspace(folder, true);
+		IFolder recreatedFolder = projects[0].getFolder("folder");
+		ensureExistsInWorkspace(recreatedFolder, true);
 		//
-		fileSync = folder.getFile("fileSync");
+		fileSync = recreatedFolder.getFile("fileSync");
 		ensureExistsInWorkspace(fileSync, true);
 		//
-		fileUnsync = folder.getFile("fileUnsync");
+		fileUnsync = recreatedFolder.getFile("fileUnsync");
 		ensureExistsInWorkspace(fileUnsync, true);
 		//
-		fileCreated = folder.getFile("fileCreated");
+		fileCreated = recreatedFolder.getFile("fileCreated");
 		ensureExistsInFileSystem(fileCreated); // create only in file system
 		//
-		subfolderSync = folder.getFolder("subfolderSync");
+		subfolderSync = recreatedFolder.getFolder("subfolderSync");
 		ensureExistsInWorkspace(subfolderSync, true);
 		//
 		deletedfolderSync = subfolderSync.getFolder("deletedfolderSync");
 		ensureExistsInWorkspace(deletedfolderSync, true);
 		//
-		subfolderUnsync = folder.getFolder("subfolderUnsync");
+		subfolderUnsync = recreatedFolder.getFolder("subfolderUnsync");
 		ensureExistsInWorkspace(subfolderUnsync, true);
 		//
 		subsubfolderUnsync = subfolderUnsync.getFolder("subsubfolderUnsync");
@@ -387,23 +348,18 @@ public class DeleteTest extends LocalStoreTest {
 		ensureOutOfSync(subsubfileUnsync);
 
 		/* delete */
-		try {
-			folder.delete(false, null);
-			fail("2.0");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> recreatedFolder.delete(false, null));
 
 		/* assert resources do not exist anymore in the file system */
-		assertTrue("2.1", folder.getLocation().toFile().exists());
-		assertTrue("2.2", !fileSync.getLocation().toFile().exists());
-		assertTrue("2.3", fileUnsync.getLocation().toFile().exists());
-		assertTrue("2.4", !subfolderSync.getLocation().toFile().exists());
-		assertTrue("2.5", subfolderUnsync.getLocation().toFile().exists());
-		assertTrue("2.6", !deletedfolderSync.getLocation().toFile().exists());
-		assertTrue("2.7", subsubfolderUnsync.getLocation().toFile().exists());
-		assertTrue("2.8", subsubfileUnsync.getLocation().toFile().exists());
-		assertTrue("2.9", !subsubfileSync.getLocation().toFile().exists());
-		assertTrue("2.10", fileCreated.getLocation().toFile().exists());
+		assertTrue(recreatedFolder.getLocation().toFile().exists());
+		assertFalse(fileSync.getLocation().toFile().exists());
+		assertTrue(fileUnsync.getLocation().toFile().exists());
+		assertFalse(subfolderSync.getLocation().toFile().exists());
+		assertTrue(subfolderUnsync.getLocation().toFile().exists());
+		assertFalse(deletedfolderSync.getLocation().toFile().exists());
+		assertTrue(subsubfolderUnsync.getLocation().toFile().exists());
+		assertTrue(subsubfileUnsync.getLocation().toFile().exists());
+		assertFalse(subsubfileSync.getLocation().toFile().exists());
+		assertTrue(fileCreated.getLocation().toFile().exists());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.localstore.FileSystemResourceManager;
@@ -51,7 +50,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	}
 
 	@Test
-	public void testBug440110() throws URISyntaxException, CoreException {
+	public void testBug440110() throws Exception {
 		String projectName = getUniqueString();
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(projectName);
@@ -59,28 +58,27 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		projectDescription.setLocationURI(new URI(Bug440110FileSystem.SCHEME + "://" + projectName));
 		project.create(projectDescription, null);
 		project.open(null);
-		assertEquals("0.1", Bug440110FileSystem.SCHEME, project.getLocationURI().getScheme());
+		assertEquals(Bug440110FileSystem.SCHEME, project.getLocationURI().getScheme());
 
 		IFolder folder = project.getFolder("folder");
 		folder.create(true, true, null);
-		assertEquals("0.2", Bug440110FileSystem.SCHEME, folder.getLocationURI().getScheme());
+		assertEquals(Bug440110FileSystem.SCHEME, folder.getLocationURI().getScheme());
 
 		Bug440110FileSystem.clearFetchedFileTree();
 		folder.refreshLocal(IResource.DEPTH_ZERO, null);
-		assertFalse("1.0", Bug440110FileSystem.hasFetchedFileTree());
+		assertFalse(Bug440110FileSystem.hasFetchedFileTree());
 
 		Bug440110FileSystem.clearFetchedFileTree();
 		folder.refreshLocal(IResource.DEPTH_ONE, null);
-		assertTrue("2.0", Bug440110FileSystem.hasFetchedFileTree());
+		assertTrue(Bug440110FileSystem.hasFetchedFileTree());
 
 		Bug440110FileSystem.clearFetchedFileTree();
 		folder.refreshLocal(IResource.DEPTH_INFINITE, null);
-		assertTrue("3.0", Bug440110FileSystem.hasFetchedFileTree());
+		assertTrue(Bug440110FileSystem.hasFetchedFileTree());
 	}
 
 	@Test
 	public void testContainerFor() {
-
 		/* test null parameter */
 		assertThrows(RuntimeException.class, () -> getLocalManager().containerForLocation(null));
 
@@ -91,25 +89,25 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		IFolder folder = projects[0].getFolder(path);
 		IPath location = projects[0].getLocation().append(path);
 		IFolder testFolder = (IFolder) getLocalManager().containerForLocation(location);
-		assertEquals("2.1", folder, testFolder);
+		assertEquals(folder, testFolder);
 
 		// project/folder/target
 		path = IPath.fromOSString("folder/target");
 		folder = projects[0].getFolder(path);
 		location = projects[0].getLocation().append(path);
 		testFolder = (IFolder) getLocalManager().containerForLocation(location);
-		assertEquals("2.2", folder, testFolder);
+		assertEquals(folder, testFolder);
 
 		// project/folder/folder/target
 		path = IPath.fromOSString("folder/folder/target");
 		folder = projects[0].getFolder(path);
 		location = projects[0].getLocation().append(path);
 		testFolder = (IFolder) getLocalManager().containerForLocation(location);
-		assertEquals("2.3", folder, testFolder);
+		assertEquals(folder, testFolder);
 
 		/* non-existent location */
 		testFolder = (IFolder) getLocalManager().containerForLocation(IPath.fromOSString("../this/path/must/not/exist"));
-		assertNull("3.1", testFolder);
+		assertNull(testFolder);
 	}
 
 	/**
@@ -125,15 +123,14 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 
 		/* create file with flag false */
 		file.create(getContents(originalContent), false, null);
-		assertTrue("1.2", file.exists());
-		assertTrue("1.3", file.isLocal(IResource.DEPTH_ZERO));
-		assertEquals("1.4", file.getStore().fetchInfo().getLastModified(), file.getResourceInfo(false, false).getLocalSyncInfo());
-		assertTrue("1.5", compareContent(getContents(originalContent), getLocalManager().read(file, true, null)));
+		assertTrue(file.exists());
+		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
+		assertEquals(file.getStore().fetchInfo().getLastModified(), file.getResourceInfo(false, false).getLocalSyncInfo());
+		assertTrue(compareContent(getContents(originalContent), getLocalManager().read(file, true, null)));
 	}
 
 	@Test
 	public void testFileFor() {
-
 		/* test null parameter */
 		assertThrows(RuntimeException.class, () -> getLocalManager().fileForLocation(null));
 
@@ -144,25 +141,25 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		IFile file = projects[0].getFile(path);
 		IPath location = projects[0].getLocation().append(path);
 		IFile testFile = getLocalManager().fileForLocation(location);
-		assertEquals("2.1", file, testFile);
+		assertEquals(file, testFile);
 
 		// project/folder/file
 		path = IPath.fromOSString("folder/file");
 		file = projects[0].getFile(path);
 		location = projects[0].getLocation().append(path);
 		testFile = getLocalManager().fileForLocation(location);
-		assertEquals("2.2", file, testFile);
+		assertEquals(file, testFile);
 
 		// project/folder/folder/file
 		path = IPath.fromOSString("folder/folder/file");
 		file = projects[0].getFile(path);
 		location = projects[0].getLocation().append(path);
 		testFile = getLocalManager().fileForLocation(location);
-		assertEquals("2.3", file, testFile);
+		assertEquals(file, testFile);
 
 		/* non-existent location */
 		testFile = getLocalManager().fileForLocation(IPath.fromOSString("../this/path/must/not/exist"));
-		assertNull("7.1", testFile);
+		assertNull(testFile);
 	}
 
 	@Test
@@ -176,7 +173,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		ensureDoesNotExistInFileSystem(resources);
 
 		// exists
-		assertTrue("1.0", project.isLocal(IResource.DEPTH_INFINITE)); // test
+		assertTrue(project.isLocal(IResource.DEPTH_INFINITE)); // test
 
 		// test the depth parameter
 		final IFolder folder = project.getFolder("Folder1");
@@ -187,9 +184,9 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 			}
 		};
 		getWorkspace().run(operation, null);
-		assertTrue("2.0", project.isLocal(IResource.DEPTH_ONE));
-		assertTrue("3.0", folder.isLocal(IResource.DEPTH_ZERO));
-		assertFalse("4.0", folder.isLocal(IResource.DEPTH_INFINITE));
+		assertTrue(project.isLocal(IResource.DEPTH_ONE));
+		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
+		assertFalse(folder.isLocal(IResource.DEPTH_INFINITE));
 
 		// remove the trash
 		ensureDoesNotExistInWorkspace(project);
@@ -202,11 +199,10 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	 */
 	@Test
 	public void testLocationFor() {
-
 		/* test project */
 		IPath location = projects[0].getLocation();
-		assertTrue("2.1", location.equals(getLocalManager().locationFor(projects[0])));
-		assertTrue("2.2", location.equals(getWorkspace().getRoot().getLocation().append(projects[0].getName())));
+		assertEquals(getLocalManager().locationFor(projects[0]), location);
+		assertEquals(getWorkspace().getRoot().getLocation().append(projects[0].getName()), location);
 	}
 
 	@Test
@@ -216,7 +212,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		IFile file = projects[0].getFile("file");
 		ensureExistsInFileSystem(file);
 		projects[0].refreshLocal(IResource.DEPTH_ZERO, null);
-		assertFalse("1.1", file.exists());
+		assertFalse(file.exists());
 		/* DEPTH_ONE */
 		IFolder folder = projects[0].getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
@@ -225,25 +221,25 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		ensureExistsInFileSystem(subfolder);
 		ensureExistsInFileSystem(subfile);
 		projects[0].refreshLocal(IResource.DEPTH_ONE, null);
-		assertTrue("2.1", file.exists());
-		assertTrue("2.2", folder.exists());
-		assertFalse("2.3", subfolder.exists());
-		assertFalse("2.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertFalse(subfolder.exists());
+		assertFalse(subfile.exists());
 		/* DEPTH_INFINITE */
 		projects[0].refreshLocal(IResource.DEPTH_INFINITE, null);
-		assertTrue("3.1", file.exists());
-		assertTrue("3.2", folder.exists());
-		assertTrue("3.3", subfolder.exists());
-		assertTrue("3.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertTrue(subfolder.exists());
+		assertTrue(subfile.exists());
 
 		/* closed project */
 		file = projects[0].getFile("closed");
 		projects[0].close(null);
 		ensureExistsInFileSystem(file);
 		projects[0].open(null);
-		assertFalse("4.1", file.exists());
+		assertFalse(file.exists());
 		projects[0].refreshLocal(IResource.DEPTH_INFINITE, null);
-		assertTrue("4.2", file.exists());
+		assertTrue(file.exists());
 
 		/* refreshing an inexisting project should do nothing */
 		getWorkspace().getRoot().getProject("inexistingProject").refreshLocal(IResource.DEPTH_INFINITE, null);
@@ -361,7 +357,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		ensureExistsInFileSystem(folder);
 		/* force = true */
 		write(folder, true, null);
-		assertTrue("2.1", folder.getLocation().toFile().isDirectory());
+		assertTrue(folder.getLocation().toFile().isDirectory());
 		/* force = false */
 		assertThrows(CoreException.class, () -> write(folder, false, null));
 		ensureDoesNotExistInFileSystem(folder);
@@ -369,11 +365,11 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* inexisting resource on destination */
 		/* force = true */
 		write(folder, true, null);
-		assertTrue("3.1", folder.getLocation().toFile().isDirectory());
+		assertTrue(folder.getLocation().toFile().isDirectory());
 		ensureDoesNotExistInFileSystem(folder);
 		/* force = false */
 		write(folder, false, null);
-		assertTrue("3.1", folder.getLocation().toFile().isDirectory());
+		assertTrue(folder.getLocation().toFile().isDirectory());
 	}
 
 	/**
@@ -394,9 +390,9 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 			//write project in a runnable, otherwise tree will be locked
 			((Project) project).writeDescription(IResource.FORCE);
 		}, null);
-		assertTrue("2.2", fileStore.fetchInfo().isDirectory());
+		assertTrue(fileStore.fetchInfo().isDirectory());
 		long lastModified = ((Resource) dotProject).getStore().fetchInfo().getLastModified();
-		assertEquals("2.3", lastModified, ((Resource) project).getResourceInfo(false, false).getLocalSyncInfo());
+		assertEquals(lastModified, ((Resource) project).getResourceInfo(false, false).getLocalSyncInfo());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -13,11 +13,21 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import java.io.*;
-import org.eclipse.core.filesystem.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.localstore.FileSystemResourceManager;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -178,18 +188,13 @@ public abstract class LocalStoreTest extends ResourceTest {
 	 * Copy the data from the input stream to the output stream.
 	 * Close just the input stream.
 	 */
-	public void transferDataWithoutCloseStreams(InputStream input, OutputStream output) {
-		try {
-			int c = 0;
-			while ((c = input.read()) != -1) {
-				output.write(c);
-			}
-			//input.close();
-			//output.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-			assertTrue(e.toString(), false);
+	public void transferDataWithoutCloseStreams(InputStream input, OutputStream output) throws IOException {
+		int c = 0;
+		while ((c = input.read()) != -1) {
+			output.write(c);
 		}
+		// input.close();
+		// output.close();
 	}
 
 	protected boolean verifyNode(IFileStore node) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.internal.resources.ICoreConstants;
 import org.eclipse.core.internal.resources.Project;
 import org.eclipse.core.internal.resources.TestingSupport;
@@ -54,39 +56,30 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 
 		// run synchronize
 		//The .project file has been deleted, so this will fail
-		try {
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-			fail("1.0");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> project.refreshLocal(IResource.DEPTH_INFINITE, null));
 
 		/* project should still exists */
-		assertTrue("1.1", project.exists());
+		assertTrue(project.exists());
 
 		/* resources should not exist anymore */
 		for (int i = 1; i < resources.length; i++) {
-			assertTrue("1.2", !resources[i].exists());
+			assertFalse("Resource does unexpectedly exist: " + resources[i], resources[i].exists());
 		}
 	}
 
-	public void testProjectWithNoResources() {
+	public void testProjectWithNoResources() throws CoreException {
 		/* initialize common objects */
 		Project project = (Project) projects[0];
 
-		try {
-			/* check normal behaviour */
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-		assertTrue("1.1", project.exists());
+		/* check normal behaviour */
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
+		assertTrue(project.exists());
 	}
 
 	/**
 	 * Simple synchronization test. Uses one solution and one project.
 	 */
-	public void testSimpleSync() {
+	public void testSimpleSync() throws Exception {
 		/* initialize common objects */
 		Project project = (Project) projects[0];
 
@@ -102,12 +95,8 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		ensureExistsInWorkspace((IFile) file, "");
 		ensureExistsInWorkspace(folder, true);
 
-		try {
-			// run synchronize
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		// run synchronize
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
 		//-----------------------------------------------------------
 		// test synchronize
@@ -133,22 +122,16 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		//
 		ensureDoesNotExistInFileSystem(file);
 		ensureDoesNotExistInFileSystem(folder);
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException e) {
-			fail("3.0", e);
-		}
+
+		Thread.sleep(5000);
+
 		file = project.getFolder(IPath.fromOSString("file"));
 		folder = project.getFile(IPath.fromOSString("folder"));
 		ensureExistsInFileSystem(file);
 		ensureExistsInFileSystem((IFile) folder);
 
-		try {
-			// run synchronize
-			project.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		// run synchronize
+		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
 		//-----------------------------------------------------------
 		// test synchronize

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/PrefixPoolTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/PrefixPoolTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.internal.localstore.PrefixPool;
@@ -24,21 +25,8 @@ public class PrefixPoolTest {
 
 	@Test
 	public void testIllegalCapacity() {
-		boolean exceptionOK=true;
-		try {
-			new PrefixPool(0);
-			exceptionOK=false;
-		} catch(IllegalArgumentException e) {
-			/*ignore, exception is expected*/
-		}
-		assertTrue(exceptionOK);
-		try {
-			new PrefixPool(-1);
-			exceptionOK=false;
-		} catch(IllegalArgumentException e) {
-			/*ignore, exception is expected*/
-		}
-		assertTrue(exceptionOK);
+		assertThrows(IllegalArgumentException.class, () -> new PrefixPool(0));
+		assertThrows(IllegalArgumentException.class, () -> new PrefixPool(-1));
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -13,10 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import java.io.*;
+import static org.junit.Assert.assertThrows;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.core.internal.localstore.*;
+import org.eclipse.core.internal.localstore.ILocalStoreConstants;
+import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
+import org.eclipse.core.internal.localstore.SafeChunkyOutputStream;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.runtime.IPath;
 
@@ -90,7 +96,7 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 
 	public void testFailure() throws Exception {
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue(!target.exists());
+		assertFalse(target.exists());
 
 		// misc
 		byte[] fakeEnd = new byte[ILocalStoreConstants.END_CHUNK.length];
@@ -181,16 +187,13 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 		}
 
 		try (DataInputStream input = new DataInputStream(new SafeChunkyInputStream(target))) {
-			input.readUTF();
-			fail("Should throw EOFException");
-		} catch (EOFException e) {
-			// should hit here
+			assertThrows(EOFException.class, () -> input.readUTF());
 		}
 	}
 
 	public void testSimple() throws Exception {
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue(!target.exists());
+		assertFalse(target.exists());
 
 		// write chunks
 		byte[] chunk1 = getRandomString().getBytes();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -23,134 +23,114 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 public class SafeFileInputOutputStreamTest extends ResourceTest {
-	protected File temp;
+	protected IPath temp;
 
-	public SafeFileOutputStream createSafeStream(File target, String errorCode) {
-		return createSafeStream(target.getAbsolutePath(), null, errorCode);
+	public SafeFileOutputStream createSafeStream(File target) throws IOException {
+		return createSafeStream(target.getAbsolutePath(), null);
 	}
 
-	public SafeFileOutputStream createSafeStream(String targetPath, String tempFilePath, String errorCode) {
-		try {
-			return new SafeFileOutputStream(targetPath, tempFilePath);
-		} catch (IOException e) {
-			fail(errorCode, e);
-		}
-		return null; // never happens
+	public SafeFileOutputStream createSafeStream(String targetPath, String tempFilePath)
+			throws IOException {
+		return new SafeFileOutputStream(targetPath, tempFilePath);
 	}
 
-	@Override
-	public InputStream getContents(java.io.File target, String errorCode) {
-		try {
-			return new SafeFileInputStream(target);
-		} catch (IOException e) {
-			fail(errorCode, e);
-		}
-		return null; // never happens
+	public InputStream getContents(java.io.File target) throws IOException {
+		return new SafeFileInputStream(target);
 	}
 
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
 		IPath location = getRandomLocation();
-		temp = location.append("temp").toFile();
-		temp.mkdirs();
-		assertTrue("could not create temp directory", temp.isDirectory());
+		temp = location.append("temp");
+		temp.toFile().mkdirs();
+		deleteOnTearDown(temp);
+		assertTrue("could not create temp directory", temp.toFile().isDirectory());
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		Workspace.clear(temp.getParentFile());
-		super.tearDown();
-	}
-
-	public void testSafeFileInputStream() {
-		File target = new File(temp, "target");
+	public void testSafeFileInputStream() throws IOException {
+		File target = new File(temp.toFile(), "target");
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue("1.0", !target.exists());
+		assertFalse(target.exists());
 
 		// define temp path
 		IPath parentLocation = IPath.fromOSString(target.getParentFile().getAbsolutePath());
 		IPath tempLocation = parentLocation.append(target.getName() + ".backup");
 
 		// we did not have a file on the destination, so we should not have a temp file
-		SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString(), "2.0");
+		SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString());
 		File tempFile = tempLocation.toFile();
 		String contents = getRandomString();
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
 
 		// now we should have a temp file
-		safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString(), "4.0");
+		safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString());
 		tempFile = tempLocation.toFile();
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
 
-		assertTrue("5.0", target.exists());
-		assertTrue("5.1", !tempFile.exists());
-		InputStream diskContents;
-		try {
-			diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath());
-			assertTrue("5.2", compareContent(diskContents, getContents(contents)));
-		} catch (IOException e) {
-			fail("5.3", e);
-		}
+		assertTrue(target.exists());
+		assertFalse(tempFile.exists());
+		InputStream diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath());
+		assertTrue(compareContent(diskContents, getContents(contents)));
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
-	public void testSimple() {
-		File target = new File(temp, "target");
+	public void testSimple() throws IOException {
+		File target = new File(temp.toFile(), "target");
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue("1.0", !target.exists());
+		assertTrue(!target.exists());
 
 		// basic use (like a FileOutputStream)
-		SafeFileOutputStream safeStream = createSafeStream(target, "1.0");
+		SafeFileOutputStream safeStream = createSafeStream(target);
 		String contents = getRandomString();
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
-		InputStream diskContents = getContents(target, "1.2");
-		assertTrue("1.3", compareContent(diskContents, getContents(contents)));
+		InputStream diskContents = getContents(target);
+		assertTrue(compareContent(diskContents, getContents(contents)));
 
 		// update target contents
 		contents = getRandomString();
-		safeStream = createSafeStream(target, "2.0");
+		safeStream = createSafeStream(target);
 		File tempFile = new File(safeStream.getTempFilePath());
-		assertTrue("2.0", tempFile.exists());
+		assertTrue(tempFile.exists());
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
-		diskContents = getContents(target, "3.1");
-		assertTrue("3.2", compareContent(diskContents, getContents(contents)));
-		assertTrue("3.3", !tempFile.exists());
+		diskContents = getContents(target);
+		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertFalse(tempFile.exists());
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
-	public void testSpecifiedTempFile() {
-		File target = new File(temp, "target");
+	public void testSpecifiedTempFile() throws IOException {
+		File target = new File(temp.toFile(), "target");
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue("1.0", !target.exists());
+		assertTrue(!target.exists());
 
 		// define temp path
 		IPath parentLocation = IPath.fromOSString(target.getParentFile().getAbsolutePath());
 		IPath tempLocation = parentLocation.append(target.getName() + ".backup");
 
 		// we did not have a file on the destination, so we should not have a temp file
-		SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString(), "2.0");
+		SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString());
 		File tempFile = tempLocation.toFile();
-		assertTrue("2.1", !tempFile.exists());
+		assertFalse(tempFile.exists());
 
 		// update target contents
 		String contents = getRandomString();
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
-		InputStream diskContents = getContents(target, "3.1");
-		assertTrue("3.2", compareContent(diskContents, getContents(contents)));
-		assertTrue("3.3", !tempFile.exists());
+		InputStream diskContents = getContents(target);
+		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertFalse(tempFile.exists());
 
 		// now we should have a temp file
-		safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString(), "4.0");
+		safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString());
 		tempFile = tempLocation.toFile();
-		assertTrue("4.1", tempFile.exists());
+		assertTrue(tempFile.exists());
 
 		// update target contents
 		contents = getRandomString();
 		transferStreams(getContents(contents), safeStream, target.getAbsolutePath());
-		diskContents = getContents(target, "5.1");
-		assertTrue("5.2", compareContent(diskContents, getContents(contents)));
-		assertTrue("5.3", !tempFile.exists());
+		diskContents = getContents(target);
+		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertFalse(tempFile.exists());
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
@@ -30,12 +30,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SymlinkResourceTest extends LocalStoreTest {
 
-	protected void mkLink(IFileStore dir, String src, String tgt, boolean isDir) {
-		try {
-			createSymLink(dir.toLocalFile(EFS.NONE, getMonitor()), src, tgt, isDir);
-		} catch (CoreException e) {
-			fail("mkLink", e);
-		}
+	protected void mkLink(IFileStore dir, String src, String tgt, boolean isDir) throws CoreException {
+		createSymLink(dir.toLocalFile(EFS.NONE, getMonitor()), src, tgt, isDir);
 	}
 
 	protected void createBug232426Structure(IFileStore rootDir) throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -43,18 +43,8 @@ public class UnifiedTreeTest extends LocalStoreTest {
 	protected void createFiles(IFileStore folder, Hashtable<String, String> set) throws Exception {
 		for (int i = 0; i < limit; i++) {
 			IFileStore child = folder.getChild("fsFile" + i);
-			OutputStream out = null;
-			try {
-				out = child.openOutputStream(EFS.NONE, null);
+			try (OutputStream out = child.openOutputStream(EFS.NONE, null)) {
 				out.write("contents".getBytes());
-			} finally {
-				try {
-					if (out != null) {
-						out.close();
-					}
-				} catch (IOException e) {
-					//ignore
-				}
 			}
 			set.put(child.toString(), "");
 		}
@@ -171,9 +161,9 @@ public class UnifiedTreeTest extends LocalStoreTest {
 			IFileStore store = ((Resource) resource).getStore();
 			String key = store.fetchInfo().getName();
 			if (node.existsInFileSystem()) {
-				assertEquals("1.0", key, node.getLocalName());
+				assertEquals(key, node.getLocalName());
 			}
-			assertEquals("1.1", store, node.getStore());
+			assertEquals(store, node.getStore());
 
 			/* force children to be added to the queue */
 			node.getChildren();
@@ -196,8 +186,8 @@ public class UnifiedTreeTest extends LocalStoreTest {
 		tree.accept(visitor);
 
 		/* if the hash table is empty, we walked through all resources */
-		assertTrue("2.0", !set.isEmpty());
-		assertTrue("2.1", set.size() != initialSize);
+		assertFalse(set.isEmpty());
+		assertTrue(set.size() != initialSize);
 	}
 
 	/**
@@ -225,9 +215,9 @@ public class UnifiedTreeTest extends LocalStoreTest {
 			final IResource resource = node.getResource();
 			IFileStore store = ((Resource) resource).getStore();
 			if (node.existsInFileSystem()) {
-				assertEquals("1.0", store.fetchInfo().getName(), node.getLocalName());
+				assertEquals(store.fetchInfo().getName(), node.getLocalName());
 			}
-			assertEquals("1.1", store, node.getStore());
+			assertEquals(store, node.getStore());
 			/* remove from the hash table the resource we're visiting */
 			set.remove(resource.getLocation().toOSString());
 			return true;
@@ -238,7 +228,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 		tree.accept(visitor);
 
 		/* if the hash table is empty, we walked through all resources */
-		assertTrue("2.0", set.isEmpty());
+		assertTrue(set.isEmpty());
 	}
 
 	/**


### PR DESCRIPTION
Affects all tests in `org.eclipse.core.tests.internal.localstore`

* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Replaces assertTrue(!...) with assertFalse(...)

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.
