### PR TITLE
Simplify test functionality for creating resource hierarchies #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -44,11 +44,6 @@ import org.junit.Test;
 
 public class FileSystemResourceManagerTest extends LocalStoreTest implements ICoreConstants {
 
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/Folder1/", "/Folder1/File1", "/Folder1/Folder2/", "/Folder1/Folder2/File2", "/Folder1/Folder2/Folder3/"};
-	}
-
 	@Test
 	public void testBug440110() throws Exception {
 		String projectName = getUniqueString();
@@ -168,7 +163,8 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		final IProject project = projects[0];
 
 		// create resources
-		IResource[] resources = buildResources(project, defineHierarchy());
+		IResource[] resources = buildResources(project, new String[] { "/Folder1/", "/Folder1/File1",
+				"/Folder1/Folder2/", "/Folder1/Folder2/File2", "/Folder1/Folder2/Folder3/" });
 		ensureExistsInWorkspace(resources, true);
 		ensureDoesNotExistInFileSystem(resources);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -30,11 +30,6 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		assertTrue(existsInFileSystemWithNoContent(target));
 	}
 
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/File1", "/Folder1/", "/Folder1/File1", "/Folder1/Folder2/"};
-	}
-
 	private boolean existsInFileSystemWithNoContent(IResource resource) {
 		IPath path = resource.getLocation();
 		return path.toFile().exists() && path.toFile().length() == 0;
@@ -48,7 +43,8 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		TestingSupport.waitForSnapshot();
 
 		// create resources
-		IResource[] resources = buildResources(project, defineHierarchy());
+		IResource[] resources = buildResources(project,
+				new String[] { "/File1", "/Folder1/", "/Folder1/File1", "/Folder1/Folder2/" });
 		ensureExistsInWorkspace(resources, true);
 
 		// delete project's default directory

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -42,11 +42,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MoveTest extends LocalStoreTest {
 
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "/file1", "/file2", "/folder1/", "/folder1/file3", "/folder1/file4", "/folder2/", "/folder2/file5", "/folder2/file6", "/folder1/folder3/", "/folder1/folder3/file7", "/folder1/folder3/file8"};
-	}
-
 	/**
 	 * This test has Windows as the target OS. Drives C: and D: should be available.
 	 */
