### PR TITLE
Cleanup fail() calls in several ResourceTest implementations #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.properties;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -57,18 +58,14 @@ public class PropertyManagerTest extends LocalStoreTest {
 		}
 	}
 
-	private void createProperties(IFile target, QualifiedName[] names, String[] values) {
+	private void createProperties(IFile target, QualifiedName[] names, String[] values) throws CoreException {
 		for (int i = 0; i < names.length; i++) {
 			names[i] = new QualifiedName("org.eclipse.core.tests", "prop" + i);
 			values[i] = "property value" + i;
 		}
 		// create properties
 		for (int i = 0; i < names.length; i++) {
-			try {
-				target.setPersistentProperty(names[i], values[i]);
-			} catch (CoreException e) {
-				fail("1." + i, e);
-			}
+			target.setPersistentProperty(names[i], values[i]);
 		}
 	}
 
@@ -112,29 +109,14 @@ public class PropertyManagerTest extends LocalStoreTest {
 		}
 	}
 
-	private void join(Thread[] threads) {
-		//wait for all threads to finish
-		for (Thread thread : threads) {
-			try {
-				thread.join();
-			} catch (InterruptedException e) {
-				fail("#join", e);
-			}
-		}
-	}
-
 	/**
 	 * Tests concurrent acces to the property store.
 	 */
