### PR TITLE
Disable Bug468PerformanceTest #715

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
@@ -30,6 +30,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.QualifiedName;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 //Test case for GitHub Issue 468
@@ -141,6 +142,7 @@ public class Bug468PerformanceTest extends TestCase {
 	// For 3 tries, the time was around 18000 ms to 25000 ms in windows 10 machine,
 	// so, set a limit of 1 minute.
 	@Test
+	@Ignore("See https://github.com/eclipse-platform/eclipse.platform/issues/715")
 	public void test() throws CoreException {
 		IFolder tempFolder = this.project.getFolder(TEMP_FOLDER_NAME);
 		long[] timeTakenForDeletingFiles = new long[1];


### PR DESCRIPTION
The test often exceeds 60 seconds timeout on MacOS machines. Proposals for replacing the performance test with a functionality test have been made. To avoid spending more than a minute on a single test until the test has been replaced, this change disables the test until then.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/715