### PR TITLE
Remove JUnit 3 fail operations from ResourceTest

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -320,7 +320,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	}
 
 	@Test
-	public void testWriteFileNotInWorkspace() {
+	public void testWriteFileNotInWorkspace() throws CoreException {
 		// Bug 571133
 		IProject project = projects[0];
 		IFile file = project.getFile("testWriteFile2");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -296,7 +296,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("3.5", 0, states.length);
 	}
 
-	public void testBug28238() {
+	public void testBug28238() throws CoreException {
 		// paths to mimic files in the workspace
 		IProject project = getWorkspace().getRoot().getProject("myproject28238");
 		IFolder folder = project.getFolder("myfolder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -40,7 +40,7 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		return path.toFile().exists() && path.toFile().length() == 0;
 	}
 
-	public void testProjectDeletion() {
+	public void testProjectDeletion() throws CoreException {
 		/* initialize common objects */
 		Project project = (Project) projects[0];
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -160,7 +160,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	 * Tests concurrent access to the property store while the project is being
 	 * deleted.
 	 */
-	public void testConcurrentDelete() {
+	public void testConcurrentDelete() throws CoreException {
 		Thread[] threads;
 		final IFile target = projects[0].getFile("target");
 		final int REPEAT = 8;
@@ -403,7 +403,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	/**
 	 * See bug 93849.
 	 */
-	public void testFileRename() {
+	public void testFileRename() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("proj");
 		IFolder folder = project.getFolder("folder");
@@ -442,7 +442,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	/**
 	 * See bug 93849.
 	 */
-	public void testFolderRename() {
+	public void testFolderRename() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("proj");
 		IFolder folder1a = project.getFolder("folder1");
@@ -515,7 +515,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	/**
 	 * See bug 93849.
 	 */
-	public void testProjectRename() {
+	public void testProjectRename() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project1a = root.getProject("proj1");
 		ensureExistsInWorkspace(project1a, true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -220,7 +220,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		assertFalse("No cycles", projectOrder.hasCycles);
 	}
 
-	public void testBug543776() throws CoreException {
+	public void testBug543776() throws Exception {
 		IFile projectFile = project0.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		String projectDescription = readStringInFileSystem(projectFile);
 		projectDescription = projectDescription.replace(PROJECT_0_NAME, "anotherName");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -112,7 +112,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 	}
 
-	public void testSimple() {
+	public void testSimple() throws CoreException {
 		IProject project = getProject("foo");
 		String qualifier = "org.eclipse.core.tests.resources";
 		String key = "key" + getUniqueString();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -142,7 +142,7 @@ public class IFileTest extends ResourceTest {
 	 * Returns some interesting files.  These files are created
 	 * during setup.
 	 */
-	public IFile[] interestingFiles() {
+	public IFile[] interestingFiles() throws CoreException {
 		refreshFiles();
 		IFile[] result = new IFile[allFiles.size()];
 		allFiles.toArray(result);
@@ -207,7 +207,7 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Makes sure file requirements are met (out of sync, workspace only, etc).
 	 */
-	public void refreshFile(IFile file) {
+	public void refreshFile(IFile file) throws CoreException {
 		if (file.getName().equals(LOCAL_ONLY)) {
 			ensureDoesNotExistInWorkspace(file);
 			//project must exist to access file system store.
@@ -243,7 +243,7 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Makes sure file requirements are met (out of sync, workspace only, etc).
 	 */
-	public void refreshFiles() {
+	public void refreshFiles() throws CoreException {
 		for (IFile file : allFiles) {
 			refreshFile(file);
 		}
@@ -360,7 +360,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testCreate") {
 			@Override
-			public void cleanUp(Object[] args, int count) {
+			public void cleanUp(Object[] args, int count) throws CoreException {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}
@@ -597,7 +597,7 @@ public class IFileTest extends ResourceTest {
 	}
 
 	@Test
-	public void testFileCreation_Bug107188() {
+	public void testFileCreation_Bug107188() throws CoreException {
 		//create from stream that is canceled
 		IFile target = projects[0].getFile("file1");
 		ensureDoesNotExistInWorkspace(target);
@@ -718,7 +718,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles()};
 		new TestPerformer("IFileTest.testGetContents") {
 			@Override
-			public void cleanUp(Object[] args, int count) {
+			public void cleanUp(Object[] args, int count) throws CoreException {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}
@@ -860,7 +860,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testSetContents1") {
 			@Override
-			public void cleanUp(Object[] args, int count) {
+			public void cleanUp(Object[] args, int count) throws CoreException {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -57,7 +57,7 @@ public class IFolderTest extends ResourceTest {
 		assertExistsInWorkspace("1.1", afterFile);
 	}
 
-	public void testCopyMissingFolder() {
+	public void testCopyMissingFolder() throws CoreException {
 		//tests copying a folder that is missing from the file system
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder before = project.getFolder("OldFolder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -609,7 +609,7 @@ public class IPathVariableTest extends ResourceTest {
 	 * attempting to get the location of a resource that would live under an
 	 * existing IFile.
 	 */
-	public void testDiscoverLocationOfInvalidFile() {
+	public void testDiscoverLocationOfInvalidFile() throws CoreException {
 		IPath filep = IPath.fromOSString("someFile");
 		IPath invalidChild = filep.append("invalidChild");
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -197,7 +197,7 @@ public class IResourceTest extends ResourceTest {
 
 	/**
 	 * Returns interesting resources for refresh local / sync tests. */
-	protected IResource[] buildInterestingResources() {
+	protected IResource[] buildInterestingResources() throws CoreException {
 		IProject emptyProject = getWorkspace().getRoot().getProject("EmptyProject");
 		IProject fullProject = getWorkspace().getRoot().getProject("FullProject");
 		//resource pattern is: empty file, empty folder, full folder, repeat
@@ -213,7 +213,7 @@ public class IResourceTest extends ResourceTest {
 		return result;
 	}
 
-	private IResource[] buildSampleResources(IContainer root) {
+	private IResource[] buildSampleResources(IContainer root) throws CoreException {
 		// do not change the example resources unless you change references to
 		// specific indices in setUp()
 		IResource[] result = buildResources(root, new String[] {"1/", "1/1/", "1/1/1/", "1/1/1/1", "1/1/2/", "1/1/2/1/", "1/1/2/2/", "1/1/2/3/", "1/2/", "1/2/1", "1/2/2", "1/2/3/", "1/2/3/1", "1/2/3/2", "1/2/3/3", "1/2/3/4", "2", "2"});
@@ -482,7 +482,7 @@ public class IResourceTest extends ResourceTest {
 	/**
 	 * Sets up the workspace and file system for this test. */
 	protected void setupBeforeState(IResource receiver, IResource target, int state, int depth, boolean addVerifier)
-			throws OperationCanceledException, InterruptedException {
+			throws OperationCanceledException, InterruptedException, CoreException {
 		// Wait for any outstanding refresh to finish
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -45,7 +45,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
 	@Test
-	public void testFindFilesNonCanonicalPath() {
+	public void testFindFilesNonCanonicalPath() throws CoreException {
 		// this test is for windows only
 		Assume.assumeTrue(OS.isWindows());
 
@@ -60,11 +60,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		fileLocationLower = fileLocationLower.setDevice(fileLocationLower.getDevice().toLowerCase());
 		IPath fileLocationUpper = fileLocationLower.setDevice(fileLocationLower.getDevice().toUpperCase());
 		//create the link with lower case device
-		try {
-			link.createLink(fileLocationLower, IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.99", e);
-		}
+		link.createLink(fileLocationLower, IResource.NONE, getMonitor());
+
 		//try to find the file using the upper case device
 		IFile[] files = getWorkspace().getRoot().findFilesForLocation(fileLocationUpper);
 		assertEquals("1.0", 1, files.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -791,7 +791,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("4.1", first || second || third);
 	}
 
-	public void testValidateEdit() {
+	public void testValidateEdit() throws CoreException {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
 		if (!isReadOnlySupported()) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -1552,7 +1552,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests bug 298849.
 	 */
-	public void testMoveFolderWithLinks() throws CoreException {
+	public void testMoveFolderWithLinks() throws Exception {
 		// create a folder
 		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
 		folderWithLinks.create(true, true, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -145,7 +145,7 @@ public class MarkerTest extends ResourceTest {
 		assertFalse(String.format("Marker '%s' is subtype of %s", marker, superType), marker.isSubtypeOf(superType));
 	}
 
-	public IResource[] createLargeHierarchy() {
+	public IResource[] createLargeHierarchy() throws CoreException {
 		ArrayList<String> result = new ArrayList<>();
 		result.add("/");
 		new MarkerTest().addChildren(result, IPath.ROOT, 3, 4);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -18,13 +18,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.eclipse.core.internal.resources.PreferenceInitializer;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
 import org.eclipse.core.internal.utils.Messages;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.osgi.util.NLS;
-import org.hamcrest.*;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
 import org.junit.Test;
 
 /**
@@ -152,7 +157,7 @@ public class ProjectEncodingTest extends ResourceTest {
 		Job.getJobManager().join(ValidateProjectEncoding.class, getMonitor());
 	}
 
-	private void whenProjectIsCreated() {
+	private void whenProjectIsCreated() throws CoreException {
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
 		ensureExistsInWorkspace(project, true);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -59,7 +59,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 		ensureExistsInWorkspace(projects, true);
 	}
 
-	private void populateProject(IProject project) {
+	private void populateProject(IProject project) throws CoreException {
 		// add files and folders to project
 		IFile file = project.getFile("file");
 		ensureExistsInFileSystem(file);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -127,7 +127,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		assertTrue("2.4", !project.getResourceAttributes().isHidden());
 	}
 
-	public void testAttributeReadOnly() {
+	public void testAttributeReadOnly() throws CoreException {
 		// only activate this test on platforms that support it
 		if (!isAttributeSupported(EFS.ATTRIBUTE_READ_ONLY)) {
 			return;
@@ -161,7 +161,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		assertNull("1.0", project.getResourceAttributes());
 	}
 
-	public void testNonExistingResource() {
+	public void testNonExistingResource() throws CoreException {
 		//asking for attributes of a non-existent resource should return null
 		IProject project = getWorkspace().getRoot().getProject("testNonExistingResource");
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
@@ -21,7 +21,7 @@ import org.eclipse.core.tests.resources.OldCorePerformanceTest;
 public class BenchCopyFile extends OldCorePerformanceTest {
 	private static final int COUNT = 5000;
 
-	public void testCopyFile() {
+	public void testCopyFile() throws CoreException {
 		IFileStore input = getTempStore();
 		createFileInFileSystem(input, getRandomContents());
 		IFileStore[] output = new IFileStore[COUNT];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -96,7 +96,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		new PerformanceTestRunner() {
 
 			@Override
-			protected void setUp() {
+			protected void setUp() throws CoreException {
 				ensureExistsInWorkspace(file, getRandomContents());
 			}
 
@@ -131,7 +131,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		new PerformanceTestRunner() {
 
 			@Override
-			protected void setUp() {
+			protected void setUp() throws CoreException {
 				ensureExistsInWorkspace(new IResource[] {project, folder1, folder2}, true);
 				try {
 					file1.create(getRandomContents(), IResource.FORCE, getMonitor());
@@ -170,7 +170,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}.run(this, 10, 5);
 	}
 
-	private void testClearHistory(final int filesPerFolder, final int statesPerFile) {
+	private void testClearHistory(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
 		ensureDoesNotExistInWorkspace(base);
@@ -178,7 +178,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			private IWorkspaceDescription original;
 
 			@Override
-			protected void setUp() {
+			protected void setUp() throws CoreException {
 				original = setMaxFileStates("0.1", 1);
 				// make sure we start with no garbage
 				cleanHistory();
@@ -205,15 +205,15 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}.run(this, 4, 3);
 	}
 
-	public void testClearHistory100x4() {
+	public void testClearHistory100x4() throws CoreException {
 		testClearHistory(100, 4);
 	}
 
-	public void testClearHistory20x20() {
+	public void testClearHistory20x20() throws CoreException {
 		testClearHistory(20, 20);
 	}
 
-	public void testClearHistory4x100() {
+	public void testClearHistory4x100() throws CoreException {
 		testClearHistory(4, 100);
 	}
 
@@ -250,7 +250,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		testCopyHistory(4, 100);
 	}
 
-	private void testGetDeletedMembers(int filesPerFolder, int statesPerFile) {
+	private void testGetDeletedMembers(int filesPerFolder, int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFolder base = project.getFolder("base");
 		createTree(base, filesPerFolder, statesPerFile);
@@ -269,19 +269,19 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}.run(this, 2, 5);
 	}
 
-	public void testGetDeletedMembers100x4() {
+	public void testGetDeletedMembers100x4() throws CoreException {
 		testGetDeletedMembers(100, 4);
 	}
 
-	public void testGetDeletedMembers20x20() {
+	public void testGetDeletedMembers20x20() throws CoreException {
 		testGetDeletedMembers(20, 20);
 	}
 
-	public void testGetDeletedMembers4x100() {
+	public void testGetDeletedMembers4x100() throws CoreException {
 		testGetDeletedMembers(4, 100);
 	}
 
-	public void testGetHistory() {
+	public void testGetHistory() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFile file = project.getFile("file.txt");
 		ensureExistsInWorkspace(file, getRandomContents());
@@ -304,7 +304,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}.run(this, 1, 150);
 	}
 
-	private void testHistoryCleanUp(final int filesPerFolder, final int statesPerFile) {
+	private void testHistoryCleanUp(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
 		ensureDoesNotExistInWorkspace(base);
@@ -312,7 +312,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			private IWorkspaceDescription original;
 
 			@Override
-			protected void setUp() {
+			protected void setUp() throws CoreException {
 				original = setMaxFileStates("0.1", 1);
 				// make sure we start with no garbage
 				cleanHistory();
@@ -336,11 +336,11 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}.run(this, 5, 1);
 	}
 
-	public void testHistoryCleanUp100x4() {
+	public void testHistoryCleanUp100x4() throws CoreException {
 		testHistoryCleanUp(100, 4);
 	}
 
-	public void testHistoryCleanUp20x20() {
+	public void testHistoryCleanUp20x20() throws CoreException {
 		testHistoryCleanUp(20, 20);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -14,9 +14,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
@@ -35,7 +40,7 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 	/**
 	 * Creates a tree of resources.
 	 */
-	private List<IResource> createTree(IFolder base, int filesPerFolder) {
+	private List<IResource> createTree(IFolder base, int filesPerFolder) throws CoreException {
 		IFolder[] folders = new IFolder[5];
 		folders[0] = base.getFolder("folder1");
 		folders[1] = base.getFolder("folder2");
@@ -55,7 +60,8 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		return resources;
 	}
 
-	private void testGetProperty(int filesPerFolder, final int properties, int measurements, int repetitions) {
+	private void testGetProperty(int filesPerFolder, final int properties, int measurements, int repetitions)
+			throws CoreException {
 		IProject proj1 = getWorkspace().getRoot().getProject("proj1");
 		final IFolder folder1 = proj1.getFolder("folder1");
 		final List<IResource> allResources = createTree(folder1, filesPerFolder);
@@ -91,19 +97,20 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 
 	}
 
-	public void testGetProperty100x4() {
+	public void testGetProperty100x4() throws CoreException {
 		testGetProperty(100, 4, 10, 2);
 	}
 
-	public void testGetProperty20x20() {
+	public void testGetProperty20x20() throws CoreException {
 		testGetProperty(20, 20, 10, 2);
 	}
 
-	public void testGetProperty4x100() {
+	public void testGetProperty4x100() throws CoreException {
 		testGetProperty(4, 100, 10, 1);
 	}
 
-	private void testSetProperty(int filesPerFolder, int properties, int measurements, int repetitions) {
+	private void testSetProperty(int filesPerFolder, int properties, int measurements, int repetitions)
+			throws CoreException {
 		IProject proj1 = getWorkspace().getRoot().getProject("proj1");
 		final IFolder folder1 = proj1.getFolder("folder1");
 		final List<IResource> allResources = createTree(folder1, filesPerFolder);
@@ -131,15 +138,15 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		}.run(this, measurements, repetitions);
 	}
 
-	public void testSetProperty100x4() {
+	public void testSetProperty100x4() throws CoreException {
 		testSetProperty(100, 4, 10, 1);
 	}
 
-	public void testSetProperty20x20() {
+	public void testSetProperty20x20() throws CoreException {
 		testSetProperty(20, 20, 10, 4);
 	}
 
-	public void testSetProperty4x100() {
+	public void testSetProperty4x100() throws CoreException {
 		testSetProperty(4, 100, 10, 20);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
@@ -17,8 +17,15 @@ package org.eclipse.core.tests.resources.perf;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.Random;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -275,7 +282,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 		}.run(this, REPEATS, 3);
 	}
 
-	public void testLoadSnapshot() {
+	public void testLoadSnapshot() throws CoreException {
 		// 2 minutes total test time, 528 msec test execution time
 		IProject snapProject = getWorkspace().getRoot().getProject("SnapProject");
 		ensureExistsInWorkspace(snapProject, true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -50,7 +50,7 @@ public class Bug_264182 extends ResourceTest {
 		super.tearDown();
 	}
 
-	public void testBug() {
+	public void testBug() throws CoreException {
 		// create a linked resource
 		final IFile file = project.getFile(getUniqueString());
 		IFileStore tempFileStore = getTempStore();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -39,7 +39,7 @@ public class IFileTest extends ResourceTest {
 	 * ERROR_WRITE.
 	 */
 	@Test
-	public void testBug25658() {
+	public void testBug25658() throws CoreException {
 
 		// This test is no longer valid since the error code is dependent on whether
 		// or not the parent folder is marked as read-only. We need to write a different
@@ -75,7 +75,7 @@ public class IFileTest extends ResourceTest {
 	 * to the user.
 	 */
 	@Test
-	public void testBug25662() {
+	public void testBug25662() throws CoreException {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -39,7 +39,7 @@ public class IFolderTest extends ResourceTest {
 	 * error code and message to the user.
 	 */
 	@Test
-	public void testBug25662() {
+	public void testBug25662() throws CoreException {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -191,7 +191,7 @@ public class IResourceTest extends ResourceTest {
 		assertTrue("1.0", !project.isSynchronized(IResource.DEPTH_INFINITE));
 	}
 
-	public void testBug111821() {
+	public void testBug111821() throws CoreException {
 		//this test only makes sense on Windows
 		if (!OS.isWindows()) {
 			return;
@@ -359,7 +359,7 @@ public class IResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
 	}
 
-	public void testDelete_Bug8754() {
+	public void testDelete_Bug8754() throws CoreException {
 		//In this test, we delete with force false on a file that does not exist in the file system,
 		//and ensure that the returned exception is of type OUT_OF_SYNC_LOCAL
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -44,7 +44,7 @@ public class Snapshot2Test extends SnapshotTest {
 		return new String[] {"/added file", "/yet another file", "/a folder/"};
 	}
 
-	public void testChangeMyProject() {
+	public void testChangeMyProject() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.1", project.exists());


### PR DESCRIPTION
Replaces fail(String, Throwable) operations in ResourceTest utility methods by rethrowing the exception in order to separate those methods to a utility class and prepare for a migration to JUnit 4/5.

This is part of preparatory work for migrating the `ResourceTests` to JUnit 4.