### PR TITLE
Cleanup and simplify builder tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuilderTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuilderTests.java
@@ -23,6 +23,6 @@ import org.junit.runners.Suite;
 		BuildDeltaVerificationTest.class, CustomBuildTriggerTest.class, EmptyDeltaTest.class,
 		MultiProjectBuildTest.class, RelaxedSchedRuleBuilderTest.class, BuildConfigurationsTest.class,
 		BuildContextTest.class, ParallelBuildChainTest.class, ComputeProjectOrderTest.class, AutoBuildJobTest.class })
-public class AllBuildderTests {
+public class AllBuilderTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -224,7 +224,8 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 			// inside the ExecutionException
 			throw e.getCause();
 		} catch (TimeoutException e) {
-			fail("This test timed out which means there is no safeguard to avoid waiting indefinitely "
+			throw new IllegalStateException(
+					"This test timed out which means there is no safeguard to avoid waiting indefinitely "
 					+ "for an auto-build job while the JobManager is suspended", e);
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
@@ -15,7 +15,14 @@ package org.eclipse.core.tests.internal.builders;
 
 import org.eclipse.core.internal.events.BuildContext;
 import org.eclipse.core.internal.resources.BuildConfiguration;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IBuildContext;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -48,16 +55,6 @@ public class BuildContextTest extends AbstractBuilderTest {
 		setupProject(project0);
 		setupProject(project1);
 		setupProject(project2);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
-		// Cleanup
-		project0.delete(true, null);
-		project1.delete(true, null);
-		project2.delete(true, null);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -13,7 +13,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -26,7 +34,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		super(name);
 	}
 
-	public void testIsBeforeThisProject() {
+	public void testIsBeforeThisProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");
 		IProject before1 = root.getProject("Before1");
@@ -35,43 +43,28 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		IProject after2 = root.getProject("After2");
 		ensureExistsInWorkspace(new IResource[] {project, before1, before2, after1, after2}, true);
 
-		try {
-			setBuildOrder(before1, before2, project, after1, after2);
-			setAutoBuilding(false);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
-		try {
-			IProjectDescription description = project.getDescription();
-			ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
-			description.setBuildSpec(new ICommand[] {command1});
-			project.setDescription(description, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		setBuildOrder(before1, before2, project, after1, after2);
+		setAutoBuilding(false);
+
+		IProjectDescription description = project.getDescription();
+		ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
+		description.setBuildSpec(new ICommand[] { command1 });
+		project.setDescription(description, IResource.NONE, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
 		CycleBuilder builder = CycleBuilder.getInstance();
 		builder.resetBuildCount();
 		builder.setBeforeProjects(new IProject[] {before1, before2});
 		builder.setAfterProjects(new IProject[] {after1, after2});
 
-		try {
-			//create a file to ensure incremental build is called
-			project.getFile("Foo.txt").create(getRandomContents(), IResource.NONE, getMonitor());
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			builder.resetBuildCount();
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// create a file to ensure incremental build is called
+		project.getFile("Foo.txt").create(getRandomContents(), IResource.NONE, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		builder.resetBuildCount();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 	}
 
-	public void skipTestNeedRebuild() {
+	public void skipTestNeedRebuild() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");
 		IFolder unsorted = project.getFolder(SortBuilder.DEFAULT_UNSORTED_FOLDER);
@@ -81,128 +74,77 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		ensureExistsInWorkspace(unsortedFile, true);
 
 		//setup so that the sortbuilder and cycle builder are both touching files in the project
-		try {
-			setAutoBuilding(true);
-			IProjectDescription description = project.getDescription();
-			ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
-			ICommand command2 = createCommand(description, SortBuilder.BUILDER_NAME, "Build1");
-			description.setBuildSpec(new ICommand[] {command1, command2});
-			project.setDescription(description, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		setAutoBuilding(true);
+		IProjectDescription description = project.getDescription();
+		ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
+		ICommand command2 = createCommand(description, SortBuilder.BUILDER_NAME, "Build1");
+		description.setBuildSpec(new ICommand[] { command1, command2 });
+		project.setDescription(description, IResource.NONE, getMonitor());
+
 		CycleBuilder builder = CycleBuilder.getInstance();
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
 		//don't request rebuilds and ensure we're only called once
 		builder.setRebuildsToRequest(0);
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
-		assertEquals("4.1", 1, builder.getBuildCount());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(1, builder.getBuildCount());
 
 		//force an incremental build
 		IFile file = project.getFile("foo.txt");
 		builder.resetBuildCount();
-		try {
-			file.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.2", e);
-		}
-		assertEquals("4.3", 1, builder.getBuildCount());
+		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		assertEquals(1, builder.getBuildCount());
 
 		//request 1 rebuild and ensure we're called twice
 		builder.setRebuildsToRequest(1);
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
-		assertEquals("5.1", 2, builder.getBuildCount());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(2, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		try {
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.2", e);
-		}
-		assertEquals("5.3", 2, builder.getBuildCount());
+		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		assertEquals(2, builder.getBuildCount());
 
 		//request 5 rebuilds and ensure we're called six times
 		builder.setRebuildsToRequest(5);
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("6.0", e);
-		}
-		assertEquals("6.1", 6, builder.getBuildCount());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(6, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		try {
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("6.2", e);
-		}
-		assertEquals("6.3", 6, builder.getBuildCount());
+		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		assertEquals(6, builder.getBuildCount());
 
 		//request many rebuilds and ensure we're called according to the build policy
 		int maxBuilds = getWorkspace().getDescription().getMaxBuildIterations();
 		builder.setRebuildsToRequest(maxBuilds * 2);
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
-		assertEquals("7.1", maxBuilds, builder.getBuildCount());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		try {
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("7.2", e);
-		}
-		assertEquals("7.3", maxBuilds, builder.getBuildCount());
+		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//change the rebuild policy and ensure we're called the correct number of times
 		maxBuilds = 7;
-		try {
-			IWorkspaceDescription desc = getWorkspace().getDescription();
-			desc.setMaxBuildIterations(maxBuilds);
-			getWorkspace().setDescription(desc);
-		} catch (CoreException e) {
-			fail("8.0", e);
-		}
+		IWorkspaceDescription desc = getWorkspace().getDescription();
+		desc.setMaxBuildIterations(maxBuilds);
+		getWorkspace().setDescription(desc);
 		builder.setRebuildsToRequest(maxBuilds * 2);
 		builder.resetBuildCount();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("8.1", e);
-		}
-		assertEquals("8.2", maxBuilds, builder.getBuildCount());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		try {
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("8.3", e);
-		}
-		assertEquals("8.4", maxBuilds, builder.getBuildCount());
+		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		assertEquals(maxBuilds, builder.getBuildCount());
 
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
@@ -13,7 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -40,76 +44,53 @@ public class BuilderEventTest extends AbstractBuilderTest {
 		getWorkspace().removeResourceChangeListener(listener);
 	}
 
-	public void testEventsOnClean() {
+	public void testEventsOnClean() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2")});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
+		project.setDescription(desc, getMonitor());
 		listener.reset();
 		//start with an incremental build
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
-		assertEquals("2.0", getWorkspace(), listener.getSource());
-		assertEquals("2.1", IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
-		assertEquals("2.2", true, listener.hadPreBuild());
-		assertEquals("2.3", true, listener.hadPostBuild());
-		assertEquals("2.4", true, listener.hadPostChange());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		assertEquals(getWorkspace(), listener.getSource());
+		assertEquals(IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
+		assertTrue(listener.hadPreBuild());
+		assertTrue(listener.hadPostBuild());
+		assertTrue(listener.hadPostChange());
 
 		//do a second incremental build and ensure we still get the events
 		listener.reset();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
-		assertEquals("2.0", getWorkspace(), listener.getSource());
-		assertEquals("2.1", IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
-		assertEquals("2.2", true, listener.hadPreBuild());
-		assertEquals("2.3", true, listener.hadPostBuild());
-		assertEquals("2.4", true, listener.hadPostChange());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		assertEquals(getWorkspace(), listener.getSource());
+		assertEquals(IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
+		assertTrue(listener.hadPreBuild());
+		assertTrue(listener.hadPostBuild());
+		assertTrue(listener.hadPostChange());
 
 		//do a full build and ensure we still get the event
 		listener.reset();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
-		assertEquals("3.0", getWorkspace(), listener.getSource());
-		assertEquals("3.1", IncrementalProjectBuilder.FULL_BUILD, listener.getBuildKind());
-		assertEquals("3.2", true, listener.hadPreBuild());
-		assertEquals("3.3", true, listener.hadPostBuild());
-		assertEquals("3.4", true, listener.hadPostChange());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		assertEquals(getWorkspace(), listener.getSource());
+		assertEquals(IncrementalProjectBuilder.FULL_BUILD, listener.getBuildKind());
+		assertTrue(listener.hadPreBuild());
+		assertTrue(listener.hadPostBuild());
+		assertTrue(listener.hadPostChange());
 
 		//do a clean build and ensure we get the same events
 		listener.reset();
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
-		assertEquals("4.0", getWorkspace(), listener.getSource());
-		assertEquals("4.1", IncrementalProjectBuilder.CLEAN_BUILD, listener.getBuildKind());
-		assertEquals("4.2", true, listener.hadPreBuild());
-		assertEquals("4.3", true, listener.hadPostBuild());
-		assertEquals("4.4", true, listener.hadPostChange());
+		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		assertEquals(getWorkspace(), listener.getSource());
+		assertEquals(IncrementalProjectBuilder.CLEAN_BUILD, listener.getBuildKind());
+		assertTrue(listener.hadPreBuild());
+		assertTrue(listener.hadPostBuild());
+		assertTrue(listener.hadPostChange());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -14,15 +14,34 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.*;
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
+import org.eclipse.core.tests.harness.TestBarrier2;
+import org.eclipse.core.tests.harness.TestJob;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * This class tests public API related to building and to build specifications.
@@ -67,7 +86,7 @@ public class BuilderTest extends AbstractBuilderTest {
 	public void testAardvarkBuildOrder() {
 		IWorkspace workspace = getWorkspace();
 		//builder order should initially be null
-		assertEquals("1.0", null, workspace.getDescription().getBuildOrder());
+		assertNull(workspace.getDescription().getBuildOrder());
 	}
 
 	/**
@@ -75,7 +94,7 @@ public class BuilderTest extends AbstractBuilderTest {
 	 *
 	 * @see SortBuilder
 	 */
-	public void testAutoBuildPR() {
+	public void testAutoBuildPR() throws CoreException {
 		//REF: 1FUQUJ4
 		// Create some resource handles
 		IWorkspace workspace = getWorkspace();
@@ -85,146 +104,104 @@ public class BuilderTest extends AbstractBuilderTest {
 		IFile fileA = folder.getFile("A");
 		IFile fileB = sub.getFile("B");
 		// Create some resources
-		try {
-			// Turn auto-building on
-			setAutoBuilding(true);
-			project1.create(getMonitor());
-			project1.open(getMonitor());
-			// Set build spec
-			IProjectDescription desc = project1.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			command.getArguments().put(TestBuilder.BUILD_ID, "Project1Build1");
-			desc.setBuildSpec(new ICommand[] {command});
-			project1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// Turn auto-building on
+		setAutoBuilding(true);
+		project1.create(getMonitor());
+		project1.open(getMonitor());
+		// Set build spec
+		IProjectDescription desc = project1.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		command.getArguments().put(TestBuilder.BUILD_ID, "Project1Build1");
+		desc.setBuildSpec(new ICommand[] { command });
+		project1.setDescription(desc, getMonitor());
+
 		// Create folders and files
-		try {
-			folder.create(true, true, getMonitor());
-			fileA.create(getRandomContents(), true, getMonitor());
-			sub.create(true, true, getMonitor());
-			fileB.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		folder.create(true, true, getMonitor());
+		fileA.create(getRandomContents(), true, getMonitor());
+		sub.create(true, true, getMonitor());
+		fileB.create(getRandomContents(), true, getMonitor());
 	}
 
 	/**
 	 * Tests installing and running a builder that always fails during
 	 * instantation.
 	 */
-	public void testBrokenBuilder() {
+	public void testBrokenBuilder() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command1 = desc.newCommand();
-			command1.setBuilderName(BrokenBuilder.BUILDER_NAME);
-			ICommand command2 = desc.newCommand();
-			command2.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command1, command2});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		ICommand command1 = desc.newCommand();
+		command1.setBuilderName(BrokenBuilder.BUILDER_NAME);
+		ICommand command2 = desc.newCommand();
+		command2.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command1, command2 });
+		project.setDescription(desc, getMonitor());
 		//do an incremental build -- build should fail, but second builder
 		// should run
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			fail("3.0");
-		} catch (CoreException e) {
-			//expected
-		}
+		assertThrows(CoreException.class,
+				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor()));
+
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-		verifier.assertLifecycleEvents("3.1");
+		verifier.assertLifecycleEvents();
+
 		//build again -- it should succeed this time
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 	}
 
-	public void testBuildClean() {
+	public void testBuildClean() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2")});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
+		project.setDescription(desc, getMonitor());
+
 		//start with a clean build
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		FussyProgressMonitor monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
+		monitor.assertUsedUp();
+
 		DeltaVerifierBuilder verifier = DeltaVerifierBuilder.getInstance();
 		assertTrue("3.2", verifier.wasCleanBuild());
 		// Now do an incremental build - since delta was null it should appear as a clean build
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.3", e);
-		}
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+		monitor.assertUsedUp();
 		assertTrue("3.4", verifier.wasFullBuild());
 		// next time it will appear as an incremental build
-		try {
-			project.touch(getMonitor());
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.5", e);
-		}
+		project.touch(getMonitor());
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+		monitor.assertUsedUp();
 		assertTrue("3.6", verifier.wasIncrementalBuild());
+
 		//do another clean
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.7", e);
-		}
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
+		monitor.assertUsedUp();
 		assertTrue("3.8", verifier.wasCleanBuild());
+
 		//doing a full build should still look like a full build
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.9", e);
-		}
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		monitor.assertUsedUp();
 		assertTrue("3.10", verifier.wasFullBuild());
 	}
 
@@ -233,7 +210,7 @@ public class BuilderTest extends AbstractBuilderTest {
 	 *
 	 * @see SortBuilder
 	 */
-	public void testBuildCommands() {
+	public void testBuildCommands() throws CoreException {
 		// Create some resource handles
 		IWorkspace workspace = getWorkspace();
 		IProject project1 = workspace.getRoot().getProject("PROJECT" + 1);
@@ -241,164 +218,132 @@ public class BuilderTest extends AbstractBuilderTest {
 		IFile file1 = project1.getFile("FILE1");
 		IFile file2 = project2.getFile("FILE2");
 		//set the build order
-		try {
-			IWorkspaceDescription workspaceDesc = workspace.getDescription();
-			workspaceDesc.setBuildOrder(new String[] {project1.getName(), project2.getName()});
-			workspace.setDescription(workspaceDesc);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		IWorkspaceDescription workspaceDesc = workspace.getDescription();
+		workspaceDesc.setBuildOrder(new String[] { project1.getName(), project2.getName() });
+		workspace.setDescription(workspaceDesc);
 		TestBuilder verifier = null;
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create some resources
-			project1.create(getMonitor());
-			project1.open(getMonitor());
-			project2.create(getMonitor());
-			project2.open(getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
-			file2.create(getRandomContents(), true, getMonitor());
-			// Do an initial build to get the builder instance
-			IProjectDescription desc = project1.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Project1Build1")});
-			project1.setDescription(desc, getMonitor());
-			project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Project1Build1");
-			verifier.assertLifecycleEvents("1.0");
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create some resources
+		project1.create(getMonitor());
+		project1.open(getMonitor());
+		project2.create(getMonitor());
+		project2.open(getMonitor());
+		file1.create(getRandomContents(), true, getMonitor());
+		file2.create(getRandomContents(), true, getMonitor());
+		// Do an initial build to get the builder instance
+		IProjectDescription desc = project1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Project1Build1") });
+		project1.setDescription(desc, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Project1Build1");
+		verifier.assertLifecycleEvents();
+
 		// Build spec with no commands
-		try {
-			IProjectDescription desc = project1.getDescription();
-			desc.setBuildSpec(new ICommand[] {});
-			project1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		desc = project1.getDescription();
+		desc.setBuildSpec(new ICommand[] {});
+		project1.setDescription(desc, getMonitor());
+
 		// Build the project -- should do nothing
-		try {
-			verifier.reset();
-			dirty(file1);
-			project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.assertLifecycleEvents("3.1");
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
+		verifier.reset();
+		dirty(file1);
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.assertLifecycleEvents();
+
 		// Build command with no arguments -- will use default build ID
-		try {
-			IProjectDescription desc = project1.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
+		desc = project1.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project1.setDescription(desc, getMonitor());
+
 		// Build the project
 		// Note that since the arguments have changed, the identity of the build
 		// command is different so a new builder will be instantiated
-		try {
-			dirty(file1);
-			project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("5.2");
-		} catch (CoreException e) {
-			fail("5.99", e);
-		}
+		dirty(file1);
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
+
 		// Create and set a build specs for project one
-		try {
-			IProjectDescription desc = project1.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Project1Build1")});
-			project1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("6.99", e);
-		}
+		desc = project1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Project1Build1") });
+		project1.setDescription(desc, getMonitor());
+
 		// Create and set a build spec for project two
-		try {
-			IProjectDescription desc = project2.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1"), createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2")});
-			project2.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("7.99", e);
-		}
+		desc = project2.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1"),
+				createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
+		project2.setDescription(desc, getMonitor());
+
 		// Build
-		try {
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Project1Build1");
-			//second builder is touched for the first time
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Project2Build1");
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Project2Build2");
-			dirty(file1);
-			dirty(file2);
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.assertLifecycleEvents("8.0");
-			verifier.addExpectedLifecycleEvent("Project1Build1");
-			dirty(file1);
-			project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier.assertLifecycleEvents("8.2");
-			dirty(file2);
-			project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Project2Build1");
-			verifier.addExpectedLifecycleEvent("Project2Build2");
-			verifier.assertLifecycleEvents("8.3");
-		} catch (CoreException e) {
-			fail("8.99", e);
-		}
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Project1Build1");
+		// second builder is touched for the first time
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Project2Build1");
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Project2Build2");
+		dirty(file1);
+		dirty(file2);
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.assertLifecycleEvents();
+		verifier.addExpectedLifecycleEvent("Project1Build1");
+		dirty(file1);
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		verifier.assertLifecycleEvents();
+		dirty(file2);
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Project2Build1");
+		verifier.addExpectedLifecycleEvent("Project2Build2");
+		verifier.assertLifecycleEvents();
+
 		// Change order of build commands
-		try {
-			IProjectDescription desc = project2.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2"), createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1")});
-			project2.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("10.99", e);
-		}
+		desc = project2.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2"),
+				createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1") });
+		project2.setDescription(desc, getMonitor());
+
 		// Build
-		try {
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Project1Build1");
-			verifier.addExpectedLifecycleEvent("Project2Build2");
-			verifier.addExpectedLifecycleEvent("Project2Build1");
-			verifier.assertLifecycleEvents("11.0");
-			dirty(file1);
-			dirty(file2);
-			project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Project1Build1");
-			verifier.assertLifecycleEvents("11.2");
-			dirty(file1);
-			dirty(file2);
-			project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Project2Build2");
-			verifier.addExpectedLifecycleEvent("Project2Build1");
-			verifier.assertLifecycleEvents("11.3 ");
-		} catch (CoreException e) {
-			fail("11.99", e);
-		}
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Project1Build1");
+		verifier.addExpectedLifecycleEvent("Project2Build2");
+		verifier.addExpectedLifecycleEvent("Project2Build1");
+		verifier.assertLifecycleEvents();
+		dirty(file1);
+		dirty(file2);
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Project1Build1");
+		verifier.assertLifecycleEvents();
+		dirty(file1);
+		dirty(file2);
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Project2Build2");
+		verifier.addExpectedLifecycleEvent("Project2Build1");
+		verifier.assertLifecycleEvents();
 	}
 
 	/**
 	 * Tests that a pre_build listener is not called if there have been no changes
 	 * since the last build of any kind occurred.  See https://bugs.eclipse.org/bugs/show_bug.cgi?id=154880.
 	 */
-	public void testPreBuildEvent() {
+	public void testPreBuildEvent() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		final boolean[] notified = new boolean[] {false};
 		IProject proj1 = workspace.getRoot().getProject("PROJECT" + 1);
 		final IResourceChangeListener listener = event -> notified[0] = true;
-		workspace.addResourceChangeListener(listener, IResourceChangeEvent.PRE_BUILD);
 		try {
+			workspace.addResourceChangeListener(listener, IResourceChangeEvent.PRE_BUILD);
 			// Turn auto-building off
 			setAutoBuilding(false);
 			// Create some resources
@@ -412,9 +357,7 @@ public class BuilderTest extends AbstractBuilderTest {
 			notified[0] = false;
 			//now turn on autobuild and see if the listener is notified again
 			setAutoBuilding(true);
-			assertTrue("1.0", !notified[0]);
-		} catch (CoreException e) {
-			fail("2.99", e);
+			assertFalse(notified[0]);
 		} finally {
 			workspace.removeResourceChangeListener(listener);
 		}
@@ -425,150 +368,124 @@ public class BuilderTest extends AbstractBuilderTest {
 	 *
 	 * @see SortBuilder
 	 */
-	public void testBuildOrder() {
+	public void testBuildOrder() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		IProject proj1 = workspace.getRoot().getProject("PROJECT" + 1);
 		IProject proj2 = workspace.getRoot().getProject("PROJECT" + 2);
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create some resources
-			proj1.create(getMonitor());
-			proj1.open(getMonitor());
-			proj2.create(getMonitor());
-			proj2.open(getMonitor());
-			//set the build order
-			setBuildOrder(proj1, proj2);
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create some resources
+		proj1.create(getMonitor());
+		proj1.open(getMonitor());
+		proj2.create(getMonitor());
+		proj2.open(getMonitor());
+		// set the build order
+		setBuildOrder(proj1, proj2);
+
 		// Create and set a build specs for project one
-		try {
-			IProjectDescription desc = proj1.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-			proj1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		IProjectDescription desc = proj1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
+		proj1.setDescription(desc, getMonitor());
+
 		// Create and set a build spec for project two
-		try {
-			IProjectDescription desc = proj2.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build1"), createCommand(desc, "Build2")});
-			proj2.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
-		// Set up a plug-in lifecycle verifier for testing purposes
-		TestBuilder verifier = null;
+		desc = proj2.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
+		proj2.setDescription(desc, getMonitor());
+
 		// Build the workspace
-		try {
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.assertLifecycleEvents("4.0 ");
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		// Set up a plug-in lifecycle verifier for testing purposes
+		TestBuilder verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.assertLifecycleEvents();
+
 		//build in reverse order
-		try {
-			setBuildOrder(proj2, proj1);
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.assertLifecycleEvents("5.0");
-		} catch (CoreException e) {
-			fail("5.99");
-		}
+		setBuildOrder(proj2, proj1);
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.assertLifecycleEvents();
+
 		//only specify build order for project1
-		try {
-			setBuildOrder(proj1);
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.assertLifecycleEvents("6.0");
-		} catch (CoreException e) {
-			fail("6.99");
-		}
+		setBuildOrder(proj1);
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.assertLifecycleEvents();
+
 		//only specify build order for project2
-		try {
-			setBuildOrder(proj2, proj1);
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.assertLifecycleEvents("7.0");
-		} catch (CoreException e) {
-			fail("7.99");
-		}
+		setBuildOrder(proj2, proj1);
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.assertLifecycleEvents();
 	}
 
 	/**
 	 * Tests that changing the dynamic build order will induce an autobuild on a project.
 	 * This is a regression test for bug 60653.
 	 */
-	public void testChangeDynamicBuildOrder() {
+	public void testChangeDynamicBuildOrder() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		final IProject proj1 = workspace.getRoot().getProject("PROJECT" + 1);
 		final IProject proj2 = workspace.getRoot().getProject("PROJECT" + 2);
-		try {
-			// Turn auto-building on and make sure there is no explicit build order
-			setAutoBuilding(true);
-			IWorkspaceDescription wsDescription = getWorkspace().getDescription();
-			wsDescription.setBuildOrder(null);
-			getWorkspace().setDescription(wsDescription);
-			// Create and set a build spec for project two
-			getWorkspace().run((IWorkspaceRunnable) monitor -> {
-				proj2.create(getMonitor());
-				proj2.open(getMonitor());
-				IProjectDescription desc = proj2.getDescription();
-				desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build1")});
-				proj2.setDescription(desc, getMonitor());
-			}, getMonitor());
-			waitForBuild();
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		// Turn auto-building on and make sure there is no explicit build order
+		setAutoBuilding(true);
+		IWorkspaceDescription wsDescription = getWorkspace().getDescription();
+		wsDescription.setBuildOrder(null);
+		getWorkspace().setDescription(wsDescription);
+		// Create and set a build spec for project two
+		getWorkspace().run((IWorkspaceRunnable) monitor -> {
+			proj2.create(getMonitor());
+			proj2.open(getMonitor());
+			IProjectDescription desc = proj2.getDescription();
+			desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1") });
+			proj2.setDescription(desc, getMonitor());
+		}, getMonitor());
+		waitForBuild();
+
 		// Set up a plug-in lifecycle verifier for testing purposes
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.reset();
 		//create project two and establish a build order by adding a dynamic
 		//reference from proj2->proj1 in the same operation
-		try {
-			getWorkspace().run((IWorkspaceRunnable) monitor -> {
-				// Create and set a build specs for project one
-				proj1.create(getMonitor());
-				proj1.open(getMonitor());
-				IProjectDescription desc = proj1.getDescription();
-				desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-				proj1.setDescription(desc, getMonitor());
+		getWorkspace().run((IWorkspaceRunnable) monitor -> extracted(proj1, proj2), getMonitor());
 
-				//add the dynamic reference to project two
-				IProjectDescription description = proj2.getDescription();
-				description.setDynamicReferences(new IProject[] {proj1});
-				proj2.setDescription(description, IResource.NONE, null);
-			}, getMonitor());
-		} catch (CoreException e1) {
-			fail("2.99", e1);
-		}
 		waitForBuild();
 		//ensure the build happened in the correct order, and that both projects were built
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		verifier.addExpectedLifecycleEvent("Build0");
 		verifier.addExpectedLifecycleEvent("Build1");
-		verifier.assertLifecycleEvents("3.0");
+		verifier.assertLifecycleEvents();
+	}
+
+	private void extracted(final IProject proj1, final IProject proj2) throws CoreException {
+		// Create and set a build specs for project one
+		proj1.create(getMonitor());
+		proj1.open(getMonitor());
+		IProjectDescription desc = proj1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
+		proj1.setDescription(desc, getMonitor());
+		// add the dynamic reference to project two
+		IProjectDescription description = proj2.getDescription();
+		description.setDynamicReferences(new IProject[] { proj1 });
+		proj2.setDescription(description, IResource.NONE, null);
 	}
 
 	/**
@@ -576,7 +493,7 @@ public class BuilderTest extends AbstractBuilderTest {
 	 * to be built in the correct order.
 	 * This is a regression test for bug 330194.
 	 */
-	public void testChangeDynamicBuildOrderDuringPreBuild() throws Exception {
+	public void testChangeDynamicBuildOrderDuringPreBuild() throws Throwable {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		final IProject proj1 = workspace.getRoot().getProject("bug_330194_referencer");
@@ -598,6 +515,9 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Ensure the builder is instantiated
 		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 
+		final AtomicReference<ThrowingRunnable> exceptionInMainThreadCallback = new AtomicReference<>(
+				Function::identity);
+
 		// Add pre-build listener that swap around the dependencies
 		IResourceChangeListener buildListener = event -> {
 			try {
@@ -614,7 +534,9 @@ public class BuilderTest extends AbstractBuilderTest {
 				proj1.setDescription(desc1, getMonitor());
 				proj2.setDescription(desc2, getMonitor());
 			} catch (CoreException e) {
-				fail();
+				exceptionInMainThreadCallback.set(() -> {
+					throw e;
+				});
 			}
 		};
 		try {
@@ -627,14 +549,14 @@ public class BuilderTest extends AbstractBuilderTest {
 			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 			verifier.addExpectedLifecycleEvent("Build1");
 			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.assertLifecycleEvents("1.0");
+			verifier.assertLifecycleEvents();
 			verifier.reset();
 
 			// FULL_BUILD 2
 			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 			verifier.addExpectedLifecycleEvent("Build0");
 			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.assertLifecycleEvents("2.0");
+			verifier.assertLifecycleEvents();
 			verifier.reset();
 
 			// AUTO_BUILD
@@ -643,7 +565,7 @@ public class BuilderTest extends AbstractBuilderTest {
 			waitForBuild();
 			verifier.addExpectedLifecycleEvent("Build1");
 			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.assertLifecycleEvents("3.0");
+			verifier.assertLifecycleEvents();
 			verifier.reset();
 
 			// AUTO_BUILD 2
@@ -651,9 +573,10 @@ public class BuilderTest extends AbstractBuilderTest {
 			waitForBuild();
 			verifier.addExpectedLifecycleEvent("Build0");
 			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.assertLifecycleEvents("4.0");
+			verifier.assertLifecycleEvents();
 			verifier.reset();
 
+			exceptionInMainThreadCallback.get().run();
 		} finally {
 			getWorkspace().removeResourceChangeListener(buildListener);
 		}
@@ -662,399 +585,306 @@ public class BuilderTest extends AbstractBuilderTest {
 	/**
 	 * Ensure that build order is preserved when project is closed/opened.
 	 */
-	public void testCloseOpenProject() {
+	public void testCloseOpenProject() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("PROJECT" + 1);
-		try {
-			// Create some resources
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		// Create some resources
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec
-		try {
-			IProjectDescription desc = project.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build1"), createCommand(desc, "Build2")});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
-		try {
-			project.close(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
+		project.setDescription(desc, getMonitor());
+
+		project.close(getMonitor());
+		project.open(getMonitor());
+
 		//ensure the build spec hasn't changed
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand[] commands = desc.getBuildSpec();
-			assertEquals("4.0", 2, commands.length);
-			assertEquals("4.1", commands[0].getBuilderName(), SortBuilder.BUILDER_NAME);
-			assertEquals("4.2", commands[1].getBuilderName(), SortBuilder.BUILDER_NAME);
-			Map<String, String> args = commands[0].getArguments();
-			assertEquals("4.3", "Build1", args.get(TestBuilder.BUILD_ID));
-			args = commands[1].getArguments();
-			assertEquals("4.4", "Build2", args.get(TestBuilder.BUILD_ID));
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
+		desc = project.getDescription();
+		ICommand[] commands = desc.getBuildSpec();
+		assertEquals(2, commands.length);
+		assertEquals(commands[0].getBuilderName(), SortBuilder.BUILDER_NAME);
+		assertEquals(commands[1].getBuilderName(), SortBuilder.BUILDER_NAME);
+		Map<String, String> args = commands[0].getArguments();
+		assertEquals("Build1", args.get(TestBuilder.BUILD_ID));
+		args = commands[1].getArguments();
+		assertEquals("Build2", args.get(TestBuilder.BUILD_ID));
 	}
 
 	/**
 	 * Tests that when a project is copied, the copied project has a full build
 	 * but the source project does not.
 	 */
-	public void testCopyProject() {
+	public void testCopyProject() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		IProject proj1 = workspace.getRoot().getProject("testCopyProject" + 1);
 		IProject proj2 = workspace.getRoot().getProject("testCopyProject" + 2);
-		try {
-			// Turn auto-building on
-			setAutoBuilding(true);
-			// Create some resources
-			proj1.create(getMonitor());
-			proj1.open(getMonitor());
-			ensureDoesNotExistInWorkspace(proj2);
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		// Turn auto-building on
+		setAutoBuilding(true);
+		// Create some resources
+		proj1.create(getMonitor());
+		proj1.open(getMonitor());
+		ensureDoesNotExistInWorkspace(proj2);
+
 		// Create and set a build spec for project one
-		try {
-			IProjectDescription desc = proj1.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-			proj1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		IProjectDescription desc = proj1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
+		proj1.setDescription(desc, getMonitor());
+
 		waitForBuild();
 		SortBuilder.getInstance().reset();
-		try {
-			IProjectDescription desc = proj1.getDescription();
-			desc.setName(proj2.getName());
-			proj1.copy(desc, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
+		desc = proj1.getDescription();
+		desc.setName(proj2.getName());
+		proj1.copy(desc, IResource.NONE, getMonitor());
+
 		waitForEncodingRelatedJobs();
 		waitForBuild();
 		SortBuilder builder = SortBuilder.getInstance();
-		assertEquals("4.0", proj2, builder.getProject());
+		assertEquals(proj2, builder.getProject());
 
 		//builder 2 should have done a full build
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		builder.addExpectedLifecycleEvent("Build0");
-		builder.assertLifecycleEvents("4.4");
-		assertTrue("4.5", builder.wasFullBuild());
-
+		builder.assertLifecycleEvents();
+		assertTrue(builder.wasFullBuild());
 	}
 
 	/**
 	 * Tests an implicit workspace build order created by setting dynamic
 	 * project references.
 	 */
-	public void testDynamicBuildOrder() {
+	public void testDynamicBuildOrder() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		IProject proj1 = workspace.getRoot().getProject("PROJECT" + 1);
 		IProject proj2 = workspace.getRoot().getProject("PROJECT" + 2);
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create some resources
-			proj1.create(getMonitor());
-			proj1.open(getMonitor());
-			proj2.create(getMonitor());
-			proj2.open(getMonitor());
-			//establish a build order by adding a dynamic reference from
-			// proj2->proj1
-			IProjectDescription description = proj2.getDescription();
-			description.setDynamicReferences(new IProject[] {proj1});
-			proj2.setDescription(description, IResource.NONE, null);
-			IWorkspaceDescription wsDescription = getWorkspace().getDescription();
-			wsDescription.setBuildOrder(null);
-			getWorkspace().setDescription(wsDescription);
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create some resources
+		proj1.create(getMonitor());
+		proj1.open(getMonitor());
+		proj2.create(getMonitor());
+		proj2.open(getMonitor());
+		// establish a build order by adding a dynamic reference from
+		// proj2->proj1
+		IProjectDescription description = proj2.getDescription();
+		description.setDynamicReferences(new IProject[] { proj1 });
+		proj2.setDescription(description, IResource.NONE, null);
+		IWorkspaceDescription wsDescription = getWorkspace().getDescription();
+		wsDescription.setBuildOrder(null);
+		getWorkspace().setDescription(wsDescription);
+
 		// Create and set a build specs for project one
-		try {
-			IProjectDescription desc = proj1.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-			proj1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.99", e);
-		}
+		IProjectDescription desc = proj1.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
+		proj1.setDescription(desc, getMonitor());
+
 		// Create and set a build spec for project two
-		try {
-			IProjectDescription desc = proj2.getDescription();
-			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build1"), createCommand(desc, "Build2")});
-			proj2.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("3.99", e);
-		}
-		// Set up a plug-in lifecycle verifier for testing purposes
-		TestBuilder verifier = null;
+		desc = proj2.getDescription();
+		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
+		proj2.setDescription(desc, getMonitor());
+
 		// Build the workspace
-		try {
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.assertLifecycleEvents("4.0 ");
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		// Set up a plug-in lifecycle verifier for testing purposes
+		TestBuilder verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.assertLifecycleEvents();
+
 		//build in reverse order
-		try {
-			//reverse the order by adding a dynamic reference from proj1->proj2
-			IProjectDescription description = proj2.getDescription();
-			description.setDynamicReferences(new IProject[0]);
-			proj2.setDescription(description, IResource.NONE, null);
-			description = proj1.getDescription();
-			description.setDynamicReferences(new IProject[] {proj2});
-			proj1.setDescription(description, IResource.NONE, null);
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent("Build1");
-			verifier.addExpectedLifecycleEvent("Build2");
-			verifier.addExpectedLifecycleEvent("Build0");
-			verifier.assertLifecycleEvents("5.0");
-		} catch (CoreException e) {
-			fail("5.99");
-		}
+		// reverse the order by adding a dynamic reference from proj1->proj2
+		description = proj2.getDescription();
+		description.setDynamicReferences(new IProject[0]);
+		proj2.setDescription(description, IResource.NONE, null);
+		description = proj1.getDescription();
+		description.setDynamicReferences(new IProject[] { proj2 });
+		proj1.setDescription(description, IResource.NONE, null);
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent("Build1");
+		verifier.addExpectedLifecycleEvent("Build2");
+		verifier.addExpectedLifecycleEvent("Build0");
+		verifier.assertLifecycleEvents();
 	}
 
 	/**
 	 * Tests that enabling autobuild causes a build to occur.
 	 */
-	public void testEnableAutobuild() {
+	public void testEnableAutobuild() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+
+		// Cause a build by enabling autobuild
+		setAutoBuilding(true);
 		// Set up a plug-in lifecycle verifier for testing purposes
-		TestBuilder verifier = null;
-		//Cause a build by enabling autobuild
-		try {
-			setAutoBuilding(true);
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.1");
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		TestBuilder verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
 	}
 
 	/**
 	 * Tests installing and running a builder that always fails in its build method
 	 */
-	public void testExceptionBuilder() {
+	public void testExceptionBuilder() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
+		IProjectDescription desc = project.getDescription();
+		ICommand command1 = desc.newCommand();
+		command1.setBuilderName(ExceptionBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command1 });
+		project.setDescription(desc, getMonitor());
+
+		final AtomicReference<Boolean> listenerCalled = new AtomicReference<>();
+		IResourceChangeListener listener = event -> listenerCalled.set(true);
 		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command1 = desc.newCommand();
-			command1.setBuilderName(ExceptionBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command1});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		final boolean[] listenerCalled = new boolean[] {false};
-		IResourceChangeListener listener = event -> listenerCalled[0] = true;
-		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.POST_BUILD);
-		//do an incremental build -- build should fail, but POST_BUILD should still occur
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			fail("3.0");
-		} catch (CoreException e) {
-			//see discussion in bug 273147 about build exception severity
-			assertEquals("3.1", IStatus.ERROR, e.getStatus().getSeverity());
-			//expected
+			getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.POST_BUILD);
+			// do an incremental build -- build should fail, but POST_BUILD should still
+			// occur
+			CoreException exception = assertThrows(CoreException.class,
+				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor()));
+			// see discussion in bug 273147 about build exception severity
+			assertEquals(IStatus.ERROR, exception.getStatus().getSeverity());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
-		assertTrue("1.0", listenerCalled[0]);
+		assertTrue(listenerCalled.get());
 	}
 
 	/**
 	 * Tests the method IncrementProjectBuilder.forgetLastBuiltState
 	 */
-	public void testForgetLastBuiltState() {
+	public void testForgetLastBuiltState() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+
 		// Set up a plug-in lifecycle verifier for testing purposes
 		SortBuilder verifier = null;
 		//do an initial build
-		try {
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
-			verifier = SortBuilder.getInstance();
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		verifier = SortBuilder.getInstance();
+
 		//forget last built state
 		verifier.forgetLastBuiltState();
 		// Now do another incremental build. Delta should be null
-		try {
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
-			assertTrue("4.0", verifier.wasDeltaNull());
-		} catch (CoreException e) {
-			fail("4.99", e);
-		}
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		assertTrue(verifier.wasDeltaNull());
+
 		// Do another incremental build, requesting a null build state. Delta
 		// should not be null
 		verifier.requestForgetLastBuildState();
-		try {
-			project.touch(getMonitor());
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
-			assertTrue("5.0", !verifier.wasDeltaNull());
-		} catch (CoreException e) {
-			fail("5.99", e);
-		}
+		project.touch(getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		assertFalse(verifier.wasDeltaNull());
+
 		//try a snapshot when a builder has a null tree
-		try {
-			getWorkspace().save(false, getMonitor());
-		} catch (CoreException e) {
-			fail("6.99");
-		}
+		getWorkspace().save(false, getMonitor());
+
 		// Do another incremental build. Delta should be null
-		try {
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
-			assertTrue("7.0", verifier.wasDeltaNull());
-		} catch (CoreException e) {
-			fail("7.99", e);
-		}
-		// Delete the project
-		try {
-			project.delete(false, getMonitor());
-		} catch (CoreException e) {
-			fail("99.99", e);
-		}
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		assertTrue(verifier.wasDeltaNull());
 	}
 
 	/**
 	 * Tests that a client invoking a manual incremental build before autobuild has had
 	 * a chance to run will block until the build completes. See bug 275879.
 	 */
-	public void testIncrementalBuildBeforeAutobuild() {
+	public void testIncrementalBuildBeforeAutobuild() throws CoreException {
 		// Create some resource handles
 		final IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		final IFile input = project.getFolder(SortBuilder.DEFAULT_UNSORTED_FOLDER).getFile("File.txt");
 		final IFile output = project.getFolder(SortBuilder.DEFAULT_SORTED_FOLDER).getFile("File.txt");
-		try {
-			setAutoBuilding(true);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-			ensureExistsInWorkspace(input, getRandomContents());
-		} catch (CoreException e) {
-			fail("0.99", e);
-		}
+
+		setAutoBuilding(true);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+		ensureExistsInWorkspace(input, getRandomContents());
+
 		waitForBuild();
 		assertTrue("1.0", output.exists());
 
 		//change the file and then immediately perform build
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try {
-			getWorkspace().run((IWorkspaceRunnable) monitor -> {
-				input.setContents(new ByteArrayInputStream(new byte[] {5, 4, 3, 2, 1}), IResource.NONE, getMonitor());
-				project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-				transferStreams(output.getContents(), out, null);
-			}, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		getWorkspace().run((IWorkspaceRunnable) monitor -> {
+			input.setContents(new ByteArrayInputStream(new byte[] { 5, 4, 3, 2, 1 }), IResource.NONE, getMonitor());
+			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+			transferStreams(output.getContents(), out, null);
+		}, getMonitor());
+
 		byte[] result = out.toByteArray();
 		byte[] expected = new byte[] {1, 2, 3, 4, 5};
-		assertEquals("2.0", expected.length, result.length);
-		for (int i = 0; i < expected.length; i++) {
-			assertEquals("2.1." + i, expected[i], result[i]);
-		}
+		assertArrayEquals(expected, result);
 	}
 
 	/**
 	 * Tests that autobuild is interrupted by a background scheduled job, but eventually completes.
 	 */
-	public void testInterruptAutobuild() {
+	public void testInterruptAutobuild() throws Exception {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		final IFile file = project.getFile("File.txt");
-		try {
-			setAutoBuilding(true);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-			file.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		setAutoBuilding(true);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, getMonitor());
 		waitForBuild();
 
 		// Set up a plug-in lifecycle verifier for testing purposes
@@ -1087,17 +917,11 @@ public class BuilderTest extends AbstractBuilderTest {
 			//wait for job to be scheduled
 			barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 			//wait for test job to complete
-			try {
-				blockedJob.join();
-			} catch (InterruptedException e) {
-				fail("1.99", e);
-			}
+			blockedJob.join();
 			//autobuild should now run after the blocking job is finished
 			waitForBuild();
 			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("2.0");
-		} catch (CoreException e) {
-			fail("2.99", e);
+			verifier.assertLifecycleEvents();
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -1106,84 +930,62 @@ public class BuilderTest extends AbstractBuilderTest {
 	/**
 	 * Tests the lifecycle of a builder.
 	 */
-	public void testLifecycleEvents() {
+	public void testLifecycleEvents() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		// Set up a plug-in lifecycle verifier for testing purposes
-		TestBuilder verifier = null;
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+
 		//try to do an incremental build when there has never
 		//been a batch build
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.1");
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		FussyProgressMonitor monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+		// Set up a plug-in lifecycle verifier for testing purposes
+		TestBuilder verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
+		monitor.assertUsedUp();
+
 		// Now do another incremental build. Since we just did one, nothing
 		// should happen in this one.
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			verifier.assertLifecycleEvents("3.4");
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.5", e);
-		}
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+		verifier.assertLifecycleEvents();
+		monitor.assertUsedUp();
+
 		// Now do a batch build
-		try {
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.6");
-			monitor.assertUsedUp();
-		} catch (CoreException e) {
-			fail("3.8", e);
-		}
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
+		monitor.assertUsedUp();
+
 		// Close the project
-		try {
-			project.close(getMonitor());
-		} catch (CoreException e) {
-			fail("4.1", e);
-		}
+		project.close(getMonitor());
+
 		// Open the project, build it, and delete it
-		try {
-			project.open(getMonitor());
-			FussyProgressMonitor monitor = new FussyProgressMonitor();
-			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-			monitor.assertUsedUp();
-			project.delete(false, getMonitor());
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("5.0");
-		} catch (CoreException e) {
-			fail("5.1", e);
-		}
+		project.open(getMonitor());
+		monitor = new FussyProgressMonitor();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		monitor.assertUsedUp();
+		project.delete(false, getMonitor());
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
 	}
 
 	/**
@@ -1191,49 +993,34 @@ public class BuilderTest extends AbstractBuilderTest {
 	 *
 	 * @see SortBuilder
 	 */
-	public void testMoveProject() {
+	public void testMoveProject() throws CoreException {
 		// Create some resource handles
 		IWorkspace workspace = getWorkspace();
 		IProject proj1 = workspace.getRoot().getProject("PROJECT" + 1);
 		IProject proj2 = workspace.getRoot().getProject("Destination");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create some resources
-			proj1.create(getMonitor());
-			proj1.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create some resources
+		proj1.create(getMonitor());
+		proj1.open(getMonitor());
+
 		// Create and set a build specs for project one
-		try {
-			IProjectDescription desc = proj1.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			command.getArguments().put(TestBuilder.BUILD_ID, "Build0");
-			desc.setBuildSpec(new ICommand[] {command});
-			proj1.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		IProjectDescription desc = proj1.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		command.getArguments().put(TestBuilder.BUILD_ID, "Build0");
+		desc.setBuildSpec(new ICommand[] { command });
+		proj1.setDescription(desc, getMonitor());
+
 		// build project1
-		try {
-			proj1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		proj1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+
 		// move proj1 to proj2
-		try {
-			proj1.move(proj2.getFullPath(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		proj1.move(proj2.getFullPath(), false, getMonitor());
+
 		// build proj2
-		try {
-			proj2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		proj2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
 	}
 
 	/**
@@ -1244,52 +1031,44 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		final IFile file = project.getFile("File.txt");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-			file.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+		file.create(getRandomContents(), IResource.NONE, getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(SortBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		// Set up a plug-in lifecycle verifier for testing purposes
-		TestBuilder verifier = null;
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(SortBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] {command});
+		project.setDescription(desc, getMonitor());
+
+
 		//try to do an incremental build when there has never
 		//been a batch build
-		try {
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier = SortBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.1");
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		// Set up a plug-in lifecycle verifier for testing purposes
+		TestBuilder verifier = SortBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
+
 		// Now make a change and then turn autobuild on. Turning it on should
 		// cause a build.
 		IWorkspaceRunnable r = monitor -> {
 			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
-			IWorkspaceDescription desc = getWorkspace().getDescription();
-			desc.setAutoBuilding(true);
-			getWorkspace().setDescription(desc);
+			IWorkspaceDescription description = getWorkspace().getDescription();
+			description.setAutoBuilding(true);
+			getWorkspace().setDescription(description);
 		};
 		waitForBuild();
 		getWorkspace().run(r, getMonitor());
 		waitForBuild();
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-		verifier.assertLifecycleEvents("4.0");
+		verifier.assertLifecycleEvents();
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 
 /**
@@ -25,51 +28,38 @@ public class EmptyDeltaTest extends AbstractBuilderTest {
 		super(name);
 	}
 
-	public void testBuildEvents() {
+	public void testBuildEvents() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("TestBuildEvents");
-		try {
-			// Turn auto-building off
-			setAutoBuilding(false);
-			// Create and open a project
-			project.create(getMonitor());
-			project.open(getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+
+		// Turn auto-building off
+		setAutoBuilding(false);
+		// Create and open a project
+		project.create(getMonitor());
+		project.open(getMonitor());
+
 		// Create and set a build spec for the project
-		try {
-			IProjectDescription desc = project.getDescription();
-			ICommand command = desc.newCommand();
-			command.setBuilderName(EmptyDeltaBuilder.BUILDER_NAME);
-			desc.setBuildSpec(new ICommand[] {command});
-			project.setDescription(desc, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		// Set up a plug-in lifecycle verifier for testing purposes
-		EmptyDeltaBuilder verifier = null;
+		IProjectDescription desc = project.getDescription();
+		ICommand command = desc.newCommand();
+		command.setBuilderName(EmptyDeltaBuilder.BUILDER_NAME);
+		desc.setBuildSpec(new ICommand[] { command });
+		project.setDescription(desc, getMonitor());
+
 		//do an initial incremental build
-		try {
-			new EmptyDeltaBuilder().reset();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier = EmptyDeltaBuilder.getInstance();
-			verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
-			verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.1");
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		new EmptyDeltaBuilder().reset();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		// Set up a plug-in lifecycle verifier for testing purposes
+		EmptyDeltaBuilder verifier = EmptyDeltaBuilder.getInstance();
+		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
+		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
+
 		// Now do another incremental build. Even though the delta is empty, it should be called
-		try {
-			verifier.reset();
-			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-			verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
-			verifier.assertLifecycleEvents("3.3");
-		} catch (CoreException e) {
-			fail("3.4", e);
-		}
+		verifier.reset();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
+		verifier.assertLifecycleEvents();
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
@@ -16,7 +16,11 @@ package org.eclipse.core.tests.internal.builders;
 
 import java.util.List;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
 
@@ -37,7 +41,6 @@ public class RebuildTest extends AbstractBuilderTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		getWorkspace().getRoot().delete(true, null);
 		// Turn auto-building off
 		setAutoBuilding(false);
 		boolean earlyExitAllowed = ((Workspace) getWorkspace()).getBuildManager()
@@ -47,7 +50,6 @@ public class RebuildTest extends AbstractBuilderTest {
 
 	@Override
 	protected void tearDown() throws Exception {
-		getWorkspace().getRoot().delete(true, null);
 		IWorkspaceDescription description = getWorkspace().getDescription();
 		description.setMaxBuildIterations(maxBuildIterations);
 		getWorkspace().setDescription(description);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TestBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TestBuilder.java
@@ -44,7 +44,8 @@ public abstract class TestBuilder extends IncrementalProjectBuilder {
 		/**
 		 * Fetch the scheduling rule for the build
 		 */
-		public ISchedulingRule getRule(String name, IncrementalProjectBuilder builder, int trigger, Map<String, String> args) {
+		public ISchedulingRule getRule(String name, IncrementalProjectBuilder projectBuilder, int trigger,
+				Map<String, String> args) {
 			return ResourcesPlugin.getWorkspace().getRoot();
 		}
 
@@ -101,8 +102,8 @@ public abstract class TestBuilder extends IncrementalProjectBuilder {
 	 * failure if expectations are not met. If successful, clears the list of
 	 * expected and actual events in preparation for the next test.
 	 */
-	public void assertLifecycleEvents(String text) {
-		Assert.assertEquals(text, expectedEvents, actualEvents);
+	public void assertLifecycleEvents() {
+		Assert.assertEquals(expectedEvents, actualEvents);
 		reset();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
@@ -22,7 +22,7 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ org.eclipse.core.tests.filesystem.AllFileSystemTests.class,
-		org.eclipse.core.tests.internal.alias.AllAliasTests.class, org.eclipse.core.tests.internal.builders.AllBuildderTests.class,
+		org.eclipse.core.tests.internal.alias.AllAliasTests.class, org.eclipse.core.tests.internal.builders.AllBuilderTests.class,
 		org.eclipse.core.tests.internal.dtree.AllDtreeTests.class,
 		org.eclipse.core.tests.internal.localstore.AllLocalStoreTests.class,
 		org.eclipse.core.tests.internal.mapping.AllMappingTests.class,

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -77,10 +77,10 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		// setting description file will also trigger build
 		descFile.setContents(projectFileWithoutWater(), IResource.FORCE, getMonitor());
 		//assert that builder was skipped
-		builder.assertLifecycleEvents("1.0");
+		builder.assertLifecycleEvents();
 
 		//assert that the builder is still in the build spec
-		assertTrue("1.1", hasBuilder(project, SnowBuilder.BUILDER_NAME));
+		assertTrue(hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
 		getWorkspace().save(true, getMonitor());
 	}
@@ -93,14 +93,14 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
 
 		//assert that the builder is still in the build spec
-		assertTrue("1.0", hasBuilder(project, SnowBuilder.BUILDER_NAME));
+		assertTrue(hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
 		//perform a build and ensure snow builder isn't called
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
 		SnowBuilder builder = SnowBuilder.getInstance();
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-		builder.assertLifecycleEvents("1.1");
+		builder.assertLifecycleEvents();
 
 		getWorkspace().save(true, getMonitor());
 	}
@@ -120,7 +120,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		SnowBuilder builder = SnowBuilder.getInstance();
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
-		builder.assertLifecycleEvents("1.1");
+		builder.assertLifecycleEvents();
 
 		//now re-enable the nature and ensure that the delta was null
 		waitForBuild();
@@ -130,8 +130,8 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
 		project.setDescription(desc, IResource.FORCE, getMonitor());
 		waitForBuild();
-		builder.assertLifecycleEvents("2.0");
-		assertTrue("2.1", builder.wasDeltaNull());
+		builder.assertLifecycleEvents();
+		assertTrue(builder.wasDeltaNull());
 
 	}
 


### PR DESCRIPTION
Affects all tests in `org.eclipse.core.tests.internal.builders`

* Moves assertions erroneously checked in other thread to the main thread
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Adds missing try-with-resources blocks
* Replaces all fail(String, Throwable) calls in preparation for migration to JUnit 4/5
* Renames `AllBuildderTests` to `AllBuilderTests`

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.