### PR TITLE
Disable Bug468PerformanceTest (JUnit 3) #715

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
@@ -18,6 +18,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ PropertyManagerTest.class, Bug468PerformanceTest.class })
+@Suite.SuiteClasses({ PropertyManagerTest.class,
+// Bug468PerformanceTest.class
+})
 public class AllPropertiesTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/Bug468PerformanceTest.java
@@ -143,7 +143,7 @@ public class Bug468PerformanceTest extends TestCase {
 	// so, set a limit of 1 minute.
 	@Test
 	@Ignore("See https://github.com/eclipse-platform/eclipse.platform/issues/715")
-	public void test() throws CoreException {
+	public void _test() throws CoreException {
 		IFolder tempFolder = this.project.getFolder(TEMP_FOLDER_NAME);
 		long[] timeTakenForDeletingFiles = new long[1];
 


### PR DESCRIPTION
#891 was incomplete, because the test contains JUnit 4 annotations but is executed as JUnit 3 test, so they have no effect. This change extends the test disablement to be handled by JUnit 3.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/715