### PR TITLE
Move create/ensure methods from ResourceTest to utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -27,6 +27,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 /**
  * This class needs to be used with SaveManager2Test. Basically this

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -25,6 +25,8 @@ import org.eclipse.core.tests.resources.saveparticipant2.SaveParticipant2Plugin;
 import org.eclipse.core.tests.resources.saveparticipant3.SaveParticipant3Plugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 
 /**
  * This class needs to be used with SaveManager2Test. Basically this

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -29,6 +29,9 @@ import org.osgi.framework.Bundle;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 
 /**
  * @see SaveManager1Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.filesystem;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -156,7 +157,7 @@ public class FileStoreTest extends LocalStoreTest {
 		destination = tempDest.getChild(subfolderName);
 		deleteOnTearDown(destination);
 		String anotherContent = "nothing..................gnihton";
-		createFile(destination, anotherContent);
+		createOrOverwriteFile(destination, anotherContent);
 		assertTrue("5.1", !destination.fetchInfo().isDirectory());
 		final IFileStore immutableDestination = destination;
 		assertThrows(CoreException.class, () -> target.copy(immutableDestination, EFS.NONE, null));
@@ -195,7 +196,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
 		IFileStore existing = getTempStore();
-		createFile(existing, getRandomString());
+		createOrOverwriteFile(existing, getRandomString());
 		// try to copy when parent of destination does not exist
 		assertThrows(CoreException.class, () -> existing.copy(child, EFS.NONE, getMonitor()));
 		// destination should not exist
@@ -212,7 +213,7 @@ public class FileStoreTest extends LocalStoreTest {
 		String content = "this is just a simple content \n to a simple file \n to test a 'simple' copy";
 		IFileStore fileWithSmallName = temp.getChild("filename");
 		fileWithSmallName.delete(EFS.NONE, null);
-		createFile(fileWithSmallName, content);
+		createOrOverwriteFile(fileWithSmallName, content);
 		System.out.println(fileWithSmallName.fetchInfo().getName());
 		assertTrue("1.3", fileWithSmallName.fetchInfo().exists());
 		assertTrue("1.4", compareContent(getContents(content), fileWithSmallName.openInputStream(EFS.NONE, null)));
@@ -243,7 +244,7 @@ public class FileStoreTest extends LocalStoreTest {
 		String content = "this is just a simple content \n to a simple file \n to test a 'simple' copy";
 		IFileStore target = temp.getChild("target");
 		target.delete(EFS.NONE, null);
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		assertTrue("1.3", target.fetchInfo().exists());
 		assertTrue("1.4", compareContent(getContents(content), target.openInputStream(EFS.NONE, null)));
 
@@ -276,7 +277,7 @@ public class FileStoreTest extends LocalStoreTest {
 			sb.append("asdjhasldhaslkfjhasldkfjhasdlkfjhasdlfkjhasdflkjhsdaf");
 		}
 		IFileStore bigFile = temp.getChild("bigFile");
-		createFile(bigFile, sb.toString());
+		createOrOverwriteFile(bigFile, sb.toString());
 		assertTrue("7.1", bigFile.fetchInfo().exists());
 		assertTrue("7.2", compareContent(getContents(sb.toString()), bigFile.openInputStream(EFS.NONE, null)));
 		IFileStore destination = temp.getChild("copy of bigFile");
@@ -309,7 +310,7 @@ public class FileStoreTest extends LocalStoreTest {
 
 		IFileStore target = tempSrc.getChild(subfolderName);
 		target.delete(EFS.NONE, null);
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		deleteOnTearDown(target);
 		assertTrue("1.3", target.fetchInfo().exists());
 		assertTrue("1.4", compareContent(getContents(content), target.openInputStream(EFS.NONE, null)));
@@ -333,7 +334,7 @@ public class FileStoreTest extends LocalStoreTest {
 		destination = tempDest.getChild(subfolderName);
 		deleteOnTearDown(destination);
 		String anotherContent = "nothing..................gnihton";
-		createFile(destination, anotherContent);
+		createOrOverwriteFile(destination, anotherContent);
 		assertTrue("5.1", !destination.fetchInfo().isDirectory());
 		target.copy(destination, IResource.DEPTH_INFINITE, null);
 		assertTrue("5.2", compareContent(getContents(content), destination.openInputStream(EFS.NONE, null)));
@@ -347,7 +348,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertThrows(CoreException.class, () -> target.copy(immutableDestination, EFS.NONE, null));
 		/* test if the input stream inside the copy method was closed */
 		target.delete(EFS.NONE, null);
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		assertTrue("6.3", destination.fetchInfo().isDirectory());
 		destination.delete(EFS.NONE, null);
 	}
@@ -401,7 +402,7 @@ public class FileStoreTest extends LocalStoreTest {
 		// create target file
 		IFileStore target = tempC.getChild("target");
 		String content = "just a content.....tnetnoc a tsuj";
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		assertTrue("1.3", target.fetchInfo().exists());
 		// create target tree
 		IFileStore tree = tempC.getChild("tree");
@@ -419,7 +420,7 @@ public class FileStoreTest extends LocalStoreTest {
 
 		/* rename file (but destination is already a file) */
 		String anotherContent = "another content";
-		createFile(destination, anotherContent);
+		createOrOverwriteFile(destination, anotherContent);
 		final IFileStore immutableFileDestination = destination;
 		assertThrows(CoreException.class, () -> target.move(immutableFileDestination, EFS.NONE, null));
 		assertTrue("3.2", !target.fetchInfo().isDirectory());
@@ -463,7 +464,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore target = tempSrc.getChild(subfolderName);
 		deleteOnTearDown(target);
 		String content = "just a content.....tnetnoc a tsuj";
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		assertTrue("1.3", target.fetchInfo().exists());
 		// create target tree
 		IFileStore tree = tempSrc.getChild("tree");
@@ -496,7 +497,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
 		IFileStore existing = getTempStore();
-		createFile(existing, getRandomString());
+		createOrOverwriteFile(existing, getRandomString());
 		// try to move when parent of destination does not exist
 		assertThrows(CoreException.class, () -> existing.move(child, EFS.NONE, getMonitor()));
 		// destination should not exist
@@ -571,7 +572,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore targetFolder = createDir(root.toString(), true);
 		deleteOnTearDown(targetFolder);
 		IFileStore targetFile = targetFolder.getChild("targetFile");
-		createFileInFileSystem(targetFile);
+		createFile(targetFile);
 
 		// file
 		boolean init = targetFile.fetchInfo().getAttribute(attribute);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -17,6 +17,9 @@ package org.eclipse.core.tests.internal.alias;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -433,7 +436,7 @@ public class BasicAliasTest extends ResourceTest {
 		assertTrue("3.0", dirStore.fetchInfo().isDirectory());
 
 		IFileStore childStore = dirStore.getChild("child");
-		createFileInFileSystem(childStore);
+		createFile(childStore);
 		assertTrue("4.0", childStore.fetchInfo().exists());
 
 		// Create and open the first project. Project links to the directory.
@@ -704,7 +707,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		// delete the project that contains the links
 		IFile fileInLinkedProject = pLinked.getFile("fileInLinkedProject.txt");
-		createFileInFileSystem(((Resource) fileInLinkedProject).getStore(), getRandomContents());
+		createFile(((Resource) fileInLinkedProject).getStore(), getRandomContents());
 		// failure expected here because it is out of sync
 		assertThrows(CoreException.class, () -> getWorkspace().getRoot().delete(IResource.NONE, getMonitor()));
 		waitForRefresh();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.alias;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -14,6 +14,8 @@
  ******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.util.Map;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.ICommand;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.internal.events.BuildContext;
 import org.eclipse.core.internal.resources.BuildConfiguration;
 import org.eclipse.core.resources.IBuildConfiguration;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SNOW;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_WATER;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.transferStreams;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -628,7 +631,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create some resources
 		proj1.create(getMonitor());
 		proj1.open(getMonitor());
-		ensureDoesNotExistInWorkspace(proj2);
+		removeFromWorkspace(proj2);
 
 		// Create and set a build spec for project one
 		IProjectDescription desc = proj1.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.eclipse.core.tests.resources.TestUtil.waitForCondition;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.events;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -71,7 +71,7 @@ public class BlobStoreTest extends LocalStoreTest {
 
 		/* delete existing blob */
 		IFileStore target = root.getChild("target");
-		createFile(target, "bla bla bla");
+		createOrOverwriteFile(target, "bla bla bla");
 		uuid = store.addBlob(target, true);
 		assertTrue(store.fileFor(uuid).fetchInfo().exists());
 		store.deleteBlob(uuid);
@@ -90,7 +90,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		IFileStore target = root.getChild("target");
 		UniversalUniqueIdentifier uuid = null;
 		String content = "nothing important........tnatropmi gnihton";
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		uuid = store.addBlob(target, true);
 		InputStream input = store.getBlob(uuid);
 		assertTrue(compareContent(getContents(content), input));
@@ -105,7 +105,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		IFileStore target = root.getChild("target");
 		UniversalUniqueIdentifier uuid = null;
 		String content = "nothing important........tnatropmi gnihton";
-		createFile(target, content);
+		createOrOverwriteFile(target, content);
 		uuid = store.addBlob(target, true);
 		InputStream input = store.getBlob(uuid);
 		assertTrue(compareContent(getContents(content), input));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
@@ -345,7 +347,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		IFile herringRouge = project.getFile(name);
 
 		// create a file in the local file system with the same name but different casing
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		ensureExistsInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
@@ -368,7 +370,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		IFile herringRouge = project.getFile(name);
 
 		// create a file in the local file system with the same name but different casing
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		ensureExistsInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -56,7 +60,7 @@ public class CopyTest extends LocalStoreTest {
 
 		/* copy to absolute path */
 		IResource destination = testProjects[0].getFile("copy of file.txt");
-		ensureDoesNotExistInFileSystem(destination);
+		removeFromFileSystem(destination);
 		file.copy(destination.getFullPath(), true, null);
 		assertTrue(destination.exists());
 		/* assert properties were properly copied */
@@ -66,13 +70,13 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not((sessionValue))));
 		}
-		ensureDoesNotExistInWorkspace(destination);
-		ensureDoesNotExistInFileSystem(destination);
+		removeFromWorkspace(destination);
+		removeFromFileSystem(destination);
 
 		/* copy to relative path */
 		IPath path = IPath.fromOSString("copy of file.txt");
 		IFile destinationInFolder = folder.getFile(path);
-		ensureDoesNotExistInFileSystem(destinationInFolder);
+		removeFromFileSystem(destinationInFolder);
 		file.copy(path, true, null);
 		assertTrue(destinationInFolder.exists());
 		/* assert properties were properly copied */
@@ -82,8 +86,8 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not(sessionValue)));
 		}
