### PR TITLE
Move utility method ResourceTest#setBuildOrder() to only consumers #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -15,7 +15,13 @@
 package org.eclipse.core.tests.internal.builders;
 
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import java.util.stream.Stream;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -63,6 +69,16 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	 */
 	protected void dirty(IFile file) throws CoreException {
 		file.setContents(getRandomContents(), true, true, getMonitor());
+	}
+
+	/**
+	 * Sets the workspace build order to just contain the given projects.
+	 */
+	protected void setBuildOrder(IProject... projects) throws CoreException {
+		IWorkspace workspace = getWorkspace();
+		IWorkspaceDescription desc = workspace.getDescription();
+		desc.setBuildOrder(Stream.of(projects).map(IProject::getName).toArray(String[]::new));
+		workspace.setDescription(desc);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -34,7 +34,6 @@ import java.nio.file.attribute.FileTime;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -938,16 +937,6 @@ public abstract class ResourceTest extends CoreTest {
 			workspace.setDescription(description);
 		}
 		waitForBuild();
-	}
-
-	/**
-	 * Sets the workspace build order to just contain the given projects.
-	 */
-	protected void setBuildOrder(IProject... projects) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setBuildOrder(Stream.of(projects).map(IProject::getName).toArray(String[]::new));
-		workspace.setDescription(desc);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -23,6 +23,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
@@ -66,7 +67,10 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 		unsortedFile1.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);
 		unsortedFile2.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);
 
-		setBuildOrder(project1, project2);
+		// set build order
+		IWorkspaceDescription workspaceDescription = workspace.getDescription();
+		workspaceDescription.setBuildOrder(new String[] { project1.getName(), project2.getName() });
+		workspace.setDescription(workspaceDescription);
 		setAutoBuilding(false);
 
 		// configure builder for project1


### PR DESCRIPTION
The method ResourceTest#setBuildOrder() has two consuming paths in the inheritance hierarchy, one concrete test class and one abstract test class that is lower in the type hierarchy. This change pushes down the utility method to clean up the REsourceTest inheritance hierarchy.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903