### PR TITLE
Initialize cause of some InterruptedExceptions when they represent some cancelation by the user

### DIFF
--- a/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/search/FindUnusedMembers.java
+++ b/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/search/FindUnusedMembers.java
@@ -17,10 +17,30 @@ package org.eclipse.core.tools.search;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
-import org.eclipse.core.runtime.*;
-import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.core.dom.*;
-import org.eclipse.jdt.core.search.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringScopeFactory;
 import org.eclipse.jface.operation.IRunnableWithProgress;
@@ -202,7 +222,9 @@ public class FindUnusedMembers implements IRunnableWithProgress {
 		try {
 			process(monitor);
 		} catch (OperationCanceledException e) {
-			throw new InterruptedException();
+			InterruptedException interruptedException = new InterruptedException(e.getMessage());
+			interruptedException.initCause(e);
+			throw interruptedException;
 		} catch (CoreException e) {
 			throw new InvocationTargetException(e);
 		}


### PR DESCRIPTION
Pack an `OperationCanceledException` inside the `InterruptedException` when this is thrown due to the user canceling an operation. This makes it easier to determine the cause of the `InterruptedException` from outside the methods (i.e. in the catch-clauses)

Same idea as https://github.com/eclipse-platform/eclipse.platform.ui/pull/1259