### PR TITLE
Fixed unneeded version bump on org.eclipse.debug.ui

### DIFF
--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.18.400.qualifier
+Bundle-Version: 3.18.300.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
This fixes API error saying unnecessary version bump. The bundle was not published yet via IBuild, so we can revert.

Regression from
https://github.com/eclipse-platform/eclipse.platform/pull/800