### PR TITLE
Correct output and source specifications in build.properties

### DIFF
--- a/debug/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.unittest.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.unittest.ui;singleton:=true
-Bundle-Version: 1.1.200.qualifier
+Bundle-Version: 1.1.300.qualifier
 Bundle-Activator: org.eclipse.unittest.internal.UnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/debug/org.eclipse.unittest.ui/build.properties
+++ b/debug/org.eclipse.unittest.ui/build.properties
@@ -19,6 +19,7 @@ bin.includes = plugin.xml,\
                META-INF/
 
 source.. = src/
+output.. = bin/
 src.includes = about.html,\
                schema/
 

--- a/platform/org.eclipse.platform/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.platform/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform; singleton:=true
-Bundle-Version: 4.31.0.qualifier
+Bundle-Version: 4.31.100.qualifier
 Bundle-ClassPath: platform.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/platform/org.eclipse.platform/build.properties
+++ b/platform/org.eclipse.platform/build.properties
@@ -48,6 +48,7 @@ bin.includes = about.html,\
                700E4F39BC05364B.asc
 src.includes = about.html
 source.platform.jar = src-intro/
+output.platform.jar = bin-intro/
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 tycho.pomless.parent = ../../

--- a/resources/bundles/org.eclipse.core.resources.spysupport/build.properties
+++ b/resources/bundles/org.eclipse.core.resources.spysupport/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 src.includes=about.html
 bin.includes=about.html, META-INF/,.
 qualifier=context

--- a/resources/bundles/org.eclipse.core.resources/.classpath
+++ b/resources/bundles/org.eclipse.core.resources/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src_ant"/>
+	<classpathentry kind="src" output="bin_ant" path="src_ant"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/resources/bundles/org.eclipse.core.resources/.gitignore
+++ b/resources/bundles/org.eclipse.core.resources/.gitignore
@@ -1,3 +1,3 @@
 temp.folder
-src_ant_bin
+bin_ant
 ant_tasks

--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.20.0.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/build.properties
+++ b/resources/bundles/org.eclipse.core.resources/build.properties
@@ -11,8 +11,10 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/
-source.ant_tasks/resources-ant.jar=src_ant/
+source.. = src/
+output.. = bin/
+source.ant_tasks/resources-ant.jar = src_ant/
+output.ant_tasks/resources-ant.jar = bin_ant/
 src.includes = about.html,\
                schema/,\
                natives/

--- a/resources/bundles/org.eclipse.core.tools.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.tools.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core Resources Tools
 Bundle-SymbolicName: org.eclipse.core.tools.resources;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tools.resources,
  org.eclipse.core.tools.resources.markers

--- a/resources/bundles/org.eclipse.core.tools.resources/build.properties
+++ b/resources/bundles/org.eclipse.core.tools.resources/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 src.includes=*.html
 bin.includes=plugin.xml,icons/,doc/,*.html,.options, META-INF/,.
 qualifier=context

--- a/resources/bundles/org.eclipse.core.tools.resources/pom.xml
+++ b/resources/bundles/org.eclipse.core.tools.resources/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.tools.resources</artifactId>
-  <version>1.7.100-SNAPSHOT</version>
+  <version>1.7.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Save Participant
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant; singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant
 Require-Bundle: org.eclipse.core.resources,

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 417025 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/pom.xml
@@ -24,6 +24,6 @@
   </properties>
 
   <artifactId>org.eclipse.core.tests.resources.saveparticipant</artifactId>
-  <version>3.6.0-SNAPSHOT</version>
+  <version>3.6.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant1
 Bundle-Name: Save Participant 1
 Bundle-Activator: org.eclipse.core.tests.resources.saveparticipant1.SaveParticipant1Plugin
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant1
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant1
 Require-Bundle: org.eclipse.core.resources,

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant1/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 417025 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant2
 Bundle-Name: Save Participant 2
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant2
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant2
 Require-Bundle: org.eclipse.core.resources,

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant2/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 417025 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Save Participant 3
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant3
 Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant3
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.resources.saveparticipant3
 Require-Bundle: org.eclipse.core.resources,

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant3/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 417025 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.11.400.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 417025 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                .,\
                MultipleProjectTestFiles/,\

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.300-SNAPSHOT</version>
+  <version>3.11.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/runtime/bundles/org.eclipse.core.contenttype/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.contenttype/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.contenttype; singleton:=true
-Bundle-Version: 3.9.200.qualifier
+Bundle-Version: 3.9.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.preferences;bundle-version="[3.2.0,4.0.0)",

