### PR TITLE
Remove ResourceTest#assert*(String, ...) methods #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -139,13 +139,13 @@ public class SaveManager1Test extends SaveManagerTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_1));
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("3.1", resources);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		project.close(null);
 		project.open(null);
-		assertExistsInFileSystem("4.1", resources);
-		assertExistsInWorkspace("4.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		getWorkspace().save(true, null);
 	}
@@ -202,13 +202,13 @@ public class SaveManager1Test extends SaveManagerTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_1));
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("3.1", resources);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		project.close(null);
 		project.open(null);
-		assertExistsInFileSystem("4.1", resources);
-		assertExistsInWorkspace("4.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 
 	/**
@@ -224,8 +224,8 @@ public class SaveManager1Test extends SaveManagerTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_2));
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("3.1", resources);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// add a builder to this project
 		IProjectDescription description = project.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -108,14 +108,14 @@ public class SaveManager2Test extends SaveManagerTest {
 
 		// verify its children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_2));
-		assertExistsInFileSystem("1.0", resources);
-		assertDoesNotExistInWorkspace("1.1", resources);
+		assertExistsInFileSystem(resources);
+		assertDoesNotExistInWorkspace(resources);
 
 		project.open(null);
 		assertTrue("2.1", project.exists());
 		assertTrue("2.2", project.isOpen());
-		assertExistsInFileSystem("2.3", resources);
-		assertExistsInWorkspace("2.4", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// verify builder -- cause an incremental build
 		touch(project);
@@ -135,8 +135,8 @@ public class SaveManager2Test extends SaveManagerTest {
 
 		// verify children still exist
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_1));
-		assertExistsInFileSystem("1.0", resources);
-		assertExistsInWorkspace("1.1", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// add a file to test save participant delta
 		IFile file = project.getFile("addedFile");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -533,17 +533,17 @@ public class BasicAliasTest extends ResourceTest {
 		IFolder destFolder1 = fLinkOverlap1.getFolder(source.getName());
 		IFolder destFolder2 = fLinkOverlap2.getFolder(source.getName());
 		IResource[] allDest = new IResource[] {destFolder1, destFolder2};
-		assertDoesNotExistInWorkspace("1.0", allDest);
+		assertDoesNotExistInWorkspace(allDest);
 
 		//copy to dest 1
 		source.copy(destFolder1.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("1.2", allDest);
+		assertExistsInWorkspace(allDest);
 
 		destFolder2.delete(IResource.NONE, getMonitor());
 
 		//copy to dest 2
 		source.copy(destFolder2.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("1.5", allDest);
+		assertExistsInWorkspace(allDest);
 
 		destFolder1.delete(IResource.NONE, getMonitor());
 	}
@@ -786,9 +786,10 @@ public class BasicAliasTest extends ResourceTest {
 		//delete the overlapping project - it should delete the children of the linked folder
 		//but leave the actual links intact in the resource tree
 		pOverlap.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
-		assertDoesNotExistInWorkspace("1.1", new IResource[] {pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked});
-		assertDoesNotExistInFileSystem("1.2", new IResource[] {pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked, lLinked, fLinked});
-		assertExistsInWorkspace("1.3", new IResource[] {pLinked, fLinked, lLinked});
+		assertDoesNotExistInWorkspace(new IResource[] { pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked });
+		assertDoesNotExistInFileSystem(
+				new IResource[] { pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked, lLinked, fLinked });
+		assertExistsInWorkspace(new IResource[] { pLinked, fLinked, lLinked });
 	}
 
 	@Test
@@ -834,43 +835,43 @@ public class BasicAliasTest extends ResourceTest {
 		IFile destination = pNoOverlap.getFile("MoveDestination");
 		//file in linked folder
 		lChildLinked.move(destination.getFullPath(), IResource.NONE, getMonitor());
-		assertDoesNotExistInWorkspace("1.1", lChildLinked);
-		assertDoesNotExistInWorkspace("1.2", lChildOverlap);
-		assertExistsInWorkspace("1.3", destination);
+		assertDoesNotExistInWorkspace(lChildLinked);
+		assertDoesNotExistInWorkspace(lChildOverlap);
+		assertExistsInWorkspace(destination);
 		assertOverlap("1.4", lChildLinked, lChildOverlap);
 		assertTrue("1.5", lChildLinked.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("1.6", destination.isSynchronized(IResource.DEPTH_INFINITE));
 
 		destination.move(lChildLinked.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("2.1", lChildLinked);
-		assertExistsInWorkspace("2.2", lChildOverlap);
-		assertDoesNotExistInWorkspace("2.3", destination);
+		assertExistsInWorkspace(lChildLinked);
+		assertExistsInWorkspace(lChildOverlap);
+		assertDoesNotExistInWorkspace(destination);
 		assertOverlap("2.4", lChildLinked, lChildOverlap);
 		//duplicate file
 		lOverlap.move(destination.getFullPath(), IResource.NONE, getMonitor());
-		assertDoesNotExistInWorkspace("3.1", lOverlap);
-		assertExistsInWorkspace("3.2", lLinked);
-		assertDoesNotExistInFileSystem("3.25", lLinked);
-		assertExistsInWorkspace("3.3", destination);
+		assertDoesNotExistInWorkspace(lOverlap);
+		assertExistsInWorkspace(lLinked);
+		assertDoesNotExistInFileSystem(lLinked);
+		assertExistsInWorkspace(destination);
 		assertEquals("3.4", lLinked.getLocation(), lOverlap.getLocation());
 		assertTrue("3.4.1", lLinked.isSynchronized(IResource.DEPTH_INFINITE));
 
 		destination.move(lOverlap.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("3.5", lLinked);
-		assertExistsInWorkspace("3.6", lOverlap);
-		assertDoesNotExistInWorkspace("3.7", destination);
+		assertExistsInWorkspace(lLinked);
+		assertExistsInWorkspace(lOverlap);
+		assertDoesNotExistInWorkspace(destination);
 		assertOverlap("3.8", lLinked, lOverlap);
 		//file in duplicate folder
 		lChildOverlap.move(destination.getFullPath(), IResource.NONE, getMonitor());
-		assertDoesNotExistInWorkspace("3.1", lChildLinked);
-		assertDoesNotExistInWorkspace("3.2", lChildOverlap);
-		assertExistsInWorkspace("3.3", destination);
+		assertDoesNotExistInWorkspace(lChildLinked);
+		assertDoesNotExistInWorkspace(lChildOverlap);
+		assertExistsInWorkspace(destination);
 		assertOverlap("3.4", lChildLinked, lChildOverlap);
 
 		destination.move(lChildOverlap.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("3.5", lChildLinked);
-		assertExistsInWorkspace("3.6", lChildOverlap);
-		assertDoesNotExistInWorkspace("3.7", destination);
+		assertExistsInWorkspace(lChildLinked);
+		assertExistsInWorkspace(lChildOverlap);
+		assertDoesNotExistInWorkspace(destination);
 		assertOverlap("3.8", lChildLinked, lChildOverlap);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -90,10 +90,10 @@ public class MoveTest extends LocalStoreTest {
 
 		// assert file was moved
 		IFile newFile = destination.getFile(fileName);
-		assertDoesNotExistInWorkspace("4.1", file);
-		assertDoesNotExistInFileSystem("4.2", file);
-		assertExistsInWorkspace("4.3", newFile);
-		assertExistsInFileSystem("4.4", newFile);
+		assertDoesNotExistInWorkspace(file);
+		assertDoesNotExistInFileSystem(file);
+		assertExistsInWorkspace(newFile);
+		assertExistsInFileSystem(newFile);
 
 		// assert properties still exist (server, local and session)
 		for (int j = 0; j < numberOfProperties; j++) {
@@ -193,10 +193,10 @@ public class MoveTest extends LocalStoreTest {
 
 		// assert folder was renamed
 		IFolder newFolder = destination.getFolder(folderName);
-		assertDoesNotExistInWorkspace("4.1", folder);
-		assertDoesNotExistInFileSystem("4.2", folder);
-		assertExistsInWorkspace("4.3", newFolder);
-		assertExistsInFileSystem("4.4", newFolder);
+		assertDoesNotExistInWorkspace(folder);
+		assertDoesNotExistInFileSystem(folder);
+		assertExistsInWorkspace(newFolder);
+		assertExistsInFileSystem(newFolder);
 
 		// assert properties still exist (server, local and session)
 		for (int j = 0; j < numberOfProperties; j++) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -524,8 +524,8 @@ public class CharsetTest extends ResourceTest {
 			verifier.waitForEvent(10000);
 			IFile regularPrefs = getResourcesPreferenceFile(project1, false);
 			IFile derivedPrefs = getResourcesPreferenceFile(project1, true);
-			assertExistsInWorkspace("0.2", regularPrefs);
-			assertDoesNotExistInWorkspace("0.3", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertDoesNotExistInWorkspace(derivedPrefs);
 
 			//1 - setting preference on project
 			verifier.reset();
@@ -534,8 +534,8 @@ public class CharsetTest extends ResourceTest {
 			setDerivedEncodingStoredSeparately(project1, true);
 			assertTrue("1.1", verifier.waitForEvent(10000));
 			assertTrue("1.2 " + verifier.getMessage(), verifier.isDeltaValid());
-			assertExistsInWorkspace("1.3", regularPrefs);
-			assertDoesNotExistInWorkspace("1.4", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertDoesNotExistInWorkspace(derivedPrefs);
 			assertTrue("1.5", isDerivedEncodingStoredSeparately(project1));
 
 			//2 - changing charset for file
@@ -545,8 +545,8 @@ public class CharsetTest extends ResourceTest {
 			a.setCharset("UTF-8", getMonitor());
 			assertTrue("2.1", verifier.waitForEvent(10000));
 			assertTrue("2.2 " + verifier.getMessage(), verifier.isDeltaValid());
-			assertExistsInWorkspace("2.3", regularPrefs);
-			assertDoesNotExistInWorkspace("2.4", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertDoesNotExistInWorkspace(derivedPrefs);
 
 			//3 - setting derived == 'true' for file
 			// TODO update the test when bug 345271 is fixed
@@ -554,8 +554,8 @@ public class CharsetTest extends ResourceTest {
 			//wait for all resource deltas
 			// Thread.sleep(500);
 			waitForCharsetManagerJob();
-			assertExistsInWorkspace("3.1", regularPrefs);
-			assertExistsInWorkspace("3.2", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertExistsInWorkspace(derivedPrefs);
 			assertTrue("3.3", derivedPrefs.isDerived());
 
 			//4 - setting derived == 'false' for file
@@ -564,8 +564,8 @@ public class CharsetTest extends ResourceTest {
 			//wait for all resource deltas
 			// Thread.sleep(500);
 			waitForCharsetManagerJob();
-			assertExistsInWorkspace("4.1", regularPrefs);
-			assertDoesNotExistInWorkspace("4.2", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertDoesNotExistInWorkspace(derivedPrefs);
 
 			//5 - moving file to derived folder
 			IFile source = project1.getFolder("a1").getFile("a.txt");
@@ -578,10 +578,10 @@ public class CharsetTest extends ResourceTest {
 			waitForCharsetManagerJob();
 			assertTrue("5.1", backgroundVerifier.waitForAllDeltas(10000, 15000));
 			backgroundVerifier.assertExpectedDeltasWereReceived("5.2");
-			assertExistsInWorkspace("5.3", regularPrefs);
-			assertExistsInWorkspace("5.4", derivedPrefs);
-			assertDoesNotExistInWorkspace("5.5", source);
-			assertExistsInWorkspace("5.6", destination);
+			assertExistsInWorkspace(regularPrefs);
+			assertExistsInWorkspace(derivedPrefs);
+			assertDoesNotExistInWorkspace(source);
+			assertExistsInWorkspace(destination);
 			assertTrue("5.7", derivedPrefs.isDerived());
 			assertCharsetIs("5.8", "UTF-8", new IResource[] { a }, true);
 
@@ -595,8 +595,8 @@ public class CharsetTest extends ResourceTest {
 			assertTrue("6.1.2", backgroundVerifier.waitForFirstDelta(10000));
 			assertTrue("6.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
 			backgroundVerifier.assertExpectedDeltasWereReceived("6.2.2");
-			assertExistsInWorkspace("6.3", regularPrefs);
-			assertDoesNotExistInWorkspace("6.4", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertDoesNotExistInWorkspace(derivedPrefs);
 
 			//7 - setting preference on project with derived files
 			verifier.reset();
@@ -608,8 +608,8 @@ public class CharsetTest extends ResourceTest {
 			assertTrue("7.1.2", backgroundVerifier.waitForFirstDelta(10000));
 			assertTrue("7.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
 			backgroundVerifier.assertExpectedDeltasWereReceived("7.2.2");
-			assertExistsInWorkspace("7.3", regularPrefs);
-			assertExistsInWorkspace("7.4", derivedPrefs);
+			assertExistsInWorkspace(regularPrefs);
+			assertExistsInWorkspace(derivedPrefs);
 			assertTrue("7.5", isDerivedEncodingStoredSeparately(project1));
 			assertTrue("7.6", derivedPrefs.isDerived());
 
@@ -846,7 +846,7 @@ public class CharsetTest extends ResourceTest {
 			// now reopen the project and ensure the settings were not forgotten
 			IProject projectB = workspace.getRoot().getProject(project.getName());
 			projectB.open(null);
-			assertExistsInWorkspace("0.9", getResourcesPreferenceFile(projectB, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(projectB, false));
 			assertEquals("1.0", "FOO", projectB.getDefaultCharset());
 			assertEquals("3.0", "FRED", projectB.getFile("file1.txt").getCharset());
 			assertEquals("2.0", "BAR", projectB.getFolder("folder").getDefaultCharset());
@@ -1255,19 +1255,19 @@ public class CharsetTest extends ResourceTest {
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2}, true);
-			assertExistsInWorkspace("1.0", getResourcesPreferenceFile(project, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			project.setDefaultCharset("FOO", getMonitor());
-			assertExistsInWorkspace("2.0", getResourcesPreferenceFile(project, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			project.setDefaultCharset(null, getMonitor());
-			assertDoesNotExistInWorkspace("3.0", getResourcesPreferenceFile(project, false));
+			assertDoesNotExistInWorkspace(getResourcesPreferenceFile(project, false));
 			file1.setCharset("FRED", getMonitor());
-			assertExistsInWorkspace("4.0", getResourcesPreferenceFile(project, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			folder.setDefaultCharset("BAR", getMonitor());
-			assertExistsInWorkspace("5.0", getResourcesPreferenceFile(project, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			file1.setCharset(null, getMonitor());
-			assertExistsInWorkspace("6.0", getResourcesPreferenceFile(project, false));
+			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			folder.setDefaultCharset(null, getMonitor());
-			assertDoesNotExistInWorkspace("7.0", getResourcesPreferenceFile(project, false));
+			assertDoesNotExistInWorkspace(getResourcesPreferenceFile(project, false));
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -1370,7 +1370,7 @@ public class CharsetTest extends ResourceTest {
 			ensureExistsInWorkspace(project, true);
 			project.setDefaultCharset("FOO", getMonitor());
 			IFile file = project.getFile("file.xml");
-			assertDoesNotExistInWorkspace("2.0", file);
+			assertDoesNotExistInWorkspace(file);
 			assertEquals("2.2", "FOO", file.getCharset());
 			e = assertThrows(CoreException.class, () -> file.setCharset("BAR", getMonitor()));
 			assertEquals("file should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
@@ -1378,7 +1378,7 @@ public class CharsetTest extends ResourceTest {
 			file.setCharset("BAR", getMonitor());
 			assertEquals("2.8", "BAR", file.getCharset());
 			file.delete(IResource.NONE, null);
-			assertDoesNotExistInWorkspace("2.10", file);
+			assertDoesNotExistInWorkspace(file);
 			assertEquals("2.11", "FOO", file.getCharset());
 		} finally {
 			clearAllEncodings(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -15,7 +15,16 @@ package org.eclipse.core.tests.resources;
 
 import static org.junit.Assert.assertThrows;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 
 public class HiddenResourceTest extends ResourceTest {
@@ -260,8 +269,8 @@ public class HiddenResourceTest extends ResourceTest {
 		// copy the project
 		int flags = IResource.FORCE;
 		project.copy(destProject.getFullPath(), flags, getMonitor());
-		assertExistsInWorkspace("1.2", resources);
-		assertExistsInWorkspace("1.3", destResources);
+		assertExistsInWorkspace(resources);
+		assertExistsInWorkspace(destResources);
 
 		// do it again and but just copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
@@ -269,8 +278,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.copy(destFolder.getFullPath(), flags, getMonitor());
-		assertExistsInWorkspace("2.2", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("2.3", new IResource[] {destFolder, destSubFile});
+		assertExistsInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
 		// set all the resources to be hidden
 		// copy the project
@@ -278,8 +287,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, getMonitor());
-		assertExistsInWorkspace("3.2", resources);
-		assertExistsInWorkspace("3.3", destResources);
+		assertExistsInWorkspace(resources);
+		assertExistsInWorkspace(destResources);
 
 		// do it again but only copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
@@ -287,8 +296,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.copy(destFolder.getFullPath(), flags, getMonitor());
-		assertExistsInWorkspace("4.2", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("4.3", new IResource[] {destFolder, destSubFile});
+		assertExistsInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
 	public void testMove() throws CoreException {
@@ -313,8 +322,8 @@ public class HiddenResourceTest extends ResourceTest {
 		// move the project
 		int flags = IResource.FORCE;
 		project.move(destProject.getFullPath(), flags, getMonitor());
-		assertDoesNotExistInWorkspace("1.2", resources);
-		assertExistsInWorkspace("1.3", destResources);
+		assertDoesNotExistInWorkspace(resources);
+		assertExistsInWorkspace(destResources);
 
 		// do it again and but just move the folder
 		ensureDoesNotExistInWorkspace(destResources);
@@ -322,8 +331,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.move(destFolder.getFullPath(), flags, getMonitor());
-		assertDoesNotExistInWorkspace("2.2", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("2.3", new IResource[] {destFolder, destSubFile});
+		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
 		// set all the resources to be hidden
 		// move the project
@@ -331,8 +340,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, getMonitor());
-		assertDoesNotExistInWorkspace("3.2", resources);
-		assertExistsInWorkspace("3.3", destResources);
+		assertDoesNotExistInWorkspace(resources);
+		assertExistsInWorkspace(destResources);
 
 		// do it again but only move the folder
 		ensureDoesNotExistInWorkspace(destResources);
@@ -340,8 +349,8 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.move(destFolder.getFullPath(), flags, getMonitor());
-		assertDoesNotExistInWorkspace("4.2", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("4.3", new IResource[] {destFolder, destSubFile});
+		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
 	public void testDelete() throws CoreException {
@@ -357,49 +366,49 @@ public class HiddenResourceTest extends ResourceTest {
 		int flags = IResource.ALWAYS_DELETE_PROJECT_CONTENT | IResource.FORCE;
 		// delete the project
 		project.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("1.1", resources);
+		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
 		file.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("1.3", file);
-		assertExistsInWorkspace("1.4", new IResource[] {project, folder, subFile});
+		assertDoesNotExistInWorkspace(file);
+		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		folder.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("1.6", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("1.7", new IResource[] {project, file});
+		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set one child to be hidden
 		ensureExistsInWorkspace(resources, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
 		project.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("2.2", resources);
+		assertDoesNotExistInWorkspace(resources);
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("2.5", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("2.6", new IResource[] {project, file});
+		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set all resources to be hidden
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
 		project.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("3.2", resources);
+		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		file.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("3.5", file);
-		assertExistsInWorkspace("3.6", new IResource[] {project, folder, subFile});
+		assertDoesNotExistInWorkspace(file);
+		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.delete(flags, getMonitor());
-		assertDoesNotExistInWorkspace("3.9", new IResource[] {folder, subFile});
-		assertExistsInWorkspace("3.10", new IResource[] {project, file});
+		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
+		assertExistsInWorkspace(new IResource[] { project, file });
 	}
 
 	public void testDeltas() throws CoreException {
@@ -501,17 +510,17 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 
 		// check to see if all the resources exist in the workspace tree.
-		assertExistsInWorkspace("1.0", resources);
+		assertExistsInWorkspace(resources);
 
 		// set a folder to be hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		assertHidden(folder, true, IResource.DEPTH_ZERO);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInWorkspace(resources);
 
 		// set all resources to be hidden
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		assertHidden(project, true, IResource.DEPTH_INFINITE);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInWorkspace(resources);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -571,8 +571,8 @@ public class IFileTest extends ResourceTest {
 		monitor.prepare();
 		assertThrows(CoreException.class, () -> fileFromStream.create(content, false, monitor));
 		monitor.assertUsedUp();
-		assertDoesNotExistInWorkspace("6.2", fileFromStream);
-		assertDoesNotExistInFileSystem("6.3", fileFromStream);
+		assertDoesNotExistInWorkspace(fileFromStream);
+		assertDoesNotExistInFileSystem(fileFromStream);
 
 		// cleanup
 		folder = projects[0].getFolder("folder1");
@@ -612,8 +612,8 @@ public class IFileTest extends ResourceTest {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		assertThrows(OperationCanceledException.class, () -> target.create(content, false, monitor));
 		monitor.assertUsedUp();
-		assertDoesNotExistInWorkspace("3.0", target);
-		assertDoesNotExistInFileSystem("4.0", target);
+		assertDoesNotExistInWorkspace(target);
+		assertDoesNotExistInFileSystem(target);
 	}
 
 	@Test
@@ -797,8 +797,8 @@ public class IFileTest extends ResourceTest {
 			assertThrows(CoreException.class, () -> target.setContents(content, IResource.NONE, monitor));
 			monitor.sanityCheck();
 		}
-		assertExistsInWorkspace("4.2", target);
-		assertExistsInFileSystem("4.3", target);
+		assertExistsInWorkspace(target);
+		assertExistsInFileSystem(target);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -45,16 +45,16 @@ public class IFolderTest extends ResourceTest {
 		beforeFile.create(getRandomContents(), false, getMonitor());
 
 		// Be sure the resources exist and then move them.
-		assertExistsInWorkspace("1.0", before);
-		assertExistsInWorkspace("1.1", beforeFile);
-		assertDoesNotExistInWorkspace("1.2", after);
-		assertDoesNotExistInWorkspace("1.3", afterFile);
+		assertExistsInWorkspace(before);
+		assertExistsInWorkspace(beforeFile);
+		assertDoesNotExistInWorkspace(after);
+		assertDoesNotExistInWorkspace(afterFile);
 		before.move(after.getFullPath(), IResource.NONE, getMonitor());
 
-		assertDoesNotExistInWorkspace("1.2", before);
-		assertDoesNotExistInWorkspace("1.3", beforeFile);
-		assertExistsInWorkspace("1.0", after);
-		assertExistsInWorkspace("1.1", afterFile);
+		assertDoesNotExistInWorkspace(before);
+		assertDoesNotExistInWorkspace(beforeFile);
+		assertExistsInWorkspace(after);
+		assertExistsInWorkspace(afterFile);
 	}
 
 	public void testCopyMissingFolder() throws CoreException {
@@ -201,7 +201,7 @@ public class IFolderTest extends ResourceTest {
 		//
 		assertExistsInWorkspace(before);
 		project.getFolder("c").delete(true, getMonitor());
-		assertDoesNotExistInWorkspace("1.0", before);
+		assertDoesNotExistInWorkspace(before);
 	}
 
 	public void testFolderMove() throws Throwable {
@@ -216,11 +216,11 @@ public class IFolderTest extends ResourceTest {
 		file.setContents(getContents(content), true, false, getMonitor());
 
 		// Be sure the resources exist and then move them.
-		assertExistsInWorkspace("1.0", before);
+		assertExistsInWorkspace(before);
 		project.getFolder("b").move(project.getFullPath().append("a"), true, getMonitor());
 
 		//
-		assertDoesNotExistInWorkspace("2.0", before);
+		assertDoesNotExistInWorkspace(before);
 		assertExistsInWorkspace(after);
 		file = project.getFile(IPath.fromOSString("a/b/z"));
 		assertTrue("2.1", compareContent(getContents(content), file.getContents(false)));
@@ -282,8 +282,8 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(source, true);
 		IFolder dest = project.getFolder("Folder2");
 		source.move(dest.getFullPath(), true, getMonitor());
-		assertExistsInWorkspace("1.0", dest);
-		assertDoesNotExistInWorkspace("1.1", source);
+		assertExistsInWorkspace(dest);
+		assertDoesNotExistInWorkspace(source);
 	}
 
 	public void testReadOnlyFolderCopy() throws Exception {
@@ -298,8 +298,8 @@ public class IFolderTest extends ResourceTest {
 		source.setReadOnly(true);
 		IFolder dest = project.getFolder("Folder2");
 		source.copy(dest.getFullPath(), true, getMonitor());
-		assertExistsInWorkspace("1.0", dest);
-		assertExistsInWorkspace("1.1", source);
+		assertExistsInWorkspace(dest);
+		assertExistsInWorkspace(source);
 		assertTrue("1.2", dest.isReadOnly());
 
 		// cleanup - ensure that the files can be deleted.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -338,17 +338,17 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(resources, true);
 		destination = getWorkspace().getRoot().getProject("DestProject");
-		assertDoesNotExistInWorkspace("1.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 		// set a property to copy
 		sourceChild = resources[1];
 		sourceChild.setPersistentProperty(qname, value);
 		source.copy(destination.getFullPath(), false, monitor);
 		monitor.assertUsedUp();
-		assertExistsInWorkspace("1.3", project);
-		assertExistsInWorkspace("1.4", resources);
+		assertExistsInWorkspace(project);
+		assertExistsInWorkspace(resources);
 		resources = buildResources((IProject) destination, children);
-		assertExistsInWorkspace("1.5", destination);
-		assertExistsInWorkspace("1.6", resources);
+		assertExistsInWorkspace(destination);
+		assertExistsInWorkspace(resources);
 		// ensure the properties were copied ok
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
@@ -368,18 +368,18 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
-		assertDoesNotExistInWorkspace("2.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 		// set a property to copy
 		sourceChild = resources[1];
 		sourceChild.setPersistentProperty(qname, value);
 		monitor.prepare();
 		((IProject) source).copy(description, false, monitor);
 		monitor.assertUsedUp();
-		assertExistsInWorkspace("2.3", project);
-		assertExistsInWorkspace("2.4", resources);
+		assertExistsInWorkspace(project);
+		assertExistsInWorkspace(resources);
 		resources = buildResources((IProject) destination, children);
-		assertExistsInWorkspace("2.5", destination);
-		assertExistsInWorkspace("2.6", resources);
+		assertExistsInWorkspace(destination);
+		assertExistsInWorkspace(resources);
 		// ensure the properties were copied ok
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
@@ -400,7 +400,7 @@ public class IProjectTest extends ResourceTest {
 		destination = destProject.getFolder("MyFolder");
 		ensureExistsInWorkspace(new IResource[] {project, destProject}, true);
 		ensureExistsInWorkspace(resources, true);
-		assertDoesNotExistInWorkspace("3.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 
 		monitor.prepare();
 		IResource projectToCopy = source;
@@ -419,7 +419,7 @@ public class IProjectTest extends ResourceTest {
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(resources, true);
-		assertDoesNotExistInWorkspace("4.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 
 		monitor.prepare();
 		IResource folderToCopy = source;
@@ -2122,7 +2122,7 @@ public class IProjectTest extends ResourceTest {
 
 		// make sure all the resources still exist.
 		IResourceVisitor visitor = resource -> {
-			assertExistsInWorkspace("2.1." + resource.getFullPath(), resource);
+			assertExistsInWorkspace(resource);
 			return true;
 		};
 		getWorkspace().getRoot().accept(visitor);
@@ -2146,7 +2146,7 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(resources, true);
 		destination = getWorkspace().getRoot().getProject("DestProject");
-		assertDoesNotExistInWorkspace("1.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 		// set a property to move
 		sourceChild = resources[1];
 		sourceChild.setPersistentProperty(qname, value);
@@ -2155,11 +2155,11 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		source.move(destination.getFullPath(), false, monitor);
 		monitor.assertUsedUp();
-		assertDoesNotExistInWorkspace("1.4", project);
-		assertDoesNotExistInWorkspace("1.5", resources);
+		assertDoesNotExistInWorkspace(project);
+		assertDoesNotExistInWorkspace(resources);
 		resources = buildResources((IProject) destination, children);
-		assertExistsInWorkspace("1.6", destination);
-		assertExistsInWorkspace("1.7", resources);
+		assertExistsInWorkspace(destination);
+		assertExistsInWorkspace(resources);
 		// ensure properties are moved too
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
@@ -2187,15 +2187,15 @@ public class IProjectTest extends ResourceTest {
 		sourceChild.createMarker(IMarker.PROBLEM);
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
-		assertDoesNotExistInWorkspace("2.3", destination);
+		assertDoesNotExistInWorkspace(destination);
 		monitor.prepare();
 		((IProject) source).move(description, false, monitor);
 		monitor.assertUsedUp();
-		assertDoesNotExistInWorkspace("2.5", project);
-		assertDoesNotExistInWorkspace("2.6", resources);
+		assertDoesNotExistInWorkspace(project);
+		assertDoesNotExistInWorkspace(resources);
 		resources = buildResources((IProject) destination, children);
-		assertExistsInWorkspace("2.7", destination);
-		assertExistsInWorkspace("2.8", resources);
+		assertExistsInWorkspace(destination);
+		assertExistsInWorkspace(resources);
 		// ensure properties are moved too
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
@@ -2317,15 +2317,15 @@ public class IProjectTest extends ResourceTest {
 		sourceChild.createMarker(IMarker.PROBLEM);
 		IProject destination = getWorkspace().getRoot().getProject("DestProject");
 		description.setName(destination.getName());
-		assertDoesNotExistInWorkspace("2.3", destination);
+		assertDoesNotExistInWorkspace(destination);
 		monitor.prepare();
 		project.move(description, false, monitor);
 		monitor.assertUsedUp();
-		assertDoesNotExistInWorkspace("2.5", project);
-		assertDoesNotExistInWorkspace("2.6", resources);
+		assertDoesNotExistInWorkspace(project);
+		assertDoesNotExistInWorkspace(resources);
 		resources = buildResources(destination, children);
-		assertExistsInWorkspace("2.7", destination);
-		assertExistsInWorkspace("2.8", resources);
+		assertExistsInWorkspace(destination);
+		assertExistsInWorkspace(resources);
 		// ensure properties are moved too
 		IResource destChild = resources[1];
 		actualPropertyValue = destChild.getPersistentProperty(qname);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -772,7 +772,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
 			assertTrue("deletion did unexpectedly not succeed", listener1.deletePerformed);
-			assertDoesNotExistInWorkspace("5.0", f);
+			assertDoesNotExistInWorkspace(f);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener1);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -2069,7 +2069,7 @@ public class IResourceTest extends ResourceTest {
 		// listener)
 		project.create(null);
 		project.open(null);
-		assertExistsInWorkspace("1.3", project);
+		assertExistsInWorkspace(project);
 		// define an operation which will create a bunch of resources including
 		// a project.
 		for (IResource resource : resources) {
@@ -2085,7 +2085,7 @@ public class IResourceTest extends ResourceTest {
 				break;
 			}
 		}
-		assertExistsInWorkspace("1.5", resources);
+		assertExistsInWorkspace(resources);
 		project.delete(true, false, getMonitor());
 	}
 
@@ -2273,12 +2273,12 @@ public class IResourceTest extends ResourceTest {
 		String[] hierarchy = {"Folder/", "Folder/Folder/", "Folder/Folder/Folder/", "Folder/Folder/Folder/Folder/"};
 		IResource[] resources = buildResources(folder, hierarchy);
 		ensureExistsInFileSystem(resources);
-		assertDoesNotExistInWorkspace("3.0", resources);
+		assertDoesNotExistInWorkspace(resources);
 
 		folder.refreshLocal(IResource.DEPTH_ONE, getMonitor());
 
-		assertExistsInWorkspace("5.0", folder.getFolder("Folder"));
-		assertDoesNotExistInWorkspace("5.1", folder.getFolder("Folder/Folder"));
+		assertExistsInWorkspace(folder.getFolder("Folder"));
+		assertDoesNotExistInWorkspace(folder.getFolder("Folder/Folder"));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -337,13 +337,13 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IProject destination = getWorkspace().getRoot().getProject("DestProject");
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
 
-		assertDoesNotExistInWorkspace("1.1", destination);
+		assertDoesNotExistInWorkspace(destination);
 		// without the fix, this call will cause an infinite loop in
 		// PathVariableUtil.getUniqueVariableName()
 		existingProject.move(description, IResource.SHALLOW, getMonitor());
 		IProject destProject = ResourcesPlugin.getWorkspace().getRoot().getProject("DestProject");
-		assertExistsInWorkspace("2.0", destProject);
-		assertExistsInWorkspace("2.1", destProject.getFile(linkName));
+		assertExistsInWorkspace(destProject);
+		assertExistsInWorkspace(destProject.getFile(linkName));
 
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -706,11 +706,11 @@ public class LinkedResourceTest extends ResourceTest {
 		IFile newChildFile = newFolder.getFile(childName);
 		IResource[] newResources = new IResource[] { destination, newFile, newFolder, newChildFile };
 
-		assertDoesNotExistInWorkspace("2.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 
 		existingProject.move(destination.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("3.0", newResources);
-		assertDoesNotExistInWorkspace("3.1", oldResources);
+		assertExistsInWorkspace(newResources);
+		assertDoesNotExistInWorkspace(oldResources);
 		assertTrue("3.2", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("3.3", destination.isSynchronized(IResource.DEPTH_INFINITE));
 
@@ -1504,11 +1504,11 @@ public class LinkedResourceTest extends ResourceTest {
 		IFile newChildFile = newFolder.getFile(childName);
 		IResource[] newResources = new IResource[] { destination, newFile, newFolder, newChildFile };
 
-		assertDoesNotExistInWorkspace("2.0", destination);
+		assertDoesNotExistInWorkspace(destination);
 
 		existingProject.move(destination.getFullPath(), IResource.SHALLOW, getMonitor());
-		assertExistsInWorkspace("3.0", newResources);
-		assertDoesNotExistInWorkspace("3.1", oldResources);
+		assertExistsInWorkspace(newResources);
+		assertDoesNotExistInWorkspace(oldResources);
 
 		assertTrue("3.2", newFile.isLinked());
 		assertEquals("3.3", resolve(fileLocation), newFile.getLocation());
@@ -1520,8 +1520,8 @@ public class LinkedResourceTest extends ResourceTest {
 
 		// now do a deep move back to the original project
 		destination.move(existingProject.getFullPath(), IResource.NONE, getMonitor());
-		assertExistsInWorkspace("5.1", oldResources);
-		assertDoesNotExistInWorkspace("5.2", newResources);
+		assertExistsInWorkspace(oldResources);
+		assertDoesNotExistInWorkspace(newResources);
 		assertTrue("5.3", !file.isLinked());
 		assertTrue("5.4", !folder.isLinked());
 		assertEquals("5.5", existingProject.getLocation().append(file.getProjectRelativePath()), file.getLocation());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -225,30 +225,30 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		// removes the variable - the location will be undefined (null)
 		manager.setValue(VARIABLE_NAME, null);
-		assertExistsInWorkspace("3,1", file);
+		assertExistsInWorkspace(file);
 
 		//refresh local - should not fail or make the link disappear
 		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
 		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		assertExistsInWorkspace("3.3", file);
+		assertExistsInWorkspace(file);
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
 		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
-		assertExistsInWorkspace("3.5", file);
+		assertExistsInWorkspace(file);
 		// the location is null
 		assertNull("3.6", file.getLocation());
 
@@ -259,9 +259,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// re-creates the variable with its previous value
 		manager.setValue(VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("5.0", file);
+		assertExistsInWorkspace(file);
 		assertNotNull("5.1", file.getLocation());
-		assertExistsInFileSystem("5.2", file);
+		assertExistsInFileSystem(file);
 		// the contents must be the original ones
 		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
@@ -280,30 +280,30 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomProjectLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		// removes the variable - the location will be undefined (null)
 		manager.setValue(PROJECT_VARIABLE_NAME, null);
-		assertExistsInWorkspace("3,1", file);
+		assertExistsInWorkspace(file);
 
 		// refresh local - should not fail or make the link disappear
 		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
 		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		assertExistsInWorkspace("3.3", file);
+		assertExistsInWorkspace(file);
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
 		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
-		assertExistsInWorkspace("3.5", file);
+		assertExistsInWorkspace(file);
 		// the location is null
 		assertNull("3.6", file.getLocation());
 
@@ -315,9 +315,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// re-creates the variable with its previous value
 		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("5.0", file);
+		assertExistsInWorkspace(file);
 		assertNotNull("5.1", file.getLocation());
-		assertExistsInFileSystem("5.2", file);
+		assertExistsInFileSystem(file);
 		// the contents must be the original ones
 		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
@@ -343,16 +343,16 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IPath resolvedPath = URIUtil.toPath(file.getPathVariableManager().resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		IFile newFile = nonExistingFileInExistingFolder;
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		assertExistsInWorkspace("3,1", newFile);
+		assertExistsInWorkspace(newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertEquals("3,3", newFile.getLocation(), resolvedPath);
 	}
@@ -391,16 +391,16 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IPath resolvedPath = existingProjectInSubDirectory.getPathVariableManager().resolvePath(variableBasedLocation);
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		IFile newFile = nonExistingFileInExistingFolder;
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		assertExistsInWorkspace("3,1", newFile);
+		assertExistsInWorkspace(newFile);
 		IPath newLocation = newFile.getLocation();
 		assertTrue("3,2", !newLocation.equals(newFile.getRawLocation()));
 		IPath newRawLocation = newFile.getRawLocation();
@@ -426,19 +426,19 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IPath resolvedPath = manager.resolvePath(variableBasedLocation);
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		IFile newFile = nonExistingFileInExistingFolder;
 		// removes the variable - the location will be undefined (null)
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
-		assertExistsInWorkspace("3,1", newFile);
+		assertExistsInWorkspace(newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertTrue("3,3", newFile.getRawLocation().equals(variableBasedLocation));
 		assertTrue("3,4", newFile.getRawLocation().equals(variableBasedLocation));
@@ -459,19 +459,19 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IPath resolvedPath = manager.resolvePath(variableBasedLocation);
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		IFile newFile = nonExistingFileInOtherExistingProject;
 		// moves the variable - the location will be undefined (null)
 		file.move(newFile.getFullPath(), IResource.SHALLOW, getMonitor());
-		assertExistsInWorkspace("3,1", newFile);
+		assertExistsInWorkspace(newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertTrue("3,3", newFile.getRawLocation().equals(variableBasedLocation));
 		assertTrue("3,4", newFile.getLocation().equals(resolvedPath));
@@ -491,30 +491,30 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomRelativeProjectLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		// removes the variable - the location will be undefined (null)
 		manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, null);
-		assertExistsInWorkspace("3,1", file);
+		assertExistsInWorkspace(file);
 
 		// refresh local - should not fail or make the link disappear
 		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
 		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 
-		assertExistsInWorkspace("3.3", file);
+		assertExistsInWorkspace(file);
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
 		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
 
-		assertExistsInWorkspace("3.5", file);
+		assertExistsInWorkspace(file);
 		// the location is null
 		assertNull("3.6", file.getLocation());
 
@@ -526,9 +526,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// re-creates the variable with its previous value
 		manager.setValue(PROJECT_RELATIVE_VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("5.0", file);
+		assertExistsInWorkspace(file);
 		assertNotNull("5.1", file.getLocation());
-		assertExistsInFileSystem("5.2", file);
+		assertExistsInFileSystem(file);
 		// the contents must be the original ones
 		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
@@ -548,27 +548,27 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", folder);
+		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
 		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", folder);
-		assertExistsInWorkspace("2.1", childFile);
-		assertExistsInFileSystem("2.2", folder);
-		assertExistsInFileSystem("2.3", childFile);
+		assertExistsInWorkspace(folder);
+		assertExistsInWorkspace(childFile);
+		assertExistsInFileSystem(folder);
+		assertExistsInFileSystem(childFile);
 
 		// removes the variable - the location will be undefined (null)
 		manager.setValue(VARIABLE_NAME, null);
-		assertExistsInWorkspace("3.1", folder);
+		assertExistsInWorkspace(folder);
 
 		//refresh local - should not fail but should cause link's children to disappear
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("3.3", folder);
-		assertDoesNotExistInWorkspace("3.4", childFile);
+		assertExistsInWorkspace(folder);
+		assertDoesNotExistInWorkspace(childFile);
 
 		//try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
@@ -588,23 +588,23 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertThrows(CoreException.class,
 				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
 
-		assertExistsInWorkspace("4.1", folder);
+		assertExistsInWorkspace(folder);
 		// the location is null
 		assertNull("4.2", folder.getLocation());
 
 		// re-creates the variable with its previous value
 		manager.setValue(VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("6.0", folder);
+		assertExistsInWorkspace(folder);
 		assertNotNull("6.1", folder.getLocation());
-		assertExistsInFileSystem("6.2", folder);
-		assertDoesNotExistInWorkspace("6.3", childFile);
-		assertExistsInFileSystem("6.4", childFile);
+		assertExistsInFileSystem(folder);
+		assertDoesNotExistInWorkspace(childFile);
+		assertExistsInFileSystem(childFile);
 
 		// refresh should recreate the child
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("7.1", folder);
-		assertExistsInWorkspace("7.2", childFile);
+		assertExistsInWorkspace(folder);
+		assertExistsInWorkspace(childFile);
 	}
 
 	/**
@@ -664,28 +664,28 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomProjectLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", folder);
+		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
 		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
 		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", folder);
-		assertExistsInWorkspace("2.1", childFile);
-		assertExistsInFileSystem("2.2", folder);
-		assertExistsInFileSystem("2.3", childFile);
+		assertExistsInWorkspace(folder);
+		assertExistsInWorkspace(childFile);
+		assertExistsInFileSystem(folder);
+		assertExistsInFileSystem(childFile);
 
 		// removes the variable - the location will be undefined (null)
 		manager.setValue(PROJECT_VARIABLE_NAME, null);
-		assertExistsInWorkspace("3.1", folder);
+		assertExistsInWorkspace(folder);
 
 		// refresh local - should not fail but should cause link's children to
 		// disappear
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("3.3", folder);
-		assertDoesNotExistInWorkspace("3.4", childFile);
+		assertExistsInWorkspace(folder);
+		assertDoesNotExistInWorkspace(childFile);
 
 		// try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
@@ -705,23 +705,23 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertThrows(CoreException.class,
 				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
 
-		assertExistsInWorkspace("4.1", folder);
+		assertExistsInWorkspace(folder);
 		// the location is null
 		assertNull("4.2", folder.getLocation());
 
 		// re-creates the variable with its previous value
 		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("6.0", folder);
+		assertExistsInWorkspace(folder);
 		assertNotNull("6.1", folder.getLocation());
-		assertExistsInFileSystem("6.2", folder);
-		assertDoesNotExistInWorkspace("6.3", childFile);
-		assertExistsInFileSystem("6.4", childFile);
+		assertExistsInFileSystem(folder);
+		assertDoesNotExistInWorkspace(childFile);
+		assertExistsInFileSystem(childFile);
 
 		// refresh should recreate the child
 		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("7.1", folder);
-		assertExistsInWorkspace("7.2", childFile);
+		assertExistsInWorkspace(folder);
+		assertExistsInWorkspace(childFile);
 	}
 
 	/**
@@ -792,14 +792,14 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		// changes the variable value - the file location will change
 		IPath newLocation = super.getRandomLocation();
@@ -812,15 +812,15 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
-		assertExistsInWorkspace("3.2", file);
+		assertExistsInWorkspace(file);
 		// the location is different - does not exist anymore
-		assertDoesNotExistInFileSystem("3.3", file);
+		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
 		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
 
 		// now the file exists in a different location
-		assertExistsInFileSystem("4.1", file);
+		assertExistsInFileSystem(file);
 
 		// its location must have changed reflecting the variable change
 		IPath expectedNewLocation = manager.resolvePath(variableBasedLocation);
@@ -836,8 +836,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// restore the previous value
 		manager.setValue(VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("5.1", file);
-		assertExistsInFileSystem("5.2", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 		// the contents must be the original ones
 		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
@@ -857,14 +857,14 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath variableBasedLocation = getRandomProjectLocation();
 
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("1.0", file);
+		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
 		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
 
 		// now the file exists in both workspace and file system
-		assertExistsInWorkspace("2.0", file);
-		assertExistsInFileSystem("2.1", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 
 		// changes the variable value - the file location will change
 		IPath newLocation = super.getRandomLocation();
@@ -877,15 +877,15 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
-		assertExistsInWorkspace("3.2", file);
+		assertExistsInWorkspace(file);
 		// the location is different - does not exist anymore
-		assertDoesNotExistInFileSystem("3.3", file);
+		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
 		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
 
 		// now the file exists in a different location
-		assertExistsInFileSystem("4.1", file);
+		assertExistsInFileSystem(file);
 
 		// its location must have changed reflecting the variable change
 		IPath expectedNewLocation = manager.resolvePath(variableBasedLocation);
@@ -901,8 +901,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// restore the previous value
 		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);
 
-		assertExistsInWorkspace("5.1", file);
-		assertExistsInFileSystem("5.2", file);
+		assertExistsInWorkspace(file);
+		assertExistsInFileSystem(file);
 		// the contents must be the original ones
 		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
 	}
@@ -959,14 +959,14 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 		IPath resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("3.0", file);
+		assertDoesNotExistInWorkspace(file);
 		assertEquals("3.1", targetPath, resolvedPath);
 
 		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 
 		resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("5.0", file);
+		assertDoesNotExistInWorkspace(file);
 		assertEquals("5.1", targetPath, resolvedPath);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -174,24 +174,8 @@ public abstract class ResourceTest extends CoreTest {
 	 * Assert that the given resource does not exist in the local store.
 	 */
 	public void assertDoesNotExistInFileSystem(IResource resource) {
-		assertDoesNotExistInFileSystem("", resource); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist in the
-	 * local store.
-	 */
-	public void assertDoesNotExistInFileSystem(IResource[] resources) {
-		assertDoesNotExistInFileSystem("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that the given resource does not exist in the local store.
-	 */
-	public void assertDoesNotExistInFileSystem(String message, IResource resource) {
 		if (existsInFileSystem(resource)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath() + " unexpectedly exists in the file system");
+			fail(resource.getFullPath() + " unexpectedly exists in the file system");
 		}
 	}
 
@@ -199,9 +183,9 @@ public abstract class ResourceTest extends CoreTest {
 	 * Assert that each element of the resource array does not exist in the
 	 * local store.
 	 */
-	public void assertDoesNotExistInFileSystem(String message, IResource[] resources) {
+	public void assertDoesNotExistInFileSystem(IResource[] resources) {
 		for (IResource resource : resources) {
-			assertDoesNotExistInFileSystem(message, resource);
+			assertDoesNotExistInFileSystem(resource);
 		}
 	}
 
@@ -210,25 +194,8 @@ public abstract class ResourceTest extends CoreTest {
 	 * resource info tree.
 	 */
 	public void assertDoesNotExistInWorkspace(IResource resource) {
-		assertDoesNotExistInWorkspace("", resource); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that each element of the resource array does not exist
-	 * in the workspace resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(IResource[] resources) {
-		assertDoesNotExistInWorkspace("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert that the given resource does not exist in the workspace
-	 * resource info tree.
-	 */
-	public void assertDoesNotExistInWorkspace(String message, IResource resource) {
 		if (existsInWorkspace(resource, false)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath().toString() + " unexpectedly exists in the workspace");
+			fail(resource.getFullPath().toString() + " unexpectedly exists in the workspace");
 		}
 	}
 
@@ -236,9 +203,9 @@ public abstract class ResourceTest extends CoreTest {
 	 * Assert that each element of the resource array does not exist
 	 * in the workspace resource info tree.
 	 */
-	public void assertDoesNotExistInWorkspace(String message, IResource[] resources) {
+	public void assertDoesNotExistInWorkspace(IResource[] resources) {
 		for (IResource resource : resources) {
-			assertDoesNotExistInWorkspace(message, resource);
+			assertDoesNotExistInWorkspace(resource);
 		}
 	}
 
@@ -248,51 +215,26 @@ public abstract class ResourceTest extends CoreTest {
 	 * correct Path -&gt; File mapping.
 	 */
 	public void assertExistsInFileSystem(IResource resource) {
-		assertExistsInFileSystem("", resource); //$NON-NLS-1$
+		if (!existsInFileSystem(resource)) {
+			fail(resource.getFullPath() + " unexpectedly does not exist in the file system");
+		}
 	}
 
 	/**
-	 * Assert that each element in the resource array  exists in the local store.
+	 * Assert that each element in the resource array exists in the local store.
 	 */
 	public void assertExistsInFileSystem(IResource[] resources) {
-		assertExistsInFileSystem("", resources); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the local
-	 * store. Use the resource manager to ensure that we have a
-	 * correct Path -&gt; File mapping.
-	 */
-	public void assertExistsInFileSystem(String message, IResource resource) {
-		if (!existsInFileSystem(resource)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath() + " unexpectedly does not exist in the file system");
-		}
-	}
-
-	/**
-	 * Assert that each element in the resource array  exists in the local store.
-	 */
-	public void assertExistsInFileSystem(String message, IResource[] resources) {
 		for (IResource resource : resources) {
-			assertExistsInFileSystem(message, resource);
+			assertExistsInFileSystem(resource);
 		}
 	}
 
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
+	/*
+	 * Assert whether or not the given resource exists in the workspace resource
+	 * info tree.
 	 */
 	public void assertExistsInWorkspace(IResource resource) {
-		assertExistsInWorkspace("", resource, false); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(IResource resource, boolean phantom) {
-		assertExistsInWorkspace("", resource, phantom); //$NON-NLS-1$
+		assertExistsInWorkspace(resource, false); // $NON-NLS-1$
 	}
 
 	/**
@@ -300,7 +242,17 @@ public abstract class ResourceTest extends CoreTest {
 	 * workspace resource info tree.
 	 */
 	public void assertExistsInWorkspace(IResource[] resources) {
-		assertExistsInWorkspace("", resources, false); //$NON-NLS-1$
+		assertExistsInWorkspace(resources, false); // $NON-NLS-1$
+	}
+
+	/**
+	 * Assert that each element of the resource array exists in the workspace
+	 * resource info tree.
+	 */
+	public void assertExistsInWorkspace(IResource resource, boolean phantom) {
+		if (!existsInWorkspace(resource, phantom)) {
+			fail(resource.getFullPath().toString() + " unexpectedly does not exist in the workspace");
+		}
 	}
 
 	/**
@@ -308,45 +260,8 @@ public abstract class ResourceTest extends CoreTest {
 	 * workspace resource info tree.
 	 */
 	public void assertExistsInWorkspace(IResource[] resources, boolean phantom) {
-		assertExistsInWorkspace("", resources, phantom); //$NON-NLS-1$
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource resource) {
-		assertExistsInWorkspace(message, resource, false);
-	}
-
-	/**
-	 * Assert whether or not the given resource exists in the workspace
-	 * resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource resource, boolean phantom) {
-		if (!existsInWorkspace(resource, phantom)) {
-			String formatted = message == null ? "" : message + " ";
-			fail(formatted + resource.getFullPath().toString() + " unexpectedly does not exist in the workspace");
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource[] resources) {
 		for (IResource resource : resources) {
-			assertExistsInWorkspace(message, resource, false);
-		}
-	}
-
-	/**
-	 * Assert that each element of the resource array exists in the
-	 * workspace resource info tree.
-	 */
-	public void assertExistsInWorkspace(String message, IResource[] resources, boolean phantom) {
-		for (IResource resource : resources) {
-			assertExistsInWorkspace(message, resource, phantom);
+			assertExistsInWorkspace(resource, phantom);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -184,7 +184,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IFile childFile = folder.getFile(getUniqueString());
 		IResource[] oldResources = new IResource[] {existingProject, file, folder, childFile};
 
-		assertDoesNotExistInWorkspace("1.0", new IResource[] { folder, file, childFile });
+		assertDoesNotExistInWorkspace(new IResource[] { folder, file, childFile });
 
 		createFileInFileSystem(fileLocation);
 		folderLocation.toFile().mkdir();
@@ -196,7 +196,7 @@ public class VirtualFolderTest extends ResourceTest {
 
 		// move the project
 		IProject destinationProject = getWorkspace().getRoot().getProject("MoveTargetProject");
-		assertDoesNotExistInWorkspace("3.0", destinationProject);
+		assertDoesNotExistInWorkspace(destinationProject);
 
 		existingProject.move(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
 
@@ -205,8 +205,8 @@ public class VirtualFolderTest extends ResourceTest {
 		IFile newChildFile = newFolder.getFile(childFile.getName());
 		IResource[] newResources = new IResource[] { destinationProject, newFile, newFolder, newChildFile };
 
-		assertExistsInWorkspace("5.0", newResources);
-		assertDoesNotExistInWorkspace("6.1", oldResources);
+		assertExistsInWorkspace(newResources);
+		assertDoesNotExistInWorkspace(oldResources);
 		assertTrue("7.0", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("8.0", destinationProject.isSynchronized(IResource.DEPTH_INFINITE));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -54,11 +54,11 @@ public class Bug_026294 extends ResourceTest {
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
-		assertExistsInFileSystem("0.0", file1);
-		assertExistsInFileSystem("0.1", file2);
-		assertExistsInFileSystem("0.2", file3);
-		assertExistsInFileSystem("0.3", folder);
-		assertExistsInFileSystem("0.4", projectFile);
+		assertExistsInFileSystem(file1);
+		assertExistsInFileSystem(file2);
+		assertExistsInFileSystem(file3);
+		assertExistsInFileSystem(folder);
+		assertExistsInFileSystem(projectFile);
 
 		// opens a file so it cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
@@ -69,27 +69,27 @@ public class Bug_026294 extends ResourceTest {
 
 			// Delete is best-case so check all the files.
 			// Do a check on disk and in the workspace in case something is out of sync.
-			assertExistsInWorkspace("2.1.1", project);
-			assertExistsInFileSystem("2.1.2", project);
+			assertExistsInWorkspace(project);
+			assertExistsInFileSystem(project);
 
-			assertExistsInWorkspace("2.2.1", file1);
-			assertExistsInFileSystem("2.2.2", file1);
+			assertExistsInWorkspace(file1);
+			assertExistsInFileSystem(file1);
 			assertTrue("2.2.3", file1.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertDoesNotExistInWorkspace("2.3.1", file2);
-			assertDoesNotExistInFileSystem("2.3.2", file2);
+			assertDoesNotExistInWorkspace(file2);
+			assertDoesNotExistInFileSystem(file2);
 			assertTrue("2.3.3", file2.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertDoesNotExistInWorkspace("2.4.1", file3);
-			assertDoesNotExistInFileSystem("2.4.2", file3);
+			assertDoesNotExistInWorkspace(file3);
+			assertDoesNotExistInFileSystem(file3);
 			assertTrue("2.4.3", file3.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertExistsInWorkspace("2.5.1", folder);
-			assertExistsInFileSystem("2.5.2", folder);
+			assertExistsInWorkspace(folder);
+			assertExistsInFileSystem(folder);
 			assertTrue("2.5.3", folder.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertExistsInWorkspace("2.6.1", projectFile);
-			assertExistsInFileSystem("2.6.2", projectFile);
+			assertExistsInWorkspace(projectFile);
+			assertExistsInFileSystem(projectFile);
 			assertTrue("2.6.3", projectFile.isSynchronized(IResource.DEPTH_INFINITE));
 
 			assertTrue("2.7.0", project.isSynchronized(IResource.DEPTH_ZERO));
@@ -182,7 +182,7 @@ public class Bug_026294 extends ResourceTest {
 					() -> project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor()));
 			assertTrue("2.1", project.exists());
 			assertTrue("2.7", project.isSynchronized(IResource.DEPTH_INFINITE));
-			assertExistsInFileSystem("2.8", projectFile);
+			assertExistsInFileSystem(projectFile);
 
 		}
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
@@ -190,7 +190,7 @@ public class Bug_026294 extends ResourceTest {
 		assertTrue("5.1", !project.exists());
 		assertTrue("5.3", project.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("6.0", !projectRoot.toFile().exists());
-		assertDoesNotExistInFileSystem("7.0", projectFile);
+		assertDoesNotExistInFileSystem(projectFile);
 	}
 
 	/**
@@ -225,7 +225,7 @@ public class Bug_026294 extends ResourceTest {
 
 			assertTrue("3.0", project.exists());
 			assertTrue("3.1", project.isSynchronized(IResource.DEPTH_INFINITE));
-			assertExistsInFileSystem("3.2", projectFile);
+			assertExistsInFileSystem(projectFile);
 
 			project.open(getMonitor());
 		} finally {
@@ -238,7 +238,7 @@ public class Bug_026294 extends ResourceTest {
 		assertTrue("6.0", !project.exists());
 		assertTrue("6.1", project.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("6.2", !projectRoot.toFile().exists());
-		assertDoesNotExistInFileSystem("6.3", projectFile);
+		assertDoesNotExistInFileSystem(projectFile);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -51,10 +51,10 @@ public class Bug_029671 extends ResourceTest {
 			assertTrue("3.0", folder.isPhantom());
 			assertTrue("4.0", file.isPhantom());
 
-			assertExistsInWorkspace("5.0", targetFolder);
+			assertExistsInWorkspace(targetFolder);
 			assertTrue("5.1", !targetFolder.isPhantom());
 
-			assertExistsInWorkspace("6.0", targetFile);
+			assertExistsInWorkspace(targetFile);
 			assertTrue("6.1", !targetFile.isPhantom());
 		} finally {
 			synchronizer.remove(partner);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -56,17 +56,17 @@ public class Bug_044106 extends ResourceTest {
 		IFile linkedFile = project.getFile("linkedFile");
 		String local = linkedFile.getLocation().toOSString();
 		createSymLink(target, local);
-		assertExistsInFileSystem("1.2", linkedFile);
+		assertExistsInFileSystem(linkedFile);
 
 		// do a refresh and ensure that the resources are in the workspace
 		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("2.1", linkedFile);
+		assertExistsInWorkspace(linkedFile);
 
 		// delete the file
 		linkedFile.delete(deleteFlags, getMonitor());
 
 		// ensure that the folder and file weren't deleted in the filesystem
-		assertDoesNotExistInWorkspace("4.0", linkedFile);
+		assertDoesNotExistInWorkspace(linkedFile);
 		assertTrue("4.1", linkDestFile.fetchInfo().exists());
 	}
 
@@ -94,13 +94,13 @@ public class Bug_044106 extends ResourceTest {
 		IFile linkedFile = linkedFolder.getFile(linkDestFile.getName());
 		String local = linkedFolder.getLocation().toOSString();
 		createSymLink(target, local);
-		assertExistsInFileSystem("1.2", linkedFolder);
-		assertExistsInFileSystem("1.3", linkedFile);
+		assertExistsInFileSystem(linkedFolder);
+		assertExistsInFileSystem(linkedFile);
 
 		// do a refresh and ensure that the resources are in the workspace
 		linkedFolder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInWorkspace("2.1", linkedFolder);
-		assertExistsInWorkspace("2.2", linkedFile);
+		assertExistsInWorkspace(linkedFolder);
+		assertExistsInWorkspace(linkedFile);
 
 		// delete the folder or project
 		if (deleteParent) {
@@ -110,8 +110,8 @@ public class Bug_044106 extends ResourceTest {
 		}
 
 		// ensure that the folder and file weren't deleted in the filesystem
-		assertDoesNotExistInWorkspace("4.0", linkedFolder);
-		assertDoesNotExistInWorkspace("4.1", linkedFile);
+		assertDoesNotExistInWorkspace(linkedFolder);
+		assertDoesNotExistInWorkspace(linkedFile);
 		assertTrue("4.2", linkDestLocation.fetchInfo().exists());
 		assertTrue("4.3", linkDestFile.fetchInfo().exists());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -56,7 +56,7 @@ public class Bug_079398 extends ResourceTest {
 		// will conform to the policy
 		file1.copy(file2.getFullPath(), true, getMonitor());
 
-		assertExistsInWorkspace("1.0", file2);
+		assertExistsInWorkspace(file2);
 		sourceStates = file1.getHistory(getMonitor());
 		// the source is unaffected so far
 		assertEquals("1.2", 10, sourceStates.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
@@ -70,7 +70,7 @@ public class Bug_226264 extends ResourceTest {
 
 		assertTrue("2.0: " + job.getResult(), job.getResult().isOK());
 
-		assertDoesNotExistInWorkspace("3.0", project1);
-		assertDoesNotExistInWorkspace("4.0", project2);
+		assertDoesNotExistInWorkspace(project1);
+		assertDoesNotExistInWorkspace(project2);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -37,7 +37,7 @@ public class Bug_233939 extends ResourceTest {
 		createSymLink(container.getLocation().toFile(), linkName, linkTarget.toOSString(), false);
 		container.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
 		IResource theLink = container.findMember(linkName);
-		assertExistsInWorkspace("2.1", theLink);
+		assertExistsInWorkspace(theLink);
 		assertTrue("2.2", theLink.getResourceAttributes().isSymbolicLink());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -51,7 +51,7 @@ public class Bug_265810 extends ResourceTest {
 		// create a linked resource
 		final IFile file = project.getFile(getUniqueString());
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("2.0", file);
+		assertDoesNotExistInWorkspace(file);
 		file.createLink(createFolderAtRandomLocation(), IResource.NONE, new NullProgressMonitor());
 		file.setContents(getContents("contents for a file"), IResource.NONE, new NullProgressMonitor());
 
@@ -61,7 +61,7 @@ public class Bug_265810 extends ResourceTest {
 		// create a new linked file
 		final IFile newFile = project.getFile("newFile");
 		// the file should not exist yet
-		assertDoesNotExistInWorkspace("5.0", newFile);
+		assertDoesNotExistInWorkspace(newFile);
 		newFile.createLink(createFolderAtRandomLocation(), IResource.NONE, new NullProgressMonitor());
 
 		// save the .project [2] content

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -80,16 +80,16 @@ public class NLTest extends ResourceTest {
 		IResource[] resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
 		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInFileSystem("2.1", resources);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 		ensureDoesNotExistInWorkspace(resources);
 
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
 		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		assertExistsInFileSystem("3.1", resources);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -50,10 +50,10 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		assertEquals("0.0", ContentDescriptionManager.INVALID_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
 		IProject project = workspace.getRoot().getProject("proj1");
-		assertDoesNotExistInWorkspace("0.1", project);
+		assertDoesNotExistInWorkspace(project);
 		Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		IFile file = project.getFile("foo.txt");
-		assertDoesNotExistInWorkspace("0.2", file);
+		assertDoesNotExistInWorkspace(file);
 		ensureExistsInWorkspace(file, getRandomContents());
 		// this will also cause the cache flush job to be scheduled
 		file.getContentDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
@@ -14,7 +14,10 @@
 package org.eclipse.core.tests.resources.session;
 
 import junit.framework.Test;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.AutomatedResourceTests;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
@@ -64,7 +67,7 @@ public class TestMultiSnap extends WorkspaceSerializationTest {
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 
-		assertExistsInWorkspace("1.4", new IResource[] {project, folder, file});
+		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -71,7 +71,7 @@ public class TestSaveSnap extends WorkspaceSerializationTest {
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 
-		assertExistsInWorkspace("1.4", new IResource[] {project, folder, file});
+		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -68,7 +68,7 @@ public class TestSnapSaveSnap extends WorkspaceSerializationTest {
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 
-		assertExistsInWorkspace("1.4", new IResource[] {project, folder, file});
+		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -44,8 +44,8 @@ public class Snapshot1Test extends SnapshotTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("1.1", resources);
-		assertExistsInWorkspace("1.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		project.close(null);
 		assertTrue("2.1", project.exists());
@@ -65,8 +65,8 @@ public class Snapshot1Test extends SnapshotTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("3.1", resources);
-		assertExistsInWorkspace("3.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 
 	public void testSnapshotWorkspace() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -53,8 +53,8 @@ public class Snapshot2Test extends SnapshotTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("1.1", resources);
-		assertExistsInWorkspace("1.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 
 	public void testChangeProject2() throws CoreException {
@@ -69,8 +69,8 @@ public class Snapshot2Test extends SnapshotTest {
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());
 		ensureExistsInWorkspace(resources, true);
-		assertExistsInFileSystem("1.1", resources);
-		assertExistsInWorkspace("1.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 
 	public void testSnapshotWorkspace() throws CoreException {
@@ -88,8 +88,8 @@ public class Snapshot2Test extends SnapshotTest {
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot1Test.defineHierarchy1());
-		assertExistsInFileSystem("2.1", resources);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// Project2
 		project = getWorkspace().getRoot().getProject(PROJECT_2);
@@ -98,7 +98,7 @@ public class Snapshot2Test extends SnapshotTest {
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot1Test.defineHierarchy2());
-		assertExistsInFileSystem("5.1", resources);
-		assertExistsInWorkspace("5.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -44,8 +44,8 @@ public class Snapshot3Test extends SnapshotTest {
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot2Test.defineHierarchy1());
-		assertExistsInFileSystem("2.1", resources);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// Project2
 		project = getWorkspace().getRoot().getProject(PROJECT_2);
@@ -57,7 +57,7 @@ public class Snapshot3Test extends SnapshotTest {
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot2Test.defineHierarchy2());
-		assertExistsInFileSystem("5.1", resources);
-		assertExistsInWorkspace("5.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -53,8 +53,8 @@ public class Snapshot4Test extends SnapshotTest {
 		// remove resources
 		IFile file = project.getFile("added file");
 		file.delete(true, true, null);
-		assertDoesNotExistInFileSystem("1.1", file);
-		assertDoesNotExistInWorkspace("1.2", file);
+		assertDoesNotExistInFileSystem(file);
+		assertDoesNotExistInWorkspace(file);
 
 		// full save
 		getWorkspace().save(true, null);
@@ -62,8 +62,8 @@ public class Snapshot4Test extends SnapshotTest {
 		// remove resources
 		file = project.getFile("yet another file");
 		file.delete(true, true, null);
-		assertDoesNotExistInFileSystem("3.1", file);
-		assertDoesNotExistInWorkspace("3.2", file);
+		assertDoesNotExistInFileSystem(file);
+		assertDoesNotExistInWorkspace(file);
 
 		// snapshot
 		getWorkspace().save(false, null);
@@ -71,8 +71,8 @@ public class Snapshot4Test extends SnapshotTest {
 		// remove resources
 		IFolder folder = project.getFolder("a folder");
 		folder.delete(true, true, null);
-		assertDoesNotExistInFileSystem("5.1", folder);
-		assertDoesNotExistInWorkspace("5.2", folder);
+		assertDoesNotExistInFileSystem(folder);
+		assertDoesNotExistInWorkspace(folder);
 
 		// snapshot
 		getWorkspace().save(false, null);
@@ -99,8 +99,8 @@ public class Snapshot4Test extends SnapshotTest {
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot3Test.defineHierarchy1());
-		assertExistsInFileSystem("2.1", resources);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 
 		// Project2
 		project = getWorkspace().getRoot().getProject(PROJECT_2);
@@ -112,7 +112,7 @@ public class Snapshot4Test extends SnapshotTest {
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot3Test.defineHierarchy2());
-		assertExistsInFileSystem("5.1", resources);
-		assertExistsInWorkspace("5.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -30,17 +30,17 @@ public class Snapshot5Test extends SnapshotTest {
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot4Test.defineHierarchy1());
-		assertExistsInFileSystem("2.1", resources);
-		assertExistsInWorkspace("2.2", resources);
+		assertExistsInFileSystem(resources);
+		assertExistsInWorkspace(resources);
 		IFile file = project.getFile("added file");
-		assertDoesNotExistInFileSystem("2.3", file);
-		assertDoesNotExistInWorkspace("2.4", file);
+		assertDoesNotExistInFileSystem(file);
+		assertDoesNotExistInWorkspace(file);
 		file = project.getFile("yet another file");
-		assertDoesNotExistInFileSystem("2.5", file);
-		assertDoesNotExistInWorkspace("2.6", file);
+		assertDoesNotExistInFileSystem(file);
+		assertDoesNotExistInWorkspace(file);
 		IFolder folder = project.getFolder("a folder");
-		assertDoesNotExistInFileSystem("2.7", folder);
-		assertDoesNotExistInWorkspace("2.8", folder);
+		assertDoesNotExistInFileSystem(folder);
+		assertDoesNotExistInWorkspace(folder);
 
 		// Project2
 		project = getWorkspace().getRoot().getProject(PROJECT_2);


### PR DESCRIPTION
This change removes all assert*() methods from ResourceTest that accept a string and replaces all calls to use the according methods that do not accept a string. All callers only pass order numbers of assertions within the test methods to this assertion utility, which are unnecessary as failing tests deliver stack traces from which the failing statement is obvious.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903