@@ -266,7 +261,9 @@ public class MoveTest extends LocalStoreTest {
 		ensureExistsInWorkspace(folderSource, true);
 
 		// create hierarchy
-		String[] hierarchy = defineHierarchy();
+		String[] hierarchy = new String[] { "/", "/file1", "/file2", "/folder1/", "/folder1/file3",
+				"/folder1/file4", "/folder2/", "/folder2/file5", "/folder2/file6", "/folder1/folder3/",
+				"/folder1/folder3/file7", "/folder1/folder3/file8" };
 		IResource[] resources = buildResources(folderSource, hierarchy);
 		ensureExistsInWorkspace(resources, true);
 
@@ -337,7 +334,9 @@ public class MoveTest extends LocalStoreTest {
 		ensureExistsInWorkspace(folderSource, true);
 
 		// build hierarchy
-		String[] hierarchy = defineHierarchy();
+		String[] hierarchy = new String[] { "/", "/file1", "/file2", "/folder1/", "/folder1/file3", "/folder1/file4",
+				"/folder2/", "/folder2/file5", "/folder2/file6", "/folder1/folder3/", "/folder1/folder3/file7",
+				"/folder1/folder3/file8" };
 		IResource[] resources = buildResources(folderSource, hierarchy);
 		ensureExistsInWorkspace(resources, true);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -63,15 +63,6 @@ public class ISynchronizerTest extends ResourceTest {
 		}
 	}
 
-	/**
-	 * Return a string array which defines the hierarchy of a tree.
-	 * Folder resources must have a trailing slash.
-	 */
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/"};
-	}
-
 	/*
 	 * Internal method used for flushing all sync information for a particular resource
 	 * and its children.
@@ -96,7 +87,9 @@ public class ISynchronizerTest extends ResourceTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		resources = createHierarchy();
+		resources = buildResources(getWorkspace().getRoot(),
+				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
+		ensureExistsInWorkspace(resources, true);
 	}
 
 	@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -58,9 +58,13 @@ import org.osgi.framework.ServiceReference;
 
 public class IWorkspaceTest extends ResourceTest {
 
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "/Project/", "/Project/Folder/", "/Project/Folder/File",};
+	private IResource[] buildResourceHierarchy() throws CoreException {
+		return buildResources(getWorkspace().getRoot(),
+				new String[] { "/", "/Project/", "/Project/Folder/", "/Project/Folder/File", });
+	}
+
+	private void ensureResourceHierarchyExist() throws CoreException {
+		ensureExistsInWorkspace(buildResourceHierarchy(), true);
 	}
 
 	/**
@@ -96,7 +100,7 @@ public class IWorkspaceTest extends ResourceTest {
 	 * See also testMultiCopy()
 	 */
 	public void testCopy() throws CoreException {
-		IResource[] resources = buildResources();
+		IResource[] resources = buildResourceHierarchy();
 		IProject project = (IProject) resources[1];
 		IFolder folder = (IFolder) resources[2];
 		IFile file = (IFile) resources[3];
@@ -113,7 +117,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertThrows(CoreException.class,
 				() -> getWorkspace().copy(new IResource[] { file }, folder.getFullPath(), false, getMonitor()));
 
-		createHierarchy();
+		ensureResourceHierarchyExist();
 
 		//copy to bogus destination
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file },
@@ -212,7 +216,7 @@ public class IWorkspaceTest extends ResourceTest {
 	 * 		IStatus delete([IResource, boolean, IProgressMonitor)
 	 */
 	public void testDelete() throws CoreException {
-		IResource[] resources = buildResources();
+		IResource[] resources = buildResourceHierarchy();
 		IProject project = (IProject) resources[1];
 		IFolder folder = (IFolder) resources[2];
 		IFile file = (IFile) resources[3];
@@ -221,14 +225,14 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(new IResource[] {project, folder, file}, false, getMonitor()).isOK());
 		assertTrue(getWorkspace().delete(new IResource[] {file}, false, getMonitor()).isOK());
 		assertTrue(getWorkspace().delete(new IResource[] {}, false, getMonitor()).isOK());
-		createHierarchy();
+		ensureResourceHierarchyExist();
 
 		//delete existing resources
 		resources = new IResource[] {file, project, folder};
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		createHierarchy();
+		ensureResourceHierarchyExist();
 		resources = new IResource[] {file};
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
@@ -238,7 +242,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		createHierarchy();
+		ensureResourceHierarchyExist();
 
 		//delete a combination of existing and non-existent resources
 		IProject fakeProject = getWorkspace().getRoot().getProject("pigment");
@@ -247,7 +251,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		createHierarchy();
+		ensureResourceHierarchyExist();
 		resources = new IResource[] {fakeProject, file};
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
@@ -257,7 +261,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		createHierarchy();
+		ensureResourceHierarchyExist();
 	}
 
 	/**
@@ -542,7 +546,7 @@ public class IWorkspaceTest extends ResourceTest {
 	 */
 	public void testMultiCopy() throws CoreException {
 		/* create common objects */
-		IResource[] resources = buildResources();
+		IResource[] resources = buildResourceHierarchy();
 		IProject project = (IProject) resources[1];
 		IFolder folder = (IFolder) resources[2];
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -170,19 +170,12 @@ public class MarkerTest extends ResourceTest {
 		marker.setAttribute(IMarker.SEVERITY, severity);
 	}
 
-	/**
-	 * Return a string array which defines the hierarchy of a tree.
-	 * Folder resources must have a trailing slash.
-	 */
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/"};
-	}
-
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		resources = createHierarchy();
+		resources = buildResources(getWorkspace().getRoot(),
+				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
+		ensureExistsInWorkspace(resources, true);
 
 		// disable autorefresh an wait till that is finished
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -235,7 +235,6 @@ public class ProjectEncodingTest extends ResourceTest {
 	}
 
 	private void buildAndWaitForBuildFinish() {
-		buildResources();
 		waitForBuild();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -266,17 +266,10 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Return a collection of resources the hierarchy defined by defineHeirarchy().
-	 */
-	public IResource[] buildResources() {
-		return buildResources(getWorkspace().getRoot(), defineHierarchy());
-	}
-
-	/**
 	 * Return a collection of resources for the given hierarchy at
 	 * the given root.
 	 */
-	public IResource[] buildResources(IContainer root, String[] hierarchy) {
+	public IResource[] buildResources(IContainer root, String[] hierarchy) throws CoreException {
 		IResource[] result = new IResource[hierarchy.length];
 		for (int i = 0; i < hierarchy.length; i++) {
 			IPath path = IPath.fromOSString(hierarchy[i]);
@@ -423,27 +416,6 @@ public abstract class ResourceTest extends CoreTest {
 			throw new CoreException(
 					new Status(IStatus.ERROR, PI_RESOURCES_TESTS, "failed creating file in file system", e));
 		}
-	}
-
-	public IResource[] createHierarchy() throws CoreException {
-		IResource[] result = buildResources();
-		ensureExistsInWorkspace(result, true);
-		return result;
-	}
-
-	/**
-	 * Returns a collection of string paths describing the standard
-	 * resource hierarchy for this test.  In the string forms, folders are
-	 * represented as having trailing separators ('/').  All other resources
-	 * are files.  It is generally assumed that this hierarchy will be
-	 * inserted under some project structure.
-	 * For example,
-	 * <pre>
-	 *    return new String[] {"/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1"};
-	 * </pre>
-	 */
-	public String[] defineHierarchy() {
-		return new String[0];
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -32,6 +32,9 @@ import org.eclipse.core.runtime.Platform;
  * Test suites for {@link org.eclipse.core.internal.resources.PlatformURLResourceConnection}
  */
 public class ResourceURLTest extends ResourceTest {
+	private final String[] resourcePaths = new String[] { "/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2",
+			"/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5" };
+
 	private static final String CONTENT = "content";
 	protected static IPath[] interestingPaths;
 	protected static IResource[] interestingResources;
@@ -56,18 +59,6 @@ public class ResourceURLTest extends ResourceTest {
 		assertEquals(metric, file);
 	}
 
-	/**
-	 * Returns a collection of string paths describing the standard
-	 * resource hierarchy for this test.  In the string forms, folders are
-	 * represented as having trailing separators ('/').  All other resources
-	 * are files.  It is generally assumed that this hierarchy will be
-	 * inserted under some solution and project structure.
-	 */
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2", "/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5"};
-	}
-
 	protected IProject getTestProject() {
 		return getWorkspace().getRoot().getProject("testProject");
 	}
@@ -85,7 +76,7 @@ public class ResourceURLTest extends ResourceTest {
 	}
 
 	public void testBasicURLs() throws Throwable {
-		IResource[] resources = buildResources();
+		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
 		ensureExistsInWorkspace(resources, true);
 		for (IResource resource : resources) {
 			checkURL(resource);
@@ -98,7 +89,7 @@ public class ResourceURLTest extends ResourceTest {
 		desc.setLocation(Platform.getLocation().append("../testproject"));
 		project.create(desc, null);
 		project.open(null);
-		IResource[] resources = buildResources(project, defineHierarchy());
+		IResource[] resources = buildResources(project, resourcePaths);
 		ensureExistsInWorkspace(resources, true);
 		for (IResource resource : resources) {
 			checkURL(resource);
@@ -106,7 +97,7 @@ public class ResourceURLTest extends ResourceTest {
 	}
 
 	public void testNonExistantURLs() throws Throwable {
-		IResource[] resources = buildResources();
+		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
 		for (int i = 1; i < resources.length; i++) {
 			final int index = i;
 			assertThrows(IOException.class, () -> checkURL(resources[index]));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -37,18 +37,6 @@ import org.eclipse.core.tests.harness.FussyProgressMonitor;
  * solution, project, folder and file.
  */
 public class WorkspaceTest extends ResourceTest {
-	/**
-	 * Returns a collection of string paths describing the standard
-	 * resource hierarchy for this test.  In the string forms, folders are
-	 * represented as having trailing separators ('/').  All other resources
-	 * are files.  It is generally assumed that this hierarchy will be
-	 * inserted under some solution and project structure.
-	 */
-	@Override
-	public String[] defineHierarchy() {
-		return new String[] {"/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2", "/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5"};
-	}
-
 	protected IProject getTestProject() {
 		return getWorkspace().getRoot().getProject("testProject");
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -47,7 +47,6 @@ public class BenchWorkspace extends ResourceTest {
 		}
 	}
 
-	@Override
 	public String[] defineHierarchy() {
 		//define a hierarchy with NUM_FOLDERS folders, NUM_FILES files.
 		String[] names = new String[NUM_FOLDERS * (FILES_PER_FOLDER + 1)];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -40,18 +41,18 @@ public class Bug_029851 extends ResourceTest {
 		return result;
 	}
 
-	@Override
-	public String[] defineHierarchy() {
+	private void createResourceHierarchy() throws CoreException {
 		int depth = 3;
 		int breadth = 3;
 		IPath prefix = IPath.fromOSString("/a/");
 		Collection<String> result = createChildren(breadth, depth, prefix);
 		result.add(prefix.toString());
-		return result.toArray(new String[0]);
+		IResource[] resources = buildResources(getWorkspace().getRoot(), result.toArray(new String[0]));
+		ensureExistsInWorkspace(resources, true);
 	}
 
 	public void test() throws CoreException {
-		createHierarchy();
+		createResourceHierarchy();
 		final QualifiedName key = new QualifiedName("local", getUniqueString());
 		final String value = getUniqueString();
 		IResourceVisitor visitor = resource -> {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -35,13 +35,9 @@ import org.eclipse.core.tests.resources.ResourceTest;
  */
 public class Bug_303517 extends ResourceTest {
 
-	String[] resources = new String[] {"/", "/Bug303517/", "/Bug303517/Folder/", "/Bug303517/Folder/Resource",};
+	private final String[] resourcePaths = new String[] { "/", "/Bug303517/", "/Bug303517/Folder/",
+			"/Bug303517/Folder/Resource", };
 	private boolean originalRefreshSetting;
-
-	@Override
-	public String[] defineHierarchy() {
-		return resources;
-	}
 
 	@Override
 	protected void setUp() throws Exception {
@@ -50,6 +46,8 @@ public class Bug_303517 extends ResourceTest {
 		originalRefreshSetting = prefs.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
 		prefs.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
+		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
+		ensureExistsInWorkspace(resources, true);
 	}
 
 	@Override
@@ -64,8 +62,7 @@ public class Bug_303517 extends ResourceTest {
 	 * Tests that file deleted is updated after #getContents
 	 */
 	public void testExists() throws Exception {
-		createHierarchy();
-		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resources[resources.length - 1]));
+		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
 		assertTrue("1.1", f.isSynchronized(IResource.DEPTH_ONE));
 
@@ -89,8 +86,7 @@ public class Bug_303517 extends ResourceTest {
 	 * Tests that file discovered out-of-sync during #getContents is updated
 	 */
 	public void testGetContents() throws Exception {
-		createHierarchy();
-		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resources[resources.length - 1]));
+		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
 		assertTrue("1.1", f.isSynchronized(IResource.DEPTH_ONE));
 
@@ -116,8 +112,7 @@ public class Bug_303517 extends ResourceTest {
 	 * Tests that file discovered out-of-sync during #getContents is updated
 	 */
 	public void testGetContentsTrue() throws Exception {
-		createHierarchy();
-		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resources[resources.length - 1]));
+		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
 		assertTrue("1.1", f.isSynchronized(IResource.DEPTH_ONE));
 
@@ -148,8 +143,7 @@ public class Bug_303517 extends ResourceTest {
 	 * Tests that resource discovered out-of-sync during #isSynchronized is updated
 	 */
 	public void testIsSynchronized() throws Exception {
-		createHierarchy();
-		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resources[resources.length - 1]));
+		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
 		assertTrue("1.1", f.isSynchronized(IResource.DEPTH_ONE));
 
@@ -169,8 +163,7 @@ public class Bug_303517 extends ResourceTest {
 	 * Tests that when changing resource gender is correctly picked up.
 	 */
 	public void testChangeResourceGender() throws Exception {
-		createHierarchy();
-		IResource f = getWorkspace().getRoot().getFile(IPath.fromOSString(resources[resources.length - 1]));
+		IResource f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
 		assertTrue("1.1", f.isSynchronized(IResource.DEPTH_ONE));
 
@@ -193,7 +186,7 @@ public class Bug_303517 extends ResourceTest {
 		assertFalse("1.3", f.exists());
 		assertFalse("1.4", f.isSynchronized(IResource.DEPTH_ONE));
 		// Folder + child are now in-sync
-		f = getWorkspace().getRoot().getFolder(IPath.fromOSString(resources[resources.length - 1]));
+		f = getWorkspace().getRoot().getFolder(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.5", f.exists());
 		assertTrue("1.6", f.isSynchronized(IResource.DEPTH_INFINITE));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
@@ -41,8 +41,6 @@ public class ConcurrencyTest extends ResourceTest {
 		project.create(null);
 		project.open(null);
 
-		buildResources(project, defineHierarchy());
-
 		ConcurrentOperation01 op1 = new ConcurrentOperation01(getWorkspace());
 		ConcurrentOperation01 op2 = new ConcurrentOperation01(getWorkspace());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -17,12 +17,13 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 
 /**
  * Only verifies previous session.
  */
 public class Snapshot5Test extends SnapshotTest {
-	public void testVerifyPreviousSession() {
+	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
 		assertTrue("0.0", project.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
@@ -84,7 +84,7 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		test.testChangeProject2();
 	}
 
-	public void test5() {
+	public void test5() throws CoreException {
 		if (skipTest()) {
 			return;
 		}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -13,11 +13,23 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.tests.resources.ResourceTest;
 
 import junit.framework.Test;
@@ -103,15 +115,6 @@ public class WorkspaceTest extends ResourceTest {
 				((IFile) r).setContents(getRandomContents(100), true, false, null);
 			}
 		}
-		return result;
-	}
-	public IResource[] buildEmptyResources(IContainer container, String[] hierarchy, boolean includeContainer) throws CoreException {
-		List<IResource> resources = new ArrayList<>(hierarchy.length + 1);
-		resources.addAll(Arrays.asList(buildResources(container, hierarchy)));
-		if (includeContainer)
-			resources.add(container);
-		IResource[] result = resources.toArray(new IResource[resources.size()]);
-		ensureExistsInWorkspace(result, true);
 		return result;
 	}
 	/**


### PR DESCRIPTION
The ResourceTest class provides several functions for defining and creating a hierarchy of resources encoded into a string array. This functionality is hard to understand as it uses a default factory method in the ResourceTest class that may be called by a template method in ResourceTest and may be overwritten in subclasses. In addition, the functionality is not used very often.

This change streamlines the functionality for creating resource hierarchies. It makes the creation explicit where it is required by inlining the string definitions where possible or implementing the hierarchy creation in the actual test class rather than relying on the template method in the ResourceTest superclass. This makes the tests more independent from their JUnit 3-specific type hierarchy.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903