--- a/runtime/bundles/org.eclipse.core.contenttype/build.properties
+++ b/runtime/bundles/org.eclipse.core.contenttype/build.properties
@@ -23,4 +23,3 @@ bin.includes = META-INF/,\
                OSGI-INF/
 src.includes = about.html,\
                schema/
-source.. = src/

--- a/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.expressions; singleton:=true
-Bundle-Version: 3.9.200.qualifier
+Bundle-Version: 3.9.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.expressions,

--- a/runtime/bundles/org.eclipse.core.expressions/build.properties
+++ b/runtime/bundles/org.eclipse.core.expressions/build.properties
@@ -20,3 +20,4 @@ bin.includes = plugin.xml,\
 src.includes = about.html,\
                schema/
 source.. = src/
+output.. = bin/

--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.30.0.qualifier
+Bundle-Version: 3.30.100.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/build.properties
+++ b/runtime/bundles/org.eclipse.core.runtime/build.properties
@@ -18,5 +18,6 @@ bin.includes = .options,\
                .,\
                META-INF/
 source.. = src/
+output.. = bin/
 src.includes = about.html,\
                schema/

--- a/runtime/bundles/org.eclipse.core.tools/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.tools; singleton:=true
-Bundle-Version: 1.9.100.qualifier
+Bundle-Version: 1.9.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.tools;x-internal:=true,

--- a/runtime/bundles/org.eclipse.core.tools/build.properties
+++ b/runtime/bundles/org.eclipse.core.tools/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 src.includes=*.html
 bin.includes = plugin.xml,\
                icons/,\

--- a/runtime/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/runtime/features/org.eclipse.core.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.core.runtime.feature"
       label="%featureName"
-      version="1.4.200.qualifier"
+      version="1.4.300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/runtime/tests/org.eclipse.core.contenttype.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.contenttype.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.contenttype.tests;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/runtime/tests/org.eclipse.core.contenttype.tests/build.properties
+++ b/runtime/tests/org.eclipse.core.contenttype.tests/build.properties
@@ -12,6 +12,7 @@
 #     Mickael Istria (Red Hat Inc.) - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = test.xml,\
                about.html,\
                plugin.properties,\

--- a/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.expressions.tests; singleton:=true
-Bundle-Version: 3.7.200.qualifier
+Bundle-Version: 3.7.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/runtime/tests/org.eclipse.core.expressions.tests/build.properties
+++ b/runtime/tests/org.eclipse.core.expressions.tests/build.properties
@@ -14,6 +14,7 @@
 #     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474642
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                test.xml,\
                about.html,\

--- a/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Harness
 Bundle-SymbolicName: org.eclipse.core.tests.harness;singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.harness;version="2.0",
  org.eclipse.core.tests.session;version="2.0"

--- a/runtime/tests/org.eclipse.core.tests.harness/build.properties
+++ b/runtime/tests/org.eclipse.core.tests.harness/build.properties
@@ -14,6 +14,7 @@
 #     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474642
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = .,\
                about.html,\
                META-INF/

--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.21.200.qualifier
+Bundle-Version: 3.21.300.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/build.properties
+++ b/runtime/tests/org.eclipse.core.tests.runtime/build.properties
@@ -14,6 +14,7 @@
 #     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474642
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                .,\
                Plugin_Testing/,\

