### PR TITLE
Replace calls to ResourceTest.cleanup()

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -105,7 +105,8 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 	@Override
 	protected void tearDown() throws Exception {
 		// Cleanup workspace first to ensure that auto-build is not started on projects
-		cleanup();
+		waitForBuild();
+		getWorkspace().getRoot().delete(true, true, getMonitor());
 		super.tearDown();
 		TimerBuilder.abortCurrentBuilds();
 	}
@@ -143,7 +144,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 
 	@Test
 	public void testIndividualProjectBuilds_WithManyProjects_ProjectRelaxedRule() throws Exception {
-		int numberOfParallelBuilds = 60;
+		int numberOfParallelBuilds = 30;
 		var longRunningProjects = createMultipleTestProjects(numberOfParallelBuilds, BuildDurationType.LONG_RUNNING,
 				RuleType.CURRENT_PROJECT_RELAXED);
 		executeIndividualFullProjectBuilds(numberOfParallelBuilds, () -> {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -471,7 +471,8 @@ public class IResourceTest extends ResourceTest {
 		public void cleanUp(Object[] args, int countArg) throws Exception {
 			// Reinitialize projects if necessary
 			if (reinitializeOnCleanup) {
-				IResourceTest.this.cleanup();
+				waitForBuild();
+				getWorkspace().getRoot().delete(true, true, getMonitor());
 				IResourceTest.this.initializeProjects();
 				reinitializeOnCleanup = false;
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -428,7 +428,7 @@ public abstract class ResourceTest extends CoreTest {
 		return result;
 	}
 
-	protected void cleanup() throws CoreException {
+	private void cleanup() throws CoreException {
 		// Wait for any build job that may still be executed
 		waitForBuild();
 		final IFileStore[] toDelete = storesToDelete.toArray(new IFileStore[0]);


### PR DESCRIPTION
Some test classes manually call the cleanup() method of ResourceTest just to remove the projects in the workspace. Since this method contains more functionality than that and should be private to the ResourceTest teardown functionality, this change replaces the calls to the method with ordinary cleanups of the workspace.