-		ensureDoesNotExistInWorkspace(destinationInFolder);
-		ensureDoesNotExistInFileSystem(destinationInFolder);
+		removeFromWorkspace(destinationInFolder);
+		removeFromFileSystem(destinationInFolder);
 
 		/* copy folder to destination under its hierarchy */
 		IFolder destinationInSubfolder = folder.getFolder("subfolder");
@@ -111,13 +115,13 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not(sessionValue)));
 		}
-		ensureDoesNotExistInWorkspace(destinationFolder);
-		ensureDoesNotExistInFileSystem(destinationFolder);
+		removeFromWorkspace(destinationFolder);
+		removeFromFileSystem(destinationFolder);
 
 		/* copy a file that is not local but exists in the workspace */
 		IFile ghostFile = testProjects[0].getFile("ghost");
 		ghostFile.create(null, true, null);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		IFile destinationFile = testProjects[0].getFile("destination");
 		assertThrows(CoreException.class, () -> ghostFile.copy(destinationFile.getFullPath(), true, null));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.Workspace;
@@ -298,7 +301,7 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);
-		ensureDoesNotExistInFileSystem(deletedfolderSync);
+		removeFromFileSystem(deletedfolderSync);
 		ensureOutOfSync(subsubfileUnsync);
 
 		/* delete */
@@ -344,7 +347,7 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);
-		ensureDoesNotExistInFileSystem(deletedfolderSync);
+		removeFromFileSystem(deletedfolderSync);
 		ensureOutOfSync(subsubfileUnsync);
 
 		/* delete */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -170,7 +174,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		// create resources
 		IResource[] resources = buildResources(project, defineHierarchy());
 		ensureExistsInWorkspace(resources, true);
-		ensureDoesNotExistInFileSystem(resources);
+		removeFromFileSystem(resources);
 
 		// exists
 		assertTrue(project.isLocal(IResource.DEPTH_INFINITE)); // test
@@ -189,7 +193,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertFalse(folder.isLocal(IResource.DEPTH_INFINITE));
 
 		// remove the trash
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	/**
@@ -292,14 +296,14 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		file.setContents(another, true, false, null);
 
 		/* test the overwrite parameter (false) */
-		ensureDoesNotExistInFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
+		removeFromFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
 		InputStream another3 = getContents(anotherContent);
 		waitForRefresh(); // wait for refresh to ensure that file is not present in workspace
 		assertThrows("Should fail writing non existing file", CoreException.class,
 				() -> write(file, another3, false, null));
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	// See https://github.com/eclipse-platform/eclipse.platform/issues/103
@@ -333,7 +337,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertThrows(CoreException.class, () -> write(file, another, false, null));
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	@Test
@@ -344,14 +348,14 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		ensureExistsInWorkspace(folder, true);
 
 		/* existing file on destination */
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		IFile file = project.getFile("testWriteFolder");
 		ensureExistsInFileSystem(file);
 		/* force = true */
 		assertThrows(CoreException.class, () -> write(folder, true, null));
 		/* force = false */
 		assertThrows(CoreException.class, () -> write(folder, false, null));
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		/* existing folder on destination */
 		ensureExistsInFileSystem(folder);
@@ -360,13 +364,13 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertTrue(folder.getLocation().toFile().isDirectory());
 		/* force = false */
 		assertThrows(CoreException.class, () -> write(folder, false, null));
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 
 		/* inexisting resource on destination */
 		/* force = true */
 		write(folder, true, null);
 		assertTrue(folder.getLocation().toFile().isDirectory());
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		/* force = false */
 		write(folder, false, null);
 		assertTrue(folder.getLocation().toFile().isDirectory());
@@ -385,7 +389,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		// create project and then delete from file system
 		// wrap in runnable to prevent snapshot from occurring in the middle.
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			ensureDoesNotExistInFileSystem(project);
+			removeFromFileSystem(project);
 			assertFalse("2.1", fileStore.fetchInfo().isDirectory());
 			//write project in a runnable, otherwise tree will be locked
 			((Project) project).writeDescription(IResource.FORCE);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -308,7 +310,7 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// location of the data on disk
 		IFileStore fileStore = getTempStore();
-		createFileInFileSystem(fileStore);
+		createFile(fileStore);
 		assertEquals("1.0" + " file already has state", 0, store.getStates(file.getFullPath(), getMonitor()).length);
 
 		// add the data to the history store
@@ -1069,7 +1071,7 @@ public class HistoryStoreTest extends ResourceTest {
 			historyStore.addState(file.getFullPath(), ((Resource) file).getStore(), fileInfo, true);
 			contents = "This file has some contents in testGetContents.";
 			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
-				createFileInFileSystem(file.getLocation(), is);
+				createFile(file.getLocation(), is);
 			}
 			file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