--- a/team/bundles/org.eclipse.core.net.linux/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.core.net.linux/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-Localization: fragment
 Bundle-SymbolicName: org.eclipse.core.net.linux;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.1.100.qualifier
 Fragment-Host: org.eclipse.core.net;bundle-version="1.1.0"
 Eclipse-PlatformFilter: (osgi.os=linux)
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/team/bundles/org.eclipse.core.net.linux/build.properties
+++ b/team/bundles/org.eclipse.core.net.linux/build.properties
@@ -17,3 +17,4 @@ bin.includes = fragment.properties,\
                about.html
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/team/bundles/org.eclipse.core.net.linux/pom.xml
+++ b/team/bundles/org.eclipse.core.net.linux/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.net.linux</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/team/bundles/org.eclipse.core.net.win32/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.core.net.win32/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-Localization: fragment
 Bundle-SymbolicName: org.eclipse.core.net.win32;singleton:=true
-Bundle-Version: 1.1.200.qualifier
+Bundle-Version: 1.1.300.qualifier
 Fragment-Host: org.eclipse.core.net;bundle-version="1.1.0"
 Eclipse-PlatformFilter: (osgi.os=win32)
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/team/bundles/org.eclipse.core.net.win32/build.properties
+++ b/team/bundles/org.eclipse.core.net.win32/build.properties
@@ -17,3 +17,4 @@ bin.includes = fragment.properties,\
                META-INF/
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/team/bundles/org.eclipse.core.net.win32/pom.xml
+++ b/team/bundles/org.eclipse.core.net.win32/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.core.net.win32</artifactId>
-  <version>1.1.200-SNAPSHOT</version>
+  <version>1.1.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/team/bundles/org.eclipse.team.core/build.properties
+++ b/team/bundles/org.eclipse.team.core/build.properties
@@ -18,5 +18,6 @@ bin.includes = about.html,\
                .,\
                .options,\
                META-INF/
-source..=src/
-src.includes=about.html,schema/
+source.. = src/
+output.. = bin/
+src.includes = about.html,schema/

--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/build.properties
+++ b/team/bundles/org.eclipse.team.ui/build.properties
@@ -19,5 +19,6 @@ bin.includes = about.html,\
                .,\
                META-INF/,\
                .options
-source..=src/
-src.includes=about.html,schema/
+source.. = src/
+output.. = bin/
+src.includes = about.html,schema/

--- a/team/examples/org.eclipse.compare.examples.xml/.classpath
+++ b/team/examples/org.eclipse.compare.examples.xml/.classpath
@@ -3,6 +3,10 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="tests"/>
+	<classpathentry kind="src" output="bin_tests" path="tests">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/team/examples/org.eclipse.compare.examples.xml/.gitignore
+++ b/team/examples/org.eclipse.compare.examples.xml/.gitignore
@@ -1,0 +1,1 @@
+bin_tests/

--- a/team/examples/org.eclipse.compare.examples.xml/META-INF/MANIFEST.MF
+++ b/team/examples/org.eclipse.compare.examples.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.examples.xml; singleton:=true
-Bundle-Version: 3.6.200.qualifier
+Bundle-Version: 3.6.300.qualifier
 Bundle-Activator: org.eclipse.compare.examples.xml.XMLPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/examples/org.eclipse.compare.examples.xml/build.properties
+++ b/team/examples/org.eclipse.compare.examples.xml/build.properties
@@ -13,7 +13,7 @@
 #     Mickael Istria (Red Hat Inc.) - 419531 Get rid of nested jars
 ###############################################################################
 source.. = src/
-
+output.. = bin/
 bin.includes = doc-html/,\
                about.html,\
                plugin.properties,\

--- a/team/examples/org.eclipse.compare.examples.xml/pom.xml
+++ b/team/examples/org.eclipse.compare.examples.xml/pom.xml
@@ -18,6 +18,6 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.compare.examples.xml</artifactId>
-  <version>3.6.200-SNAPSHOT</version>
+  <version>3.6.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/team/examples/org.eclipse.compare.examples/META-INF/MANIFEST.MF
+++ b/team/examples/org.eclipse.compare.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.examples; singleton:=true
-Bundle-Version: 3.4.200.qualifier
+Bundle-Version: 3.4.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.compare.examples.structurecreator

--- a/team/examples/org.eclipse.compare.examples/build.properties
+++ b/team/examples/org.eclipse.compare.examples/build.properties
@@ -13,7 +13,7 @@
 #     Mickael Istria (Red Hat Inc.) - 419531 Get rid of nested jars
 ###############################################################################
 source.. = src/