-	public void testConcurrentAccess() {
+	public void testConcurrentAccess() throws Exception {
 
 		// create common objects
 		final IFile target = projects[0].getFile("target");
-		try {
-			target.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		target.create(getRandomContents(), true, getMonitor());
 
 		// prepare keys and values
 		final int N = 50;
@@ -144,16 +126,11 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		final CoreException[] errorPointer = new CoreException[1];
 		Thread[] threads = createThreads(target, names, values, errorPointer);
-		join(threads);
-		if (errorPointer[0] != null) {
-			fail("2.0", errorPointer[0]);
+		for (Thread thread : threads) {
+			thread.join();
 		}
-
-		// remove trash
-		try {
-			target.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
+		if (errorPointer[0] != null) {
+			throw errorPointer[0];
 		}
 	}
 
@@ -161,7 +138,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	 * Tests concurrent access to the property store while the project is being
 	 * deleted.
 	 */
-	public void testConcurrentDelete() throws CoreException {
+	public void testConcurrentDelete() throws Exception {
 		Thread[] threads;
 		final IFile target = projects[0].getFile("target");
 		final int REPEAT = 8;
@@ -178,28 +155,16 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 			final CoreException[] errorPointer = new CoreException[1];
 			threads = createThreads(target, names, values, errorPointer);
-			try {
-				//give the threads a chance to start
-				Thread.sleep(10);
-			} catch (InterruptedException e) {
-				fail("1.98", e);
+			// give the threads a chance to start
+			Thread.sleep(10);
+			// delete the project while the threads are still running
+			target.getProject().delete(IResource.NONE, getMonitor());
+			for (Thread thread : threads) {
+				thread.join();
 			}
-			try {
-				//delete the project while the threads are still running
-				target.getProject().delete(IResource.NONE, getMonitor());
-			} catch (CoreException e) {
-				fail("1.99." + i, e);
-			}
-			join(threads);
 			if (errorPointer[0] != null) {
-				fail("2.0." + i, errorPointer[0]);
+				throw errorPointer[0];
 			}
-		}
-		// remove trash
-		try {
-			target.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
 		}
 	}
 
@@ -398,7 +363,6 @@ public class PropertyManagerTest extends LocalStoreTest {
 		assertNull("3.1", manager.getProperty(source, propName));
 		assertNull("3.2", manager.getProperty(sourceFolder, propName));
 		assertNull("3.3", manager.getProperty(sourceFile, propName));
-
 	}
 
 	/**
@@ -411,33 +375,16 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IFile file1a = folder.getFile("file1");
 		ensureExistsInWorkspace(file1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
-		try {
-			file1a.setPersistentProperty(key, "value");
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
-		try {
-			file1a.move(IPath.fromOSString("file2"), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.6", e);
-		}
+		file1a.setPersistentProperty(key, "value");
+		file1a.move(IPath.fromOSString("file2"), true, getMonitor());
 		IFile file1b = folder.getFile("file1");
 		ensureExistsInWorkspace(file1b, true);
 		String value = null;
-		try {
-			value = file1b.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("0.8", e);
-		}
+		value = file1b.getPersistentProperty(key);
 		assertNull("1.0", value);
 		file1a = folder.getFile("file2");
-		try {
-			value = file1a.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		value = file1a.getPersistentProperty(key);
 		assertEquals("2.0", "value", value);
-
 	}
 
 	/**
@@ -449,46 +396,25 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IFolder folder1a = project.getFolder("folder1");
 		ensureExistsInWorkspace(folder1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
-		try {
-			folder1a.setPersistentProperty(key, "value");
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
-		try {
-			folder1a.move(IPath.fromOSString("folder2"), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.6", e);
-		}
+		folder1a.setPersistentProperty(key, "value");
+		folder1a.move(IPath.fromOSString("folder2"), true, getMonitor());
 		IFolder folder1b = project.getFolder("folder1");
 		ensureExistsInWorkspace(folder1b, true);
 		String value = null;
-		try {
-			value = folder1b.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("0.8", e);
-		}
+		value = folder1b.getPersistentProperty(key);
 		assertNull("1.0", value);
 		folder1a = project.getFolder("folder2");
-		try {
-			value = folder1a.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		value = folder1a.getPersistentProperty(key);
 		assertEquals("2.0", "value", value);
-
 	}
 
 	/**
 	 * Do a stress test by adding a very large property to the store.
 	 */
-	public void testLargeProperty() {
+	public void testLargeProperty() throws CoreException {
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		try {
-			target.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		target.create(getRandomContents(), true, getMonitor());
 
 		QualifiedName name = new QualifiedName("stressTest", "prop");
 		final int SIZE = 10000;
@@ -497,20 +423,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 			valueBuf.append("a");
 		}
 		String value = valueBuf.toString();
-		try {
-			target.setPersistentProperty(name, value);
-			//should fail
-			fail("1.0");
-		} catch (CoreException e) {
-			// expected
-		}
-
-		// remove trash
-		try {
-			target.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
-		}
+		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 	}
 
 	/**
@@ -521,32 +434,15 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IProject project1a = root.getProject("proj1");
 		ensureExistsInWorkspace(project1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
-		try {
-			project1a.setPersistentProperty(key, "value");
-		} catch (CoreException e) {
-			fail("0.5", e);
-		}
-		try {
-			project1a.move(IPath.fromOSString("proj2"), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.6", e);
-		}
+		project1a.setPersistentProperty(key, "value");
+		project1a.move(IPath.fromOSString("proj2"), true, getMonitor());
 		IProject project1b = root.getProject("proj1");
 		ensureExistsInWorkspace(project1b, true);
-		String value = null;
-		try {
-			value = project1b.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("0.8", e);
-		}
+		String value = project1b.getPersistentProperty(key);
 		assertNull("1.0", value);
 
 		project1a = root.getProject("proj2");
-		try {
-			value = project1a.getPersistentProperty(key);
-		} catch (CoreException e) {
-			fail("1.9", e);
-		}
+		value = project1a.getPersistentProperty(key);
 		assertEquals("2.0", "value", value);
 	}
 
@@ -582,20 +478,13 @@ public class PropertyManagerTest extends LocalStoreTest {
 		}
 		assertEquals("3.0", 0, manager.getProperties(target).size());
 		manager.deleteProperties(target, IResource.DEPTH_INFINITE);
-
-		// remove trash
-		target.delete(false, monitor);
 	}
 
-	public void testSimpleUpdate() {
+	public void testSimpleUpdate() throws CoreException {
 
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		try {
-			target.create(getRandomContents(), true, getMonitor());
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		target.create(getRandomContents(), true, getMonitor());
 
 		// prepare keys and values
 		int N = 3;
@@ -608,50 +497,26 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		// create properties
 		for (int i = 0; i < N; i++) {
-			try {
-				target.setPersistentProperty(names[i], values[i]);
-			} catch (CoreException e) {
-				fail("1." + i, e);
-			}
+			target.setPersistentProperty(names[i], values[i]);
 		}
 
 		// verify
 		for (int i = 0; i < N; i++) {
-			try {
-				assertTrue("2.0", target.getPersistentProperty(names[i]).equals(values[i]));
-			} catch (CoreException e) {
-				fail("3." + i, e);
-			}
+			assertTrue("2.0", target.getPersistentProperty(names[i]).equals(values[i]));
 		}
 
 		for (int j = 0; j < 20; j++) {
-
 			// change properties
 			for (int i = 0; i < N; i++) {
-				try {
-					values[i] = values[i] + " - changed";
-					target.setPersistentProperty(names[i], values[i]);
-				} catch (CoreException e) {
-					fail("4." + i, e);
-				}
+				values[i] = values[i] + " - changed";
+				target.setPersistentProperty(names[i], values[i]);
 			}
 
 			// verify
 			for (int i = 0; i < N; i++) {
-				try {
-					assertTrue("5.0", target.getPersistentProperty(names[i]).equals(values[i]));
-				} catch (CoreException e) {
-					fail("6." + i, e);
-				}
+				assertTrue("5.0", target.getPersistentProperty(names[i]).equals(values[i]));
 			}
 
-		}
-
-		// remove trash
-		try {
-			target.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("20.0", e);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -299,18 +299,15 @@ public class CharsetTest extends ResourceTest {
 		}
 	}
 
-	private void setDerivedEncodingStoredSeparately(String tag, IProject project, boolean value) {
+	private void setDerivedEncodingStoredSeparately(IProject project, boolean value)
+			throws BackingStoreException {
 		org.osgi.service.prefs.Preferences prefs = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		if (!value) {
 			prefs.remove(ResourcesPlugin.PREF_SEPARATE_DERIVED_ENCODINGS);
 		} else {
 			prefs.putBoolean(ResourcesPlugin.PREF_SEPARATE_DERIVED_ENCODINGS, true);
 		}
-		try {
-			prefs.flush();
-		} catch (BackingStoreException e) {
-			fail(tag, e);
-		}
+		prefs.flush();
 	}
 
 	private static IEclipsePreferences getResourcesPreferences() {
@@ -399,7 +396,7 @@ public class CharsetTest extends ResourceTest {
 		}
 	}
 
-	public void testBug333056() throws CoreException {
+	public void testBug333056() throws Exception {
 		IProject project = null;
 		try {
 			IWorkspace workspace = getWorkspace();
@@ -417,7 +414,7 @@ public class CharsetTest extends ResourceTest {
 			folder.setDerived(true, getMonitor());
 			assertEquals("3.0", "BAR", file.getCharset(true));
 
-			setDerivedEncodingStoredSeparately("4.0", project, true);
+			setDerivedEncodingStoredSeparately(project, true);
 			assertEquals("5.0", "BAR", file.getCharset(true));
 		} finally {
 			clearAllEncodings(project);
@@ -508,7 +505,7 @@ public class CharsetTest extends ResourceTest {
 		assertTrue("6.9", file.getCharset().equals("ascii"));
 	}
 
-	public void testBug207510() throws CoreException, InterruptedException {
+	public void testBug207510() throws CoreException, InterruptedException, BackingStoreException {
 		IWorkspace workspace = getWorkspace();
 		CharsetVerifier verifier = new CharsetVerifierWithExtraInfo(CharsetVerifier.IGNORE_BACKGROUND_THREAD);
 		MultipleDeltasCharsetVerifier backgroundVerifier = new MultipleDeltasCharsetVerifier(CharsetVerifier.IGNORE_CREATION_THREAD);
@@ -534,7 +531,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.reset();
 			verifier.addExpectedChange(regularPrefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			setDerivedEncodingStoredSeparately("1.0", project1, true);
+			setDerivedEncodingStoredSeparately(project1, true);
 			assertTrue("1.1", verifier.waitForEvent(10000));
 			assertTrue("1.2 " + verifier.getMessage(), verifier.isDeltaValid());
 			assertExistsInWorkspace("1.3", regularPrefs);
@@ -593,7 +590,7 @@ public class CharsetTest extends ResourceTest {
 			backgroundVerifier.reset();
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.REMOVED, 0);
-			setDerivedEncodingStoredSeparately("6.0", project1, false);
+			setDerivedEncodingStoredSeparately(project1, false);
 			assertTrue("6.1.1", verifier.waitForEvent(10000));
 			assertTrue("6.1.2", backgroundVerifier.waitForFirstDelta(10000));
 			assertTrue("6.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
@@ -606,7 +603,7 @@ public class CharsetTest extends ResourceTest {
 			backgroundVerifier.reset();
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.ADDED, 0);
-			setDerivedEncodingStoredSeparately("7.0", project1, true);
+			setDerivedEncodingStoredSeparately(project1, true);
 			assertTrue("7.1.1", verifier.waitForEvent(10000));
 			assertTrue("7.1.2", backgroundVerifier.waitForFirstDelta(10000));
 			assertTrue("7.2.1 " + verifier.getMessage(), verifier.isDeltaValid());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -61,17 +61,13 @@ public class IResourceDeltaTest extends ResourceTest {
 
 		// Create and open the resources
 		IWorkspaceRunnable body = monitor -> ensureExistsInWorkspace(allResources, true);
-		try {
-			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().run(body, getMonitor());
 	}
 
 	/**
 	 * Tests the IResourceDelta#findMember method.
 	 */
-	public void testFindMember() {
+	public void testFindMember() throws CoreException {
 		/*
 		 * The following changes will occur:
 		 * - change file1
@@ -117,8 +113,6 @@ public class IResourceDeltaTest extends ResourceTest {
 		};
 		try {
 			getWorkspace().run(body, getMonitor());
-		} catch (CoreException e) {
-			fail("Exception1", e);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -124,11 +124,7 @@ public class IWorkspaceTest extends ResourceTest {
 				() -> getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, getMonitor()));
 
 		//create the destination
-		try {
-			folder2.create(false, true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		folder2.create(false, true, getMonitor());
 
 		//source file doesn't exist
 		assertThrows(CoreException.class,
@@ -140,21 +136,13 @@ public class IWorkspaceTest extends ResourceTest {
 
 		//make sure the first copy worked
 		assertTrue("1.5", fileCopy.exists());
-		try {
-			fileCopy.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("1.6", e);
-		}
+		fileCopy.delete(true, getMonitor());
 
 		// create the files
 		IFile projectFile = project.getFile("ProjectPhile");
-		try {
-			file2.create(getRandomContents(), false, getMonitor());
-			file3.create(getRandomContents(), false, getMonitor());
-			projectFile.create(getRandomContents(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("1.7", e);
-		}
+		file2.create(getRandomContents(), false, getMonitor());
+		file3.create(getRandomContents(), false, getMonitor());
+		projectFile.create(getRandomContents(), false, getMonitor());
 
 		//source files aren't siblings
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file, projectFile },
@@ -182,11 +170,7 @@ public class IWorkspaceTest extends ResourceTest {
 		//make sure the first copy worked
 		fileCopy = folder2.getFile("File");
 		assertTrue("2.2", fileCopy.exists());
-		try {
-			fileCopy.delete(true, getMonitor());
-		} catch (CoreException e) {
-			fail("2.3", e);
-		}
+		fileCopy.delete(true, getMonitor());
 
 		//resource out of sync with filesystem
 		ensureOutOfSync(file);
@@ -198,30 +182,16 @@ public class IWorkspaceTest extends ResourceTest {
 		/********** NON FAILURE CASES ***********/
 
 		//empty resource list
-		try {
-			getWorkspace().copy(new IResource[] {}, folder2.getFullPath(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		} catch (ArrayIndexOutOfBoundsException e) {
-			fail("Fails because of 1FTXL69", e);
-		}
+		getWorkspace().copy(new IResource[] {}, folder2.getFullPath(), false, getMonitor());
 
 		//copy single file
-		try {
-			getWorkspace().copy(new IResource[] {file}, folder2.getFullPath(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("3.1", e);
-		}
+		getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, getMonitor());
 		assertTrue("3.2", fileCopy.exists());
 		ensureDoesNotExistInWorkspace(fileCopy);
 		ensureDoesNotExistInFileSystem(fileCopy);
 
 		//copy two files
-		try {
-			getWorkspace().copy(new IResource[] {file, file2}, folder2.getFullPath(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("3.3", e);
-		}
+		getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, getMonitor());
 		assertTrue("3.4", fileCopy.exists());
 		assertTrue("3.5", file2Copy.exists());
 		ensureDoesNotExistInWorkspace(fileCopy);
@@ -230,17 +200,9 @@ public class IWorkspaceTest extends ResourceTest {
 		ensureDoesNotExistInFileSystem(file2Copy);
 
 		//copy a folder
-		try {
-			getWorkspace().copy(new IResource[] {folder}, folder2.getFullPath(), false, getMonitor());
-		} catch (CoreException e) {
-			fail("3.6", e);
-		}
+		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, getMonitor());
 		assertTrue("3.7", folderCopy.exists());
-		try {
-			assertTrue("3.8", folderCopy.members().length > 0);
-		} catch (CoreException e) {
-			fail("3.9", e);
-		}
+		assertTrue("3.8", folderCopy.members().length > 0);
 		ensureDoesNotExistInWorkspace(folderCopy);
 		ensureDoesNotExistInFileSystem(folderCopy);
 	}
@@ -303,12 +265,8 @@ public class IWorkspaceTest extends ResourceTest {
 	 * 	{@link IWorkspace#forgetSavedTree(String)}.
 	 */
 	public void testForgetSavedTree() {
-		try {
-			//according to javadoc spec, null means forget all plugin trees
-			getWorkspace().forgetSavedTree(null);
-		} catch (RuntimeException e) {
-			fail("4.99", e);
-		}
+		// according to javadoc spec, null means forget all plugin trees
+		getWorkspace().forgetSavedTree(null);
 	}
 
 	/**
@@ -714,7 +672,7 @@ public class IWorkspaceTest extends ResourceTest {
 	/**
 	 * Test thread safety of the API method IWorkspace.setDescription.
 	 */
-	public void testMultiSetDescription() {
+	public void testMultiSetDescription() throws CoreException {
 		final int THREAD_COUNT = 2;
 		final CoreException[] errorPointer = new CoreException[1];
 		Thread[] threads = new Thread[THREAD_COUNT];
@@ -748,7 +706,7 @@ public class IWorkspaceTest extends ResourceTest {
 			}
 		}
 		if (errorPointer[0] != null) {
-			fail("1.0", errorPointer[0]);
+			throw errorPointer[0];
 		}
 	}
 
@@ -969,7 +927,7 @@ public class IWorkspaceTest extends ResourceTest {
 	 * Performs black box testing of the following method:
 	 *     IStatus validateProjectLocation(IProject, IPath)
 	 */
-	public void testValidateProjectLocation() {
+	public void testValidateProjectLocation() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("Project");
 
@@ -1039,17 +997,13 @@ public class IWorkspaceTest extends ResourceTest {
 		final String PATH_VAR_NAME = "FOOVAR";
 		final IPath PATH_VAR_VALUE = getRandomLocation();
 		try {
-			try {
-				IPath varPath = IPath.fromOSString(PATH_VAR_NAME);
-				workspace.getPathVariableManager().setValue(PATH_VAR_NAME, PATH_VAR_VALUE);
-				assertTrue("8.1", workspace.validateProjectLocation(project, varPath).isOK());
-				assertTrue("8.2", workspace.validateProjectLocation(project, varPath.append("test")).isOK());
-				assertTrue("8.3", workspace.validateProjectLocation(project, varPath.append("test/ing")).isOK());
-			} finally {
-				workspace.getPathVariableManager().setValue(PATH_VAR_NAME, null);
-			}
-		} catch (CoreException e) {
-			fail("8.99", e);
+			IPath varPath = IPath.fromOSString(PATH_VAR_NAME);
+			workspace.getPathVariableManager().setValue(PATH_VAR_NAME, PATH_VAR_VALUE);
+			assertTrue("8.1", workspace.validateProjectLocation(project, varPath).isOK());
+			assertTrue("8.2", workspace.validateProjectLocation(project, varPath.append("test")).isOK());
+			assertTrue("8.3", workspace.validateProjectLocation(project, varPath.append("test/ing")).isOK());
+		} finally {
+			workspace.getPathVariableManager().setValue(PATH_VAR_NAME, null);
 		}
 
 		//cannot overlap with another project's location
@@ -1061,13 +1015,9 @@ public class IWorkspaceTest extends ResourceTest {
 		IProject closed = workspace.getRoot().getProject("ClosedProject");
 		IProjectDescription closedDesc = workspace.newProjectDescription(closed.getName());
 		closedDesc.setLocation(closedProjectLocation);
-		try {
-			open.create(openDesc, null);
-			open.open(null);
-			closed.create(closedDesc, null);
-		} catch (CoreException e) {
-			fail("9.99", e);
-		}
+		open.create(openDesc, null);
+		open.open(null);
+		closed.create(closedDesc, null);
 		IPath linkLocation = getRandomLocation();
 		try {
 			//indirect test: setting the project description may validate location, which shouldn't complain
@@ -1098,8 +1048,6 @@ public class IWorkspaceTest extends ResourceTest {
 			assertTrue("11.1", workspace.validateProjectLocation(project, defaultProjectLocation.append(project.getName())).isOK());
 			assertFalse("11.2",
 					workspace.validateProjectLocation(project, defaultProjectLocation.append("foo")).isOK());
-		} catch (CoreException e) {
-			fail("11.99", e);
 		} finally {
 			Workspace.clear(linkLocation.toFile());
 			//make sure we clean up project directories
@@ -1130,19 +1078,15 @@ public class IWorkspaceTest extends ResourceTest {
 	 * Performs black box testing of the following method:
 	 *     IStatus validateProjectLocationURI(IProject, URI)
 	 */
-	public void testValidateProjectLocationURI() {
+	public void testValidateProjectLocationURI() throws URISyntaxException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("Project");
-		try {
-			//URI with no scheme
-			URI uri = new URI("eferfsdfwer");
-			assertFalse("1.0", workspace.validateProjectLocationURI(project, uri).isOK());
-			//URI with unknown scheme
-			uri = new URI("blorts://foo.com?bad");
-			assertFalse("1.1", workspace.validateProjectLocationURI(project, uri).isOK());
-		} catch (URISyntaxException e) {
-			fail("1.99", e);
-		}
+		// URI with no scheme
+		URI uri = new URI("eferfsdfwer");
+		assertFalse("1.0", workspace.validateProjectLocationURI(project, uri).isOK());
+		// URI with unknown scheme
+		uri = new URI("blorts://foo.com?bad");
+		assertFalse("1.1", workspace.validateProjectLocationURI(project, uri).isOK());
 	}
 
 	public void testWorkspaceService() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -16,6 +16,8 @@
 
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -213,7 +215,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileVariableRemoved() {
+	public void testFileVariableRemoved() throws CoreException {
 		final IPathVariableManager manager = getWorkspace().getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -225,47 +227,26 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		// removes the variable - the location will be undefined (null)
-		try {
-			manager.setValue(VARIABLE_NAME, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue(VARIABLE_NAME, null);
 		assertExistsInWorkspace("3,1", file);
 
 		//refresh local - should not fail or make the link disappear
-		try {
-			file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-			file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.2");
-		}
+		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		assertExistsInWorkspace("3.3", file);
 
 		// try to change resource's contents
-		try {
-			file.setContents(getContents("new contents"), IResource.NONE, null);
-			// Resource has no-defined location - should fail
-			fail("3.4");
-		} catch (CoreException re) {
-			// success: resource had no defined location
-		}
+		// Resource has no-defined location - should fail
+		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace("3.5", file);
 		// the location is null
@@ -276,28 +257,20 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		getWorkspace().validateLinkLocation(other, getRandomLocation());
 
 		// re-creates the variable with its previous value
-		try {
-			manager.setValue(VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		manager.setValue(VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("5.0", file);
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem("5.2", file);
 		// the contents must be the original ones
-		try {
-			assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
 
 	/**
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileProjectVariableRemoved() {
+	public void testFileProjectVariableRemoved() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -309,47 +282,26 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		// removes the variable - the location will be undefined (null)
-		try {
-			manager.setValue(PROJECT_VARIABLE_NAME, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue(PROJECT_VARIABLE_NAME, null);
 		assertExistsInWorkspace("3,1", file);
 
 		// refresh local - should not fail or make the link disappear
-		try {
-			file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-			file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.2");
-		}
+		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		assertExistsInWorkspace("3.3", file);
 
 		// try to change resource's contents
-		try {
-			file.setContents(getContents("new contents"), IResource.NONE, null);
-			// Resource has no-defined location - should fail
-			fail("3.4");
-		} catch (CoreException re) {
-			// success: resource had no defined location
-		}
+		// Resource has no-defined location - should fail
+		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace("3.5", file);
 		// the location is null
@@ -361,21 +313,13 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		getWorkspace().validateLinkLocation(other, getRandomLocation());
 
 		// re-creates the variable with its previous value
-		try {
-			manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("5.0", file);
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem("5.2", file);
 		// the contents must be the original ones
-		try {
-			assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
 
 	/**
@@ -383,7 +327,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * moved to a new project.
 	 * This is a regression test for bug 266679
 	 */
-	public void testMoveFileToDifferentProject() {
+	public void testMoveFileToDifferentProject() throws Exception {
 
 		IFile file = existingProjectInSubDirectory.getFile("my_link");
 
@@ -391,39 +335,23 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = null;
 		IPath targetPath = existingProjectInSubDirectory.getLocation().removeLastSegments(1).append("outside.txt");
 		if (!targetPath.toFile().exists()) {
-			try {
-				targetPath.toFile().createNewFile();
-			} catch (IOException e2) {
-				fail("0.4", e2);
-			}
+			targetPath.toFile().createNewFile();
 		}
 		toDelete.add(targetPath);
 
-		try {
-			variableBasedLocation = convertToRelative(targetPath, file, true, null);
-		} catch (CoreException e1) {
-			fail("0.99", e1);
-		}
+		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 
 		IPath resolvedPath = URIUtil.toPath(file.getPathVariableManager().resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		IFile newFile = nonExistingFileInExistingFolder;
-		try {
-			file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace("3,1", newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertEquals("3,3", newFile.getLocation(), resolvedPath);
@@ -438,7 +366,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * relative to PROJECT_LOC is moved to a different project.
 	 * This is a regression test for bug 266679
 	 */
-	public void testPROJECT_LOC_MoveFileToDifferentProject() {
+	public void testPROJECT_LOC_MoveFileToDifferentProject() throws Exception {
 
 		String[] existingVariables = nonExistingFileInExistingFolder.getProject().getPathVariableManager().getPathVariableNames();
 		for (String existingVariable : existingVariables) {
@@ -453,41 +381,25 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = null;
 		IPath targetPath = existingProjectInSubDirectory.getLocation().removeLastSegments(3).append("outside.txt");
 		if (!targetPath.toFile().exists()) {
-			try {
-				targetPath.toFile().createNewFile();
-			} catch (IOException e2) {
-				fail("0.4", e2);
-			}
+			targetPath.toFile().createNewFile();
 		}
 		toDelete.add(targetPath);
 
-		try {
-			existingProjectInSubDirectory.getPathVariableManager().setValue("P_RELATIVE",
-					IPath.fromPortableString("${PARENT-3-PROJECT_LOC}"));
-			variableBasedLocation = IPath.fromPortableString("P_RELATIVE/outside.txt");
-		} catch (CoreException e1) {
-			fail("0.99", e1);
-		}
+		existingProjectInSubDirectory.getPathVariableManager().setValue("P_RELATIVE",
+				IPath.fromPortableString("${PARENT-3-PROJECT_LOC}"));
+		variableBasedLocation = IPath.fromPortableString("P_RELATIVE/outside.txt");
 
 		IPath resolvedPath = existingProjectInSubDirectory.getPathVariableManager().resolvePath(variableBasedLocation);
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		IFile newFile = nonExistingFileInExistingFolder;
-		try {
-			file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace("3,1", newFile);
 		IPath newLocation = newFile.getLocation();
 		assertTrue("3,2", !newLocation.equals(newFile.getRawLocation()));
@@ -504,7 +416,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a linked file location is
 	 * is moved to a new project.
 	 */
-	public void testMoveFileProjectVariable() {
+	public void testMoveFileProjectVariable() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -516,16 +428,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
@@ -533,11 +437,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IFile newFile = nonExistingFileInExistingFolder;
 		// removes the variable - the location will be undefined (null)
-		try {
-			file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace("3,1", newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertTrue("3,3", newFile.getRawLocation().equals(variableBasedLocation));
@@ -549,7 +449,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testMoveFileToNewProjectProjectVariable() {
+	public void testMoveFileToNewProjectProjectVariable() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -561,16 +461,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
@@ -578,11 +470,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IFile newFile = nonExistingFileInOtherExistingProject;
 		// moves the variable - the location will be undefined (null)
-		try {
-			file.move(newFile.getFullPath(), IResource.SHALLOW, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.move(newFile.getFullPath(), IResource.SHALLOW, getMonitor());
 		assertExistsInWorkspace("3,1", newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertTrue("3,3", newFile.getRawLocation().equals(variableBasedLocation));
@@ -593,7 +481,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileProjectRelativeVariableRemoved() {
+	public void testFileProjectRelativeVariableRemoved() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -605,47 +493,26 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		// removes the variable - the location will be undefined (null)
-		try {
-			manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, null);
 		assertExistsInWorkspace("3,1", file);
 
 		// refresh local - should not fail or make the link disappear
-		try {
-			file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-			file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.2");
-		}
+		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
 		assertExistsInWorkspace("3.3", file);
 
 		// try to change resource's contents
-		try {
-			file.setContents(getContents("new contents"), IResource.NONE, null);
-			// Resource has no-defined location - should fail
-			fail("3.4");
-		} catch (CoreException re) {
-			// success: resource had no defined location
-		}
+		// Resource has no-defined location - should fail
+		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace("3.5", file);
 		// the location is null
@@ -657,28 +524,20 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		getWorkspace().validateLinkLocation(other, getRandomLocation());
 
 		// re-creates the variable with its previous value
-		try {
-			manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("5.0", file);
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem("5.2", file);
 		// the contents must be the original ones
-		try {
-			assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
 
 	/**
 	 * Tests a scenario where a variable used in a linked folder location is
 	 * removed.
 	 */
-	public void testFolderVariableRemoved() {
+	public void testFolderVariableRemoved() throws CoreException {
 		final IPathVariableManager manager = getWorkspace().getPathVariableManager();
 
 		IFolder folder = nonExistingFolderInExistingProject;
@@ -691,17 +550,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", folder);
 
-		try {
-			folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-			childFile.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", folder);
@@ -710,72 +561,39 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem("2.3", childFile);
 
 		// removes the variable - the location will be undefined (null)
-		try {
-			manager.setValue(VARIABLE_NAME, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue(VARIABLE_NAME, null);
 		assertExistsInWorkspace("3.1", folder);
 
 		//refresh local - should not fail but should cause link's children to disappear
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInWorkspace("3.3", folder);
 		assertDoesNotExistInWorkspace("3.4", childFile);
 
 		//try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
-		try {
-			existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor());
-			//should fail
-			fail("3.5");
-		} catch (CoreException e) {
-			//expected
-		}
+		assertThrows(CoreException.class,
+				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
 		assertTrue("3.6", !destination.exists());
 
 		//try to create a sub-file
-		try {
-			destination.create(getRandomContents(), IResource.NONE, getMonitor());
-			//should fail
-			fail("3.7");
-		} catch (CoreException e) {
-			//expected
-		}
+		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, getMonitor()));
 
 		//try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
-		try {
-			subFolder.create(IResource.NONE, true, getMonitor());
-			//should fail
-			fail("3.8");
-		} catch (CoreException e) {
-			//expected
-		}
+		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, getMonitor()));
 
 		// try to change resource's contents
-		try {
-			childFile.setContents(getContents("new contents"), IResource.NONE, null);
-			// Resource has no-defined location - should fail
-			fail("4.0");
-		} catch (CoreException re) {
-			// success: resource had no defined location
-		}
+		// Resource has no-defined location - should fail
+		assertThrows(CoreException.class,
+				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace("4.1", folder);
 		// the location is null
 		assertNull("4.2", folder.getLocation());
 
 		// re-creates the variable with its previous value
-		try {
-			manager.setValue(VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		manager.setValue(VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("6.0", folder);
 		assertNotNull("6.1", folder.getLocation());
@@ -784,11 +602,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem("6.4", childFile);
 
 		// refresh should recreate the child
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInWorkspace("7.1", folder);
 		assertExistsInWorkspace("7.2", childFile);
 	}
@@ -801,58 +615,45 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * is marked read-only.
 	 * See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=210664">Bug 210664</a>.
 	 */
-	public void testImportWrongLineEndings_Bug210664() throws IOException {
+	public void testImportWrongLineEndings_Bug210664() throws Exception {
 		// Choose a project to work on
 		IProject proj = existingProject;
-		IFileStore projStore = null;
 		IPath randomLocationWithPathVariable = getRandomLocation();
-
-		try {
-			projStore = EFS.getStore(proj.getLocationURI());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		IFileStore projStore = EFS.getStore(proj.getLocationURI());
 
 		// Don't run this test if we cannot set a file read-only
 		if ((projStore.getFileSystem().attributes() & EFS.ATTRIBUTE_READ_ONLY) == 0) {
 			return;
 		}
 
-		try {
-			// Create a linked resource with a non-existing path variable
-			IFolder folder = proj.getFolder("SOME_LINK");
-			folder.createLink(randomLocationWithPathVariable, IResource.ALLOW_MISSING_LOCAL, null);
+		// Create a linked resource with a non-existing path variable
+		IFolder folder = proj.getFolder("SOME_LINK");
+		folder.createLink(randomLocationWithPathVariable, IResource.ALLOW_MISSING_LOCAL, null);
 
-			// Close the project, and convert line endings
-			IFileStore projFile = projStore.getChild(".project");
-			proj.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
-			IFileStore projNew = projStore.getChild(".project.new");
-			convertLineEndings(projFile, projNew, getMonitor());
+		// Close the project, and convert line endings
+		IFileStore projFile = projStore.getChild(".project");
+		proj.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+		IFileStore projNew = projStore.getChild(".project.new");
+		convertLineEndings(projFile, projNew, getMonitor());
 
-			// Set the project read-only
-			projNew.move(projFile, EFS.OVERWRITE, getMonitor());
-			IFileInfo info = projFile.fetchInfo(EFS.NONE, getMonitor());
-			info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-			projFile.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
-			toSetWritable = projFile; /* for cleanup */
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		// Set the project read-only
+		projNew.move(projFile, EFS.OVERWRITE, getMonitor());
+		IFileInfo info = projFile.fetchInfo(EFS.NONE, getMonitor());
+		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
+		projFile.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+		toSetWritable = projFile; /* for cleanup */
 
-		try {
-			//Bug 210664: Open project with wrong line endings and non-existing path variable
-			proj.create(null);
-			proj.open(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		// Bug 210664: Open project with wrong line endings and non-existing path
+		// variable
+		proj.create(null);
+		proj.open(IResource.NONE, getMonitor());
 	}
 
 	/**
 	 * Tests a scenario where a variable used in a linked folder location is
 	 * removed.
 	 */
-	public void testFolderProjectVariableRemoved() {
+	public void testFolderProjectVariableRemoved() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFolder folder = nonExistingFolderInExistingProject;
@@ -865,17 +666,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", folder);
 
-		try {
-			folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-			childFile.create(getRandomContents(), IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
+		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", folder);
@@ -884,73 +677,40 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem("2.3", childFile);
 
 		// removes the variable - the location will be undefined (null)
-		try {
-			manager.setValue(PROJECT_VARIABLE_NAME, null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		manager.setValue(PROJECT_VARIABLE_NAME, null);
 		assertExistsInWorkspace("3.1", folder);
 
 		// refresh local - should not fail but should cause link's children to
 		// disappear
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("3.2", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInWorkspace("3.3", folder);
 		assertDoesNotExistInWorkspace("3.4", childFile);
 
 		// try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
-		try {
-			existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor());
-			// should fail
-			fail("3.5");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class,
+				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
 		assertTrue("3.6", !destination.exists());
 
 		// try to create a sub-file
-		try {
-			destination.create(getRandomContents(), IResource.NONE, getMonitor());
-			// should fail
-			fail("3.7");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, getMonitor()));
 
 		// try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
-		try {
-			subFolder.create(IResource.NONE, true, getMonitor());
-			// should fail
-			fail("3.8");
-		} catch (CoreException e) {
-			// expected
-		}
+		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, getMonitor()));
 
 		// try to change resource's contents
-		try {
-			childFile.setContents(getContents("new contents"), IResource.NONE, null);
-			// Resource has no-defined location - should fail
-			fail("4.0");
-		} catch (CoreException re) {
-			// success: resource had no defined location
-		}
+		// Resource has no-defined location - should fail
+		assertThrows(CoreException.class,
+				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace("4.1", folder);
 		// the location is null
 		assertNull("4.2", folder.getLocation());
 
 		// re-creates the variable with its previous value
-		try {
-			manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("6.0", folder);
 		assertNotNull("6.1", folder.getLocation());
@@ -959,11 +719,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem("6.4", childFile);
 
 		// refresh should recreate the child
-		try {
-			folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		} catch (CoreException e) {
-			fail("7.0", e);
-		}
+		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		assertExistsInWorkspace("7.1", folder);
 		assertExistsInWorkspace("7.2", childFile);
 	}
@@ -971,111 +727,61 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	/**
 	 * Tests scenario where links are relative to undefined variables
 	 */
-	public void testUndefinedVariable() {
+	public void testUndefinedVariable() throws CoreException {
 		IPath folderLocation = IPath.fromOSString("NOVAR/folder");
 		IPath fileLocation = IPath.fromOSString("NOVAR/abc.txt");
 		IFile testFile = existingProject.getFile("UndefinedVar.txt");
 		IFolder testFolder = existingProject.getFolder("UndefinedVarTest");
 
 		//should fail to create links
-		try {
-			testFile.createLink(fileLocation, IResource.NONE, getMonitor());
-			fail("1.0");
-		} catch (CoreException e) {
-			//should fail
-		}
-		try {
-			testFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-			fail("1.1");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> testFile.createLink(fileLocation, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.createLink(folderLocation, IResource.NONE, getMonitor()));
 
 		//validate method should return warning
 		assertTrue("1.2", getWorkspace().validateLinkLocation(testFolder, folderLocation).getSeverity() == IStatus.WARNING);
 		assertTrue("1.3", getWorkspace().validateLinkLocation(testFile, fileLocation).getSeverity() == IStatus.WARNING);
 
 		//should succeed with ALLOW_MISSING_LOCAL
-		try {
-			testFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
-		try {
-			testFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("2.1", e);
-		}
+		testFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		testFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 
 		//copy should fail
 		IPath copyFileDestination = existingProject.getFullPath().append("CopyFileDest");
 		IPath copyFolderDestination = existingProject.getFullPath().append("CopyFolderDest");
 
-		try {
-			testFile.copy(copyFileDestination, IResource.NONE, getMonitor());
-			fail("3.0");
-		} catch (CoreException e) {
-			//should fail
-		}
-		try {
-			testFolder.copy(copyFolderDestination, IResource.NONE, getMonitor());
-			fail("3.1");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> testFile.copy(copyFileDestination, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.copy(copyFolderDestination, IResource.NONE, getMonitor()));
 
 		//move should fail
 		IPath moveFileDestination = existingProject.getFullPath().append("MoveFileDest");
 		IPath moveFolderDestination = existingProject.getFullPath().append("MoveFolderDest");
 
-		try {
-			testFile.move(moveFileDestination, IResource.NONE, getMonitor());
-			fail("4.0");
-		} catch (CoreException e) {
-			//should fail
-		}
-		try {
-			testFolder.move(moveFolderDestination, IResource.NONE, getMonitor());
-			fail("4.1");
-		} catch (CoreException e) {
-			//should fail
-		}
+		assertThrows(CoreException.class, () -> testFile.move(moveFileDestination, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.move(moveFolderDestination, IResource.NONE, getMonitor()));
 
 		//refresh local should succeed
-		try {
-			testFile.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			testFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-			testFile.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-			testFolder.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-			existingProject.refreshLocal(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		testFile.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		testFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		testFile.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		testFolder.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		existingProject.refreshLocal(IResource.NONE, getMonitor());
 
 		//renaming the project shallow is ok
-		try {
-			IProject project = testFolder.getProject();
-			IProjectDescription desc = project.getDescription();
-			desc.setName("moveDest");
-			project.move(desc, IResource.SHALLOW | IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("6.0");
-		}
+		IProject project = testFolder.getProject();
+		IProjectDescription desc = project.getDescription();
+		desc.setName("moveDest");
+		project.move(desc, IResource.SHALLOW | IResource.FORCE, getMonitor());
 
 		//delete should succeed
-		try {
-			testFile.delete(IResource.NONE, getMonitor());
-			testFolder.delete(IResource.NONE, getMonitor());
-		} catch (CoreException e) {
-			fail("9.0", e);
-		}
+		testFile.delete(IResource.NONE, getMonitor());
+		testFolder.delete(IResource.NONE, getMonitor());
 	}
 
 	/**
 	 * Tests a scenario where a variable used in a linked file location is
 	 * changed.
 	 */
-	public void testVariableChanged() {
+	public void testVariableChanged() throws CoreException {
 		final IPathVariableManager manager = getWorkspace().getPathVariableManager();
 
 		IPath existingValue = manager.getValue(VARIABLE_NAME);
@@ -1088,49 +794,30 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		// changes the variable value - the file location will change
-		try {
-			IPath newLocation = super.getRandomLocation();
-			toDelete.add(newLocation);
-			manager.setValue(VARIABLE_NAME, newLocation);
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		IPath newLocation = super.getRandomLocation();
+		toDelete.add(newLocation);
+		manager.setValue(VARIABLE_NAME, newLocation);
 
 		// try to change resource's contents
-		try {
-			file.setContents(getContents("new contents"), IResource.NONE, getMonitor());
-			// Resource was out of sync - should not be able to change
-			fail("3.0");
-		} catch (CoreException e) {
-			assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, e.getStatus().getCode());
-		}
+		// Resource was out of sync - should not be able to change
+		CoreException exception = assertThrows(CoreException.class,
+				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
+		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace("3.2", file);
 		// the location is different - does not exist anymore
 		assertDoesNotExistInFileSystem("3.3", file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		try {
-			file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem("4.1", file);
@@ -1141,37 +828,25 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		try {
-			assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
-		} catch (CoreException e) {
-			fail("4.4", e);
-		}
+		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
 
 		// clean-up
 		ensureDoesNotExistInFileSystem(file);
 
 		// restore the previous value
-		try {
-			manager.setValue(VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		manager.setValue(VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("5.1", file);
 		assertExistsInFileSystem("5.2", file);
 		// the contents must be the original ones
-		try {
-			assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
 
 	/**
 	 * Tests a scenario where a variable used in a linked file location is
 	 * changed.
 	 */
-	public void testProjectVariableChanged() {
+	public void testProjectVariableChanged() throws CoreException {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IPath existingValue = manager.getValue(PROJECT_VARIABLE_NAME);
@@ -1184,49 +859,30 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("1.0", file);
 
-		try {
-			file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		} catch (CoreException e) {
-			fail("1.1", e);
-		}
-		try {
-			file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("1.2", e);
-		}
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace("2.0", file);
 		assertExistsInFileSystem("2.1", file);
 
 		// changes the variable value - the file location will change
-		try {
-			IPath newLocation = super.getRandomLocation();
-			toDelete.add(newLocation);
-			manager.setValue(PROJECT_VARIABLE_NAME, newLocation);
-		} catch (CoreException e) {
-			fail("2.2", e);
-		}
+		IPath newLocation = super.getRandomLocation();
+		toDelete.add(newLocation);
+		manager.setValue(PROJECT_VARIABLE_NAME, newLocation);
 
 		// try to change resource's contents
-		try {
-			file.setContents(getContents("new contents"), IResource.NONE, getMonitor());
-			// Resource was out of sync - should not be able to change
-			fail("3.0");
-		} catch (CoreException e) {
-			assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, e.getStatus().getCode());
-		}
+		// Resource was out of sync - should not be able to change
+		CoreException exception = assertThrows(CoreException.class,
+				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
+		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace("3.2", file);
 		// the location is different - does not exist anymore
 		assertDoesNotExistInFileSystem("3.3", file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		try {
-			file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
-		} catch (CoreException e) {
-			fail("4.0", e);
-		}
+		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem("4.1", file);
@@ -1237,30 +893,18 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		try {
-			assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
-		} catch (CoreException e) {
-			fail("4.4", e);
-		}
+		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
 
 		// clean-up
 		ensureDoesNotExistInFileSystem(file);
 
 		// restore the previous value
-		try {
-			manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
-		} catch (CoreException e) {
-			fail("5.0", e);
-		}
+		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace("5.1", file);
 		assertExistsInFileSystem("5.2", file);
 		// the contents must be the original ones
-		try {
-			assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
-		} catch (CoreException e) {
-			fail("5.4", e);
-		}
+		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
 
 	/**
@@ -1299,7 +943,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	/**
 	 * Test Bug 288880 - Redundant path variables generated when converting some linked resources to path variable-relative
 	 */
-	public void testNonRedundentPathVariablesGenerated() {
+	public void testNonRedundentPathVariablesGenerated() throws Exception {
 		IFile file = existingProjectInSubDirectory.getFile("my_link");
 
 		IPathVariableManager pathVariableManager = existingProjectInSubDirectory.getPathVariableManager();
@@ -1308,29 +952,17 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = null;
 		IPath targetPath = existingProjectInSubDirectory.getLocation().removeLastSegments(1).append("outside.txt");
 		if (!targetPath.toFile().exists()) {
-			try {
-				targetPath.toFile().createNewFile();
-			} catch (IOException e2) {
-				fail("1.0", e2);
-			}
+			targetPath.toFile().createNewFile();
 		}
 		toDelete.add(targetPath);
 
-		try {
-			variableBasedLocation = convertToRelative(targetPath, file, true, null);
-		} catch (CoreException e1) {
-			fail("2.0", e1);
-		}
+		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 		IPath resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace("3.0", file);
 		assertEquals("3.1", targetPath, resolvedPath);
 
-		try {
-			variableBasedLocation = convertToRelative(targetPath, file, true, null);
-		} catch (CoreException e1) {
-			fail("4.0", e1);
-		}
+		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 
 		resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
@@ -30,11 +30,7 @@ public class BenchCopyFile extends OldCorePerformanceTest {
 		}
 		startBench();
 		for (IFileStore element : output) {
-			try {
-				input.copy(element, EFS.NONE, null);
-			} catch (CoreException e) {
-				fail("4.99", e);
-			}
+			input.copy(element, EFS.NONE, null);
 		}
 		stopBench("copyFile", COUNT);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -14,7 +14,12 @@
 package org.eclipse.core.tests.resources.perf;
 
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -119,11 +124,7 @@ public class BenchWorkspace extends ResourceTest {
 			IResource[] resources = buildResources(project, defineHierarchy());
 			ensureExistsInWorkspace(resources, true);
 		};
-		try {
-			getWorkspace().run(runnable, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().run(runnable, null);
 	}
 
 	public void testCountResources() {
@@ -151,7 +152,7 @@ public class BenchWorkspace extends ResourceTest {
 		waitForBuild();
 	}
 
-	public void testCountResourcesDuringOperation() {
+	public void testCountResourcesDuringOperation() throws CoreException {
 		final Workspace workspace = (Workspace) getWorkspace();
 		IWorkspaceRunnable runnable = monitor -> {
 			//touch all files
@@ -166,11 +167,7 @@ public class BenchWorkspace extends ResourceTest {
 				}
 			}.run(BenchWorkspace.this, 10, 10);
 		};
-		try {
-			workspace.run(runnable, getMonitor());
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		workspace.run(runnable, getMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
@@ -15,7 +15,12 @@
 package org.eclipse.core.tests.resources.perf;
 
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
@@ -33,18 +38,17 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 	/**
 	 * Creates a project and fills it with contents
 	 */
-	void createAndPopulateProject(final IProject project, final IFolder folder, final int totalResources) {
-		try {
-			getWorkspace().run((IWorkspaceRunnable) monitor -> {
-				IProjectDescription desc = project.getWorkspace().newProjectDescription(project.getName());
-				desc.setBuildSpec(new ICommand[] {createCommand(desc, "Builder1"), createCommand(desc, "Builder2"), createCommand(desc, "Builder3"), createCommand(desc, "Builder4"), createCommand(desc, "Builder5")});
-				project.create(desc, getMonitor());
-				project.open(getMonitor());
-				createFolder(folder, totalResources);
-			}, getMonitor());
-		} catch (CoreException e) {
-			fail("Failed to create project in performance test", e);
-		}
+	void createAndPopulateProject(final IProject project, final IFolder folder, final int totalResources)
+			throws CoreException {
+		getWorkspace().run((IWorkspaceRunnable) monitor -> {
+			IProjectDescription desc = project.getWorkspace().newProjectDescription(project.getName());
+			desc.setBuildSpec(new ICommand[] { createCommand(desc, "Builder1"), createCommand(desc, "Builder2"),
+					createCommand(desc, "Builder3"), createCommand(desc, "Builder4"),
+					createCommand(desc, "Builder5") });
+			project.create(desc, getMonitor());
+			project.open(getMonitor());
+			createFolder(folder, totalResources);
+		}, getMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -72,15 +72,11 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		}
 	}
 
-	IWorkspaceDescription setMaxFileStates(String failureMessage, int maxFileStates) {
+	IWorkspaceDescription setMaxFileStates(int maxFileStates) throws CoreException {
 		IWorkspaceDescription currentDescription = getWorkspace().getDescription();
 		IWorkspaceDescription testDescription = getWorkspace().getDescription();
 		testDescription.setMaxFileStates(maxFileStates);
-		try {
-			getWorkspace().setDescription(testDescription);
-		} catch (CoreException e) {
-			fail(failureMessage, e);
-		}
+		getWorkspace().setDescription(testDescription);
 		return currentDescription;
 	}
 
@@ -90,8 +86,8 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		HistoryStoreTest.wipeHistoryStore(getMonitor());
 	}
 
-	public void testAddState() {
-		setMaxFileStates("0.01", 100);
+	public void testAddState() throws CoreException {
+		setMaxFileStates(100);
 		final IFile file = getWorkspace().getRoot().getProject("proj1").getFile("file.txt");
 		new PerformanceTestRunner() {
 
@@ -179,7 +175,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				original = setMaxFileStates("0.1", 1);
+				original = setMaxFileStates(1);
 				// make sure we start with no garbage
 				cleanHistory();
 				// create our own garbage
@@ -285,12 +281,8 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFile file = project.getFile("file.txt");
 		ensureExistsInWorkspace(file, getRandomContents());
-		try {
-			for (int i = 0; i < 100; i++) {
-				file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
-			}
-		} catch (CoreException ce) {
-			fail("0.5", ce);
+		for (int i = 0; i < 100; i++) {
+			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
 		}
 		new PerformanceTestRunner() {
 			@Override
@@ -313,7 +305,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				original = setMaxFileStates("0.1", 1);
+				original = setMaxFileStates(1);
 				// make sure we start with no garbage
 				cleanHistory();
 				// create our own garbage

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
@@ -96,11 +96,7 @@ public class MarkerPerformanceTest extends ResourceTest {
 			}
 		};
 
-		try {
-			getWorkspace().run(runnable, null);
-		} catch (CoreException e) {
-			fail("1.0", e);
-		}
+		getWorkspace().run(runnable, null);
 		markers = createdMarkers;
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -69,11 +69,8 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		final List<IResource> allResources = createTree(folder1, filesPerFolder);
 		for (IResource resource : allResources) {
 			for (int j = 0; j < properties; j++) {
-				try {
-					resource.setPersistentProperty(new QualifiedName(PI_RESOURCES_TESTS, "prop" + j), getPropertyValue(200));
-				} catch (CoreException ce) {
-					fail("0.2", ce);
-				}
+				resource.setPersistentProperty(new QualifiedName(PI_RESOURCES_TESTS, "prop" + j),
+						getPropertyValue(200));
 			}
 		}
 
@@ -91,11 +88,7 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 				}
 			}
 		}.run(this, measurements, repetitions);
-		try {
-			((Workspace) getWorkspace()).getPropertyManager().deleteProperties(folder1, IResource.DEPTH_INFINITE);
-		} catch (CoreException e) {
-			fail("0.1", e);
-		}
+		((Workspace) getWorkspace()).getPropertyManager().deleteProperties(folder1, IResource.DEPTH_INFINITE);
 
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
@@ -14,7 +14,9 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
@@ -37,10 +39,10 @@ public class TestBug316182 extends WorkspaceSessionTest {
 		CAUGHT_EXCEPTION = null;
 	}
 
-	public void test02_startWorkspace() {
+	public void test02_startWorkspace() throws Exception {
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
 		if (CAUGHT_EXCEPTION != null) {
-			fail("Test failed", CAUGHT_EXCEPTION);
+			throw CAUGHT_EXCEPTION;
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -41,16 +41,12 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	 * Returns true if this project's build spec has the given builder,
 	 * and false otherwise.
 	 */
-	protected boolean hasBuilder(IProject project, String builderId) {
-		try {
-			ICommand[] commands = project.getDescription().getBuildSpec();
-			for (ICommand command : commands) {
-				if (command.getBuilderName().equals(builderId)) {
-					return true;
-				}
+	protected boolean hasBuilder(IProject project, String builderId) throws CoreException {
+		ICommand[] commands = project.getDescription().getBuildSpec();
+		for (ICommand command : commands) {
+			if (command.getBuilderName().equals(builderId)) {
+				return true;
 			}
-		} catch (CoreException e) {
-			fail("Failed in hasBuilder(" + project.getName() + ", " + builderId + ")", e);
 		}
 		return false;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -38,45 +40,29 @@ public class HistoryStorePerformanceTest extends ResourceTest {
 		super.tearDown();
 	}
 
-	public void testPerformance() {
+	public void testPerformance() throws CoreException {
 
 		/* Create common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("file.txt");
-		try {
-			file.create(null, true, null);
-		} catch (CoreException e) {
-			fail("0.0", e);
-		}
+		file.create(null, true, null);
 		String contents = "fixed contents for performance test";
 
 		int nTimes = 1000;
 		long startTime = System.currentTimeMillis();
 		for (int i = 0; i < nTimes; i++) {
-			try {
-				file.setContents(getContents(contents), true, true, null);
-			} catch (CoreException e) {
-				fail("1.0", e);
-			}
+			file.setContents(getContents(contents), true, true, null);
 		}
 		long endTime = System.currentTimeMillis();
 		System.out.println("Adding " + nTimes + " states: " + (endTime - startTime) + " milliseconds.");
 
 		startTime = System.currentTimeMillis();
-		try {
-			file.getHistory(null);
-		} catch (CoreException e) {
-			fail("2.0", e);
-		}
+		file.getHistory(null);
 		endTime = System.currentTimeMillis();
 		System.out.println("Retrieving " + nTimes + " states: " + (endTime - startTime) + " milliseconds.");
 
 		startTime = System.currentTimeMillis();
-		try {
-			file.clearHistory(null);
-		} catch (CoreException e) {
-			fail("3.0", e);
-		}
+		file.clearHistory(null);
 		endTime = System.currentTimeMillis();
 		System.out.println("Removing " + nTimes + " states: " + (endTime - startTime) + " milliseconds.");
 	}


### PR DESCRIPTION
* Removes unnecessary try-catch blocks or replaces them with assertThrows statements
* Throw exceptions instead of calling fail()
* Remove unnecessary cleanup functionality

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903