### PR TITLE
Fix random failing ServiceSupplierTestCase.testOptionalReferences #488

### DIFF
--- a/runtime/tests/org.eclipse.e4.core.javax.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: E4 Core Tests
 Bundle-SymbolicName: org.eclipse.e4.core.javax.tests
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Activator: org.eclipse.e4.core.internal.tests.CoreTestsActivator
 Require-Bundle: org.eclipse.equinox.preferences;bundle-version="3.3.0",

--- a/runtime/tests/org.eclipse.e4.core.javax.tests/pom.xml
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/pom.xml
@@ -21,7 +21,7 @@
 		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>org.eclipse.e4.core.javax.tests</artifactId>
-	<version>1.3.200-SNAPSHOT</version>
+	<version>1.3.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<testClass>org.eclipse.e4.core.javax.tests.CoreTestSuite</testClass>

--- a/runtime/tests/org.eclipse.e4.core.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.e4.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: E4 Core Tests
 Bundle-SymbolicName: org.eclipse.e4.core.tests
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Activator: org.eclipse.e4.core.internal.tests.CoreTestsActivator
 Require-Bundle: org.eclipse.equinox.preferences;bundle-version="3.3.0",

--- a/runtime/tests/org.eclipse.e4.core.tests/pom.xml
+++ b/runtime/tests/org.eclipse.e4.core.tests/pom.xml
@@ -21,7 +21,7 @@
 		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>org.eclipse.e4.core.tests</artifactId>
-	<version>1.3.200-SNAPSHOT</version>
+	<version>1.3.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<testClass>org.eclipse.e4.core.tests.CoreTestSuite</testClass>

--- a/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/ServiceSupplierTestCase.java
+++ b/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/ServiceSupplierTestCase.java
@@ -257,14 +257,16 @@ public class ServiceSupplierTestCase {
 
 			enabler.enableDisabledServiceB();
 			// wait for asynchronous service registry and injection to finish
-			waitForCondition(() -> bean.services.size() == 2, timeoutInMillis);
+			waitForCondition(() -> bean.services.size() == 2 && bean.disabledService instanceof DisabledServiceB,
+					timeoutInMillis);
 			assertNotNull(bean.disabledService);
 			assertEquals(2, bean.services.size());
 			assertSame(DisabledServiceB.class, bean.disabledService.getClass());
 
 			enabler.disableDisabledServiceB();
 			// wait for asynchronous service registry and injection to finish
-			waitForCondition(() -> bean.services.size() == 1, timeoutInMillis);
+			waitForCondition(() -> bean.services.size() == 1 && bean.disabledService instanceof DisabledServiceA,
+					timeoutInMillis);
 			assertNotNull(bean.disabledService);
 			assertEquals(1, bean.services.size());
 			assertSame(DisabledServiceA.class, bean.disabledService.getClass());
@@ -279,7 +281,7 @@ public class ServiceSupplierTestCase {
 			enabler.disableDisabledServiceB();
 			// wait for asynchronous service registry and injection to ensure
 			// clear state after this test
-			waitForCondition(() -> bean.services.size() == 0, timeoutInMillis);
+			waitForCondition(() -> bean.services.size() == 0 && bean.disabledService == null, timeoutInMillis);
 		}
 	}
 


### PR DESCRIPTION
Fixes two issues:
1. The ServiceSupplierTestCase asserts several values that are assigned by an asynchronous task. To this end, it waits for the conditions to be fulfilled by the asynchronous task. However, the conditions are incomplete, leading to a race condition.
2. The ServiceSupplierTestCase has been duplicated for javax and jakarta and a fix for a random failure has only been applied to a single implementation in https://github.com/eclipse-platform/eclipse.platform/pull/829

This change corrects the conditions the test waits for and aligns both copies of the test class with each other.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/488