-
+output.. = bin/
 bin.includes = doc-html/,\
                about.html,\
                plugin.properties,\

--- a/team/examples/org.eclipse.compare.examples/pom.xml
+++ b/team/examples/org.eclipse.compare.examples/pom.xml
@@ -18,6 +18,6 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.compare.examples</artifactId>
-  <version>3.4.200-SNAPSHOT</version>
+  <version>3.4.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/team/examples/org.eclipse.team.examples.filesystem/META-INF/MANIFEST.MF
+++ b/team/examples/org.eclipse.team.examples.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.examples.filesystem; singleton:=true
-Bundle-Version: 3.7.200.qualifier
+Bundle-Version: 3.7.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.team.examples.filesystem,

--- a/team/examples/org.eclipse.team.examples.filesystem/build.properties
+++ b/team/examples/org.eclipse.team.examples.filesystem/build.properties
@@ -13,8 +13,9 @@
 #     Mickael Istria (Red Hat Inc.) - 419531 Get rid of nested jars
 ###############################################################################
 # Eclipse build contribution
-source..=src/
-src.includes=about.html
+source.. = src/
+output.. = bin/
+src.includes = about.html
 bin.includes = about.html,\
                icons/,\
                doc-html/,\

--- a/team/examples/org.eclipse.team.examples.filesystem/pom.xml
+++ b/team/examples/org.eclipse.team.examples.filesystem/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.team.examples.filesystem</artifactId>
-  <version>3.7.200-SNAPSHOT</version>
+  <version>3.7.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
   	<plugins>

--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.tests;singleton:=true
-Bundle-Version: 3.8.200.qualifier
+Bundle-Version: 3.8.300.qualifier
 Require-Bundle: org.junit,
  org.eclipse.compare,
  org.eclipse.jface.text,

--- a/team/tests/org.eclipse.compare.tests/build.properties
+++ b/team/tests/org.eclipse.compare.tests/build.properties
@@ -22,7 +22,8 @@ bin.includes = plugin.properties,\
 
 src.includes = about.html
 
-source..= src/
+source.. = src/
+output.. = bin/
 
 # Maven/Tycho pom model adjustments
 pom.model.property.testClass = org.eclipse.compare.tests.AllCompareTests

--- a/team/tests/org.eclipse.team.tests.core/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.team.tests.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.tests.core; singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.team.tests.core,

--- a/team/tests/org.eclipse.team.tests.core/build.properties
+++ b/team/tests/org.eclipse.team.tests.core/build.properties
@@ -12,7 +12,8 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 419531 Get rid of nested jars
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/
 bin.includes = about.html,\
                plugin.xml,\
                .,\

--- a/team/tests/org.eclipse.team.tests.core/pom.xml
+++ b/team/tests/org.eclipse.team.tests.core/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.team</groupId>
   <artifactId>org.eclipse.team.tests.core</artifactId>
-  <version>3.10.200-SNAPSHOT</version>
+  <version>3.10.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ua/org.eclipse.help.base/build.properties
+++ b/ua/org.eclipse.help.base/build.properties
@@ -11,10 +11,10 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/,\
-         src_demo/
-src.includes=schema/,about.html
+source.. = src/,\
+           src_demo/
 output.. = bin/
+src.includes = schema/,about.html
 bin.includes = doc/,\
                plugin.xml,\
                preferences.ini,\

--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.qualifier
+Bundle-Version: 4.6.200.qualifier
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/build.properties
+++ b/ua/org.eclipse.help.ui/build.properties
@@ -11,8 +11,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/
-src.includes=schema/,about.html
+source.. = src/
+output.. = bin/
+src.includes = schema/,about.html
 bin.includes = icons/,\
                plugin.xml,\
                .,\

--- a/ua/org.eclipse.help/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_plugin_name
 Bundle-SymbolicName: org.eclipse.help; singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Activator: org.eclipse.help.internal.HelpPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help/build.properties
