### PR TITLE
Replace CoreTest#transferData() with InputStream#transferTo()

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.junit.Assert.assertThrows;
 
+import java.io.IOException;
 import java.io.InputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -58,7 +59,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		return root;
 	}
 
-	public void testDeleteBlob() throws CoreException {
+	public void testDeleteBlob() throws CoreException, IOException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);
@@ -78,7 +79,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		assertFalse(store.fileFor(uuid).fetchInfo().exists());
 	}
 
-	public void testGetBlob() throws CoreException {
+	public void testGetBlob() throws CoreException, IOException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);
@@ -96,7 +97,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		assertTrue(compareContent(getContents(content), input));
 	}
 
-	public void testSetBlob() throws CoreException {
+	public void testSetBlob() throws CoreException, IOException {
 		/* initialize common objects */
 		IFileStore root = createStore();
 		BlobStore store = new BlobStore(root, 64);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -82,10 +82,12 @@ public abstract class LocalStoreTest extends ResourceTest {
 	 * Create a file with random content. If a resource exists in the same path,
 	 * the resource is deleted.
 	 */
-	protected void createFile(IFileStore target, String content) throws CoreException {
+	protected void createFile(IFileStore target, String content) throws CoreException, IOException {
 		target.delete(EFS.NONE, null);
 		InputStream input = new ByteArrayInputStream(content.getBytes());
-		transferData(input, target.openOutputStream(EFS.NONE, null));
+		try (OutputStream output = target.openOutputStream(EFS.NONE, null)) {
+			input.transferTo(output);
+		}
 		IFileInfo info = target.fetchInfo();
 		assertTrue(info.exists() && !info.isDirectory());
 	}
@@ -97,22 +99,25 @@ public abstract class LocalStoreTest extends ResourceTest {
 	protected void createIOFile(java.io.File target, String content) throws IOException {
 		target.delete();
 		InputStream input = new ByteArrayInputStream(content.getBytes());
-		transferData(input, new FileOutputStream(target));
+		try (OutputStream output = new FileOutputStream(target)) {
+			input.transferTo(output);
+		}
 		assertTrue(target.exists() && !target.isDirectory());
 	}
 
-	protected void createNode(IFileStore node) throws CoreException {
+	protected void createNode(IFileStore node) throws CoreException, IOException {
 		char type = node.getName().charAt(0);
 		if (type == 'd') {
 			node.mkdir(EFS.NONE, null);
 		} else {
 			InputStream input = getRandomContents();
-			OutputStream output = node.openOutputStream(EFS.NONE, null);
-			transferData(input, output);
+			try (OutputStream output = node.openOutputStream(EFS.NONE, null)) {
+				input.transferTo(output);
+			}
 		}
 	}
 
-	protected void createTree(IFileStore[] tree) throws CoreException {
+	protected void createTree(IFileStore[] tree) throws CoreException, IOException {
 		for (IFileStore element : tree) {
 			createNode(element);
 		}
@@ -182,19 +187,6 @@ public abstract class LocalStoreTest extends ResourceTest {
 				deleteOnTearDown(projects[i].getLocation());
 			}
 		}, null);
-	}
-
-	/**
-	 * Copy the data from the input stream to the output stream.
-	 * Close just the input stream.
-	 */
-	public void transferDataWithoutCloseStreams(InputStream input, OutputStream output) throws IOException {
-		int c = 0;
-		while ((c = input.read()) != -1) {
-			output.write(c);
-		}
-		// input.close();
-		// output.close();
 	}
 
 	protected boolean verifyNode(IFileStore node) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -1023,7 +1023,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 			try (InputStream input = new BufferedInputStream(fileInput)) {
 				ByteArrayOutputStream output = new ByteArrayOutputStream(1024);
 				buffer = output.toByteArray();
-				transferData(input, output);
+				input.transferTo(output);
 			}
 		}
 
@@ -1041,7 +1041,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		try (OutputStream fileOutput = new FileOutputStream(fileInFS)) {
 			try (OutputStream output = new BufferedOutputStream(fileOutput)) {
 				try (InputStream input = new BufferedInputStream(new ByteArrayInputStream(buffer))) {
-					transferData(input, output);
+					input.transferTo(output);
 				}
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -442,7 +442,7 @@ public class FilteredResourceTest extends ResourceTest {
 	private void modifyFileInWorkspace(final IFile file) throws IOException, CoreException {
 		try (InputStream fileInputStream = file.getContents(false)) {
 			ByteArrayOutputStream originalContentStream = new ByteArrayOutputStream();
-			transferData(fileInputStream, originalContentStream);
+			fileInputStream.transferTo(originalContentStream);
 			String originalContent = new String(originalContentStream.toByteArray(), StandardCharsets.UTF_8);
 			String newContent = originalContent + "w";
 			ByteArrayInputStream modifiedContentStream = new ByteArrayInputStream(

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
 import org.eclipse.core.filesystem.EFS;
@@ -99,9 +100,11 @@ public class LinkedResourceTest extends ResourceTest {
 		createFileInFileSystem(resolve(localFile), getRandomContents());
 	}
 
-	private byte[] getFileContents(IFile file) throws CoreException {
+	private byte[] getFileContents(IFile file) throws CoreException, IOException {
 		ByteArrayOutputStream bout = new ByteArrayOutputStream();
-		transferData(new BufferedInputStream(file.getContents()), bout);
+		try (InputStream inputStream = new BufferedInputStream(file.getContents())) {
+			inputStream.transferTo(bout);
+		}
 		return bout.toByteArray();
 	}
 
@@ -636,7 +639,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests creating a linked resource by modifying the .project file directly.
 	 * This is a regression test for bug 63331.
 	 */
-	public void testCreateLinkInDotProject() throws CoreException {
+	public void testCreateLinkInDotProject() throws Exception {
 		final IFile dotProject = existingProject.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		IFile link = nonExistingFileInExistingProject;
 		byte[] oldContents = null;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -391,8 +391,8 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public void createFileInFileSystem(IFileStore file, InputStream contents) throws CoreException {
 		file.getParent().mkdir(EFS.NONE, null);
-		try (OutputStream output = file.openOutputStream(EFS.NONE, null)) {
-			transferData(contents, output);
+		try (contents; OutputStream output = file.openOutputStream(EFS.NONE, null)) {
+			contents.transferTo(output);
 		} catch (IOException e) {
 			throw new CoreException(
 					new Status(IStatus.ERROR, PI_RESOURCES_TESTS, "failed creating file in file system", e));
@@ -569,7 +569,7 @@ public abstract class ResourceTest extends CoreTest {
 		assertNotNull("location was null for file: " + file, location);
 		try (FileInputStream inputStream = new FileInputStream(location.toFile())) {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			transferData(inputStream, outputStream);
+			inputStream.transferTo(outputStream);
 			return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new IllegalStateException("could not read from location:" + location, e);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
@@ -13,8 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import java.io.IOException;
 import java.util.Random;
-import org.eclipse.core.filesystem.*;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
@@ -44,7 +47,7 @@ public class FileSystemPerformanceTest extends LocalStoreTest {
 		return buf.toString();
 	}
 
-	void createStructure() throws CoreException {
+	void createStructure() throws CoreException, IOException {
 		baseStore = EFS.getLocalFileSystem().getStore(FileSystemHelper.getRandomLocation(getTempDir()));
 		baseStore.mkdir(EFS.NONE, null);
 		for (int i = 0; i < DIR_COUNT; i++) {
@@ -70,7 +73,7 @@ public class FileSystemPerformanceTest extends LocalStoreTest {
 		}
 	}
 
-	public void testPutFileInfo() throws CoreException {
+	public void testPutFileInfo() throws Exception {
 		createStructure();
 		PerformanceTestRunner runner = new PerformanceTestRunner() {
 			@Override

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
@@ -216,8 +216,9 @@ public class CoreTest extends TestCase {
 	 */
 	public void createFileInFileSystem(File file, InputStream contents) throws IOException {
 		file.getParentFile().mkdirs();
-		FileOutputStream output = new FileOutputStream(file);
-		transferData(contents, output);
+		try (contents; FileOutputStream output = new FileOutputStream(file)) {
+			contents.transferTo(output);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The CoreTest#transferData() method reimplements Java functionality provided by InputStream#transferTo(). This change replaces the calls to this method.