### PR TITLE
Remove ResourceTest#isCaseSensitive #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -204,7 +205,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		assertResources("4.1", nonExisting, result);
 
 		//existing file with different case
-		if (!isCaseSensitive(existing)) {
+		if (!Workspace.caseSensitive) {
 			IPath differentCase = IPath.fromOSString(existingFileLocation.toOSString().toUpperCase());
 			result = root.findFilesForLocation(differentCase);
 			assertResources("5.0", existing, result);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -625,7 +625,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 		ThrowingRunnable linkCreation = () -> link.createLink(localFolder, IResource.NONE, getMonitor());
 		// should fail on case insensitive platforms
-		if (isCaseSensitive(variant)) {
+		if (Workspace.caseSensitive) {
 			linkCreation.run();
 		} else {
 			assertThrows(CoreException.class, linkCreation);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -105,15 +105,6 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Returns whether the file system in which the provided resource
-	 * is stored is case sensitive. This succeeds whether or not the resource
-	 * exists.
-	 */
-	protected static boolean isCaseSensitive(IResource resource) {
-		return ((Resource) resource).getStore().getFileSystem().isCaseSensitive();
-	}
-
-	/**
 	 * Convenience method to copy contents from one stream to another.
 	 */
 	public static void transferStreams(InputStream source, OutputStream destination, String path) throws IOException {


### PR DESCRIPTION
Removes the obsolete utility method isCaseSensitive() in ResourceTest. For the only two consumers of that method, the information given by Workspace#caseSensitive is sufficient.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903