+++ b/ua/org.eclipse.help/build.properties
@@ -11,8 +11,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/
-src.includes=schema/,about.html
+source.. = src/
+output.. = bin/
+src.includes = schema/,about.html
 bin.includes = livehelp.js,\
                plugin.xml,\
                preferences.ini,\

--- a/ua/org.eclipse.help/pom.xml
+++ b/ua/org.eclipse.help/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.help</groupId>
   <artifactId>org.eclipse.help</artifactId>
-  <version>3.10.200-SNAPSHOT</version>
+  <version>3.10.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.eclipse.ui.cheatsheets; singleton:=true
-Bundle-Version: 3.8.200.qualifier
+Bundle-Version: 3.8.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.cheatsheets.CheatSheetPlugin
 Bundle-Vendor: %PROVIDER_NAME
 Bundle-Localization: plugin

--- a/ua/org.eclipse.ui.cheatsheets/build.properties
+++ b/ua/org.eclipse.ui.cheatsheets/build.properties
@@ -18,5 +18,6 @@ bin.includes = plugin.properties,\
                about.html,\
                META-INF/
 source.. = src/
+output.. = bin/
 src.includes = schema/,\
                about.html

--- a/ua/org.eclipse.ui.cheatsheets/pom.xml
+++ b/ua/org.eclipse.ui.cheatsheets/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.cheatsheets</artifactId>
-  <version>3.8.200-SNAPSHOT</version>
+  <version>3.8.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/ua/org.eclipse.ui.intro.quicklinks.examples/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro.quicklinks.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin_name
 Bundle-SymbolicName: org.eclipse.ui.intro.quicklinks.examples;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Vendor: %provider_name
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.intro;bundle-version="3.4.300",

--- a/ua/org.eclipse.ui.intro.quicklinks.examples/build.properties
+++ b/ua/org.eclipse.ui.intro.quicklinks.examples/build.properties
@@ -1,5 +1,3 @@
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/ua/org.eclipse.ui.intro.quicklinks.examples/pom.xml
+++ b/ua/org.eclipse.ui.intro.quicklinks.examples/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.intro.quicklinks.examples</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/ua/org.eclipse.ui.intro.solstice.examples/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro.solstice.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Examples of Extending the Solstice theme organization
 Bundle-SymbolicName: org.eclipse.ui.intro.solstice.examples;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.intro

--- a/ua/org.eclipse.ui.intro.solstice.examples/build.properties
+++ b/ua/org.eclipse.ui.intro.solstice.examples/build.properties
@@ -1,5 +1,3 @@
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/ua/org.eclipse.ui.intro.solstice.examples/pom.xml
+++ b/ua/org.eclipse.ui.intro.solstice.examples/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.intro.solstice.examples</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin_name
 Bundle-SymbolicName: org.eclipse.ui.intro; singleton:=true
-Bundle-Version: 3.7.200.qualifier
+Bundle-Version: 3.7.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.intro.impl.IntroPlugin
 Bundle-Vendor: %provider_name
 Bundle-Localization: plugin

--- a/ua/org.eclipse.ui.intro/build.properties
+++ b/ua/org.eclipse.ui.intro/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                .,\
                icons/,\

--- a/ua/org.eclipse.ui.intro/pom.xml
+++ b/ua/org.eclipse.ui.intro/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.intro</artifactId>
-  <version>3.7.200-SNAPSHOT</version>
+  <version>3.7.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.update.configurator; singleton:=true
-Bundle-Version: 3.5.200.qualifier
+Bundle-Version: 3.5.300.qualifier
 Bundle-Activator: org.eclipse.update.internal.configurator.ConfigurationActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/update/org.eclipse.update.configurator/build.properties
+++ b/update/org.eclipse.update.configurator/build.properties
@@ -19,6 +19,7 @@ bin.includes = .options,\
                OSGI-INF/
 src.includes = about.html
 source.. = src/
+output.. = bin/
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 tycho.pomless.parent = ../../


### PR DESCRIPTION
* Remove source entries in projects without source folders
* Remove duplicate source entries
* Add missing output entries
* Fix project classpaths with unseparated bin folders and adapt .gitignore