### PR TITLE
Cleanup and simplify internal.resources tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.internal.resources.BuildConfiguration;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
@@ -61,17 +63,6 @@ public class ProjectReferencesTest extends ResourceTest {
 		project3v1 = new BuildConfiguration(project3, bc1);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
-		// clean-up resources
-		project0.delete(true, null);
-		project1.delete(true, null);
-		project2.delete(true, null);
-		project3.delete(true, null);
-	}
-
 	/**
 	 * Returns a reference to the active build configuration
 	 */
@@ -99,11 +90,7 @@ public class ProjectReferencesTest extends ResourceTest {
 		assertFalse("2.0", project0.hasBuildConfig(nonExistentBC));
 
 		assertEquals("3.1", new IBuildConfiguration[0], desc.getBuildConfigReferences(nonExistentBC));
-		try {
-			project0.getReferencedBuildConfigs(nonExistentBC, true);
-			fail("3.2");
-		} catch (CoreException e) {
-		}
+		assertThrows(CoreException.class, () -> project0.getReferencedBuildConfigs(nonExistentBC, true));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
@@ -20,7 +20,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Map;
-
 import org.eclipse.core.internal.resources.ResourceInfo;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -82,25 +81,17 @@ public class ResourceInfoTest extends ResourceTest {
 		}
 	}
 
-	public void testSerialization() {
+	public void testSerialization() throws IOException {
 		ByteArrayInputStream input = null;
 		ByteArrayOutputStream output = null;
 		ResourceInfo info = new ResourceInfo();
 		ResourceInfo newInfo = new ResourceInfo();
 
 		// write out an empty info
-		try {
-			output = new ByteArrayOutputStream();
-			info.writeTo(new DataOutputStream(output));
-		} catch (IOException e) {
-			fail("1.0", e);
-		}
-		try {
-			input = new ByteArrayInputStream(output.toByteArray());
-			newInfo.readFrom(0, new DataInputStream(input));
-		} catch (IOException e) {
-			fail("1.1", e);
-		}
+		output = new ByteArrayOutputStream();
+		info.writeTo(new DataOutputStream(output));
+		input = new ByteArrayInputStream(output.toByteArray());
+		newInfo.readFrom(0, new DataInputStream(input));
 		assertEquals("1.2", info, newInfo);
 
 		// write and info with syncinfo set
@@ -113,19 +104,11 @@ public class ResourceInfoTest extends ResourceTest {
 		qname = new QualifiedName("org.eclipse.core.tests", "myTest2");
 		bytes = new byte[] {0, 1, 2, 3, 4, 5};
 		info.setSyncInfo(qname, bytes);
-		try {
-			output = new ByteArrayOutputStream();
-			info.writeTo(new DataOutputStream(output));
-		} catch (IOException e) {
-			fail("2.0", e);
-		}
-		try {
-			newInfo = new ResourceInfo();
-			input = new ByteArrayInputStream(output.toByteArray());
-			newInfo.readFrom(0, new DataInputStream(input));
-		} catch (IOException e) {
-			fail("2.1", e);
-		}
+		output = new ByteArrayOutputStream();
+		info.writeTo(new DataOutputStream(output));
+		newInfo = new ResourceInfo();
+		input = new ByteArrayInputStream(output.toByteArray());
+		newInfo.readFrom(0, new DataInputStream(input));
 		assertEquals("2.2", info, newInfo);
 	}
 }


### PR DESCRIPTION
This change affects the tests in org.eclipse.core.tests.internal.resources
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Removes unnecessary cleanup operations
* Adds missing try-with-resources blocks
* Removes all further JUnit-3-specific functionality

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.