@@ -1081,7 +1083,7 @@ public class HistoryStoreTest extends ResourceTest {
 			historyStore.addState(secondValidFile.getFullPath(), ((Resource) secondValidFile).getStore(), fileInfo, true);
 			contents = "A file with some other contents in testGetContents.";
 			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
-				createFileInFileSystem(secondValidFile.getLocation(), is);
+				createFile(secondValidFile.getLocation(), is);
 			}
 			secondValidFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -82,7 +82,7 @@ public abstract class LocalStoreTest extends ResourceTest {
 	 * Create a file with random content. If a resource exists in the same path,
 	 * the resource is deleted.
 	 */
-	protected void createFile(IFileStore target, String content) throws CoreException {
+	protected void createOrOverwriteFile(IFileStore target, String content) throws CoreException {
 		target.delete(EFS.NONE, null);
 		InputStream input = new ByteArrayInputStream(content.getBytes());
 		transferData(input, target.openOutputStream(EFS.NONE, null));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.ICoreConstants;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -17,6 +17,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.ICoreConstants;
@@ -122,10 +125,10 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 
 		// make some modifications in the local resources
 		// index stays the same
-		ensureDoesNotExistInFileSystem(toc);
+		removeFromFileSystem(toc);
 		//
-		ensureDoesNotExistInFileSystem(file);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(file);
+		removeFromFileSystem(folder);
 
 		Thread.sleep(5000);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -17,6 +17,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.File;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.File;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import java.io.File;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.ICoreConstants;
@@ -120,7 +125,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		IResource[] both = new IResource[] {folder, file};
 
 		ensureExistsInFileSystem(both);
-		ensureDoesNotExistInWorkspace(both);
+		removeFromWorkspace(both);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
@@ -134,7 +139,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		project.delete(IResource.FORCE, getMonitor());
 
 		ensureExistsInFileSystem(both);
-		ensureDoesNotExistInWorkspace(both);
+		removeFromWorkspace(both);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
@@ -150,7 +155,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* */
 		IFile file = project.getFile("file");
 		file.create(null, true, null);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		//
 		File target = file.getLocation().toFile();
 		target.mkdirs();
@@ -170,7 +175,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* test folder to file */
 		IFolder folder = project.getFolder("folder");
 		folder.create(true, true, null);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		//
 		IFile file = project.getFile("folder");
 		ensureExistsInFileSystem(file);
@@ -208,8 +213,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertFalse(file.exists());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 
 		/* test creation of a child */
 		file = project.getFile("file");
@@ -217,8 +222,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertFalse(file.exists());
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue(file.exists());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 
 		/* test changes of a child (child is folder) */
 		IFolder folder = project.getFolder("folder");
@@ -236,8 +241,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertTrue(folder.exists());
 		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue(file.exists());
-		ensureDoesNotExistInWorkspace(folder);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromWorkspace(folder);
+		removeFromFileSystem(folder);
 
 		/* test changes of a child (child is file) */
 		file = project.getFile("file");
@@ -254,8 +259,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertEquals(fileStore.fetchInfo().getLastModified(),
 				((Resource) file).getResourceInfo(false, false).getLocalSyncInfo());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 	}
 
 	public void testSimpleRefresh() throws Throwable {
@@ -265,7 +270,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* test root deletion */
 		IFile file = project.getFile("file");
 		ensureExistsInWorkspace(file, true);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		assertTrue(file.exists());
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertFalse(file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.junit.Assert.assertThrows;
 
 import java.io.DataInputStream;
@@ -69,7 +70,7 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 				// ignore
 			}
 		}
-		ensureDoesNotExistInFileSystem(temp.getParentFile());
+		removeFromFileSystem(temp.getParentFile());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.transferStreams;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.mapping;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.mapping;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
@@ -13,7 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.mapping;
 
-import org.eclipse.core.resources.*;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.mapping.IResourceChangeDescriptionFactory;
 import org.eclipse.core.resources.mapping.ResourceChangeValidator;
 import org.eclipse.core.tests.resources.ResourceTest;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.mapping;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.properties;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertNotEquals;
 
 import java.nio.charset.StandardCharsets;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -15,6 +15,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -341,9 +344,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(workspace);
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		createFile(location, stream);
 		ProjectDescription projDesc = reader.read(location);
 		assertNull(projDesc);
 	}
@@ -354,7 +357,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		createFile(store, stream);
 		ProjectDescription projDesc = readDescription(store);
 		assertNotNull("2.0", projDesc);
 		assertNull("2.1", projDesc.getName());
@@ -372,7 +375,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		createFile(store, stream);
 
 		ProjectDescription projDesc = readDescription(store);
 		assertNotNull("3.0", projDesc);
@@ -391,7 +394,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		createFile(store, stream);
 		ProjectDescription projDesc = readDescription(store);
 		assertNotNull("3.0", projDesc);
 		assertTrue("3.1", projDesc.getName().equals("abc"));
@@ -416,11 +419,11 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		InputStream stream = new ByteArrayInputStream(longProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		createFile(location, stream);
 		ProjectDescription projDesc = reader.read(location);
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
 			assertEquals("1.0." + link.getProjectRelativePath(), LONG_LOCATION_URI, link.getLocationURI());
 		}
@@ -436,11 +439,11 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(ResourcesPlugin.getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		InputStream stream = new ByteArrayInputStream(longProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		createFile(location, stream);
 		ProjectDescription projDesc = reader.read(location);
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
 			assertEquals("1.0." + link.getProjectRelativePath(), LONG_LOCATION_URI, link.getLocationURI());
 		}
@@ -462,13 +465,13 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(workspace);
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(multiLocation.toFile());
-		ensureDoesNotExistInFileSystem(singleLocation.toFile());
+		removeFromFileSystem(multiLocation.toFile());
+		removeFromFileSystem(singleLocation.toFile());
 		InputStream multiStream = new ByteArrayInputStream(multiLineProjectDescription.getBytes());
 		InputStream singleStream = new ByteArrayInputStream(singleLineProjectDescription.getBytes());
 
-		createFileInFileSystem(multiLocation, multiStream);
-		createFileInFileSystem(singleLocation, singleStream);
+		createFile(multiLocation, multiStream);
+		createFile(singleLocation, singleStream);
 		ProjectDescription multiDesc = reader.read(multiLocation);
 		ProjectDescription singleDesc = reader.read(singleLocation);
 		compareProjectDescriptions(1, multiDesc, singleDesc);
@@ -685,9 +688,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		InputStream stream = new ByteArrayInputStream(projectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		createFile(location, stream);
 		ProjectDescription projDesc = reader.read(location);
 		assertNotNull(projDesc);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.internal.resources.BuildConfiguration;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -393,7 +395,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		IProject project = getProject(getUniqueString());
 		IProject destProject = getProject(getUniqueString());
 		ensureExistsInWorkspace(project, true);
-		ensureDoesNotExistInWorkspace(destProject);
+		removeFromWorkspace(destProject);
 		IScopeContext context = new ProjectScope(project);
 		String qualifier = getUniqueString();
 		Preferences node = context.getNode(qualifier);
@@ -529,7 +531,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertTrue("1.2", getFileInWorkspace(project, ResourcesPlugin.PI_RESOURCES).exists());
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertEquals("1.3", value, node.get(key, null));
-		ensureDoesNotExistInWorkspace(project.getFolder(DIR_NAME));
+		removeFromWorkspace(project.getFolder(DIR_NAME));
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertNull("2.0", node.get(key, null));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.BuildConfiguration;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -64,7 +66,7 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		for (String property : descriptionProperties) {
 			assertTrue("2.0 - Description property is not default: " + property, defaultPropertiesList.contains(property));
 		}
-		
+
 		setDefaultWorkspaceDescription();
 	}
 
@@ -205,8 +207,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 			// ensures preferences exported match the imported ones
 			assertEquals("5.1", modified, workspace.getDescription());
 		} finally {
-			ensureDoesNotExistInFileSystem(originalPreferencesFile.removeLastSegments(1).toFile());
-			ensureDoesNotExistInFileSystem(modifiedPreferencesFile.removeLastSegments(1).toFile());
+			removeFromFileSystem(originalPreferencesFile.removeLastSegments(1).toFile());
+			removeFromFileSystem(modifiedPreferencesFile.removeLastSegments(1).toFile());
 		}
 
 		setDefaultWorkspaceDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -17,6 +17,9 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -193,7 +196,7 @@ public class CharsetTest extends ResourceTest {
 				assertEquals("2.0", "BAR", file.getCharset());
 			}, null);
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -213,7 +216,7 @@ public class CharsetTest extends ResourceTest {
 			assertExistsInWorkspace(file2);
 			assertEquals("The file's charset was correctly copied while coying the file", "BAR", file2.getCharset());
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -232,7 +235,7 @@ public class CharsetTest extends ResourceTest {
 			final IFile copiedFile = project.getFile("file2.txt");
 			assertEquals("File with explicitly set charset keeps charset", copiedFile.getCharset(true), "FOO");
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -379,7 +382,7 @@ public class CharsetTest extends ResourceTest {
 		IContentDescription description = file.getContentDescription();
 		assertNotNull("1.0", description);
 		assertEquals("1.1", text, description.getContentType());
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 		CoreException e = assertThrows(CoreException.class, file::getContentDescription);
 		// Ok, the resource does not exist.
 		assertEquals("1.3", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
@@ -767,7 +770,7 @@ public class CharsetTest extends ResourceTest {
 		assertEquals("1.0", "ISO-8859-1", file.getCharset());
 
 		//delete and recreate the file with different contents
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 		ensureExistsInWorkspace(file, new ByteArrayInputStream(SAMPLE_XML_DEFAULT_ENCODING.getBytes(StandardCharsets.UTF_8)));
 		assertEquals("2.0", "UTF-8", file.getCharset());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -187,7 +189,7 @@ public class CharsetTest extends ResourceTest {
 				assertEquals("1.0", "BAR", file.getCharset());
 				file.move(project.getFullPath().append("file2.txt"), IResource.NONE, monitor);
 				IFile file2 = project.getFile("file2.txt");
-				assertExistsInWorkspace(file2, false);
+				assertExistsInWorkspace(file2);
 				assertEquals("2.0", "BAR", file.getCharset());
 			}, null);
 		} finally {
@@ -208,7 +210,7 @@ public class CharsetTest extends ResourceTest {
 			assertEquals("Setting up file's explicit charset was successful", "BAR", file.getCharset());
 			file.move(project.getFullPath().append("file2.txt"), IResource.NONE, getMonitor());
 			IFile file2 = project.getFile("file2.txt");
-			assertExistsInWorkspace(file2, false);
+			assertExistsInWorkspace(file2);
 			assertEquals("The file's charset was correctly copied while coying the file", "BAR", file2.getCharset());
 		} finally {
 			ensureDoesNotExistInWorkspace(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.eclipse.core.internal.content.ContentTypeHandler;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -72,9 +76,9 @@ public class FilteredResourceTest extends ResourceTest {
 	protected void doCleanup() throws Exception {
 		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject}, true);
 		closedProject.close(getMonitor());
-		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
+		removeFromWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
 		resolve(localFolder).toFile().mkdirs();
-		createFileInFileSystem(resolve(localFile), getRandomContents());
+		ResourceTestUtil.createFile(resolve(localFile), getRandomContents());
 	}
 
 	/**
@@ -509,7 +513,7 @@ public class FilteredResourceTest extends ResourceTest {
 		project.close(getMonitor());
 		assertTrue("3.1", !project.isOpen());
 		// Create a file under existingFolderInExistingFolder
-		createFileInFileSystem(childLoc.append("foo"));
+		createFile(childLoc.append("foo"));
 		// Reopen the project
 		project.open(IResource.NONE, getMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -13,9 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 
 public class HiddenResourceTest extends ResourceTest {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IContainer;
@@ -264,7 +266,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = new IResource[] {destProject, destFolder, destFile, destSubFile};
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -275,7 +277,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace("1.3", destResources);
 
 		// do it again and but just copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -285,7 +287,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// set all the resources to be hidden
 		// copy the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, getMonitor());
@@ -293,7 +295,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace("3.3", destResources);
 
 		// do it again but only copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
@@ -317,7 +319,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = new IResource[] {destProject, destFolder, destFile, destSubFile};
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -328,7 +330,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace("1.3", destResources);
 
 		// do it again and but just move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -338,7 +340,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// set all the resources to be hidden
 		// move the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, getMonitor());
@@ -346,7 +348,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace("3.3", destResources);
 
 		// do it again but only move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
@@ -436,7 +438,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}
@@ -455,7 +457,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}
@@ -474,7 +476,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue("3.1." + listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -19,6 +19,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -213,7 +217,7 @@ public class IFileTest extends ResourceTest {
 	 */
 	public void refreshFile(IFile file) throws CoreException {
 		if (file.getName().equals(LOCAL_ONLY)) {
-			ensureDoesNotExistInWorkspace(file);
+			removeFromWorkspace(file);
 			//project must exist to access file system store.
 			if (file.getProject().exists()) {
 				ensureExistsInFileSystem(file);
@@ -222,14 +226,14 @@ public class IFileTest extends ResourceTest {
 		}
 		if (file.getName().equals(WORKSPACE_ONLY)) {
 			ensureExistsInWorkspace(file, true);
-			ensureDoesNotExistInFileSystem(file);
+			removeFromFileSystem(file);
 			return;
 		}
 		if (file.getName().equals(DOES_NOT_EXIST)) {
-			ensureDoesNotExistInWorkspace(file);
+			removeFromWorkspace(file);
 			//project must exist to access file system store.
 			if (file.getProject().exists()) {
-				ensureDoesNotExistInFileSystem(file);
+				removeFromFileSystem(file);
 			}
 			return;
 		}
@@ -279,7 +283,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testAppendContents2() throws CoreException {
 		IFile file = projects[0].getFile("file1");
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=true, IFile is non-local, file exists in local file system:
 		// make IFile local, append contents (the thinking being that this file,
@@ -301,7 +305,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.5", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("1.6", file.getLocation().toFile().exists());
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=true, IFile is non-local, file does not exist in local file system:
 		// fail - file not local (this file is not local for real - cannot append
@@ -318,7 +322,7 @@ public class IFileTest extends ResourceTest {
 		monitor.sanityCheck();
 		assertTrue("2.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=false, IFile is non-local, file exists in local file system:
 		// fail - file not local
@@ -336,7 +340,7 @@ public class IFileTest extends ResourceTest {
 		monitor.assertUsedUp();
 		assertTrue("3.5", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=false, IFile is non-local, file does not exist in local file system:
 		// fail - file not local
@@ -352,7 +356,7 @@ public class IFileTest extends ResourceTest {
 		monitor.sanityCheck();
 		assertTrue("4.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 	}
 
 	/**
@@ -424,7 +428,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateDerived() throws CoreException {
 		IFile derived = projects[0].getFile("derived.txt");
 		ensureExistsInWorkspace(projects[0], true);
-		ensureDoesNotExistInWorkspace(derived);
+		removeFromWorkspace(derived);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		derived.create(getRandomContents(), IResource.DERIVED, monitor);
@@ -463,7 +467,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivateDerived.txt");
 		ensureExistsInWorkspace(projects[0], true);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE | IResource.DERIVED, monitor);
@@ -486,7 +490,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivate.txt");
 		ensureExistsInWorkspace(projects[0], true);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE, monitor);
@@ -563,8 +567,8 @@ public class IFileTest extends ResourceTest {
 
 		//create from stream that throws exceptions
 		IFile fileFromStream = projects[0].getFile("file2");
-		ensureDoesNotExistInWorkspace(fileFromStream);
-		ensureDoesNotExistInFileSystem(fileFromStream);
+		removeFromWorkspace(fileFromStream);
+		removeFromFileSystem(fileFromStream);
 
 		InputStream content = new InputStream() {
 			@Override
@@ -604,8 +608,8 @@ public class IFileTest extends ResourceTest {
 	public void testFileCreation_Bug107188() throws CoreException {
 		//create from stream that is canceled
 		IFile target = projects[0].getFile("file1");
-		ensureDoesNotExistInWorkspace(target);
-		ensureDoesNotExistInFileSystem(target);
+		removeFromWorkspace(target);
+		removeFromFileSystem(target);
 
 		InputStream content = new InputStream() {
 			@Override
@@ -936,7 +940,7 @@ public class IFileTest extends ResourceTest {
 		String value = "this is a test property value";
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		// getting/setting persistent properties on non-existent resources should throw an exception
-		ensureDoesNotExistInWorkspace(target);
+		removeFromWorkspace(target);
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -15,6 +15,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -15,6 +15,9 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IFile;
@@ -66,7 +69,7 @@ public class IFolderTest extends ResourceTest {
 		IFolder after = project.getFolder("NewFolder");
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(before, true);
-		ensureDoesNotExistInFileSystem(before);
+		removeFromFileSystem(before);
 
 		// should fail because 'before' does not exist in the filesystem
 		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, getMonitor()));
@@ -80,7 +83,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
 		ensureExistsInWorkspace(project, true);
-		ensureDoesNotExistInWorkspace(derived);
+		removeFromWorkspace(derived);
 
 		derived.create(IResource.DERIVED, true, getMonitor());
 		assertTrue("1.0", derived.isDerived());
@@ -110,7 +113,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		ensureExistsInWorkspace(project, true);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, getMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
@@ -126,7 +129,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		ensureExistsInWorkspace(project, true);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE, true, getMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
@@ -314,7 +317,7 @@ public class IFolderTest extends ResourceTest {
 		String value = "this is a test property value";
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		// getting/setting persistent properties on non-existent resources should throw an exception
-		ensureDoesNotExistInWorkspace(target);
+		removeFromWorkspace(target);
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedWriter;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -19,6 +19,10 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -54,7 +58,7 @@ import org.osgi.service.prefs.Preferences;
 public class IProjectTest extends ResourceTest {
 	private final FussyProgressMonitor monitor = new FussyProgressMonitor();
 
-	public void ensureExistsInWorkspace(final IProject project, final IProjectDescription description)
+	public void createInWorkspace(final IProject project, final IProjectDescription description)
 			throws CoreException {
 		if (project == null) {
 			return;
@@ -400,7 +404,7 @@ public class IProjectTest extends ResourceTest {
 		resources = buildResources(project, children);
 		destProject = getWorkspace().getRoot().getProject("DestProject");
 		destination = destProject.getFolder("MyFolder");
-		ensureExistsInWorkspace(new IResource[] {project, destProject}, true);
+		ensureExistsInWorkspace(new IResource[] { project, destProject }, true);
 		ensureExistsInWorkspace(resources, true);
 		assertDoesNotExistInWorkspace("3.0", destination);
 
@@ -651,7 +655,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -681,7 +685,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -711,7 +715,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -744,7 +748,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -776,7 +780,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -808,7 +812,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file, otherFile }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -853,7 +857,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -863,7 +867,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("1.5", otherFileStore.fetchInfo().exists());
 		assertTrue("1.6", project.exists());
 		assertFalse("1.7", project.isOpen());
@@ -886,7 +890,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -896,7 +900,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("2.5", otherFileStore.fetchInfo().exists());
 		assertTrue("2.6", project.exists());
 		assertFalse("2.7", project.isOpen());
@@ -917,7 +921,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -927,7 +931,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("3.5", otherFileStore.fetchInfo().exists());
 		assertTrue("3.6", project.exists());
 		assertFalse("3.7", project.isOpen());
@@ -950,7 +954,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -960,7 +964,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("4.5", otherFileStore.fetchInfo().exists());
 		assertTrue("4.6", project.exists());
 		assertFalse("4.7", project.isOpen());
@@ -983,7 +987,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -993,7 +997,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("5.5", otherFileStore.fetchInfo().exists());
 		assertTrue("5.6", project.exists());
 		assertFalse("5.7", project.isOpen());
@@ -1016,7 +1020,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1026,7 +1030,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		createFileInFileSystem(otherFileStore);
+		createFile(otherFileStore);
 		assertTrue("6.5", otherFileStore.fetchInfo().exists());
 		assertTrue("6.6", project.exists());
 		assertFalse("6.7", project.isOpen());
@@ -1064,7 +1068,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.2", project.exists());
@@ -1090,7 +1094,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.2", project.exists());
@@ -1114,7 +1118,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.2", project.exists());
@@ -1138,7 +1142,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.2", project.exists());
@@ -1162,8 +1166,8 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		createInWorkspace(project, description);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.2", project.exists());
 		assertTrue("5.3", file.exists());
@@ -1186,7 +1190,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.2", project.exists());
@@ -1224,7 +1228,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1255,7 +1259,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1284,7 +1288,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1312,7 +1316,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1340,8 +1344,8 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		createInWorkspace(project, description);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1368,7 +1372,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		waitForRefresh();
 		ensureExistsInFileSystem(otherFile);
@@ -1410,7 +1414,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.0", project.exists());
@@ -1428,7 +1432,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.0", project.exists());
@@ -1445,7 +1449,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.0", project.exists());
@@ -1462,7 +1466,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.0", project.exists());
@@ -1479,7 +1483,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.0", project.exists());
@@ -1496,7 +1500,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.0", project.exists());
@@ -1656,7 +1660,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.2", project.exists());
@@ -1678,7 +1682,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.2", project.exists());
@@ -1698,7 +1702,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.2", project.exists());
@@ -1717,7 +1721,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.2", project.exists());
@@ -1738,8 +1742,8 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		createInWorkspace(project, description);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.2", project.exists());
 		assertTrue("5.3", file.exists());
@@ -1758,7 +1762,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.2", project.exists());
@@ -1792,7 +1796,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1820,7 +1824,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1846,7 +1850,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1872,7 +1876,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1896,8 +1900,8 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file}, true);
+		createInWorkspace(project, description);
+		ensureExistsInWorkspace(new IResource[] { project, file }, true);
 		ensureExistsInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1921,7 +1925,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
-		ensureExistsInWorkspace(project, description);
+		createInWorkspace(project, description);
 		ensureExistsInWorkspace(file, true);
 		waitForRefresh();
 		ensureExistsInFileSystem(otherFile);
@@ -2360,7 +2364,7 @@ public class IProjectTest extends ResourceTest {
 
 		// add content to new location
 		IFile newFile = target.getFile(childFile.getName());
-		createFileInFileSystem(childFile);
+		createFile(childFile);
 
 		// replace project location
 		IProjectDescription description = target.getDescription();
@@ -2473,7 +2477,7 @@ public class IProjectTest extends ResourceTest {
 
 	public void testCreateHiddenProject() throws CoreException {
 		IProject hiddenProject = getWorkspace().getRoot().getProject(getUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 
 		monitor.prepare();
 		hiddenProject.create(null, IResource.HIDDEN, monitor);
@@ -2499,7 +2503,7 @@ public class IProjectTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject(projectName);
 		IFolder folder = project.getFolder(getUniqueString());
 		IFile file = folder.getFile(getUniqueString());
-		ensureExistsInWorkspace(new IResource[] {project, folder, file}, true);
+		ensureExistsInWorkspace(new IResource[] { project, folder, file }, true);
 		project.open(monitor);
 		monitor.assertUsedUp();
 
@@ -2516,7 +2520,7 @@ public class IProjectTest extends ResourceTest {
 		assertFalse("1.0", p.toFile().exists());
 
 		IProject otherProject = getWorkspace().getRoot().getProject(getUniqueString());
-		ensureExistsInWorkspace(new IResource[] {otherProject}, true);
+		ensureExistsInWorkspace(new IResource[] { otherProject }, true);
 		monitor.prepare();
 		otherProject.open(monitor);
 		monitor.assertUsedUp();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -17,6 +17,8 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_EARTH;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_MISSING;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -926,7 +928,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		};
 		workspace.addResourceChangeListener(listener);
 		workspace.getSynchronizer().add(partner);
-		ensureDoesNotExistInWorkspace(phantomResources);
+		removeFromWorkspace(phantomResources);
 		try {
 			//create a phantom folder
 			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFolder, new byte[] {1}), getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -18,6 +18,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -226,7 +232,7 @@ public class IResourceTest extends ResourceTest {
 		nonExistingResources.add(result[result.length - 1]);
 
 		IResource[] deleted = buildResources(root, new String[] {"1/1/2/1/", "1/2/3/1"});
-		ensureDoesNotExistInWorkspace(deleted);
+		removeFromWorkspace(deleted);
 		nonExistingResources.addAll(Arrays.asList(deleted));
 		//out of sync
 		IResource[] unsynchronized = buildResources(root, new String[] {"1/2/3/3"});
@@ -235,7 +241,7 @@ public class IResourceTest extends ResourceTest {
 
 		//file system only
 		unsynchronized = buildResources(root, new String[] {"1/1/2/2/1"});
-		ensureDoesNotExistInWorkspace(unsynchronized);
+		removeFromWorkspace(unsynchronized);
 		ensureExistsInFileSystem(unsynchronized);
 		unsynchronizedResources.add(unsynchronized[0]);
 		return result;
@@ -311,7 +317,7 @@ public class IResourceTest extends ResourceTest {
 		//target may have changed gender
 		IResource changedTarget = getWorkspace().getRoot().findMember(target.getFullPath());
 		if (changedTarget != null && changedTarget.getType() != target.getType()) {
-			ensureDoesNotExistInWorkspace(changedTarget);
+			removeFromWorkspace(changedTarget);
 		}
 		ensureExistsInWorkspace(interestingResources, true);
 	}
@@ -505,7 +511,7 @@ public class IResourceTest extends ResourceTest {
 		switch (state) {
 			case S_WORKSPACE_ONLY :
 				ensureExistsInWorkspace(target, true);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 					// we only get a delta if the receiver of refreshLocal
@@ -517,7 +523,7 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_FILESYSTEM_ONLY :
-				ensureDoesNotExistInWorkspace(target);
+				removeFromWorkspace(target);
 				ensureExistsInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -549,15 +555,15 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_DOES_NOT_EXIST :
-				ensureDoesNotExistInWorkspace(target);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromWorkspace(target);
+				removeFromFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 				}
 				break;
 			case S_FOLDER_TO_FILE :
 				ensureExistsInWorkspace(target, true);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				ensureExistsInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -571,7 +577,7 @@ public class IResourceTest extends ResourceTest {
 				break;
 			case S_FILE_TO_FOLDER :
 				ensureExistsInWorkspace(target, true);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				target.getLocation().toFile().mkdirs();
 				if (addVerifier) {
 					verifier.reset();
@@ -1049,7 +1055,7 @@ public class IResourceTest extends ResourceTest {
 
 	private IProjectDescription prepareDestProjDesc(IProject sourceProj, IProject destProj, IPath destLocation)
 			throws CoreException {
-		ensureDoesNotExistInWorkspace(destProj);
+		removeFromWorkspace(destProj);
 		IProjectDescription desc = sourceProj.getDescription();
 		desc.setName(destProj.getName());
 		desc.setLocation(destLocation);
@@ -1826,9 +1832,9 @@ public class IResourceTest extends ResourceTest {
 			assertEquals("5.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
 			project.open(getMonitor());
-			ensureDoesNotExistInWorkspace(topFolder);
-			ensureDoesNotExistInWorkspace(topFile);
-			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(fileLocation));
+			removeFromWorkspace(topFolder);
+			removeFromWorkspace(topFile);
+			createFile(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(fileLocation));
 			folderLocation.toFile().mkdirs();
 			topFolder.createLink(folderLocation, IResource.NONE, getMonitor());
 			topFile.createLink(fileLocation, IResource.NONE, getMonitor());
@@ -1854,9 +1860,9 @@ public class IResourceTest extends ResourceTest {
 			project.open(getMonitor());
 			IPath variableFolderLocation = IPath.fromOSString(variableName).append("/VarFolderName");
 			IPath variableFileLocation = IPath.fromOSString(variableName).append("/VarFileName");
-			ensureDoesNotExistInWorkspace(topFolder);
-			ensureDoesNotExistInWorkspace(topFile);
-			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(varMan.resolvePath(variableFileLocation)));
+			removeFromWorkspace(topFolder);
+			removeFromWorkspace(topFile);
+			createFile(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(varMan.resolvePath(variableFileLocation)));
 			varMan.resolvePath(variableFolderLocation).toFile().mkdirs();
 			topFolder.createLink(variableFolderLocation, IResource.NONE, getMonitor());
 			topFile.createLink(variableFileLocation, IResource.NONE, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -14,6 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.DataInputStream;
@@ -761,6 +763,6 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// clean-up
 		synchronizer.remove(partner);
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -54,7 +57,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 
 		IFile link = project.getFile("file.txt");
 		IFileStore fileStore = getTempStore();
-		createFileInFileSystem(fileStore);
+		createFile(fileStore);
 		assertEquals("0.1", EFS.SCHEME_FILE, fileStore.getFileSystem().getScheme());
 		IPath fileLocationLower = URIUtil.toPath(fileStore.toURI());
 		fileLocationLower = fileLocationLower.setDevice(fileLocationLower.getDevice().toLowerCase());
@@ -327,7 +330,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testBug234343_folderInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, getMonitor());
 		hiddenProject.open(getMonitor());
 
@@ -345,7 +348,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testBug234343_fileInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, getMonitor());
 		hiddenProject.open(getMonitor());
 
@@ -417,7 +420,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void checkFindMethods(int updateFlags, int[][] results) throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(getUniqueString());
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 
 		project.create(null, IResource.NONE, getMonitor());
 		project.open(getMonitor());
@@ -425,8 +428,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		// a team private folder
 		IFolder teamFolder = createFolder(project, IResource.TEAM_PRIVATE, false);
 
-		IFile mFileInTeamFolder = createFile(teamFolder, updateFlags, false);
-		IFile mLinkedFileInTeamFolder = createFile(teamFolder, updateFlags, true);
+		IFile mFileInTeamFolder = createFileWithRandomName(teamFolder, updateFlags, false);
+		IFile mLinkedFileInTeamFolder = createFileWithRandomName(teamFolder, updateFlags, true);
 
 		IFolder mFolderInTeamFolder = createFolder(teamFolder, updateFlags, false);
 		IFolder mLinkedFolderInTeamFolder = createFolder(teamFolder, updateFlags, true);
@@ -434,8 +437,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		// a hidden folder
 		IFolder hiddenFolder = createFolder(project, IResource.HIDDEN, false);
 
-		IFile mFileInHiddenFolder = createFile(hiddenFolder, updateFlags, false);
-		IFile mLinkedFileInHiddenFolder = createFile(hiddenFolder, updateFlags, true);
+		IFile mFileInHiddenFolder = createFileWithRandomName(hiddenFolder, updateFlags, false);
+		IFile mLinkedFileInHiddenFolder = createFileWithRandomName(hiddenFolder, updateFlags, true);
 
 		IFolder mFolderInHiddenFolder = createFolder(hiddenFolder, updateFlags, false);
 		IFolder mLinkedFolderInHiddenFolder = createFolder(hiddenFolder, updateFlags, true);
@@ -443,8 +446,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		// a regular folder
 		IFolder folder = createFolder(project, IResource.NONE, false);
 
-		IFile mFileInFolder = createFile(folder, updateFlags, false);
-		IFile mLinkedFileInFolder = createFile(folder, updateFlags, true);
+		IFile mFileInFolder = createFileWithRandomName(folder, updateFlags, false);
+		IFile mLinkedFileInFolder = createFileWithRandomName(folder, updateFlags, true);
 
 		IFolder mFolderInFolder = createFolder(folder, updateFlags, false);
 		IFolder mLinkedFolderInFolder = createFolder(folder, updateFlags, true);
@@ -480,7 +483,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		assertEquals(foundResources, containers.length);
 	}
 
-	private IFile createFile(IContainer parent, int updateFlags, boolean linked) throws Exception {
+	private IFile createFileWithRandomName(IContainer parent, int updateFlags, boolean linked) throws Exception {
 		IFile file = parent.getFile(IPath.fromOSString(getUniqueString()));
 		if (linked) {
 			IPath path = getTempDir().append(getUniqueString());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -30,6 +30,10 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getVa
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -179,8 +183,8 @@ public class IWorkspaceTest extends ResourceTest {
 			file2Copy.create(getRandomContents(), false, getMonitor());
 			getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, getMonitor());
 		});
-		ensureDoesNotExistInWorkspace(file2Copy);
-		ensureDoesNotExistInFileSystem(file2Copy);
+		removeFromWorkspace(file2Copy);
+		removeFromFileSystem(file2Copy);
 
 		//make sure the first copy worked
 		fileCopy = folder2.getFile("File");
@@ -216,8 +220,8 @@ public class IWorkspaceTest extends ResourceTest {
 			fail("3.1", e);
 		}
 		assertTrue("3.2", fileCopy.exists());
-		ensureDoesNotExistInWorkspace(fileCopy);
-		ensureDoesNotExistInFileSystem(fileCopy);
+		removeFromWorkspace(fileCopy);
+		removeFromFileSystem(fileCopy);
 
 		//copy two files
 		try {
@@ -227,10 +231,10 @@ public class IWorkspaceTest extends ResourceTest {
 		}
 		assertTrue("3.4", fileCopy.exists());
 		assertTrue("3.5", file2Copy.exists());
-		ensureDoesNotExistInWorkspace(fileCopy);
-		ensureDoesNotExistInWorkspace(file2Copy);
-		ensureDoesNotExistInFileSystem(fileCopy);
-		ensureDoesNotExistInFileSystem(file2Copy);
+		removeFromWorkspace(fileCopy);
+		removeFromWorkspace(file2Copy);
+		removeFromFileSystem(fileCopy);
+		removeFromFileSystem(file2Copy);
 
 		//copy a folder
 		try {
@@ -244,8 +248,8 @@ public class IWorkspaceTest extends ResourceTest {
 		} catch (CoreException e) {
 			fail("3.9", e);
 		}
-		ensureDoesNotExistInWorkspace(folderCopy);
-		ensureDoesNotExistInFileSystem(folderCopy);
+		removeFromWorkspace(folderCopy);
+		removeFromFileSystem(folderCopy);
 	}
 
 	/**
@@ -613,12 +617,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("1.4", folder.getFile(file1.getName()).exists());
 		assertTrue("1.5", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("1.6", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* test duplicates */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile, file1};
@@ -629,12 +633,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("2.5", folder.getFile(file1.getName()).exists());
 		assertTrue("2.6", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("2.7", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* test no siblings */
 		IResource[] resources2 = new IResource[] { file1, anotherFile, oneMoreFile, project };
@@ -649,12 +653,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("3.6", folder.getFile(file1.getName()).exists());
 		assertTrue("3.7", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("3.8", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* inexisting resource */
 		IResource[] resources3 = new IResource[] { file1, anotherFile, project.getFile("inexisting"), oneMoreFile };
@@ -1111,8 +1115,8 @@ public class IWorkspaceTest extends ResourceTest {
 				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
 			} catch (CoreException e) {
 			}
-			ensureDoesNotExistInFileSystem(openProjectLocation.toFile());
-			ensureDoesNotExistInFileSystem(closedProjectLocation.toFile());
+			removeFromFileSystem(openProjectLocation.toFile());
+			removeFromFileSystem(closedProjectLocation.toFile());
 		}
 
 		// cannot overlap .metadata folder from the current workspace

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -27,6 +27,9 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.SET_O
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.SET_STATE;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getInvalidNatureSets;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getValidNatureSets;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -96,7 +98,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, false);
 
-		createFileInFileSystem(fileLocation);
+		createFile(fileLocation);
 		deleteOnTearDown(fileLocation);
 
 		exception = assertThrows(CoreException.class, () -> fileLink
@@ -120,7 +122,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 
-		createFileInFileSystem(fileLocation);
+		createFile(fileLocation);
 		deleteOnTearDown(fileLocation);
 
 		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
@@ -239,7 +241,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
 
-		createFileInFileSystem(fileLocation);
+		createFile(fileLocation);
 		deleteOnTearDown(fileLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
@@ -263,7 +265,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
 
-		createFileInFileSystem(fileLocation);
+		createFile(fileLocation);
 		deleteOnTearDown(fileLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -17,6 +17,12 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedInputStream;
@@ -95,10 +101,10 @@ public class LinkedResourceTest extends ResourceTest {
 		waitForRefresh();
 		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject}, true);
 		closedProject.close(getMonitor());
-		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
-		ensureDoesNotExistInFileSystem(resolve(nonExistingLocation).toFile());
+		removeFromWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
+		removeFromFileSystem(resolve(nonExistingLocation).toFile());
 		resolve(localFolder).toFile().mkdirs();
-		createFileInFileSystem(resolve(localFile), getRandomContents());
+		createFile(resolve(localFile), getRandomContents());
 	}
 
 	private byte[] getFileContents(IFile file) throws CoreException {
@@ -219,7 +225,7 @@ public class LinkedResourceTest extends ResourceTest {
 		//create local folder that will be blocked
 		ensureExistsInFileSystem(nonExistingFolderInExistingProject);
 		IFile blockedFile = nonExistingFolderInExistingProject.getFile("BlockedFile");
-		createFileInFileSystem(blockedFile.getLocation(), getRandomContents());
+		createFile(blockedFile.getLocation(), getRandomContents());
 
 		// link the folder elsewhere
 		nonExistingFolderInExistingProject.createLink(localFolder, IResource.NONE, getMonitor());
@@ -266,8 +272,8 @@ public class LinkedResourceTest extends ResourceTest {
 		IPath resolvedLocation = resolve(localFolder);
 		folder.createLink(localFolder, IResource.NONE, getMonitor());
 
-		ensureDoesNotExistInFileSystem(resolvedLocation.toFile());
-		createFileInFileSystem(resolvedLocation, getRandomContents());
+		removeFromFileSystem(resolvedLocation.toFile());
+		createFile(resolvedLocation, getRandomContents());
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		assertTrue("3.0", !folder.exists());
@@ -276,7 +282,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertEquals("3.3", resolvedLocation, file.getLocation());
 
 		//change back to folder
-		ensureDoesNotExistInFileSystem(resolvedLocation.toFile());
+		removeFromFileSystem(resolvedLocation.toFile());
 		resolvedLocation.toFile().mkdirs();
 
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
@@ -540,7 +546,7 @@ public class LinkedResourceTest extends ResourceTest {
 		deleteOnTearDown(fileLocation);
 		IFile linkedFile = nonExistingFileInExistingProject;
 		IFolder linkedFolder = nonExistingFolderInExistingProject;
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFile(resolve(fileLocation), getRandomContents());
 		linkedFolder.createLink(localFolder, IResource.NONE, getMonitor());
 		linkedFile.createLink(fileLocation, IResource.NONE, getMonitor());
 
@@ -604,7 +610,7 @@ public class LinkedResourceTest extends ResourceTest {
 		final IFileStore rootStore = getTempStore();
 		rootStore.mkdir(IResource.NONE, getMonitor());
 		IFileStore childStore = rootStore.getChild("file.txt");
-		createFileInFileSystem(childStore);
+		createFile(childStore);
 
 		IFolder link = nonExistingFolderInExistingProject;
 		link.createLink(rootStore.toURI(), IResource.BACKGROUND_REFRESH, getMonitor());
@@ -697,7 +703,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile childFile = folder.getFile(childName);
 		IResource[] oldResources = new IResource[] {file, folder, existingProject, childFile};
-		createFileInFileSystem(resolve(fileLocation));
+		createFile(resolve(fileLocation));
 		folder.createLink(localFolder, IResource.NONE, getMonitor());
 		file.createLink(fileLocation, IResource.NONE, getMonitor());
 
@@ -1257,7 +1263,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.0", linkedFile.getModificationStamp() >= 0);
 
 		// delete local file
-		ensureDoesNotExistInFileSystem(resolve(location).toFile());
+		removeFromFileSystem(resolve(location).toFile());
 		linkedFile.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertEquals("4.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
 	}
@@ -1495,7 +1501,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile childFile = folder.getFile(childName);
 		IResource[] oldResources = new IResource[] {file, folder, existingProject, childFile};
-		createFileInFileSystem(resolve(fileLocation));
+		createFile(resolve(fileLocation));
 		folder.createLink(localFolder, IResource.NONE, getMonitor());
 		file.createLink(fileLocation, IResource.NONE, getMonitor());
 
@@ -1540,7 +1546,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IFile linkedFile = existingProject.getFile("(test)");
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFile(resolve(fileLocation), getRandomContents());
 		linkedFile.createLink(fileLocation, IResource.NONE, getMonitor());
 
 		// move the project
@@ -1562,7 +1568,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFile(resolve(fileLocation), getRandomContents());
 
 		// create a linked file in the folder
 		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
@@ -1658,7 +1664,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IPath linkLocation = localFolder;
 		IPath localChild = linkLocation.append("Child");
 		IFile linkChild = link.getFile(localChild.lastSegment());
-		createFileInFileSystem(resolve(localChild));
+		createFile(resolve(localChild));
 		link.createLink(linkLocation, IResource.NONE, getMonitor());
 		assertTrue("1.0", link.exists());
 		assertTrue("1.1", linkChild.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -16,6 +16,11 @@
 
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 
 import java.io.File;
 import java.io.IOException;
@@ -1153,7 +1154,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		}
 
 		// clean-up
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		// restore the previous value
 		try {
@@ -1249,7 +1250,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		}
 
 		// clean-up
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		// restore the previous value
 		try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_WATER;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getInvalidNatureSets;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getValidNatureSets;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -74,7 +76,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		//copy to local destination should succeed
 		sourceFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
 		//copy from local to non local
-		ensureDoesNotExistInWorkspace(destinationFile);
+		removeFromWorkspace(destinationFile);
 		//copy from local to non local
 		localFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.core.internal.resources.PreferenceInitializer;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
@@ -14,10 +14,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.File;
 import java.net.URI;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.junit.Assume;
 import org.junit.Test;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -15,6 +15,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import java.io.File;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
@@ -166,7 +170,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("testNonExistingResource");
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file");
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 		assertNull("1.0", project.getResourceAttributes());
 		assertNull("1.1", folder.getResourceAttributes());
 		assertNull("1.2", file.getResourceAttributes());
@@ -235,7 +239,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		setSymlink(link, false);
 		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
 
-		ensureDoesNotExistInWorkspace(link);
+		removeFromWorkspace(link);
 
 		// create the target file in the filesystem
 		IFile target = project.getFile("target");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -33,7 +33,6 @@ import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -56,12 +55,9 @@ import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.FileSystemHelper;
@@ -181,186 +177,6 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Assert that the given resource does not exist in the local store.
-	 */
-	public void assertDoesNotExistInFileSystem(IResource resource) {
-		assertDoesNotExistInFileSystem("", resource); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist in the
-	 * local store.
-	 */
-	public void assertDoesNotExistInFileSystem(IResource[] resources) {
-		assertDoesNotExistInFileSystem("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that the given resource does not exist in the local store.
-	 */
-	public void assertDoesNotExistInFileSystem(String message, IResource resource) {
-		if (existsInFileSystem(resource)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath() + " unexpectedly exists in the file system");
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist in the
-	 * local store.
-	 */
-	public void assertDoesNotExistInFileSystem(String message, IResource[] resources) {
-		for (IResource resource : resources) {
-			assertDoesNotExistInFileSystem(message, resource);
-		}
-	}
-
-	/**
-	 * Assert that the given resource does not exist in the workspace
-	 * resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(IResource resource) {
-		assertDoesNotExistInWorkspace("", resource); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist
-	 * in the workspace resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(IResource[] resources) {
-		assertDoesNotExistInWorkspace("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that the given resource does not exist in the workspace
-	 * resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(String message, IResource resource) {
-		if (existsInWorkspace(resource, false)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath().toString() + " unexpectedly exists in the workspace");
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist
-	 * in the workspace resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(String message, IResource[] resources) {
-		for (IResource resource : resources) {
-			assertDoesNotExistInWorkspace(message, resource);
-		}
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the local
-	 * store. Use the resource manager to ensure that we have a
-	 * correct Path -&gt; File mapping.
-	 */
-	public void assertExistsInFileSystem(IResource resource) {
-		assertExistsInFileSystem("", resource); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element in the resource array  exists in the local store.
-	 */
-	public void assertExistsInFileSystem(IResource[] resources) {
-		assertExistsInFileSystem("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the local
-	 * store. Use the resource manager to ensure that we have a
-	 * correct Path -&gt; File mapping.
-	 */
-	public void assertExistsInFileSystem(String message, IResource resource) {
-		if (!existsInFileSystem(resource)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath() + " unexpectedly does not exist in the file system");
-		}
-	}
-
-	/**
-	 * Assert that each element in the resource array  exists in the local store.
-	 */
-	public void assertExistsInFileSystem(String message, IResource[] resources) {
-		for (IResource resource : resources) {
-			assertExistsInFileSystem(message, resource);
-		}
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(IResource resource) {
-		assertExistsInWorkspace("", resource, false); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(IResource resource, boolean phantom) {
-		assertExistsInWorkspace("", resource, phantom); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(IResource[] resources) {
-		assertExistsInWorkspace("", resources, false); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(IResource[] resources, boolean phantom) {
-		assertExistsInWorkspace("", resources, phantom); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource resource) {
-		assertExistsInWorkspace(message, resource, false);
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource resource, boolean phantom) {
-		if (!existsInWorkspace(resource, phantom)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath().toString() + " unexpectedly does not exist in the workspace");
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource[] resources) {
-		for (IResource resource : resources) {
-			assertExistsInWorkspace(message, resource, false);
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource[] resources, boolean phantom) {
-		for (IResource resource : resources) {
-			assertExistsInWorkspace(message, resource, phantom);
-		}
-	}
-
-	/**
 	 * Return a collection of resources the hierarchy defined by defineHeirarchy().
 	 */
 	public IResource[] buildResources() {
@@ -444,19 +260,6 @@ public abstract class ResourceTest extends CoreTest {
 		} finally {
 			assertClose(a);
 			assertClose(b);
-		}
-	}
-
-	private IPath computeDefaultLocation(IResource target) {
-		switch (target.getType()) {
-			case IResource.ROOT :
-				return Platform.getLocation();
-			case IResource.PROJECT :
-				return Platform.getLocation().append(target.getFullPath());
-			default :
-				IPath location = computeDefaultLocation(target.getProject());
-				location = location.append(target.getFullPath().removeFirstSegments(1));
-				return location;
 		}
 	}
 
@@ -741,56 +544,6 @@ public abstract class ResourceTest extends CoreTest {
 	private long getLastModifiedTime(IPath fileLocation) {
 		IFileInfo fileInfo = EFS.getLocalFileSystem().getStore(fileLocation).fetchInfo();
 		return fileInfo.getLastModified();
-	}
-
-	private boolean existsInFileSystem(IResource resource) {
-		IPath path = resource.getLocation();
-		if (path == null) {
-			path = computeDefaultLocation(resource);
-		}
-		return path.toFile().exists();
-	}
-
-	boolean existsInWorkspace(IResource resource, boolean phantom) {
-		class CheckIfResourceExistsJob extends Job {
-
-			private final AtomicBoolean resourceExists = new AtomicBoolean(false);
-
-			public CheckIfResourceExistsJob() {
-				super("Test " + ResourceTest.this.getName() + " checking whether resource exists: " + resource);
-			}
-
-			@Override
-			protected IStatus run(IProgressMonitor monitor) {
-				if (monitor.isCanceled()) {
-					return Status.CANCEL_STATUS;
-				}
-
-				IResource target = getWorkspace().getRoot().findMember(resource.getFullPath(), phantom);
-				boolean existsInWorkspace = target != null && target.getType() == resource.getType();
-				resourceExists.set(existsInWorkspace);
-
-				return Status.OK_STATUS;
-			}
-
-			boolean resourceExists() {
-				return resourceExists.get();
-			}
-		}
-
-		IWorkspace workspace = getWorkspace();
-		ISchedulingRule modifyWorkspaceRule = workspace.getRuleFactory().modifyRule(workspace.getRoot());
-
-		CheckIfResourceExistsJob checkIfResourceExistsJob = new CheckIfResourceExistsJob();
-		checkIfResourceExistsJob.setRule(modifyWorkspaceRule);
-		checkIfResourceExistsJob.schedule();
-		try {
-			checkIfResourceExistsJob.join(30_000, getMonitor());
-		} catch (OperationCanceledException | InterruptedException e) {
-			throw new IllegalStateException("failed when joining resource-existence-checking job", e);
-		}
-
-		return checkIfResourceExistsJob.resourceExists();
 	}
 
 	protected String getLineSeparatorFromFile(IFile file) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.core.tests.resources;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
+
+/**
+ * Utilities for resource tests.
+ */
+public final class ResourceTestUtil {
+	private ResourceTestUtil() {
+	}
+
+	public static IProgressMonitor getMonitor() {
+		return new FussyProgressMonitor();
+	}
+
+	/**
+	 * Assert whether or not the given resource exists in the workspace resource
+	 * info tree.
+	 */
+	public static void assertExistsInWorkspace(IResource resource) {
+		assertExistsInWorkspace("", resource); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert that each element of the resource array exists in the workspace
+	 * resource info tree.
+	 */
+	public static void assertExistsInWorkspace(IResource[] resources) {
+		assertExistsInWorkspace("", resources);
+	}
+
+	/**
+	 * Assert whether or not the given resource exists in the workspace resource
+	 * info tree.
+	 */
+	public static void assertExistsInWorkspace(String message, IResource resource) {
+		String formatted = message == null || message.isEmpty() ? "" : message + " ";
+		assertTrue(formatted + resource.getFullPath() + " unexpectedly does not exist in the workspace",
+				existsInWorkspace(resource));
+	}
+
+
+	/**
+	 * Assert that each element of the resource array exists in the workspace
+	 * resource info tree.
+	 */
+	public static void assertExistsInWorkspace(String message, IResource[] resources) {
+		for (IResource resource : resources) {
+			assertExistsInWorkspace(message, resource);
+		}
+	}
+
+	private static boolean existsInWorkspace(IResource resource) {
+		class CheckIfResourceExistsJob extends Job {
+			private final AtomicBoolean resourceExists = new AtomicBoolean(false);
+
+			public CheckIfResourceExistsJob() {
+				super("Checking whether resource exists: " + resource);
+			}
+
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+
+				IResource target = ResourceTest.getWorkspace().getRoot().findMember(resource.getFullPath(), false);
+				boolean existsInWorkspace = target != null && target.getType() == resource.getType();
+				resourceExists.set(existsInWorkspace);
+
+				return Status.OK_STATUS;
+			}
+
+			boolean resourceExists() {
+				return resourceExists.get();
+			}
+		}
+
+		IWorkspace workspace = ResourceTest.getWorkspace();
+		ISchedulingRule modifyWorkspaceRule = workspace.getRuleFactory().modifyRule(workspace.getRoot());
+
+		CheckIfResourceExistsJob checkIfResourceExistsJob = new CheckIfResourceExistsJob();
+		checkIfResourceExistsJob.setRule(modifyWorkspaceRule);
+		checkIfResourceExistsJob.schedule();
+		try {
+			checkIfResourceExistsJob.join(30_000, getMonitor());
+		} catch (OperationCanceledException | InterruptedException e) {
+			throw new IllegalStateException("failed when joining resource-existence-checking job", e);
+		}
+		return checkIfResourceExistsJob.resourceExists();
+	}
+
+	/**
+	 * Assert that the given resource does not exist in the workspace resource info
+	 * tree.
+	 */
+	public static void assertDoesNotExistInWorkspace(IResource resource) {
+		assertDoesNotExistInWorkspace("", resource); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert that each element of the resource array does not exist in the
+	 * workspace resource info tree.
+	 */
+	public static void assertDoesNotExistInWorkspace(IResource[] resources) {
+		assertDoesNotExistInWorkspace("", resources); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert that the given resource does not exist in the workspace resource info
+	 * tree.
+	 */
+	public static void assertDoesNotExistInWorkspace(String message, IResource resource) {
+		String formatted = message == null || message.isEmpty() ? "" : message + " ";
+		assertFalse(formatted + resource.getFullPath() + " unexpectedly exists in the workspace",
+				existsInWorkspace(resource));
+	}
+
+	/**
+	 * Assert that each element of the resource array does not exist in the
+	 * workspace resource info tree.
+	 */
+	public static void assertDoesNotExistInWorkspace(String message, IResource[] resources) {
+		for (IResource resource : resources) {
+			assertDoesNotExistInWorkspace(message, resource);
+		}
+	}
+
+	/**
+	 * Assert whether or not the given resource exists in the local store. Use the
+	 * resource manager to ensure that we have a correct Path -&gt; File mapping.
+	 */
+	public static void assertExistsInFileSystem(IResource resource) {
+		assertExistsInFileSystem("", resource); //$NON-NLS-1$
+	}
+
+
+	/**
+	 * Assert that each element in the resource array exists in the local store.
+	 */
+	public static void assertExistsInFileSystem(IResource[] resources) {
+		assertExistsInFileSystem("", resources); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert whether or not the given resource exists in the local store. Use the
+	 * resource manager to ensure that we have a correct Path -&gt; File mapping.
+	 */
+	public static void assertExistsInFileSystem(String message, IResource resource) {
+		String formatted = message == null || message.isEmpty() ? "" : message + " ";
+		assertTrue(formatted + resource.getFullPath() + " unexpectedly does not exist in the file system",
+				existsInFileSystem(resource));
+	}
+
+	/**
+	 * Assert that each element in the resource array exists in the local store.
+	 */
+	public static void assertExistsInFileSystem(String message, IResource[] resources) {
+		for (IResource resource : resources) {
+			assertExistsInFileSystem(message, resource);
+		}
+	}
+
+	private static boolean existsInFileSystem(IResource resource) {
+		IPath path = resource.getLocation();
+		if (path == null) {
+			path = computeDefaultLocation(resource);
+		}
+		return path.toFile().exists();
+	}
+
+	private static IPath computeDefaultLocation(IResource target) {
+		switch (target.getType()) {
+		case IResource.ROOT:
+			return Platform.getLocation();
+		case IResource.PROJECT:
+			return Platform.getLocation().append(target.getFullPath());
+		default:
+			IPath location = computeDefaultLocation(target.getProject());
+			location = location.append(target.getFullPath().removeFirstSegments(1));
+			return location;
+		}
+	}
+
+	/**
+	 * Assert that the given resource does not exist in the local store.
+	 */
+	public static void assertDoesNotExistInFileSystem(IResource resource) {
+		assertDoesNotExistInFileSystem("", resource); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert that each element of the resource array does not exist in the
+	 * local store.
+	 */
+	public static void assertDoesNotExistInFileSystem(IResource[] resources) {
+		assertDoesNotExistInFileSystem("", resources); //$NON-NLS-1$
+	}
+
+	/**
+	 * Assert that the given resource does not exist in the local store.
+	 */
+	public static void assertDoesNotExistInFileSystem(String message, IResource resource) {
+		String formatted = message == null || message.isEmpty() ? "" : message + " ";
+		assertFalse(formatted + resource.getFullPath() + " unexpectedly exists in the file system",
+				existsInFileSystem(resource));
+	}
+
+	/**
+	 * Assert that each element of the resource array does not exist in the local
+	 * store.
+	 */
+	public static void assertDoesNotExistInFileSystem(String message, IResource[] resources) {
+		for (IResource resource : resources) {
+			assertDoesNotExistInFileSystem(message, resource);
+		}
+	}
+
+}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -264,7 +266,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = { destProject, destFolder, destFile, destSubFile };
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be team private
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -275,7 +277,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// Do it again and but just copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -285,7 +287,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// set all the resources to be team private
 		// copy the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, getMonitor());
@@ -293,7 +295,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
@@ -317,7 +319,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = { destProject, destFolder, destFile, destSubFile };
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be team private
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -328,7 +330,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// Do it again and but just move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -338,7 +340,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// set all the resources to be team private
 		// move the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, getMonitor());
@@ -346,7 +348,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
@@ -434,7 +436,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			getWorkspace().run(body, getMonitor());
 			waitForBuild();
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -452,7 +454,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, getMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -470,7 +472,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, getMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -17,6 +17,9 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -141,7 +144,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(getUniqueString());
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		createFileInFileSystem(fileLocation, getRandomContents());
+		createFile(fileLocation, getRandomContents());
 		folderLocation.toFile().mkdir();
 
 		linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
@@ -188,7 +191,7 @@ public class VirtualFolderTest extends ResourceTest {
 
 		assertDoesNotExistInWorkspace("1.0", new IResource[] { folder, file, childFile });
 
-		createFileInFileSystem(fileLocation);
+		createFile(fileLocation);
 		folderLocation.toFile().mkdir();
 
 		folder.createLink(folderLocation, IResource.NONE, getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
@@ -23,7 +25,7 @@ public class BenchCopyFile extends OldCorePerformanceTest {
 
 	public void testCopyFile() throws CoreException {
 		IFileStore input = getTempStore();
-		createFileInFileSystem(input, getRandomContents());
+		createFile(input, getRandomContents());
 		IFileStore[] output = new IFileStore[COUNT];
 		for (int i = 0; i < output.length; i++) {
 			output[i] = getTempStore();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -13,8 +13,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.resources.ResourceTest;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
@@ -52,7 +52,7 @@ public class FileSystemPerformanceTest extends LocalStoreTest {
 			dir.mkdir(EFS.SHALLOW, null);
 			for (int j = 0; j < FILE_COUNT; j++) {
 				IFileStore file = dir.getChild(createString(16));
-				createFile(file, createString(16));
+				createOrOverwriteFile(file, createString(16));
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -146,7 +149,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void tearDown() {
 				try {
-					ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+					removeFromWorkspace(getWorkspace().getRoot());
 					IHistoryStore store = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 					// Remove all the entries from the history store index.  Note that
 					// this does not cause the history store states to be removed.
@@ -173,7 +176,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	private void testClearHistory(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		new PerformanceTestRunner() {
 			private IWorkspaceDescription original;
 
@@ -184,7 +187,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				cleanHistory();
 				// create our own garbage
 				createTree(base, filesPerFolder, statesPerFile);
-				ensureDoesNotExistInWorkspace(base);
+				removeFromWorkspace(base);
 			}
 
 			@Override
@@ -254,7 +257,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFolder base = project.getFolder("base");
 		createTree(base, filesPerFolder, statesPerFile);
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		// need a final reference so the inner class can see it
 		final IProject tmpProject = project;
 		new PerformanceTestRunner() {
@@ -307,7 +310,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	private void testHistoryCleanUp(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		new PerformanceTestRunner() {
 			private IWorkspaceDescription original;
 
@@ -318,7 +321,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				cleanHistory();
 				// create our own garbage
 				createTree(base, filesPerFolder, statesPerFile);
-				ensureDoesNotExistInWorkspace(base);
+				removeFromWorkspace(base);
 			}
 
 			@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.Random;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -13,11 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.refresh;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import java.util.HashMap;
 import java.util.Map;
 import junit.framework.AssertionFailedError;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
@@ -73,7 +80,7 @@ public class RefreshProviderTest extends ResourceTest {
 			link.delete(IResource.FORCE, getMonitor());
 			joinAutoRefreshJobs();
 			assertEquals("1.2", 1, provider.getMonitoredResources().length);
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 			joinAutoRefreshJobs();
 			assertEquals("1.3", 0, provider.getMonitoredResources().length);
 			//check provider for other errors
@@ -109,7 +116,7 @@ public class RefreshProviderTest extends ResourceTest {
 			project.open(getMonitor());
 			joinAutoRefreshJobs();
 			assertEquals("1.2", 1, provider.getMonitoredResources().length);
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 			joinAutoRefreshJobs();
 			assertEquals("1.3", 0, provider.getMonitoredResources().length);
 			//check provider for other errors

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IContainer;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources.regression;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
@@ -48,7 +50,7 @@ public class Bug_044106 extends ResourceTest {
 	public void doTestDeleteLinkedFile(int deleteFlags) throws Exception {
 		// create the file/folder that we are going to link to
 		IFileStore linkDestFile = getTempStore();
-		createFileInFileSystem(linkDestFile);
+		createFile(linkDestFile);
 		assertTrue("0.1", linkDestFile.fetchInfo().exists());
 
 		// create some resources in the workspace
@@ -86,7 +88,7 @@ public class Bug_044106 extends ResourceTest {
 		}
 		IFileStore linkDestLocation = getTempStore();
 		IFileStore linkDestFile = linkDestLocation.getChild(getUniqueString());
-		createFileInFileSystem(linkDestFile);
+		createFile(linkDestFile);
 		assertTrue("0.1", linkDestLocation.fetchInfo().exists());
 		assertTrue("0.2", linkDestFile.fetchInfo().exists());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
@@ -39,7 +42,7 @@ public class Bug_126104 extends ResourceTest {
 		assertTrue("1.0", destination.exists());
 
 		//try the same thing with move
-		ensureDoesNotExistInWorkspace(destination);
+		removeFromWorkspace(destination);
 		location.delete(EFS.NONE, getMonitor());
 		source.move(destination.getFullPath(), IResource.NONE, getMonitor());
 		assertTrue("3.0", !source.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -91,7 +93,7 @@ public class Bug_160251 extends ResourceTest {
 		ensureExistsInWorkspace(source, true);
 		ensureExistsInWorkspace(sourceFile, true);
 		destination.mkdir(EFS.NONE, getMonitor());
-		createFileInFileSystem(destinationFile, getRandomContents());
+		createFile(destinationFile, getRandomContents());
 
 		//move the project (should fail)
 		IProjectDescription description = source.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
@@ -13,11 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.eclipse.core.filesystem.EFS;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
 import org.eclipse.core.tests.internal.filesystem.remote.RemoteFileSystem;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.net.URI;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.URIUtil;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -15,6 +15,8 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.create;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.IFileStore;
@@ -69,7 +71,7 @@ public class Bug_233939 extends ResourceTest {
 
 		// create a file: getTempStore() will be cleaned up in tearDown()
 		IFileStore tempFileStore = getTempStore().getChild(fileName);
-		createFileInFileSystem(tempFileStore);
+		createFile(tempFileStore);
 		IPath fileInTempDirPath = URIUtil.toPath(tempFileStore.toURI());
 
 		// create a link to the file in the temp dir and refresh
@@ -92,7 +94,7 @@ public class Bug_233939 extends ResourceTest {
 		}
 		// create a folder: getTempStore() will be cleaned up in tearDown()
 		IFileStore tempStore = getTempStore();
-		createFileInFileSystem(tempStore.getChild("foo.txt"));
+		createFile(tempStore.getChild("foo.txt"));
 		IPath tempFolderPath = URIUtil.toPath(tempStore.toURI());
 
 		// create two projects with a symlink to the folder each

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.IFileStore;
@@ -55,7 +56,7 @@ public class Bug_264182 extends ResourceTest {
 		// create a linked resource
 		final IFile file = project.getFile(getUniqueString());
 		IFileStore tempFileStore = getTempStore();
-		createFileInFileSystem(tempFileStore);
+		createFile(tempFileStore);
 		assertThrows(CoreException.class,
 				() -> file.createLink(tempFileStore.toURI(), IResource.NONE, new NullProgressMonitor()));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.IFileStore;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -31,7 +33,7 @@ public class Bug_329836 extends ResourceTest {
 		}
 
 		IFileStore fileStore = getTempStore().getChild(getUniqueString());
-		createFileInFileSystem(fileStore);
+		createFile(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
 		IFileInfo info = fileStore.fetchInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.eclipse.core.resources.IFolder;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedOutputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.util.concurrent.Semaphore;
 import org.eclipse.core.resources.ICommand;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.ICommand;
@@ -29,7 +32,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.internal.builders.AbstractBuilderTest;
 import org.eclipse.core.tests.resources.usecase.SignaledBuilder;
-
 public class IProjectTest extends AbstractBuilderTest {
 	public IProjectTest(String name) {
 		super(name);
@@ -147,8 +149,8 @@ public class IProjectTest extends AbstractBuilderTest {
 
 		// create in file-system
 		location.append(folder.getName()).toFile().mkdirs();
-		createFileInFileSystem(location.append(folder.getName()).append(file2.getName()));
-		createFileInFileSystem(location.append(file1.getName()));
+		createFile(location.append(folder.getName()).append(file2.getName()));
+		createFile(location.append(file1.getName()));
 
 		// create
 		project.create(getMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -14,6 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -356,7 +360,7 @@ public class IResourceTest extends ResourceTest {
 		attributes.setReadOnly(false);
 		file.setResourceAttributes(attributes);
 		assertTrue("4.0", !file.isReadOnly());
-		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
+		removeFromWorkspace(new IResource[] {project, file});
 	}
 
 	public void testDelete_Bug8754() throws CoreException {
@@ -380,7 +384,7 @@ public class IResourceTest extends ResourceTest {
 		}
 		assertEquals("1.2", IResourceStatus.OUT_OF_SYNC_LOCAL, status.getCode());
 		//cleanup
-		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
+		removeFromWorkspace(new IResource[] {project, file});
 	}
 
 	public void testEquals_1FUOU25() {
@@ -441,7 +445,7 @@ public class IResourceTest extends ResourceTest {
 
 		final String newContents = "some other contents";
 		Thread.sleep(5000);
-		createFileInFileSystem(target.getLocation(), getContents(newContents));
+		createFile(target.getLocation(), getContents(newContents));
 
 		final AtomicReference<ThrowingRunnable> listenerInMainThreadCallback = new AtomicReference<>(() -> {
 		});

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -56,8 +60,8 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue("1.1", folder.exists());
 		assertTrue("1.2", file.exists());
-		ensureDoesNotExistInWorkspace(folder);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromWorkspace(folder);
+		removeFromFileSystem(folder);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +87,7 @@ public class NLTest extends ResourceTest {
 		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInFileSystem("2.1", resources);
 		assertExistsInWorkspace("2.2", resources);
-		ensureDoesNotExistInWorkspace(resources);
+		removeFromWorkspace(resources);
 
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.util.Map;
 import junit.framework.Test;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.transferStreams;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.core.resources.ICommand;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.File;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
@@ -13,10 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.core.internal.resources.TestingSupport;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createFile;
+
 import java.io.File;
 import junit.framework.Test;
 import org.eclipse.core.filesystem.EFS;
@@ -37,7 +39,7 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		}
 
 		IFileStore fileStore = getTempStore().getChild(getUniqueString());
-		createFileInFileSystem(fileStore);
+		createFile(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
 		IFileInfo info = fileStore.fetchInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
@@ -13,10 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ContentDescriptionManager;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ContentDescriptionManager;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.util.Map;
 import junit.framework.Test;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
+
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -60,7 +63,7 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 			assertTrue("1.2", !file.exists());
 			assertEquals("1.3", location, project.getLocation());
 		} finally {
-			ensureDoesNotExistInFileSystem(location.toFile());
+			removeFromFileSystem(location.toFile());
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.Map;
 import junit.framework.Test;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SNOW;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_WATER;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
@@ -13,8 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -66,6 +68,6 @@ public class ConcurrencyTest extends ResourceTest {
 		assertTrue("2.2", op2.getStatus().isOK());
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+		removeFromWorkspace(getWorkspace().getRoot());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.compare.tests;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -13,11 +13,25 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import java.io.*;
-import java.util.*;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 import junit.framework.Test;

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureExistsInWorkspace;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,11 +28,9 @@ import org.junit.Assert;
 
 import org.eclipse.team.core.RepositoryProvider;
 import org.eclipse.team.core.TeamException;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;


### PR DESCRIPTION
This changes moves all create*/ensure* utility methods defined in ResourceTest to the dedicated ResourceTestUtil test class. It renames the ensureDoesNotExist* methods to remove* to avoid name clashes and make the performed removal more explicit. It prepares for removing the JUnit 3 test inheritances hierarchy to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

⚠️ Depends on and currently contains the changes of #904, so has to be merged afterwards.