### PR TITLE
Provide monitor for resource tests via dedicated utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -28,6 +28,7 @@ import org.osgi.framework.BundleException;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 /**
  * This class needs to be used with SaveManager2Test. Basically this
@@ -164,7 +165,7 @@ public class SaveManager1Test extends SaveManagerTest {
 		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
 		description.setBuildSpec(new ICommand[] {command});
 		project.setDescription(description, null);
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		// close and open the project and see if the builder gets a good delta
 		project.close(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.filesystem;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -78,12 +79,12 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("file info does not exist", !info.exists());
 
 		// two-arg fetchInfo should throw exception
-		assertThrows(CoreException.class, () -> broken.fetchInfo(EFS.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> broken.fetchInfo(EFS.NONE, createTestMonitor()));
 	}
 
 	private IFileStore getDirFileStore(String path) throws CoreException {
 		IFileStore store = EFS.getFileSystem(EFS.SCHEME_FILE).getStore(IPath.fromOSString(path));
-		if (!store.toLocalFile(EFS.NONE, getMonitor()).exists()) {
+		if (!store.toLocalFile(EFS.NONE, createTestMonitor()).exists()) {
 			store.mkdir(EFS.NONE, null);
 			deleteOnTearDown(store);
 		}
@@ -198,7 +199,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore existing = getTempStore();
 		createFile(existing, getRandomString());
 		// try to copy when parent of destination does not exist
-		assertThrows(CoreException.class, () -> existing.copy(child, EFS.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> existing.copy(child, EFS.NONE, createTestMonitor()));
 		// destination should not exist
 		assertTrue("1.1", !child.fetchInfo().exists());
 	}
@@ -282,7 +283,7 @@ public class FileStoreTest extends LocalStoreTest {
 		assertTrue("7.2", compareContent(getContents(sb.toString()), bigFile.openInputStream(EFS.NONE, null)));
 		IFileStore destination = temp.getChild("copy of bigFile");
 		// IProgressMonitor monitor = new LoggingProgressMonitor(System.out);
-		IProgressMonitor monitor = getMonitor();
+		IProgressMonitor monitor = createTestMonitor();
 		bigFile.copy(destination, EFS.NONE, monitor);
 		assertTrue("7.3", compareContent(getContents(sb.toString()), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
@@ -499,7 +500,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore existing = getTempStore();
 		createFile(existing, getRandomString());
 		// try to move when parent of destination does not exist
-		assertThrows(CoreException.class, () -> existing.move(child, EFS.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> existing.move(child, EFS.NONE, createTestMonitor()));
 		// destination should not exist
 		assertTrue("1.1", !child.fetchInfo().exists());
 	}
@@ -515,10 +516,10 @@ public class FileStoreTest extends LocalStoreTest {
 		// assert that modifying a non-existing store fails
 		IFileInfo info = nonExisting.fetchInfo();
 		info.setLastModified(System.currentTimeMillis());
-		assertThrows(CoreException.class, () -> nonExisting.putInfo(info, EFS.SET_LAST_MODIFIED, getMonitor()));
+		assertThrows(CoreException.class, () -> nonExisting.putInfo(info, EFS.SET_LAST_MODIFIED, createTestMonitor()));
 		IFileInfo refetchedInfo = nonExisting.fetchInfo();
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, false);
-		assertThrows(CoreException.class, () -> nonExisting.putInfo(refetchedInfo, EFS.SET_ATTRIBUTES, getMonitor()));
+		assertThrows(CoreException.class, () -> nonExisting.putInfo(refetchedInfo, EFS.SET_ATTRIBUTES, createTestMonitor()));
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -203,11 +204,11 @@ public class BasicAliasTest extends ResourceTest {
 		IPath location = getRandomLocation();
 		location.toFile().mkdirs();
 		deleteOnTearDown(location);
-		link.createLink(location, IResource.NONE, getMonitor());
+		link.createLink(location, IResource.NONE, createTestMonitor());
 		ensureExistsInWorkspace(child, getRandomContents());
 		// move the link (rename)
 		IFolder movedLink = project.getFolder("MovedLink");
-		link.move(movedLink.getFullPath(), IResource.SHALLOW, getMonitor());
+		link.move(movedLink.getFullPath(), IResource.SHALLOW, createTestMonitor());
 		assertFalse("3.0", link.exists());
 		assertTrue("3.1", movedLink.exists());
 		assertEquals("3.2", location, movedLink.getLocation());
@@ -215,7 +216,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		// now copy the moved link
 		IFolder copiedLink = project.getFolder("CopiedLink");
-		movedLink.copy(copiedLink.getFullPath(), IResource.SHALLOW, getMonitor());
+		movedLink.copy(copiedLink.getFullPath(), IResource.SHALLOW, createTestMonitor());
 		assertFalse("4.0", link.exists());
 		assertTrue("4.1", movedLink.exists());
 		assertTrue("4.2", copiedLink.exists());
@@ -240,10 +241,10 @@ public class BasicAliasTest extends ResourceTest {
 		desc1.setLocation(top.getLocation().append(sub1.getName()));
 		IProjectDescription desc2 = getWorkspace().newProjectDescription(sub2.getName());
 		desc2.setLocation(top.getLocation().append(sub2.getName()));
-		sub1.create(desc1, getMonitor());
-		sub1.open(getMonitor());
-		sub2.create(desc2, getMonitor());
-		sub2.open(getMonitor());
+		sub1.create(desc1, createTestMonitor());
+		sub1.open(createTestMonitor());
+		sub2.create(desc2, createTestMonitor());
+		sub2.open(createTestMonitor());
 		IFile sub2File = sub2.getFile("file.txt");
 		IFile topFile = top.getFolder(sub2.getName()).getFile(sub2File.getName());
 		ensureExistsInWorkspace(sub2File, getRandomContents());
@@ -278,10 +279,10 @@ public class BasicAliasTest extends ResourceTest {
 		desc2.setLocation(location2);
 		deleteOnTearDown(location2);
 
-		testProject1.create(desc1, getMonitor());
-		testProject1.open(getMonitor());
-		testProject2.create(desc2, getMonitor());
-		testProject2.open(getMonitor());
+		testProject1.create(desc1, createTestMonitor());
+		testProject1.open(createTestMonitor());
+		testProject2.create(desc2, createTestMonitor());
+		testProject2.open(createTestMonitor());
 
 		final AliasManager aliasManager = ((Workspace) getWorkspace()).getAliasManager();
 		// force AliasManager to restart (simulates a shutdown/startup)
@@ -405,12 +406,12 @@ public class BasicAliasTest extends ResourceTest {
 		ensureExistsInWorkspace(new IResource[] {p1, p2}, true);
 
 		IFileStore tempStore = getTempStore();
-		tempStore.mkdir(EFS.NONE, getMonitor());
+		tempStore.mkdir(EFS.NONE, createTestMonitor());
 
 		replaceProject(p2, WrapperFileSystem.getWrappedURI(p2.getLocationURI()));
 
 		IFolder link2TempFolder = p1.getFolder("link2TempFolder");
-		link2TempFolder.createLink(tempStore.toURI(), IResource.NONE, getMonitor());
+		link2TempFolder.createLink(tempStore.toURI(), IResource.NONE, createTestMonitor());
 
 		// change the location of p2 project to the temp folder
 		replaceProject(p2, tempStore.toURI());
@@ -429,7 +430,7 @@ public class BasicAliasTest extends ResourceTest {
 	public void testBug258987() throws CoreException {
 		// Create the directory to which you will link. The directory needs a single file.
 		IFileStore dirStore = getTempStore();
-		dirStore.mkdir(EFS.NONE, getMonitor());
+		dirStore.mkdir(EFS.NONE, createTestMonitor());
 		assertTrue("2.0", dirStore.fetchInfo().exists());
 		assertTrue("3.0", dirStore.fetchInfo().isDirectory());
 
@@ -440,21 +441,21 @@ public class BasicAliasTest extends ResourceTest {
 		// Create and open the first project. Project links to the directory.
 		IProject project1 = ResourcesPlugin.getWorkspace().getRoot().getProject("project1");
 		IFolder folder1 = null;
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 		folder1 = project1.getFolder("subdir");
-		folder1.createLink(dirStore.toURI(), IResource.REPLACE, getMonitor());
+		folder1.createLink(dirStore.toURI(), IResource.REPLACE, createTestMonitor());
 
 		// Create and open the second project. It also links to the directory.
 		IProject project2 = ResourcesPlugin.getWorkspace().getRoot().getProject("project2");
 		IFolder folder2 = null;
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 		folder2 = project2.getFolder("subdir");
-		folder2.createLink(dirStore.toURI(), IResource.REPLACE, getMonitor());
+		folder2.createLink(dirStore.toURI(), IResource.REPLACE, createTestMonitor());
 
 		// Close the second project.
-		project2.close(getMonitor());
+		project2.close(createTestMonitor());
 
 		// Since project2 is closed, folder2 should not be an alias for folder1 anymore
 		IResource[] resources = ((Workspace) getWorkspace()).getAliasManager().computeAliases(folder1, ((Folder) folder1).getStore());
@@ -464,15 +465,15 @@ public class BasicAliasTest extends ResourceTest {
 	@Test
 	public void testCloseOpenProject() throws CoreException {
 		// close the project and make sure aliases in that project are no longer updated
-		pOverlap.close(getMonitor());
+		pOverlap.close(createTestMonitor());
 		IFile linkFile = fLinked.getFile("ChildFile.txt");
-		linkFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		linkFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		IFile closedFile = fOverlap.getFile(linkFile.getName());
 		assertFalse("1.0", closedFile.exists());
-		pOverlap.open(IResource.NONE, getMonitor());
+		pOverlap.open(IResource.NONE, createTestMonitor());
 		// should a refresh be needed when a project has been changed while it was
 		// closed?
-		pOverlap.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		pOverlap.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("1.1", closedFile.exists());
 	}
 
@@ -488,12 +489,12 @@ public class BasicAliasTest extends ResourceTest {
 		IFile linkDest = fLinked.getFile("CopyDestination");
 		IFile overlapDest = fOverlap.getFile(linkDest.getName());
 
-		sourceFile.copy(linkDest.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(linkDest.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("1.1", linkDest.exists());
 		assertTrue("1.2", overlapDest.exists());
 		assertOverlap("1.3", linkDest, overlapDest);
 
-		linkDest.delete(IResource.NONE, getMonitor());
+		linkDest.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.4", linkDest.exists());
 		assertFalse("1.5", overlapDest.exists());
 		assertOverlap("1.6", linkDest, overlapDest);
@@ -502,14 +503,14 @@ public class BasicAliasTest extends ResourceTest {
 		linkDest = lLinked;
 		overlapDest = lOverlap;
 		// first delete the file, then copy it back
-		overlapDest.delete(IResource.NONE, getMonitor());
+		overlapDest.delete(IResource.NONE, createTestMonitor());
 		// the link will still exist, but the location won't
 		assertTrue("2.1", linkDest.exists());
 		assertFalse("2.2", overlapDest.exists());
 		assertFalse("2.3", linkDest.getLocation().toFile().exists());
 		assertEquals("2.4", linkDest.getLocation(), overlapDest.getLocation());
 
-		sourceFile.copy(overlapDest.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(overlapDest.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("2.4", linkDest.exists());
 		assertTrue("2.5", overlapDest.exists());
 		assertOverlap("2.6", linkDest, overlapDest);
@@ -518,12 +519,12 @@ public class BasicAliasTest extends ResourceTest {
 		linkDest = fLinked.getFile("CopyDestination");
 		overlapDest = fOverlap.getFile(linkDest.getName());
 
-		sourceFile.copy(overlapDest.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(overlapDest.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("3.1", linkDest.exists());
 		assertTrue("3.2", overlapDest.exists());
 		assertOverlap("3.3", linkDest, overlapDest);
 
-		overlapDest.delete(IResource.NONE, getMonitor());
+		overlapDest.delete(IResource.NONE, createTestMonitor());
 		assertFalse("3.4", linkDest.exists());
 		assertFalse("3.5", overlapDest.exists());
 		assertOverlap("3.6", linkDest, overlapDest);
@@ -540,16 +541,16 @@ public class BasicAliasTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(allDest);
 
 		//copy to dest 1
-		source.copy(destFolder1.getFullPath(), IResource.NONE, getMonitor());
+		source.copy(destFolder1.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(allDest);
 
-		destFolder2.delete(IResource.NONE, getMonitor());
+		destFolder2.delete(IResource.NONE, createTestMonitor());
 
 		//copy to dest 2
-		source.copy(destFolder2.getFullPath(), IResource.NONE, getMonitor());
+		source.copy(destFolder2.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(allDest);
 
-		destFolder1.delete(IResource.NONE, getMonitor());
+		destFolder1.delete(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -560,29 +561,29 @@ public class BasicAliasTest extends ResourceTest {
 		//copying link to child should fail
 		IFolder copyDest = fLinkOverlap1.getFolder("CopyDest");
 		assertThrows(CoreException.class,
-				() -> fLinkOverlap2.copy(copyDest.getFullPath(), IResource.NONE, getMonitor()));
+				() -> fLinkOverlap2.copy(copyDest.getFullPath(), IResource.NONE, createTestMonitor()));
 		//moving link to child should fail
 		assertThrows(CoreException.class,
-				() -> fLinkOverlap2.move(copyDest.getFullPath(), IResource.NONE, getMonitor()));
+				() -> fLinkOverlap2.move(copyDest.getFullPath(), IResource.NONE, createTestMonitor()));
 
 		//copy to self should fail
 		IFolder copyDest2 = fLinkOverlap2.getFolder(copyDest.getName());
-		copyDest.create(IResource.NONE, true, getMonitor());
+		copyDest.create(IResource.NONE, true, createTestMonitor());
 
-		assertThrows(CoreException.class, () -> copyDest.copy(copyDest2.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> copyDest.copy(copyDest2.getFullPath(), IResource.NONE, createTestMonitor()));
 		//moving link to self should fail
-		assertThrows(CoreException.class, () -> copyDest.move(copyDest2.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> copyDest.move(copyDest2.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
 	@Test
 	public void testCreateDeleteFile() throws CoreException {
 		// file in linked folder
-		lChildLinked.delete(IResource.NONE, getMonitor());
+		lChildLinked.delete(IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lChildLinked, lChildOverlap);
-		lChildLinked.create(getRandomContents(), IResource.NONE, getMonitor());
+		lChildLinked.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.2", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.delete(IResource.NONE, getMonitor());
+		lOverlap.delete(IResource.NONE, createTestMonitor());
 		assertEquals("2.0", lLinked.getLocation(), lOverlap.getLocation());
 
 		assertFalse("2.1", lOverlap.exists());
@@ -593,51 +594,51 @@ public class BasicAliasTest extends ResourceTest {
 		assertTrue("2.4", lLinked.exists());
 		assertFalse("2.5", lLinked.getLocation().toFile().exists());
 		assertTrue("2.6", lLinked.isSynchronized(IResource.DEPTH_INFINITE));
-		assertThrows(CoreException.class, () -> lLinked.setContents(getRandomContents(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> lLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor()));
 
-		lOverlap.create(getRandomContents(), IResource.NONE, getMonitor());
+		lOverlap.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.8", lLinked, lOverlap);
 
 		//file in duplicate folder
-		lChildOverlap.delete(IResource.NONE, getMonitor());
+		lChildOverlap.delete(IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lChildLinked, lChildOverlap);
-		lChildOverlap.create(getRandomContents(), IResource.NONE, getMonitor());
+		lChildOverlap.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.2", lChildLinked, lChildOverlap);
 	}
 
 	@Test
 	public void testCreateDeleteFolder() throws CoreException {
 		// folder in overlapping project
-		fOverlap.delete(IResource.NONE, getMonitor());
+		fOverlap.delete(IResource.NONE, createTestMonitor());
 		// linked resources don't disappear on deletion of underlying file
 		assertTrue("1.0", fLinked.exists());
 		assertFalse("1.1", fLinked.getLocation().toFile().exists());
 
-		fOverlap.create(IResource.NONE, true, getMonitor());
+		fOverlap.create(IResource.NONE, true, createTestMonitor());
 		assertOverlap("1.2", fOverlap, fLinked);
 
 		//linked folder
-		fLinked.delete(IResource.NONE, getMonitor());
+		fLinked.delete(IResource.NONE, createTestMonitor());
 		// deleting a link should not delete file system contents
 		assertTrue("2.0", fOverlap.exists());
 		assertTrue("2.1", fOverlap.getLocation().toFile().exists());
 
-		fLinked.createLink(fOverlap.getLocation(), IResource.NONE, getMonitor());
+		fLinked.createLink(fOverlap.getLocation(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.4", fOverlap, fLinked);
 
 		//child of linked folders
 		IFolder child1 = fLinkOverlap1.getFolder("LinkChild");
 		IFolder child2 = fLinkOverlap2.getFolder(child1.getName());
 
-		child1.create(IResource.NONE, true, getMonitor());
+		child1.create(IResource.NONE, true, createTestMonitor());
 		assertOverlap("3.0", child1, child2);
-		child1.delete(IResource.NONE, getMonitor());
+		child1.delete(IResource.NONE, createTestMonitor());
 		assertFalse("3.1", child1.exists());
 		assertFalse("3.2", child2.exists());
 
-		child2.create(IResource.NONE, true, getMonitor());
+		child2.create(IResource.NONE, true, createTestMonitor());
 		assertOverlap("3.3", child1, child2);
-		child2.delete(IResource.NONE, getMonitor());
+		child2.delete(IResource.NONE, createTestMonitor());
 		assertFalse("3.4", child1.exists());
 		assertFalse("3.5", child2.exists());
 	}
@@ -650,16 +651,16 @@ public class BasicAliasTest extends ResourceTest {
 		IFile linkChild = link.getFile(folderChild.getName());
 		ensureExistsInWorkspace(folder, true);
 		ensureExistsInWorkspace(folderChild, true);
-		link.createLink(folder.getLocationURI(), IResource.NONE, getMonitor());
+		link.createLink(folder.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertTrue("1.0", linkChild.exists());
 		// manipulate file below overlapping folder and make sure alias under link is
 		// updated
-		folderChild.delete(IResource.NONE, getMonitor());
+		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.1", linkChild.exists());
 		ensureExistsInWorkspace(folderChild, true);
 		assertTrue("1.2", linkChild.exists());
 
-		link.delete(IResource.NONE, getMonitor());
+		link.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.3", linkChild.exists());
 	}
 
@@ -671,25 +672,25 @@ public class BasicAliasTest extends ResourceTest {
 		IFolder link = linkParent.getFolder("FolderLink");
 		IFile linkChild = link.getFile(folderChild.getName());
 		ensureExistsInWorkspace(new IResource[] {folder, folderChild, linkParent}, true);
-		link.createLink(folder.getLocationURI(), IResource.NONE, getMonitor());
+		link.createLink(folder.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertTrue("1.0", linkChild.exists());
 
 		// manipulate file below overlapping folder and make sure alias under link is
 		// updated
-		folderChild.delete(IResource.NONE, getMonitor());
+		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.1", linkChild.exists());
 		ensureExistsInWorkspace(folderChild, true);
 		assertTrue("1.2", linkChild.exists());
 
-		link.delete(IResource.NONE, getMonitor());
+		link.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.3", linkChild.exists());
-		link.createLink(folder.getLocationURI(), IResource.NONE, getMonitor());
+		link.createLink(folder.getLocationURI(), IResource.NONE, createTestMonitor());
 
 		// close and reopen the project and ensure the alias is still updated
-		link.getProject().close(getMonitor());
-		link.getProject().open(getMonitor());
+		link.getProject().close(createTestMonitor());
+		link.getProject().open(createTestMonitor());
 
-		folderChild.delete(IResource.NONE, getMonitor());
+		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("2.1", linkChild.exists());
 		ensureExistsInWorkspace(folderChild, true);
 		assertTrue("2.2", linkChild.exists());
@@ -698,7 +699,7 @@ public class BasicAliasTest extends ResourceTest {
 		// force AliasManager to restart (simulates a shutdown/startup)
 		aliasManager.startup(null);
 
-		folderChild.delete(IResource.NONE, getMonitor());
+		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("3.1", linkChild.exists());
 		ensureExistsInWorkspace(folderChild, true);
 		assertTrue("3.2", linkChild.exists());
@@ -707,7 +708,7 @@ public class BasicAliasTest extends ResourceTest {
 		IFile fileInLinkedProject = pLinked.getFile("fileInLinkedProject.txt");
 		createFileInFileSystem(((Resource) fileInLinkedProject).getStore(), getRandomContents());
 		// failure expected here because it is out of sync
-		assertThrows(CoreException.class, () -> getWorkspace().getRoot().delete(IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> getWorkspace().getRoot().delete(IResource.NONE, createTestMonitor()));
 		waitForRefresh();
 
 		// ensure aliases are gone (bug 144458)
@@ -721,8 +722,8 @@ public class BasicAliasTest extends ResourceTest {
 		IProject newProject = getWorkspace().getRoot().getProject("createOpenProject");
 		IProjectDescription desc = getWorkspace().newProjectDescription(newProject.getName());
 		desc.setLocationURI(fLinkOverlap1.getLocationURI());
-		newProject.create(desc, getMonitor());
-		newProject.open(getMonitor());
+		newProject.create(desc, createTestMonitor());
+		newProject.open(createTestMonitor());
 
 		//.project file should now exist in link
 		IFile linkChild = fLinkOverlap1.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -734,9 +735,9 @@ public class BasicAliasTest extends ResourceTest {
 	public void testDeleteLink() throws CoreException {
 		//test deletion of a link that overlaps a project location
 		IFolder linkOnProject = pLinked.getFolder("LinkOnProject");
-		linkOnProject.createLink(pOverlap.getLocation(), IResource.NONE, getMonitor());
+		linkOnProject.createLink(pOverlap.getLocation(), IResource.NONE, createTestMonitor());
 
-		linkOnProject.delete(IResource.NONE, getMonitor());
+		linkOnProject.delete(IResource.NONE, createTestMonitor());
 
 		// deletion of a link should not delete the project that it overlaps
 		assertFalse("2.1", linkOnProject.exists());
@@ -757,8 +758,8 @@ public class BasicAliasTest extends ResourceTest {
 
 		IProjectDescription childDesc = getWorkspace().newProjectDescription(child.getName());
 		childDesc.setLocation(parent.getLocation().append(child.getName()));
-		child.create(childDesc, getMonitor());
-		child.open(getMonitor());
+		child.create(childDesc, createTestMonitor());
+		child.open(createTestMonitor());
 
 		IFolder childDirInParent = parent.getFolder(child.getName());
 		IFile childProjectFileInParent = childDirInParent.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -766,18 +767,18 @@ public class BasicAliasTest extends ResourceTest {
 		assertTrue("1.1", childProjectFileInParent.exists());
 
 		//now delete the child and ensure the resources in the parent are gone
-		child.delete(IResource.NONE, getMonitor());
+		child.delete(IResource.NONE, createTestMonitor());
 		assertFalse("2.0", childDirInParent.exists());
 		assertFalse("2.1", childProjectFileInParent.exists());
 
 		//recreate the child and ensure resources in parent are there
-		child.create(childDesc, getMonitor());
-		child.open(getMonitor());
+		child.create(childDesc, createTestMonitor());
+		child.open(createTestMonitor());
 		assertTrue("3.0", childDirInParent.exists());
 		assertTrue("3.1", childProjectFileInParent.exists());
 
 		//delete the parent and ensure child is also deleted
-		parent.delete(IResource.NONE, getMonitor());
+		parent.delete(IResource.NONE, createTestMonitor());
 
 		assertFalse("4.0", parent.exists());
 		assertFalse("4.1", child.exists());
@@ -789,7 +790,7 @@ public class BasicAliasTest extends ResourceTest {
 	public void testDeleteProjectContents() throws CoreException {
 		//delete the overlapping project - it should delete the children of the linked folder
 		//but leave the actual links intact in the resource tree
-		pOverlap.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		pOverlap.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked });
 		assertDoesNotExistInFileSystem(
 				new IResource[] { pOverlap, fOverlap, lOverlap, lChildOverlap, lChildLinked, lLinked, fLinked });
@@ -799,34 +800,34 @@ public class BasicAliasTest extends ResourceTest {
 	@Test
 	public void testFileAppendContents() throws CoreException {
 		//linked file
-		lLinked.appendContents(getRandomContents(), IResource.NONE, getMonitor());
+		lLinked.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lLinked, lOverlap);
 
 		//file in linked folder
-		lChildLinked.appendContents(getRandomContents(), IResource.NONE, getMonitor());
+		lChildLinked.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.1", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.appendContents(getRandomContents(), IResource.NONE, getMonitor());
+		lOverlap.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lLinked, lOverlap);
 		//file in duplicate folder
-		lChildOverlap.appendContents(getRandomContents(), IResource.NONE, getMonitor());
+		lChildOverlap.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lChildLinked, lChildOverlap);
 	}
 
 	@Test
 	public void testFileSetContents() throws CoreException {
 		//linked file
-		lLinked.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		lLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lLinked, lOverlap);
 
 		//file in linked folder
-		lChildLinked.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		lChildLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.1", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		lOverlap.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lLinked, lOverlap);
 		//file in duplicate folder
-		lChildOverlap.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		lChildOverlap.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lChildLinked, lChildOverlap);
 	}
 
@@ -838,7 +839,7 @@ public class BasicAliasTest extends ResourceTest {
 	public void testMoveFile() throws CoreException {
 		IFile destination = pNoOverlap.getFile("MoveDestination");
 		//file in linked folder
-		lChildLinked.move(destination.getFullPath(), IResource.NONE, getMonitor());
+		lChildLinked.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertDoesNotExistInWorkspace(lChildLinked);
 		assertDoesNotExistInWorkspace(lChildOverlap);
 		assertExistsInWorkspace(destination);
@@ -846,13 +847,13 @@ public class BasicAliasTest extends ResourceTest {
 		assertTrue("1.5", lChildLinked.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("1.6", destination.isSynchronized(IResource.DEPTH_INFINITE));
 
-		destination.move(lChildLinked.getFullPath(), IResource.NONE, getMonitor());
+		destination.move(lChildLinked.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(lChildLinked);
 		assertExistsInWorkspace(lChildOverlap);
 		assertDoesNotExistInWorkspace(destination);
 		assertOverlap("2.4", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.move(destination.getFullPath(), IResource.NONE, getMonitor());
+		lOverlap.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertDoesNotExistInWorkspace(lOverlap);
 		assertExistsInWorkspace(lLinked);
 		assertDoesNotExistInFileSystem(lLinked);
@@ -860,19 +861,19 @@ public class BasicAliasTest extends ResourceTest {
 		assertEquals("3.4", lLinked.getLocation(), lOverlap.getLocation());
 		assertTrue("3.4.1", lLinked.isSynchronized(IResource.DEPTH_INFINITE));
 
-		destination.move(lOverlap.getFullPath(), IResource.NONE, getMonitor());
+		destination.move(lOverlap.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(lLinked);
 		assertExistsInWorkspace(lOverlap);
 		assertDoesNotExistInWorkspace(destination);
 		assertOverlap("3.8", lLinked, lOverlap);
 		//file in duplicate folder
-		lChildOverlap.move(destination.getFullPath(), IResource.NONE, getMonitor());
+		lChildOverlap.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertDoesNotExistInWorkspace(lChildLinked);
 		assertDoesNotExistInWorkspace(lChildOverlap);
 		assertExistsInWorkspace(destination);
 		assertOverlap("3.4", lChildLinked, lChildOverlap);
 
-		destination.move(lChildOverlap.getFullPath(), IResource.NONE, getMonitor());
+		destination.move(lChildOverlap.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(lChildLinked);
 		assertExistsInWorkspace(lChildOverlap);
 		assertDoesNotExistInWorkspace(destination);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
 import java.util.stream.Stream;
@@ -42,7 +43,7 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	protected void addBuilder(IProject project, String builderName) throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, builderName, "Project1Build1")});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	/**
@@ -70,7 +71,7 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	 * Dirties the given file, forcing a build.
 	 */
 	protected void dirty(IFile file) throws CoreException {
-		file.setContents(getRandomContents(), true, true, getMonitor());
+		file.setContents(getRandomContents(), true, true, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AutoBuildJobTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Map;
@@ -89,11 +90,11 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 
 	private void setupProjectWithOurBuilder() throws CoreException {
 		project = getWorkspace().getRoot().getProject(getName());
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, getName()) });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	private void requestAutoBuildJobExecution() {
@@ -200,7 +201,7 @@ public class AutoBuildJobTest extends AbstractBuilderTest {
 	 * Trigger an auto-build and wait for it to start.
 	 */
 	private void triggerAutoBuildAndWait() throws CoreException, InterruptedException {
-		project.touch(getMonitor());
+		project.touch(createTestMonitor());
 		Thread.sleep(Policy.MAX_BUILD_DELAY);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
 import org.eclipse.core.resources.IBuildConfiguration;
@@ -82,7 +83,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		// Create buildConfigs
 		desc.setBuildConfigs(new String[] {variant0, variant1, variant2});
 
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	/**
@@ -93,12 +94,12 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		ConfigurationBuilder.clearStats();
 		// Run some incremental builds while varying the active variant and whether the project was modified
 		// and check that the builder is run/not run with the correct trigger
-		file0.setContents(getRandomContents(), true, true, getMonitor());
+		file0.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(1, project0, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, project0, variant1, false, 1, 0);
 		incrementalBuild(3, project0, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(4, project0, variant1, false, 1, 0);
-		file0.setContents(getRandomContents(), true, true, getMonitor());
+		file0.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(5, project0, variant1, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		incrementalBuild(6, project0, variant2, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		incrementalBuild(7, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
@@ -109,14 +110,14 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 	 */
 	public void testCloseAndOpenProject() throws CoreException {
 		ConfigurationBuilder.clearStats();
-		file0.setContents(getRandomContents(), true, true, getMonitor());
+		file0.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(1, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, project0, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(3, project0, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
-		project0.close(getMonitor());
+		project0.close(createTestMonitor());
 		ConfigurationBuilder.clearStats();
-		project0.open(getMonitor());
+		project0.open(createTestMonitor());
 
 		incrementalBuild(4, project0, variant0, false, 0, 0);
 		incrementalBuild(5, project0, variant1, false, 0, 0);
@@ -137,21 +138,21 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 
 		ConfigurationBuilder.clearStats();
 
-		tempFile0.setContents(getRandomContents(), true, true, getMonitor());
-		tempFile1.setContents(getRandomContents(), true, true, getMonitor());
+		tempFile0.setContents(getRandomContents(), true, true, createTestMonitor());
+		tempFile1.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(1, tempProject, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, tempProject, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(3, tempProject, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
-		tempFile0.setContents(getRandomContents(), true, true, getMonitor());
+		tempFile0.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(4, tempProject, variant1, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 
-		tempFile1.setContents(getRandomContents(), true, true, getMonitor());
+		tempFile1.setContents(getRandomContents(), true, true, createTestMonitor());
 		incrementalBuild(5, tempProject, variant2, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 
-		tempProject.close(getMonitor());
+		tempProject.close(createTestMonitor());
 		ConfigurationBuilder.clearStats();
-		tempProject.open(getMonitor());
+		tempProject.open(createTestMonitor());
 
 		// verify variant0 - both File0 and File1 are expected to have changed since it
 		// was last built
@@ -195,14 +196,14 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		ConfigurationBuilder.clearBuildOrder();
 		IProjectDescription desc = project0.getDescription();
 		desc.setActiveBuildConfig(variant0);
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 		desc = project1.getDescription();
 		desc.setActiveBuildConfig(variant0);
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Note: references are not alphabetically ordered to check that references are sorted into a stable order
 		setReferences(project0, variant0, new IBuildConfiguration[] {project0.getBuildConfig(variant1), project1.getBuildConfig(variant2), project1.getBuildConfig(variant0)});
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		assertEquals("1.0", 4, ConfigurationBuilder.buildOrder.size());
 		assertEquals("1.1", project0.getBuildConfig(variant1), ConfigurationBuilder.buildOrder.get(0));
@@ -217,10 +218,10 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		checkBuild(7, project1, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
 		// Modify project1, all project1 builders should do an incremental build
-		file1.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
 
 		ConfigurationBuilder.clearBuildOrder();
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		assertEquals("8.0", 2, ConfigurationBuilder.buildOrder.size());
 		assertEquals("8.1", project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
@@ -246,12 +247,12 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		IProjectDescription desc = project0.getDescription();
 		desc.setActiveBuildConfig(variant0);
 		desc.setBuildConfigReferences(variant0, new IBuildConfiguration[] {project1.getBuildConfig(variant0)});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		// close project 1
-		project1.close(getMonitor());
+		project1.close(createTestMonitor());
 		// should still be able to build project 0.
-		getWorkspace().build(new IBuildConfiguration[] {project0.getBuildConfig(variant0)}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getBuildConfig(variant0)}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		assertEquals("1.0", 1, ConfigurationBuilder.buildOrder.size());
 		assertEquals("1.1", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
 		checkBuild(2, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
@@ -259,17 +260,17 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		// Workspace full build should also build project 0
 		ConfigurationBuilder.clearStats();
 		ConfigurationBuilder.clearBuildOrder();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals("1.0", 1, ConfigurationBuilder.buildOrder.size());
 		assertEquals("1.1", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
 		checkBuild(2, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
 		// re-open project 1
-		project1.open(getMonitor());
+		project1.open(createTestMonitor());
 
 		ConfigurationBuilder.clearStats();
 		ConfigurationBuilder.clearBuildOrder();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		assertEquals("8.0", 2, ConfigurationBuilder.buildOrder.size());
 		assertEquals("8.1", project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
@@ -293,14 +294,14 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 	private void setReferences(IProject project, String configId, IBuildConfiguration[] configs) throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigReferences(configId, configs);
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	/**
 	 * Run an incremental build for the given project variant, and check the behaviour of the build.
 	 */
 	private void incrementalBuild(int testId, IProject project, String variant, boolean shouldBuild, int expectedCount, int expectedTrigger) throws CoreException {
-		project.build(project.getBuildConfig(variant), IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(project.getBuildConfig(variant), IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		checkBuild(testId, project, variant, shouldBuild, expectedCount, expectedTrigger);
 	}
 
@@ -308,7 +309,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 	 * Clean the specified project variant.
 	 */
 	private void clean(int testId, IProject project, String variant, int expectedCount) throws CoreException {
-		project.build(project.getBuildConfig(variant), IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(project.getBuildConfig(variant), IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		ConfigurationBuilder builder = ConfigurationBuilder.getBuilder(project.getBuildConfig(variant));
 		assertNotNull(testId + ".0", builder);
 		assertEquals(testId + ".1", expectedCount, builder.buildCount);
@@ -345,7 +346,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 	public void testBuildProjectWithNotExistingReference() throws Exception {
 		// need a build to create builder
 		IBuildConfiguration buildConfig = project0.getBuildConfig(variant0);
-		project0.build(buildConfig, IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project0.build(buildConfig, IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		// Configure builder to report "interesting" projects
 		ConfigurationBuilder builder = ConfigurationBuilder.getBuilder(buildConfig);
@@ -362,13 +363,13 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		});
 
 		// need a full build to remember "interesting" projects
-		project0.build(buildConfig, IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project0.build(buildConfig, IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		// need a delta NOT in the builder's own project
-		project1.touch(getMonitor());
+		project1.touch(createTestMonitor());
 
 		// this will try to find delta for non existing resource
-		project0.build(buildConfig, IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project0.build(buildConfig, IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
@@ -79,7 +80,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		// Create buildConfigs
 		desc.setBuildConfigs(new String[] {variant0, variant1});
 
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	/**
@@ -92,7 +93,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		for (IBuildConfiguration config : configs) {
 			if (!config.equals(active)) {
 				desc.setActiveBuildConfig(config.getName());
-				project.setDescription(desc, getMonitor());
+				project.setDescription(desc, createTestMonitor());
 				return config;
 			}
 		}
@@ -115,7 +116,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 	private void setReferences(IBuildConfiguration variant, IBuildConfiguration[] refs) throws CoreException {
 		IProjectDescription desc = variant.getProject().getDescription();
 		desc.setBuildConfigReferences(variant.getName(), refs);
-		variant.getProject().setDescription(desc, getMonitor());
+		variant.getProject().setDescription(desc, createTestMonitor());
 	}
 
 	/**
@@ -157,7 +158,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 
 		setupSimpleReferences();
 		ContextBuilder.clearStats();
-		project0.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project0.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		IBuildContext context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -182,7 +183,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		ContextBuilder.clearStats();
 
 		// Build project and resolve references
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		IBuildContext context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -201,7 +202,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 
 		// Build just project0
 		ContextBuilder.clearStats();
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, false, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, false, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -216,7 +217,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		setupSimpleReferences();
 		ContextBuilder.clearStats();
 		// build project0 & project2 ; project1 will end up being built too.
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig(), project2.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig(), project2.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		IBuildContext context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -243,7 +244,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		setReferences(project2.getActiveBuildConfig(), new IBuildConfiguration[] {});
 
 		ContextBuilder.clearStats();
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		IBuildContext context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -272,7 +273,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		setReferences(project1.getActiveBuildConfig(), new IBuildConfiguration[] {});
 
 		ContextBuilder.clearStats();
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		IBuildContext context = ContextBuilder.getContext(project0.getActiveBuildConfig());
@@ -288,7 +289,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		ContextBuilder.clearStats();
 		IBuildConfiguration project1PreviousActive = project1.getActiveBuildConfig();
 		IBuildConfiguration project1NewActive = changeActiveBuildConfig(project1);
-		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, getMonitor());
+		getWorkspace().build(new IBuildConfiguration[] {project0.getActiveBuildConfig()}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
 		ContextBuilder.assertValid();
 
 		context = ContextBuilder.getContext(project0.getActiveBuildConfig());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -82,8 +83,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 * Rebuilds the solution.
 	 */
 	protected void rebuild() throws CoreException {
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 	}
 
 	/**
@@ -109,20 +110,20 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		file3 = folder2.getFile(FILE1);
 
 		// Create and open a project, folder and file
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		folder1.create(true, true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		folder1.create(true, true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Build the project
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		verifier = DeltaVerifierBuilder.getInstance();
 		assertNotNull("Builder was not instantiated", verifier);
@@ -134,8 +135,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 */
 	public void testAddAndRemoveFile() throws CoreException {
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file2.create(in, true, getMonitor());
-		file2.delete(true, getMonitor());
+		file2.create(in, true, createTestMonitor());
+		file2.delete(true, createTestMonitor());
 		rebuild();
 		// builder for project1 may not even be called (empty delta)
 		if (verifier.wasFullBuild()) {
@@ -148,8 +149,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 * Tests that the builder is receiving an appropriate delta
 	 */
 	public void testAddAndRemoveFolder() throws CoreException {
-		folder2.create(true, true, getMonitor());
-		folder2.delete(true, getMonitor());
+		folder2.create(true, true, createTestMonitor());
+		folder2.delete(true, createTestMonitor());
 		rebuild();
 		// builder for project1 may not even be called (empty delta)
 		if (verifier.wasFullBuild()) {
@@ -164,7 +165,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	public void testAddFile() throws CoreException {
 		verifier.addExpectedChange(file2, project1, IResourceDelta.ADDED, 0);
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file2.create(in, true, getMonitor());
+		file2.create(in, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -175,9 +176,9 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	public void testAddFileAndFolder() throws CoreException {
 		verifier.addExpectedChange(folder2, project1, IResourceDelta.ADDED, 0);
 		verifier.addExpectedChange(file3, project1, IResourceDelta.ADDED, 0);
-		folder2.create(true, true, getMonitor());
+		folder2.create(true, true, createTestMonitor());
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file3.create(in, true, getMonitor());
+		file3.create(in, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -187,7 +188,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 */
 	public void testAddFolder() throws CoreException {
 		verifier.addExpectedChange(folder2, project1, IResourceDelta.ADDED, 0);
-		folder2.create(true, true, getMonitor());
+		folder2.create(true, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -197,7 +198,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 */
 	public void testAddProject() throws CoreException {
 		// should not affect project1's delta
-		project2.create(getMonitor());
+		project2.create(createTestMonitor());
 		rebuild();
 		// builder for project1 should not even be called
 		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
@@ -210,7 +211,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		/* change file1's contents */
 		verifier.addExpectedChange(file1, project1, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file1.setContents(in, true, false, getMonitor());
+		file1.setContents(in, true, false, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -222,8 +223,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		/* change file1 into a folder */
 		verifier.addExpectedChange(file1, project1, IResourceDelta.CHANGED,
 				IResourceDelta.CONTENT | IResourceDelta.TYPE | IResourceDelta.REPLACED);
-		file1.delete(true, getMonitor());
-		folder3.create(true, true, getMonitor());
+		file1.delete(true, createTestMonitor());
+		folder3.create(true, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -233,16 +234,16 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 */
 	public void testChangeFolderToFile() throws CoreException {
 		/* change to a folder */
-		file1.delete(true, getMonitor());
-		folder3.create(true, true, getMonitor());
+		file1.delete(true, createTestMonitor());
+		folder3.create(true, true, createTestMonitor());
 		rebuild();
 
 		/* now change back to a file and verify */
 		verifier.addExpectedChange(file1, project1, IResourceDelta.CHANGED,
 				IResourceDelta.CONTENT | IResourceDelta.TYPE | IResourceDelta.REPLACED);
-		folder3.delete(true, getMonitor());
+		folder3.delete(true, createTestMonitor());
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 1, 2 });
-		file1.create(in, true, getMonitor());
+		file1.create(in, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -277,8 +278,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		verifier.addExpectedChange(file3, project1, IResourceDelta.ADDED, IResourceDelta.MOVED_FROM,
 				file1.getFullPath(), null);
 
-		folder2.create(true, true, getMonitor());
-		file1.move(file3.getFullPath(), true, getMonitor());
+		folder2.create(true, true, createTestMonitor());
+		file1.move(file3.getFullPath(), true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -288,7 +289,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	 */
 	public void testRemoveFile() throws CoreException {
 		verifier.addExpectedChange(file1, project1, IResourceDelta.REMOVED, 0);
-		file1.delete(true, getMonitor());
+		file1.delete(true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -299,7 +300,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 	public void testRemoveFileAndFolder() throws CoreException {
 		verifier.addExpectedChange(folder1, project1, IResourceDelta.REMOVED, 0);
 		verifier.addExpectedChange(file1, project1, IResourceDelta.REMOVED, 0);
-		folder1.delete(true, getMonitor());
+		folder1.delete(true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -312,8 +313,8 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		verifier.addExpectedChange(file1, project1, IResourceDelta.CHANGED,
 				IResourceDelta.REPLACED | IResourceDelta.CONTENT);
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file1.delete(true, getMonitor());
-		file1.create(in, true, getMonitor());
+		file1.delete(true, createTestMonitor());
+		file1.create(in, true, createTestMonitor());
 		rebuild();
 		assertDelta();
 	}
@@ -326,10 +327,10 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		verifier.addExpectedChange(file2, project1, IResourceDelta.ADDED, 0);
 
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file1.setContents(in, true, false, getMonitor());
+		file1.setContents(in, true, false, createTestMonitor());
 
 		ByteArrayInputStream in2 = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		file2.create(in2, true, getMonitor());
+		file2.create(in2, true, createTestMonitor());
 
 		rebuild();
 		assertDelta();
@@ -342,9 +343,9 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		IProjectDescription description = project.getDescription();
 		description.setBuildSpec(new ICommand[] { createCommand(description, EmptyDeltaBuilder.BUILDER_NAME, null),
 				createCommand(description, EmptyDeltaBuilder2.BUILDER_NAME, null) });
-		project.setDescription(description, getMonitor());
+		project.setDescription(description, createTestMonitor());
 
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		List<IResourceDelta> deltas = new ArrayList<>();
 
@@ -360,9 +361,9 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		EmptyDeltaBuilder2.getInstance().setRuleCallback(captureDelta);
 
 		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { 4, 5, 6 });
-		project.getFile("test").create(in, true, getMonitor());
+		project.getFile("test").create(in, true, createTestMonitor());
 
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		assertSame("both builders should receive the same cached delta ", deltas.get(0), deltas.get(1));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -51,8 +52,8 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		IProjectDescription description = project.getDescription();
 		ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
 		description.setBuildSpec(new ICommand[] { command1 });
-		project.setDescription(description, IResource.NONE, getMonitor());
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.setDescription(description, IResource.NONE, createTestMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		CycleBuilder builder = CycleBuilder.getInstance();
 		builder.resetBuildCount();
@@ -60,10 +61,10 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		builder.setAfterProjects(new IProject[] {after1, after2});
 
 		// create a file to ensure incremental build is called
-		project.getFile("Foo.txt").create(getRandomContents(), IResource.NONE, getMonitor());
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.getFile("Foo.txt").create(getRandomContents(), IResource.NONE, createTestMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 	}
 
 	public void skipTestNeedRebuild() throws CoreException {
@@ -81,56 +82,56 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		ICommand command1 = createCommand(description, CycleBuilder.BUILDER_NAME, "Build0");
 		ICommand command2 = createCommand(description, SortBuilder.BUILDER_NAME, "Build1");
 		description.setBuildSpec(new ICommand[] { command1, command2 });
-		project.setDescription(description, IResource.NONE, getMonitor());
+		project.setDescription(description, IResource.NONE, createTestMonitor());
 
 		CycleBuilder builder = CycleBuilder.getInstance();
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		//don't request rebuilds and ensure we're only called once
 		builder.setRebuildsToRequest(0);
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, builder.getBuildCount());
 
 		//force an incremental build
 		IFile file = project.getFile("foo.txt");
 		builder.resetBuildCount();
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertEquals(1, builder.getBuildCount());
 
 		//request 1 rebuild and ensure we're called twice
 		builder.setRebuildsToRequest(1);
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertEquals(2, builder.getBuildCount());
 
 		//request 5 rebuilds and ensure we're called six times
 		builder.setRebuildsToRequest(5);
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(6, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertEquals(6, builder.getBuildCount());
 
 		//request many rebuilds and ensure we're called according to the build policy
 		int maxBuilds = getWorkspace().getDescription().getMaxBuildIterations();
 		builder.setRebuildsToRequest(maxBuilds * 2);
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//change the rebuild policy and ensure we're called the correct number of times
@@ -140,12 +141,12 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		getWorkspace().setDescription(desc);
 		builder.setRebuildsToRequest(maxBuilds * 2);
 		builder.resetBuildCount();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
@@ -52,16 +53,16 @@ public class BuilderEventTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		listener.reset();
 		//start with an incremental build
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(getWorkspace(), listener.getSource());
 		assertEquals(IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
 		assertTrue(listener.hadPreBuild());
@@ -70,7 +71,7 @@ public class BuilderEventTest extends AbstractBuilderTest {
 
 		//do a second incremental build and ensure we still get the events
 		listener.reset();
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(getWorkspace(), listener.getSource());
 		assertEquals(IncrementalProjectBuilder.INCREMENTAL_BUILD, listener.getBuildKind());
 		assertTrue(listener.hadPreBuild());
@@ -79,7 +80,7 @@ public class BuilderEventTest extends AbstractBuilderTest {
 
 		//do a full build and ensure we still get the event
 		listener.reset();
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(getWorkspace(), listener.getSource());
 		assertEquals(IncrementalProjectBuilder.FULL_BUILD, listener.getBuildKind());
 		assertTrue(listener.hadPreBuild());
@@ -88,7 +89,7 @@ public class BuilderEventTest extends AbstractBuilderTest {
 
 		//do a clean build and ensure we get the same events
 		listener.reset();
-		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertEquals(getWorkspace(), listener.getSource());
 		assertEquals(IncrementalProjectBuilder.CLEAN_BUILD, listener.getBuildKind());
 		assertTrue(listener.hadPreBuild());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SNOW;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_WATER;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -62,7 +63,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
@@ -80,7 +81,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 
 		//remove the water nature, thus invalidating snow nature
@@ -88,7 +89,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.reset();
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		// setting description file will also trigger build
-		descFile.setContents(projectFileWithoutWater(), IResource.FORCE, getMonitor());
+		descFile.setContents(projectFileWithoutWater(), IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		//assert that builder was skipped
 		builder.assertLifecycleEvents();
@@ -98,7 +99,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.addExpectedLifecycleEvent(SnowBuilder.SNOW_BUILD_EVENT);
 		desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		builder.assertLifecycleEvents();
 		assertTrue(builder.wasDeltaNull());
@@ -114,7 +115,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 
 		//remove the snow nature through normal API
@@ -122,7 +123,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.reset();
 		desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER });
-		project.setDescription(desc, IResource.NONE, getMonitor());
+		project.setDescription(desc, IResource.NONE, createTestMonitor());
 		waitForBuild();
 		//make sure the snow builder wasn't run
 		builder.assertLifecycleEvents();
@@ -140,7 +141,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.addExpectedLifecycleEvent(SnowBuilder.SNOW_BUILD_EVENT);
 		desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.KEEP_HISTORY, getMonitor());
+		project.setDescription(desc, IResource.KEEP_HISTORY, createTestMonitor());
 		waitForBuild();
 		builder.assertLifecycleEvents();
 
@@ -149,7 +150,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.reset();
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		// setting description file will also trigger build
-		descFile.setContents(projectFileWithoutSnow(), IResource.FORCE, getMonitor());
+		descFile.setContents(projectFileWithoutSnow(), IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		//assert that builder was skipped
 		builder.assertLifecycleEvents();
@@ -167,7 +168,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		builder.addExpectedLifecycleEvent(SnowBuilder.SNOW_BUILD_EVENT);
 		desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		builder.assertLifecycleEvents();
 		assertTrue("5.1", builder.wasDeltaNull());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -108,21 +109,21 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create some resources
 		// Turn auto-building on
 		setAutoBuilding(true);
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 		// Set build spec
 		IProjectDescription desc = project1.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.getArguments().put(TestBuilder.BUILD_ID, "Project1Build1");
 		desc.setBuildSpec(new ICommand[] { command });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Create folders and files
-		folder.create(true, true, getMonitor());
-		fileA.create(getRandomContents(), true, getMonitor());
-		sub.create(true, true, getMonitor());
-		fileB.create(getRandomContents(), true, getMonitor());
+		folder.create(true, true, createTestMonitor());
+		fileA.create(getRandomContents(), true, createTestMonitor());
+		sub.create(true, true, createTestMonitor());
+		fileB.create(getRandomContents(), true, createTestMonitor());
 	}
 
 	/**
@@ -134,8 +135,8 @@ public class BuilderTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
@@ -144,11 +145,11 @@ public class BuilderTest extends AbstractBuilderTest {
 		ICommand command2 = desc.newCommand();
 		command2.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command1, command2 });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		//do an incremental build -- build should fail, but second builder
 		// should run
 		assertThrows(CoreException.class,
-				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor()));
+				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor()));
 
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -157,7 +158,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		verifier.assertLifecycleEvents();
 
 		//build again -- it should succeed this time
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 	}
 
 	public void testBuildClean() throws CoreException {
@@ -167,13 +168,13 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//start with a clean build
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -188,7 +189,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		monitor.assertUsedUp();
 		assertTrue("3.4", verifier.wasFullBuild());
 		// next time it will appear as an incremental build
-		project.touch(getMonitor());
+		project.touch(createTestMonitor());
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 		monitor.assertUsedUp();
@@ -228,17 +229,17 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
 		// Do an initial build to get the builder instance
 		IProjectDescription desc = project1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Project1Build1") });
-		project1.setDescription(desc, getMonitor());
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
@@ -248,12 +249,12 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Build spec with no commands
 		desc = project1.getDescription();
 		desc.setBuildSpec(new ICommand[] {});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Build the project -- should do nothing
 		verifier.reset();
 		dirty(file1);
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.assertLifecycleEvents();
 
 		// Build command with no arguments -- will use default build ID
@@ -261,13 +262,13 @@ public class BuilderTest extends AbstractBuilderTest {
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Build the project
 		// Note that since the arguments have changed, the identity of the build
 		// command is different so a new builder will be instantiated
 		dirty(file1);
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
@@ -276,13 +277,13 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create and set a build specs for project one
 		desc = project1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Project1Build1") });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// Create and set a build spec for project two
 		desc = project2.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1"),
 				createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2") });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		// Build
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -297,14 +298,14 @@ public class BuilderTest extends AbstractBuilderTest {
 		verifier.addExpectedLifecycleEvent("Project2Build2");
 		dirty(file1);
 		dirty(file2);
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.assertLifecycleEvents();
 		verifier.addExpectedLifecycleEvent("Project1Build1");
 		dirty(file1);
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		verifier.assertLifecycleEvents();
 		dirty(file2);
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Project2Build1");
 		verifier.addExpectedLifecycleEvent("Project2Build2");
 		verifier.assertLifecycleEvents();
@@ -313,22 +314,22 @@ public class BuilderTest extends AbstractBuilderTest {
 		desc = project2.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, DeltaVerifierBuilder.BUILDER_NAME, "Project2Build2"),
 				createCommand(desc, SortBuilder.BUILDER_NAME, "Project2Build1") });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		// Build
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Project1Build1");
 		verifier.addExpectedLifecycleEvent("Project2Build2");
 		verifier.addExpectedLifecycleEvent("Project2Build1");
 		verifier.assertLifecycleEvents();
 		dirty(file1);
 		dirty(file2);
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Project1Build1");
 		verifier.assertLifecycleEvents();
 		dirty(file1);
 		dirty(file2);
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Project2Build2");
 		verifier.addExpectedLifecycleEvent("Project2Build1");
 		verifier.assertLifecycleEvents();
@@ -349,12 +350,12 @@ public class BuilderTest extends AbstractBuilderTest {
 			// Turn auto-building off
 			setAutoBuilding(false);
 			// Create some resources
-			proj1.create(getMonitor());
-			proj1.open(getMonitor());
+			proj1.create(createTestMonitor());
+			proj1.open(createTestMonitor());
 			// Create and set a build spec for project one
 			IProjectDescription desc = proj1.getDescription();
 			desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-			proj1.setDescription(desc, getMonitor());
+			proj1.setDescription(desc, createTestMonitor());
 			proj1.build(IncrementalProjectBuilder.FULL_BUILD, SortBuilder.BUILDER_NAME, new HashMap<>(), null);
 			notified[0] = false;
 			//now turn on autobuild and see if the listener is notified again
@@ -379,25 +380,25 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		proj1.create(getMonitor());
-		proj1.open(getMonitor());
-		proj2.create(getMonitor());
-		proj2.open(getMonitor());
+		proj1.create(createTestMonitor());
+		proj1.open(createTestMonitor());
+		proj2.create(createTestMonitor());
+		proj2.open(createTestMonitor());
 		// set the build order
 		setBuildOrder(proj1, proj2);
 
 		// Create and set a build specs for project one
 		IProjectDescription desc = proj1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 
 		// Create and set a build spec for project two
 		desc = proj2.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
-		proj2.setDescription(desc, getMonitor());
+		proj2.setDescription(desc, createTestMonitor());
 
 		// Build the workspace
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		// Set up a plug-in lifecycle verifier for testing purposes
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -413,7 +414,7 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		//build in reverse order
 		setBuildOrder(proj2, proj1);
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Build1");
 		verifier.addExpectedLifecycleEvent("Build2");
 		verifier.addExpectedLifecycleEvent("Build0");
@@ -421,7 +422,7 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		//only specify build order for project1
 		setBuildOrder(proj1);
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Build0");
 		verifier.addExpectedLifecycleEvent("Build1");
 		verifier.addExpectedLifecycleEvent("Build2");
@@ -429,7 +430,7 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		//only specify build order for project2
 		setBuildOrder(proj2, proj1);
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Build1");
 		verifier.addExpectedLifecycleEvent("Build2");
 		verifier.addExpectedLifecycleEvent("Build0");
@@ -453,12 +454,12 @@ public class BuilderTest extends AbstractBuilderTest {
 		getWorkspace().setDescription(wsDescription);
 		// Create and set a build spec for project two
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			proj2.create(getMonitor());
-			proj2.open(getMonitor());
+			proj2.create(createTestMonitor());
+			proj2.open(createTestMonitor());
 			IProjectDescription desc = proj2.getDescription();
 			desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1") });
-			proj2.setDescription(desc, getMonitor());
-		}, getMonitor());
+			proj2.setDescription(desc, createTestMonitor());
+		}, createTestMonitor());
 		waitForBuild();
 
 		// Set up a plug-in lifecycle verifier for testing purposes
@@ -466,7 +467,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		verifier.reset();
 		//create project two and establish a build order by adding a dynamic
 		//reference from proj2->proj1 in the same operation
-		getWorkspace().run((IWorkspaceRunnable) monitor -> extracted(proj1, proj2), getMonitor());
+		getWorkspace().run((IWorkspaceRunnable) monitor -> extracted(proj1, proj2), createTestMonitor());
 
 		waitForBuild();
 		//ensure the build happened in the correct order, and that both projects were built
@@ -479,11 +480,11 @@ public class BuilderTest extends AbstractBuilderTest {
 
 	private void extracted(final IProject proj1, final IProject proj2) throws CoreException {
 		// Create and set a build specs for project one
-		proj1.create(getMonitor());
-		proj1.open(getMonitor());
+		proj1.create(createTestMonitor());
+		proj1.open(createTestMonitor());
 		IProjectDescription desc = proj1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 		// add the dynamic reference to project two
 		IProjectDescription description = proj2.getDescription();
 		description.setDynamicReferences(new IProject[] { proj1 });
@@ -508,14 +509,14 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		IProjectDescription desc = proj1.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build0")});
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 
 		desc = proj2.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, "Build1")});
-		proj2.setDescription(desc, getMonitor());
+		proj2.setDescription(desc, createTestMonitor());
 
 		// Ensure the builder is instantiated
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final AtomicReference<ThrowingRunnable> exceptionInMainThreadCallback = new AtomicReference<>(
 				Function::identity);
@@ -533,8 +534,8 @@ public class BuilderTest extends AbstractBuilderTest {
 					desc1.setDynamicReferences(new IProject[0]);
 					desc2.setDynamicReferences(new IProject[] {proj1});
 				}
-				proj1.setDescription(desc1, getMonitor());
-				proj2.setDescription(desc2, getMonitor());
+				proj1.setDescription(desc1, createTestMonitor());
+				proj2.setDescription(desc2, createTestMonitor());
 			} catch (CoreException e) {
 				exceptionInMainThreadCallback.set(() -> {
 					throw e;
@@ -548,14 +549,14 @@ public class BuilderTest extends AbstractBuilderTest {
 			verifier.reset();
 
 			// FULL_BUILD 1
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+			workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 			verifier.addExpectedLifecycleEvent("Build1");
 			verifier.addExpectedLifecycleEvent("Build0");
 			verifier.assertLifecycleEvents();
 			verifier.reset();
 
 			// FULL_BUILD 2
-			workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+			workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 			verifier.addExpectedLifecycleEvent("Build0");
 			verifier.addExpectedLifecycleEvent("Build1");
 			verifier.assertLifecycleEvents();
@@ -563,7 +564,7 @@ public class BuilderTest extends AbstractBuilderTest {
 
 			// AUTO_BUILD
 			setAutoBuilding(true);
-			proj1.touch(getMonitor());
+			proj1.touch(createTestMonitor());
 			waitForBuild();
 			verifier.addExpectedLifecycleEvent("Build1");
 			verifier.addExpectedLifecycleEvent("Build0");
@@ -571,7 +572,7 @@ public class BuilderTest extends AbstractBuilderTest {
 			verifier.reset();
 
 			// AUTO_BUILD 2
-			proj1.touch(getMonitor());
+			proj1.touch(createTestMonitor());
 			waitForBuild();
 			verifier.addExpectedLifecycleEvent("Build0");
 			verifier.addExpectedLifecycleEvent("Build1");
@@ -591,16 +592,16 @@ public class BuilderTest extends AbstractBuilderTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("PROJECT" + 1);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
-		project.close(getMonitor());
-		project.open(getMonitor());
+		project.close(createTestMonitor());
+		project.open(createTestMonitor());
 
 		//ensure the build spec hasn't changed
 		desc = project.getDescription();
@@ -627,20 +628,20 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building on
 		setAutoBuilding(true);
 		// Create some resources
-		proj1.create(getMonitor());
-		proj1.open(getMonitor());
+		proj1.create(createTestMonitor());
+		proj1.open(createTestMonitor());
 		ensureDoesNotExistInWorkspace(proj2);
 
 		// Create and set a build spec for project one
 		IProjectDescription desc = proj1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 
 		waitForBuild();
 		SortBuilder.getInstance().reset();
 		desc = proj1.getDescription();
 		desc.setName(proj2.getName());
-		proj1.copy(desc, IResource.NONE, getMonitor());
+		proj1.copy(desc, IResource.NONE, createTestMonitor());
 
 		waitForEncodingRelatedJobs();
 		waitForBuild();
@@ -668,10 +669,10 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		proj1.create(getMonitor());
-		proj1.open(getMonitor());
-		proj2.create(getMonitor());
-		proj2.open(getMonitor());
+		proj1.create(createTestMonitor());
+		proj1.open(createTestMonitor());
+		proj2.create(createTestMonitor());
+		proj2.open(createTestMonitor());
 		// establish a build order by adding a dynamic reference from
 		// proj2->proj1
 		IProjectDescription description = proj2.getDescription();
@@ -684,15 +685,15 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create and set a build specs for project one
 		IProjectDescription desc = proj1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 
 		// Create and set a build spec for project two
 		desc = proj2.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build1"), createCommand(desc, "Build2") });
-		proj2.setDescription(desc, getMonitor());
+		proj2.setDescription(desc, createTestMonitor());
 
 		// Build the workspace
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		// Set up a plug-in lifecycle verifier for testing purposes
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -714,7 +715,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		description = proj1.getDescription();
 		description.setDynamicReferences(new IProject[] { proj2 });
 		proj1.setDescription(description, IResource.NONE, null);
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent("Build1");
 		verifier.addExpectedLifecycleEvent("Build2");
 		verifier.addExpectedLifecycleEvent("Build0");
@@ -731,15 +732,15 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Cause a build by enabling autobuild
 		setAutoBuilding(true);
@@ -759,15 +760,15 @@ public class BuilderTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command1 = desc.newCommand();
 		command1.setBuilderName(ExceptionBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command1 });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		final AtomicReference<Boolean> listenerCalled = new AtomicReference<>();
 		IResourceChangeListener listener = event -> listenerCalled.set(true);
@@ -776,7 +777,7 @@ public class BuilderTest extends AbstractBuilderTest {
 			// do an incremental build -- build should fail, but POST_BUILD should still
 			// occur
 			CoreException exception = assertThrows(CoreException.class,
-				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor()));
+				() -> getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor()));
 			// see discussion in bug 273147 about build exception severity
 			assertEquals(IStatus.ERROR, exception.getStatus().getSeverity());
 		} finally {
@@ -795,40 +796,40 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Set up a plug-in lifecycle verifier for testing purposes
 		SortBuilder verifier = null;
 		//do an initial build
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, createTestMonitor());
 		verifier = SortBuilder.getInstance();
 
 		//forget last built state
 		verifier.forgetLastBuiltState();
 		// Now do another incremental build. Delta should be null
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, createTestMonitor());
 		assertTrue(verifier.wasDeltaNull());
 
 		// Do another incremental build, requesting a null build state. Delta
 		// should not be null
 		verifier.requestForgetLastBuildState();
-		project.touch(getMonitor());
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		project.touch(createTestMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, createTestMonitor());
 		assertFalse(verifier.wasDeltaNull());
 
 		//try a snapshot when a builder has a null tree
-		getWorkspace().save(false, getMonitor());
+		getWorkspace().save(false, createTestMonitor());
 
 		// Do another incremental build. Delta should be null
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, SortBuilder.BUILDER_NAME, null, createTestMonitor());
 		assertTrue(verifier.wasDeltaNull());
 	}
 
@@ -844,13 +845,13 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		setAutoBuilding(true);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		ensureExistsInWorkspace(input, getRandomContents());
 
 		waitForBuild();
@@ -860,14 +861,14 @@ public class BuilderTest extends AbstractBuilderTest {
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();
 		AtomicReference<IOException> exception = new AtomicReference<>();
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			input.setContents(new ByteArrayInputStream(new byte[] { 5, 4, 3, 2, 1 }), IResource.NONE, getMonitor());
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+			input.setContents(new ByteArrayInputStream(new byte[] { 5, 4, 3, 2, 1 }), IResource.NONE, createTestMonitor());
+			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 			try {
 				transferStreams(output.getContents(), out, null);
 			} catch (IOException e) {
 				exception.set(e);
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		if (exception.get() != null) {
 			throw exception.get();
 		}
@@ -887,14 +888,14 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		setAutoBuilding(true);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		project.setDescription(desc, createTestMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		waitForBuild();
 
 		// Set up a plug-in lifecycle verifier for testing purposes
@@ -923,7 +924,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		try {
 			getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.PRE_BUILD);
 			// Now change a file. The build should not complete until the job triggered by the listener completes
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+			file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 			//wait for job to be scheduled
 			barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 			//wait for test job to complete
@@ -947,15 +948,15 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//try to do an incremental build when there has never
 		//been a batch build
@@ -984,14 +985,14 @@ public class BuilderTest extends AbstractBuilderTest {
 		monitor.assertUsedUp();
 
 		// Close the project
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 
 		// Open the project, build it, and delete it
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
 		monitor.assertUsedUp();
-		project.delete(false, getMonitor());
+		project.delete(false, createTestMonitor());
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		verifier.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
@@ -1012,8 +1013,8 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		proj1.create(getMonitor());
-		proj1.open(getMonitor());
+		proj1.create(createTestMonitor());
+		proj1.open(createTestMonitor());
 
 		// Create and set a build specs for project one
 		IProjectDescription desc = proj1.getDescription();
@@ -1021,16 +1022,16 @@ public class BuilderTest extends AbstractBuilderTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.getArguments().put(TestBuilder.BUILD_ID, "Build0");
 		desc.setBuildSpec(new ICommand[] { command });
-		proj1.setDescription(desc, getMonitor());
+		proj1.setDescription(desc, createTestMonitor());
 
 		// build project1
-		proj1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		proj1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		// move proj1 to proj2
-		proj1.move(proj2.getFullPath(), false, getMonitor());
+		proj1.move(proj2.getFullPath(), false, createTestMonitor());
 
 		// build proj2
-		proj2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		proj2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 	}
 
 	/**
@@ -1045,21 +1046,21 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 
 		//try to do an incremental build when there has never
 		//been a batch build
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		// Set up a plug-in lifecycle verifier for testing purposes
 		TestBuilder verifier = SortBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -1070,13 +1071,13 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Now make a change and then turn autobuild on. Turning it on should
 		// cause a build.
 		IWorkspaceRunnable r = monitor -> {
-			file.setContents(getRandomContents(), IResource.NONE, getMonitor());
+			file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 			IWorkspaceDescription description = getWorkspace().getDescription();
 			description.setAutoBuilding(true);
 			getWorkspace().setDescription(description);
 		};
 		waitForBuild();
-		getWorkspace().run(r, getMonitor());
+		getWorkspace().run(r, createTestMonitor());
 		waitForBuild();
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
 		verifier.assertLifecycleEvents();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -57,8 +58,8 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		command = createCommand(desc, CustomTriggerBuilder.BUILDER_NAME, "Build0");
@@ -67,12 +68,12 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 		setAutoBuilding(true);
 
 		//do an initial workspace build to get the builder instance
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("1.0", builder);
 		assertTrue("1.1", builder.triggerForLastBuild == 0);
@@ -80,7 +81,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		//do a clean - builder should not be called
 		waitForBuild();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertEquals("2.0", 0, builder.triggerForLastBuild);
 
 		// Ensure that Auto-build doesn't cause a FULL_BUILD
@@ -89,13 +90,13 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		// But first requested build should cause a FULL_BUILD
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertTrue("3.0", builder.wasFullBuild());
 
 		// But subsequent builds shouldn't
 		builder.reset();
 		builder.clearBuildTrigger();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertTrue("3.1", builder.triggerForLastBuild == 0);
 	}
 
@@ -110,8 +111,8 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		command = createCommand(desc, CustomTriggerBuilder.BUILDER_NAME, "Build0");
@@ -120,12 +121,12 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, true);
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 		setAutoBuilding(true);
 
 		//do an initial workspace build to get the builder instance
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("1.0", builder);
 		assertEquals("1.1", 0, builder.triggerForLastBuild);
@@ -133,7 +134,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		//do a clean - builder should not be called
 		waitForBuild();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertEquals("2.0", 0, builder.triggerForLastBuild);
 
 		// Ensure that Auto-build doesn't cause a FULL_BUILD
@@ -142,16 +143,16 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		// But first requested build should cause a FULL_BUILD
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertTrue("3.0", builder.wasFullBuild());
 
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		// But subsequent INCREMENTAL_BUILD builds should cause INCREMENTAL_BUILD
 		builder.reset();
 		builder.clearBuildTrigger();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals("5.0", IncrementalProjectBuilder.INCREMENTAL_BUILD, builder.triggerForLastBuild);
 	}
 
@@ -166,8 +167,8 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		command = createCommand(desc, CustomTriggerBuilder.BUILDER_NAME, "Build0");
@@ -176,7 +177,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 
 		// Turn on autobuild without waiting for build to be finished
@@ -185,7 +186,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		workspace.setDescription(description);
 
 		// do an initial workspace build to get the builder instance
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("1.0", builder);
 		assertTrue("1.1", builder.triggerForLastBuild == 0);
@@ -193,7 +194,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		//do a clean - Ensure that Auto-build causes a FULL_BUILD
 		waitForBuild();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 
 		waitForBuild();
 		assertTrue("2.1", builder.wasFullBuild());
@@ -203,7 +204,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		IFile file = project.getFile("b.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertTrue("6.0", !builder.wasCleanBuild());
@@ -222,12 +223,12 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, CustomTriggerBuilder.BUILDER_NAME, "Build0") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 		assertTrue("1.0", command.isConfigurable());
 		//ensure that setBuilding has effect
@@ -250,23 +251,23 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// set the command back into the project for change to take effect
 		desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//ensure the builder is not called
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertTrue("2.0", builder == null || builder.triggerForLastBuild == 0);
 
-		project.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
 		assertTrue("2.1", builder == null || builder.triggerForLastBuild == 0);
 
-		project.touch(getMonitor());
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.touch(createTestMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
 		assertTrue("3.0", builder == null || builder.triggerForLastBuild == 0);
 		setAutoBuilding(true);
-		project.touch(getMonitor());
+		project.touch(createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
 		assertTrue("4.0", builder == null || builder.triggerForLastBuild == 0);
 
@@ -280,18 +281,18 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		setAutoBuilding(false);
 		desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//ensure the builder is called
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
 		assertTrue("6.1", builder.wasFullBuild());
 
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
 		assertTrue("7.1", builder.wasFullBuild());
 
-		project.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertTrue("8.1", builder.wasCleanBuild());
 	}
 
@@ -307,12 +308,12 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Build0") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 
 		assertTrue("1.0", !command.isConfigurable());
@@ -329,17 +330,17 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		//set the command back into the project for change to take effect
 		desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//ensure that builder is still called
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		SortBuilder builder = SortBuilder.getInstance();
 		assertTrue("2.0", builder.wasBuilt());
 		assertTrue("2.1", builder.wasFullBuild());
 		assertEquals("2.2", command, builder.getCommand());
 
-		project.touch(getMonitor());
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.touch(createTestMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertTrue("3.0", builder.wasBuilt());
 		assertTrue("3.1", builder.wasIncrementalBuild());
 	}
@@ -357,14 +358,14 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
 		command = createCommand(desc, CustomTriggerBuilder.BUILDER_NAME, "Build0");
 		command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, false);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 		// turn autobuild back on
 		setAutoBuilding(true);
@@ -374,7 +375,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		assertTrue("1.1", !command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
 
 		//do an initial build to get the builder instance
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("1.3", builder);
@@ -382,7 +383,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		//add a file in the project, to trigger an autobuild
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		//autobuild should not call our builder
 		waitForBuild();
@@ -390,7 +391,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		assertTrue("2.1", !builder.wasAutobuild());
 
 		//but, a subsequent incremental build should call it
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertTrue("2.1", !builder.wasAutobuild());
 		assertTrue("3.0", builder.wasIncrementalBuild());
 
@@ -407,8 +408,8 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		ICommand command = null;
 
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
@@ -418,14 +419,14 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 
 		// turn auto-building off
 		setAutoBuilding(false);
 
 		// do an initial build to get the builder instance
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
 		assertNotNull("2.0", builder);
@@ -434,26 +435,26 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// do a clean - builder should not be called
 		builder.clearBuildTrigger();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertTrue("3.0", !builder.wasCleanBuild());
 		assertTrue("3.1", !builder.wasFullBuild());
 
 		// do an incremental build - FULL_BUILD should be triggered
 		builder.clearBuildTrigger();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		assertTrue("4.0", !builder.wasCleanBuild());
 		assertTrue("4.1", builder.wasFullBuild());
 
 		// add a file in the project before an incremental build is triggered again
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		// do an incremental build - build should NOT be triggered
 		builder.clearBuildTrigger();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		assertTrue("6.0", !builder.wasCleanBuild());
 		assertTrue("6.1", !builder.wasFullBuild());
@@ -470,8 +471,8 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		ICommand command = null;
 
 		// Create some resources
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build specs for project
 		IProjectDescription desc = project.getDescription();
@@ -481,7 +482,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
 		desc.setBuildSpec(new ICommand[] {command});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		command = project.getDescription().getBuildSpec()[0];
 
 		// turn auto-building on
@@ -493,7 +494,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		// do a clean - builder should not be called
 		builder.clearBuildTrigger();
 		builder.reset();
-		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		assertTrue("2.0", !builder.wasCleanBuild());
 		assertTrue("2.1", !builder.wasFullBuild());
 
@@ -502,13 +503,13 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertEquals("4.0", 0, builder.triggerForLastBuild);
 
 		// Build the project explicitly -- full build should be triggered
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		assertTrue("4.1", builder.wasFullBuild());
 
@@ -517,7 +518,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		file = project.getFile("b.txt");
-		file.create(getRandomContents(), IResource.NONE, getMonitor());
+		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertTrue("6.0", !builder.wasCleanBuild());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
@@ -37,19 +38,19 @@ public class EmptyDeltaTest extends AbstractBuilderTest {
 		// Turn auto-building off
 		setAutoBuilding(false);
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(EmptyDeltaBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		//do an initial incremental build
 		new EmptyDeltaBuilder().reset();
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		// Set up a plug-in lifecycle verifier for testing purposes
 		EmptyDeltaBuilder verifier = EmptyDeltaBuilder.getInstance();
 		verifier.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
@@ -59,7 +60,7 @@ public class EmptyDeltaTest extends AbstractBuilderTest {
 
 		// Now do another incremental build. Even though the delta is empty, it should be called
 		verifier.reset();
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		verifier.addExpectedLifecycleEvent(TestBuilder.DEFAULT_BUILD_ID);
 		verifier.assertLifecycleEvents();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 				}
 			}
 			getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
-		}, getMonitor());
+		}, createTestMonitor());
 	}
 
 	/**
@@ -121,7 +122,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 		//add builder and do an initial build to get the instance
 		setAutoBuilding(false);
 		addBuilder(project1, DeltaVerifierBuilder.BUILDER_NAME);
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		assertTrue("1.1", builder != null);
@@ -206,19 +207,19 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 	public void testRequestMissingProject() throws CoreException {
 		//add builder and do an initial build to get the instance
 		addBuilder(project1, DeltaVerifierBuilder.BUILDER_NAME);
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		assertTrue("1.1", builder != null);
 		//always check deltas for all projects
 		final IProject[] allProjects = new IProject[] {project1, project2, project3, project4};
-		project2.close(getMonitor());
-		project3.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		project2.close(createTestMonitor());
+		project3.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 
 		builder.checkDeltas(allProjects);
 
 		//modify a file in project1 to force an autobuild
-		file1.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -242,7 +243,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 
 		//do an incremental build by creating a file
 		IFile file = project.getFile("Foo");
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.TestUtil.waitForCondition;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -108,7 +109,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 	protected void tearDown() throws Exception {
 		// Cleanup workspace first to ensure that auto-build is not started on projects
 		waitForBuild();
-		getWorkspace().getRoot().delete(true, true, getMonitor());
+		getWorkspace().getRoot().delete(true, true, createTestMonitor());
 		super.tearDown();
 		TimerBuilder.abortCurrentBuilds();
 	}
@@ -366,7 +367,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 		buildCommand.setArguments(arguments);
 		IProjectDescription projectDescription = project.getDescription();
 		projectDescription.setBuildSpec(new ICommand[] { buildCommand });
-		project.setDescription(projectDescription, getMonitor());
+		project.setDescription(projectDescription, createTestMonitor());
 	}
 
 	private void makeProjectsDependOnEachOther(List<IProject> projects) throws CoreException {
@@ -374,7 +375,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 			IProject project = projects.get(projectNumber);
 			IProjectDescription desc = project.getDescription();
 			desc.setReferencedProjects(new IProject[] { projects.get(projectNumber - 1) });
-			project.setDescription(desc, getMonitor());
+			project.setDescription(desc, createTestMonitor());
 		}
 	}
 
@@ -384,7 +385,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 			IProjectDescription description = project.getDescription();
 			description.setBuildConfigReferences(project.getActiveBuildConfig().getName(),
 					new IBuildConfiguration[] { projects.get(projectNumber - 1).getActiveBuildConfig() });
-			project.setDescription(description, getMonitor());
+			project.setDescription(description, createTestMonitor());
 		}
 	}
 
@@ -404,9 +405,9 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 					waitForRunningJobBarrier.setStatus(TestBarrier2.STATUS_RUNNING);
 					if (buildConfigurations != null) {
 						getWorkspace().build(buildConfigurations, IncrementalProjectBuilder.INCREMENTAL_BUILD, false,
-								getMonitor());
+								createTestMonitor());
 					} else {
-						getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+						getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 					}
 					return Status.OK_STATUS;
 				} catch (CoreException e) {
@@ -422,7 +423,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 		} finally {
 			TimerBuilder.abortCurrentBuilds();
 			job.cancel();
-			boolean joinSuccessful = job.join(TIMEOUT_IN_MILLIS, getMonitor());
+			boolean joinSuccessful = job.join(TIMEOUT_IN_MILLIS, createTestMonitor());
 			Assert.assertTrue("timeout occurred when waiting for job that runs the build to finish", joinSuccessful);
 		}
 	}
@@ -440,7 +441,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 				protected IStatus run(IProgressMonitor monitor) {
 					try {
 						waitForRunningJobBarriers.get(project).setStatus(TestBarrier2.STATUS_RUNNING);
-						project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+						project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 						return Status.OK_STATUS;
 					} catch (CoreException e) {
 						return new Status(IStatus.ERROR, PI_RESOURCES_TESTS, e.getMessage(),
@@ -460,7 +461,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 		} finally {
 			TimerBuilder.abortCurrentBuilds();
 			jobGroup.cancel();
-			boolean joinSuccessful = jobGroup.join(TIMEOUT_IN_MILLIS, getMonitor());
+			boolean joinSuccessful = jobGroup.join(TIMEOUT_IN_MILLIS, createTestMonitor());
 			Assert.assertTrue("timeout occurred when waiting for job group that runs the builds to finish",
 					joinSuccessful);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.List;
 import org.eclipse.core.internal.resources.Workspace;
@@ -68,8 +69,8 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject(getName());
 
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
@@ -79,10 +80,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -91,7 +92,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(RebuildingBuilder::reset);
 
 		// Confirm basic functionality first - one build per builder
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -102,7 +103,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// First builder requests rebuild - it will cause main build to loop two times
 		// and project loop will run as usually (no repetitions)
 		b1.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -121,7 +122,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// and project loop will restart from the first one, so first and second
 		// builder will run 3 times
 		b2.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -142,7 +143,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// and project loop will restart from the first one, so all builders will run 3
 		// times
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -162,7 +163,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// first and second builder 4 times, third 3 times
 		b2.setRequestProjectRebuild(project, 1);
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(4, b1.buildsCount());
 		assertEquals(4, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -189,7 +190,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		int expectedRebuildsFirstBuilders = max * max;
 		int expectedRebuildslastBuilder = max;
 		b2.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -203,18 +204,18 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject(getName());
 
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder1"),
 				createCommand(desc, builderName, "builder2"), createCommand(desc, builderName, "builder3"), });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -223,7 +224,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(RebuildingBuilder::reset);
 
 		// Confirm basic functionality first - one build per builder
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -234,7 +235,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// First builder requests rebuild - it will cause main build to loop two times
 		// and project loop will run once more
 		b1.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -251,7 +252,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// Second builder requests rebuild - it will cause main build to loop two times
 		// and project loop will run once more
 		b2.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -269,7 +270,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// and project loop will restart from the first one, so all builders will run 3
 		// times
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -287,7 +288,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// two times and project loop will restart once more
 		b2.setRequestProjectRebuild(project, 1);
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -312,7 +313,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		int expectedRebuildsFirstBuilders = max * max;
 		int expectedRebuildslastBuilder = max * max;
 		b2.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -326,8 +327,8 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject(getName());
 
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
@@ -337,10 +338,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -351,7 +352,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(true));
 
 		// Confirm basic functionality first - one build per builder
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -361,7 +362,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// First builder requests rebuild - all builders will run twice
 		b1.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -376,7 +377,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// Second builder requests rebuild - all builders will run twice
 		b2.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -395,7 +396,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// Third builder requests rebuild - all builders will run twice
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -411,7 +412,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// Second and third builder request rebuild - all builders will run twice
 		b2.setRequestProjectRebuild(project, 1);
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -430,7 +431,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		int expectedRebuildsFirstBuilders = max;
 		int expectedRebuildslastBuilder = max;
 		b2.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -442,7 +443,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// not more than (max * max) times (both inner / outer loop use limit)
 		expectedRebuildslastBuilder = max;
 		b3.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -456,8 +457,8 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project = getWorkspace().getRoot().getProject(getName());
 
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
@@ -467,10 +468,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -481,7 +482,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(false));
 
 		// Confirm basic functionality first - one build per builder
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -491,7 +492,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// First builder requests rebuild - no repetitions
 		b1.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -506,7 +507,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// Second builder requests rebuild - first & second builder will run twice
 		b2.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -522,7 +523,7 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		// Third builder requests rebuild - all builders will run three twice
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -539,7 +540,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// times, last one one time less
 		b2.setRequestProjectRebuild(project, 1);
 		b3.setRequestProjectRebuild(project, 1);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -567,7 +568,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		int expectedRebuildsFirstBuilders = max;
 		int expectedRebuildslastBuilder = 1;
 		b2.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -579,7 +580,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// not more than (max * max) times (both inner / outer loop use limit)
 		expectedRebuildslastBuilder = max;
 		b3.setRequestProjectRebuild(project, rebuilds);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstBuilders, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstBuilders, b2.buildsCount());
 		assertEquals(expectedRebuildslastBuilder, b3.buildsCount());
@@ -594,10 +595,10 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
@@ -607,10 +608,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-				project1.setDescription(desc, getMonitor());
+				project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -625,9 +626,9 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"),
 				createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -635,7 +636,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(RebuildingBuilder::reset);
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -651,7 +652,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop two times for both projects
 		b1.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -680,7 +681,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(4, b1.buildsCount());
 		assertEquals(4, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -697,7 +698,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setRequestProjectRebuild(project1, 1);
 		b4.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -718,7 +719,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(4, b1.buildsCount());
 		assertEquals(4, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -737,20 +738,20 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder1"),
 				createCommand(desc, builderName, "builder2"), createCommand(desc, builderName, "builder3"), });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -763,9 +764,9 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"), createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -773,7 +774,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(RebuildingBuilder::reset);
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -789,7 +790,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop two times for both projects and one extra time for current one
 		b1.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -820,7 +821,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -837,7 +838,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setRequestProjectRebuild(project1, 1);
 		b4.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -858,7 +859,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -881,10 +882,10 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
@@ -894,10 +895,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-				project1.setDescription(desc, getMonitor());
+				project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -914,9 +915,9 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"),
 				createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -926,7 +927,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(false));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -944,7 +945,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(4, b1.buildsCount());
 		assertEquals(4, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -980,7 +981,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setRequestProjectRebuild(project1, 1);
 		b4.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(3, b3.buildsCount());
@@ -1001,7 +1002,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(5, b1.buildsCount());
 		assertEquals(5, b2.buildsCount());
 		assertEquals(4, b3.buildsCount());
@@ -1025,7 +1026,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		int expectedBuildCycles = max;
 		b2.setRequestProjectRebuild(project1, rebuilds);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(expectedRebuildsFirstProject, b1.buildsCount());
 		assertEquals(expectedRebuildsFirstProject, b2.buildsCount());
 		assertEquals(expectedBuildCycles, b3.buildsCount());
@@ -1045,10 +1046,10 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
@@ -1058,10 +1059,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -1076,12 +1077,12 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"),
 				createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		builders.forEach(b -> b.setPropagateRebuild(false));
 		builders.forEach(b -> b.setProcessOtherBuilders(false));
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -1091,7 +1092,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(false));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1107,7 +1108,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b1.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1123,7 +1124,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b2.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1153,7 +1154,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1170,7 +1171,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b5.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1191,7 +1192,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1210,20 +1211,20 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder1"),
 				createCommand(desc, builderName, "builder2"), createCommand(desc, builderName, "builder3"), });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -1236,12 +1237,12 @@ public class RebuildTest extends AbstractBuilderTest {
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"), createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		builders.forEach(b -> b.setPropagateRebuild(false));
 		builders.forEach(b -> b.setProcessOtherBuilders(true));
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -1251,7 +1252,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(true));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1267,7 +1268,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b1.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1294,7 +1295,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b2.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1312,7 +1313,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1329,7 +1330,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b5.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1350,7 +1351,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1372,10 +1373,10 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project2 = getWorkspace().getRoot().getProject(getName() + 2);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
@@ -1385,10 +1386,10 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder2"),
 				createCommand(desc, builderName, "builder3"),
 				});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -1402,11 +1403,11 @@ public class RebuildTest extends AbstractBuilderTest {
 				createCommand(desc, builderName, "builder4"),
 				createCommand(desc, builderName, "builder5"),
 				createCommand(desc, builderName, "builder6"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		builders.forEach(b -> b.setPropagateRebuild(false));
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(6, builders.size());
 		RebuildingBuilder b4 = builders.get(3);
 		RebuildingBuilder b5 = builders.get(4);
@@ -1415,7 +1416,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setPropagateRebuild(false));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1431,7 +1432,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b1.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1447,7 +1448,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		// loop extra time
 		b2.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1477,7 +1478,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1494,7 +1495,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setRequestProjectRebuild(project1, 1);
 		b5.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1515,7 +1516,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b5.setRequestProjectRebuild(project2, 1);
 		b6.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(3, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1535,21 +1536,21 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project3 = getWorkspace().getRoot().getProject(getName() + 3);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
-		project3.create(getMonitor());
-		project3.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
+		project3.create(createTestMonitor());
+		project3.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder1"), });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -1558,9 +1559,9 @@ public class RebuildTest extends AbstractBuilderTest {
 		desc = project2.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder2"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(2, builders.size());
 		RebuildingBuilder b2 = builders.get(1);
 
@@ -1568,9 +1569,9 @@ public class RebuildTest extends AbstractBuilderTest {
 		desc = project3.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder3"), });
-		project3.setDescription(desc, getMonitor());
+		project3.setDescription(desc, createTestMonitor());
 
-		project3.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project3.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(3, builders.size());
 		RebuildingBuilder b3 = builders.get(2);
 		builders.forEach(RebuildingBuilder::reset);
@@ -1578,7 +1579,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(false));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1591,7 +1592,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(false);
 		b1.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1607,7 +1608,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setPropagateRebuild(false);
 		b2.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1626,7 +1627,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(false);
 		b1.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1647,7 +1648,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setPropagateRebuild(false);
 		b2.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1664,7 +1665,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1680,7 +1681,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1696,7 +1697,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, project2, project3);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1709,7 +1710,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(true);
 		b1.setRequestProjectRebuild(project1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1730,7 +1731,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, rebuilds);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(max - 1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(max - 2, b3.buildsCount());
@@ -1746,21 +1747,21 @@ public class RebuildTest extends AbstractBuilderTest {
 		IProject project3 = getWorkspace().getRoot().getProject(getName() + 3);
 
 		// Create and open a project
-		project1.create(getMonitor());
-		project1.open(getMonitor());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
-		project3.create(getMonitor());
-		project3.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
+		project3.create(createTestMonitor());
+		project3.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder1"), });
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		// do an initial build to create builders
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
 		assertEquals(desc.getBuildSpec().length, builders.size());
 		RebuildingBuilder b1 = builders.get(0);
@@ -1769,9 +1770,9 @@ public class RebuildTest extends AbstractBuilderTest {
 		desc = project2.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder2"), });
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
-		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project2.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(2, builders.size());
 		RebuildingBuilder b2 = builders.get(1);
 
@@ -1779,9 +1780,9 @@ public class RebuildTest extends AbstractBuilderTest {
 		desc = project3.getDescription();
 
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, builderName, "builder3"), });
-		project3.setDescription(desc, getMonitor());
+		project3.setDescription(desc, createTestMonitor());
 
-		project3.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project3.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		assertEquals(3, builders.size());
 		RebuildingBuilder b3 = builders.get(2);
 		builders.forEach(RebuildingBuilder::reset);
@@ -1789,7 +1790,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		builders.forEach(b -> b.setProcessOtherBuilders(true));
 
 		// Confirm basic functionality first - one build per builder
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1802,7 +1803,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(false);
 		b1.setRequestProjectRebuild(project2, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1818,7 +1819,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setPropagateRebuild(false);
 		b2.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1837,7 +1838,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(false);
 		b1.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1858,7 +1859,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b2.setPropagateRebuild(false);
 		b2.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1875,7 +1876,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(1, b3.buildsCount());
@@ -1891,7 +1892,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project3, 1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1907,7 +1908,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, project2, project3);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(2, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1920,7 +1921,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b1.setPropagateRebuild(true);
 		b1.setRequestProjectRebuild(project1);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(3, b1.buildsCount());
 		assertEquals(2, b2.buildsCount());
 		assertEquals(2, b3.buildsCount());
@@ -1941,7 +1942,7 @@ public class RebuildTest extends AbstractBuilderTest {
 		b3.setPropagateRebuild(false);
 		b3.setRequestProjectRebuild(project1, rebuilds);
 
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		assertEquals(max - 1, b1.buildsCount());
 		assertEquals(1, b2.buildsCount());
 		assertEquals(max - 2, b3.buildsCount());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -108,7 +109,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		addBuilder(project, EmptyDeltaBuilder.BUILDER_NAME);
 
 		// Ensure the builder is instantiated
-		project.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 
 		final TestBarrier2 tb = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 
@@ -182,10 +183,10 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, "Project1Build1"), createCommand(desc, EmptyDeltaBuilder2.BUILDER_NAME, "Project1Build2")});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Ensure the builder is instantiated
-		project.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 
 		final TestBarrier2 tb1 = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 		final TestBarrier2 tb2 = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
@@ -300,10 +301,10 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, "Project1Build1") });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Ensure the builder is instantiated
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final TestBarrier2 tb = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 		AtomicReference<Throwable> errorInBuildTriggeringJob = new AtomicReference<>();
@@ -434,10 +435,10 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, "Project1Build1"), createCommand(desc, EmptyDeltaBuilder2.BUILDER_NAME, "Project1Build2")});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Ensure the builder is instantiated
-		project.build(IncrementalProjectBuilder.CLEAN_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 
 		final TestBarrier2 tb1 = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 		final TestBarrier2 tb2 = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.Workspace;
@@ -43,7 +44,7 @@ public class DeleteTest extends LocalStoreTest {
 		IPath projectLocation = project.getLocation();
 
 		/* delete */
-		project.delete(false, true, getMonitor());
+		project.delete(false, true, createTestMonitor());
 
 		/* assert project does not exist anymore in the workspace*/
 		assertFalse(project.exists());
@@ -69,7 +70,7 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		/* assert project does not exist anymore in the workspace */
 		assertFalse(project.exists());
@@ -95,7 +96,7 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		/* assert project does not exist anymore */
 		assertFalse(project.exists());
@@ -118,7 +119,7 @@ public class DeleteTest extends LocalStoreTest {
 		filePath = file.getLocation();
 
 		/* delete */
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		/* assert project does not exist anymore */
 		assertFalse(project.exists());
@@ -146,7 +147,7 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* delete */
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		/* assert project does not exist anymore */
 		assertFalse(project.exists());
@@ -177,8 +178,8 @@ public class DeleteTest extends LocalStoreTest {
 		IPath projectLocation = project.getLocation();
 
 		/* close and delete */
-		project.close(getMonitor());
-		project.delete(false, true, getMonitor());
+		project.close(createTestMonitor());
+		project.delete(false, true, createTestMonitor());
 
 		/* assert project does not exist anymore in the workspace */
 		assertFalse(project.exists());
@@ -203,8 +204,8 @@ public class DeleteTest extends LocalStoreTest {
 		filePath = file.getLocation();
 
 		/* close and delete */
-		project.close(getMonitor());
-		project.delete(true, true, getMonitor());
+		project.close(createTestMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		/* assert project does not exist anymore */
 		assertFalse(project.exists());
@@ -228,8 +229,8 @@ public class DeleteTest extends LocalStoreTest {
 		projectLocation = project.getLocation();
 
 		/* close and delete */
-		projects[0].close(getMonitor());
-		projects[0].delete(true, false, getMonitor());
+		projects[0].close(createTestMonitor());
+		projects[0].delete(true, false, createTestMonitor());
 
 		/* assert project was deleted */
 		assertFalse(project.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.File;
@@ -62,17 +63,17 @@ public class MoveTest extends LocalStoreTest {
 		String location = getUniqueString();
 		IProject source = getWorkspace().getRoot().getProject(location + "1");
 		IProject destination = getWorkspace().getRoot().getProject(location + "2");
-		source.create(getMonitor());
-		source.open(getMonitor());
+		source.create(createTestMonitor());
+		source.open(createTestMonitor());
 
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
 		description.setLocation(IPath.fromOSString(devices[1] + location));
-		destination.create(description, getMonitor());
-		destination.open(getMonitor());
+		destination.create(description, createTestMonitor());
+		destination.open(createTestMonitor());
 
 		String fileName = "fileToBeMoved.txt";
 		IFile file = source.getFile(fileName);
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		// add some properties to file (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
@@ -86,7 +87,7 @@ public class MoveTest extends LocalStoreTest {
 
 		// move file
 		IPath dest = destination.getFile(fileName).getFullPath();
-		file.move(dest, true, getMonitor());
+		file.move(dest, true, createTestMonitor());
 
 		// assert file was moved
 		IFile newFile = destination.getFile(fileName);
@@ -164,18 +165,18 @@ public class MoveTest extends LocalStoreTest {
 		String location = getUniqueString();
 		IProject source = getWorkspace().getRoot().getProject(location + "1");
 		IProject destination = getWorkspace().getRoot().getProject(location + "2");
-		source.create(getMonitor());
-		source.open(getMonitor());
+		source.create(createTestMonitor());
+		source.open(createTestMonitor());
 
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
 		description.setLocation(IPath.fromOSString(devices[1] + location));
-		destination.create(description, getMonitor());
-		destination.open(getMonitor());
+		destination.create(description, createTestMonitor());
+		destination.open(createTestMonitor());
 
 		// get folder instance
 		String folderName = "folderToBeMoved";
 		IFolder folder = source.getFolder(folderName);
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		// add some properties to file (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
@@ -189,7 +190,7 @@ public class MoveTest extends LocalStoreTest {
 
 		// rename folder
 		IPath dest = destination.getFile(folderName).getFullPath();
-		folder.move(dest, true, getMonitor());
+		folder.move(dest, true, createTestMonitor());
 
 		// assert folder was renamed
 		IFolder newFolder = destination.getFolder(folderName);
@@ -292,7 +293,7 @@ public class MoveTest extends LocalStoreTest {
 
 		// move hierarchy
 		//IProgressMonitor monitor = new LoggingProgressMonitor(System.out);
-		IProgressMonitor monitor = getMonitor();
+		IProgressMonitor monitor = createTestMonitor();
 		folderSource.move(folderDestination.getFullPath(), true, monitor);
 
 		// get new hierarchy instance
@@ -445,11 +446,11 @@ public class MoveTest extends LocalStoreTest {
 		assertFalse(folderDestination.exists());
 		assertFalse(destChild.exists());
 		// cleanup and delete the destination
-		folderDestination.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		folderDestination.delete(true, getMonitor());
+		folderDestination.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		folderDestination.delete(true, createTestMonitor());
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		folder.move(folderDestination.getFullPath(), false, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		folder.move(folderDestination.getFullPath(), false, createTestMonitor());
 
 		folderDestination.move(folder.getFullPath(), true, null);
 		assertTrue(folder.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.File;
 import org.eclipse.core.filesystem.IFileStore;
@@ -47,7 +48,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		project.getLocation().append("A").toFile().renameTo((project.getLocation().append("a").toFile()));
 
 		// refresh the project
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//variant should exist but original shouldn't
 		assertTrue(folderVariant.exists());
@@ -128,19 +129,19 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertFalse(folder.exists());
 		assertFalse(file.isSynchronized(IResource.DEPTH_ZERO));
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
-		file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		file.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
 		assertTrue(file.exists());
 		assertTrue(folder.exists());
 
 		//try again with deleted project
-		project.delete(IResource.FORCE, getMonitor());
+		project.delete(IResource.FORCE, createTestMonitor());
 
 		ensureExistsInFileSystem(both);
 		ensureDoesNotExistInWorkspace(both);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
-		file.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		file.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
 	}
@@ -185,12 +186,12 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 
 	public void testRefreshClosedProject() throws CoreException {
 		IProject project = projects[0];
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 
 		//refreshing a closed project should not fail
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		project.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-		project.refreshLocal(IResource.DEPTH_ONE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		project.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
+		project.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());
 	}
 
 	public void testRefreshFolder() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -33,16 +34,16 @@ import org.junit.runners.JUnit4;
 public class SymlinkResourceTest extends LocalStoreTest {
 
 	protected void mkLink(IFileStore dir, String src, String tgt, boolean isDir) throws CoreException {
-		createSymLink(dir.toLocalFile(EFS.NONE, getMonitor()), src, tgt, isDir);
+		createSymLink(dir.toLocalFile(EFS.NONE, createTestMonitor()), src, tgt, isDir);
 	}
 
 	protected void createBug232426Structure(IFileStore rootDir) throws CoreException {
 		IFileStore folderA = rootDir.getChild("a");
 		IFileStore folderB = rootDir.getChild("b");
 		IFileStore folderC = rootDir.getChild("c");
-		folderA.mkdir(EFS.NONE, getMonitor());
-		folderB.mkdir(EFS.NONE, getMonitor());
-		folderC.mkdir(EFS.NONE, getMonitor());
+		folderA.mkdir(EFS.NONE, createTestMonitor());
+		folderB.mkdir(EFS.NONE, createTestMonitor());
+		folderC.mkdir(EFS.NONE, createTestMonitor());
 
 		/* create symbolic links */
 		mkLink(folderA, "link", IPath.fromOSString("../b").toOSString(), true);
@@ -53,7 +54,7 @@ public class SymlinkResourceTest extends LocalStoreTest {
 
 	protected void createBug358830Structure(IFileStore rootDir) throws CoreException {
 		IFileStore folderA = rootDir.getChild("a");
-		folderA.mkdir(EFS.NONE, getMonitor());
+		folderA.mkdir(EFS.NONE, createTestMonitor());
 
 		/* create trivial recursive symbolic link */
 		mkLink(folderA, "link", IPath.fromOSString("../").toOSString(), true);
@@ -81,11 +82,11 @@ public class SymlinkResourceTest extends LocalStoreTest {
 		final IProject project = projects[0];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			/* delete open project because we must re-open with BACKGROUND_REFRESH */
-			project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+			project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
 			project.create(null);
 			createBug232426Structure(EFS.getStore(project.getLocationURI()));
 			//Bug only happens with BACKGROUND_REFRESH.
-			project.open(IResource.BACKGROUND_REFRESH, getMonitor());
+			project.open(IResource.BACKGROUND_REFRESH, createTestMonitor());
 		}, null);
 
 		//wait for BACKGROUND_REFRESH to complete.
@@ -112,10 +113,10 @@ public class SymlinkResourceTest extends LocalStoreTest {
 		final IProject project = projects[0];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			/* delete open project because we must re-open with BACKGROUND_REFRESH */
-			project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+			project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
 			project.create(null);
 			createBug358830Structure(EFS.getStore(project.getLocationURI()));
-			project.open(IResource.BACKGROUND_REFRESH, getMonitor());
+			project.open(IResource.BACKGROUND_REFRESH, createTestMonitor());
 		}, null);
 
 		//wait for BACKGROUND_REFRESH to complete.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -239,7 +240,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 	public void test342968() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("test");
 		ensureExistsInWorkspace(project, true);
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		IProjectDescription description = project.getDescription();
 		URI projectLocation = Test342968FileSystem.getTestUriFor(EFS.getLocalFileSystem().fromLocalFile(new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile(), "test")).toURI());
@@ -248,7 +249,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 		project.delete(false, false, null);
 
 		project.create(description, IResource.NONE, null);
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		assertTrue(project.getLocationURI().equals(projectLocation));
 
@@ -284,12 +285,12 @@ public class UnifiedTreeTest extends LocalStoreTest {
 		assertFalse(folder.exists());
 		assertFalse(file.exists());
 
-		file.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		file.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue(folder.exists());
 		assertTrue(file.exists());
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.mapping;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -263,7 +264,7 @@ public class ChangeValidationTest extends ResourceTest {
 	}
 
 	private IStatus validateChange(IResourceChangeDescriptionFactory f) {
-		return ResourceChangeValidator.getValidator().validateChange(f.getDelta(), getMonitor());
+		return ResourceChangeValidator.getValidator().validateChange(f.getDelta(), createTestMonitor());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.properties;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -117,7 +118,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		// create common objects
 		final IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, getMonitor());
+		target.create(getRandomContents(), true, createTestMonitor());
 
 		// prepare keys and values
 		final int N = 50;
@@ -159,7 +160,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 			// give the threads a chance to start
 			Thread.sleep(10);
 			// delete the project while the threads are still running
-			target.getProject().delete(IResource.NONE, getMonitor());
+			target.getProject().delete(IResource.NONE, createTestMonitor());
 			for (Thread thread : threads) {
 				thread.join();
 			}
@@ -377,7 +378,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		ensureExistsInWorkspace(file1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		file1a.setPersistentProperty(key, "value");
-		file1a.move(IPath.fromOSString("file2"), true, getMonitor());
+		file1a.move(IPath.fromOSString("file2"), true, createTestMonitor());
 		IFile file1b = folder.getFile("file1");
 		ensureExistsInWorkspace(file1b, true);
 		String value = null;
@@ -398,7 +399,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		ensureExistsInWorkspace(folder1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		folder1a.setPersistentProperty(key, "value");
-		folder1a.move(IPath.fromOSString("folder2"), true, getMonitor());
+		folder1a.move(IPath.fromOSString("folder2"), true, createTestMonitor());
 		IFolder folder1b = project.getFolder("folder1");
 		ensureExistsInWorkspace(folder1b, true);
 		String value = null;
@@ -415,7 +416,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	public void testLargeProperty() throws CoreException {
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, getMonitor());
+		target.create(getRandomContents(), true, createTestMonitor());
 
 		QualifiedName name = new QualifiedName("stressTest", "prop");
 		final int SIZE = 10000;
@@ -436,7 +437,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		ensureExistsInWorkspace(project1a, true);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		project1a.setPersistentProperty(key, "value");
-		project1a.move(IPath.fromOSString("proj2"), true, getMonitor());
+		project1a.move(IPath.fromOSString("proj2"), true, createTestMonitor());
 		IProject project1b = root.getProject("proj1");
 		ensureExistsInWorkspace(project1b, true);
 		String value = project1b.getPersistentProperty(key);
@@ -485,7 +486,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, getMonitor());
+		target.create(getRandomContents(), true, createTestMonitor());
 
 		// prepare keys and values
 		int N = 3;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
@@ -13,9 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.propertytester;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.io.ByteArrayInputStream;
 import org.eclipse.core.internal.propertytester.FilePropertyTester;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -62,7 +67,7 @@ public class FilePropertyTesterTest extends ResourceTest {
 	public void testExistingTextFile() throws Throwable {
 		String expected = "org.eclipse.core.runtime.text";
 		IFile target = project.getFile("tmp.txt");
-		target.create(getRandomContents(), true, getMonitor());
+		target.create(getRandomContents(), true, createTestMonitor());
 
 		boolean ret;
 		ret = tester.test(target, CONTENT_TYPE_ID, new String[] {}, expected);
@@ -96,7 +101,7 @@ public class FilePropertyTesterTest extends ResourceTest {
 		String expectedExact = "org.eclipse.core.tests.resources.ns-root-element";
 		IFile target = project.getFile("tmp.xml");
 		byte[] bytes = IContentTypeManagerTest.XML_ROOT_ELEMENT_NS_MATCH1.getBytes("UTF-8");
-		target.create(new ByteArrayInputStream(bytes), true, getMonitor());
+		target.create(new ByteArrayInputStream(bytes), true, createTestMonitor());
 
 		boolean ret;
 		ret = tester.test(target, CONTENT_TYPE_ID, new String[] {}, expectedExact);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -269,7 +270,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 	 * Reads and returns the project description stored in the given file store.
 	 */
 	private ProjectDescription readDescription(IFileStore store) throws CoreException, IOException {
-		try (InputStream input = store.openInputStream(EFS.NONE, getMonitor())) {
+		try (InputStream input = store.openInputStream(EFS.NONE, createTestMonitor())) {
 			InputSource in = new InputSource(input);
 			return new ProjectDescriptionReader(getWorkspace()).read(in);
 		}
@@ -549,13 +550,13 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		refProjects[2] = ResourcesPlugin.getWorkspace().getRoot().getProject("org.eclipse.core.resources");
 		description.setReferencedProjects(refProjects);
 
-		try (OutputStream output = tempStore.openOutputStream(EFS.NONE, getMonitor())) {
+		try (OutputStream output = tempStore.openOutputStream(EFS.NONE, createTestMonitor())) {
 			writer.write(description, output, System.lineSeparator());
 		}
 
 		/* test read */
 		ProjectDescription description2;
-		try (InputStream input = tempStore.openInputStream(EFS.NONE, getMonitor())) {
+		try (InputStream input = tempStore.openInputStream(EFS.NONE, createTestMonitor())) {
 			InputSource in = new InputSource(input);
 			description2 = reader.read(in);
 		}
@@ -634,7 +635,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 	 * Writes a project description to a file store
 	 */
 	private void writeDescription(IFileStore store, ProjectDescription description) throws IOException, CoreException {
-		try (OutputStream output = store.openOutputStream(EFS.NONE, getMonitor())) {
+		try (OutputStream output = store.openOutputStream(EFS.NONE, createTestMonitor())) {
 			new ModelObjectWriter().write(description, output, System.lineSeparator());
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
@@ -54,7 +55,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		IProjectDescription desc = project.getDescription();
 		String[] configs = new String[] {variantId0, variantId1};
 		desc.setBuildConfigs(configs);
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		assertThat(project.getBuildConfigs(), arrayContaining(variant0, variant1));
 		assertThat(project.getBuildConfig(variantId0), is(variant0));
@@ -71,7 +72,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		assertThat(project.getActiveBuildConfig(), is(variant0));
 		desc = project.getDescription();
 		desc.setActiveBuildConfig(variantId1);
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getActiveBuildConfig(), is(variant1));
 		// test that setting the variant to an invalid id has no effect
 		desc.setActiveBuildConfig(variantId2);
@@ -85,14 +86,14 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 	public void testDuplicates() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[] {variantId0, variantId1, variantId0});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getBuildConfigs(), arrayContaining(variant0, variant1));
 	}
 
 	public void testDefaultVariant() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[] {});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		assertThat(project.getBuildConfigs(), arrayContaining(defaultVariant));
 		assertThat("project '" + project + "' is missing build config: " + defaultVariant,
@@ -101,7 +102,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		assertThat(project.getActiveBuildConfig(), is(defaultVariant));
 		desc = project.getDescription();
 		desc.setActiveBuildConfig(IBuildConfiguration.DEFAULT_CONFIG_NAME);
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getActiveBuildConfig(), is(defaultVariant));
 	}
 
@@ -109,16 +110,16 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[0]);
 		desc.setBuildConfigs(new String[] {variant0.getName(), variant1.getName()});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getActiveBuildConfig(), is(variant0));
 		desc.setBuildConfigs(new String[] {variant0.getName(), variant2.getName()});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getActiveBuildConfig(), is(variant0));
 		desc = project.getDescription();
 		desc.setActiveBuildConfig(variantId2);
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		desc.setBuildConfigs(new String[] {variant0.getName(), variant1.getName()});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 		assertThat(project.getActiveBuildConfig(), is(variant0));
 	}
 
@@ -129,13 +130,13 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		IProjectDescription desc = project.getDescription();
 		IBuildConfiguration[] configs = new IBuildConfiguration[] {variant0, variant1};
 		desc.setBuildConfigs(new String[] {configs[0].getName(), configs[1].getName()});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 
 		// Move the project. The build configurations should point at the new project
 		String newProjectName = "projectMoved";
 		desc = project.getDescription();
 		desc.setName(newProjectName);
-		project.move(desc, false, getMonitor());
+		project.move(desc, false, createTestMonitor());
 
 		IProject newProject = getWorkspace().getRoot().getProject(newProjectName);
 		assertThat("project does not exist: " + newProject, newProject.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -251,7 +252,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		touchInFilesystem(workspaceFile);
 
 		// resource change is fired
-		workspaceFile.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		workspaceFile.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
 
 		// validate new settings
 		actual = node.get(key, null);
@@ -278,7 +279,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals("1.0", value, node.get(key, null));
 
 		// delete the project
-		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 
 		// project pref should not exist
 		assertTrue("3.0", !parent.nodeExists(project.getName()));
@@ -407,7 +408,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		node.flush();
 
 		// rename the project
-		project.move(destProject.getFullPath(), true, getMonitor());
+		project.move(destProject.getFullPath(), true, createTestMonitor());
 
 		context = new ProjectScope(destProject);
 		node = context.getNode(qualifier);
@@ -508,7 +509,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		try {
 			Platform.addLogListener(logListener);
 			getWorkspace().addResourceChangeListener(rclistener, IResourceChangeEvent.POST_CHANGE);
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		} finally {
 			Platform.removeLogListener(logListener);
 			getWorkspace().removeResourceChangeListener(rclistener);
@@ -564,7 +565,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		ByteArrayOutputStream tempOutput = new ByteArrayOutputStream();
 		properties.store(tempOutput, null);
 		ByteArrayInputStream tempInput = new ByteArrayInputStream(tempOutput.toByteArray());
-		prefFile.setContents(tempInput, false, false, getMonitor());
+		prefFile.setContents(tempInput, false, false, createTestMonitor());
 
 		// here, project preferences should have caught up with the changes
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
@@ -614,7 +615,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		ByteArrayOutputStream tempOutput = new ByteArrayOutputStream();
 		properties.store(tempOutput, null);
 		ByteArrayInputStream tempInput = new ByteArrayInputStream(tempOutput.toByteArray());
-		prefFile.setContents(tempInput, false, false, getMonitor());
+		prefFile.setContents(tempInput, false, false, createTestMonitor());
 
 		// here, project preferences should have caught up with the changes
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
@@ -736,7 +737,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		IProject project = getProject(projectName);
 
 		//create project but do not open it yet
-		project.create(getMonitor());
+		project.create(createTestMonitor());
 
 		//create file with preferences that will be discovered during refresh
 		File folder = new File(project.getLocation().toOSString() + "/.settings");
@@ -751,7 +752,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		Preferences projectNode = Platform.getPreferencesService().getRootNode().node(ProjectScope.SCOPE).node(projectName);
 
 		//open the project. the new file will be found during refresh and preferences will be loaded into nodes
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		//the node was created on refresh so we can now take the node without creating it
 		Preferences node = projectNode.node(nodeName);
@@ -828,7 +829,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 			node.flush();
 			// if there is no preference, OS default line separator should be used
 			assertEquals("1.0", systemValue, getLineSeparatorFromFile(file));
-			file.delete(true, getMonitor());
+			file.delete(true, createTestMonitor());
 
 			instanceNode.put(Platform.PREF_LINE_SEPARATOR, newInstanceValue);
 			instanceNode.flush();
@@ -836,7 +837,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 			node.flush();
 			// if there is instance preference then it should be used
 			assertEquals("2.0", newInstanceValue, getLineSeparatorFromFile(file));
-			file.delete(true, getMonitor());
+			file.delete(true, createTestMonitor());
 
 			projectNode.put(Platform.PREF_LINE_SEPARATOR, newProjectValue);
 			projectNode.flush();
@@ -881,7 +882,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		IProject project = getProject(projectName);
 
 		//create project but do not open it yet
-		project.create(getMonitor());
+		project.create(createTestMonitor());
 
 		//create file with preferences that will be discovered during refresh
 		File folder = new File(project.getLocation().toOSString() + "/.settings");
@@ -898,7 +899,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		Preferences node = projectNode.node(nodeName);
 
 		//open the project; the new file will be found during refresh
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		//loading preferences from a file must not remove nodes that were previously created
 		assertTrue(node == projectNode.node(nodeName));
@@ -915,9 +916,9 @@ public class ProjectPreferencesTest extends ResourceTest {
 		node.put(key, value);
 		node.flush();
 		// close the project
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		// now reopen the project and ensure the settings were not forgotten
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		node = new ProjectScope(project).getNode(qualifier);
 		assertEquals("2.1", value, node.get(key, null));
 	}
@@ -970,7 +971,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		props.store(output, null);
 		try (InputStream input = new ByteArrayInputStream(output.toByteArray())) {
-			workspaceFile.setContents(input, IResource.NONE, getMonitor());
+			workspaceFile.setContents(input, IResource.NONE, createTestMonitor());
 		}
 
 		// validate new settings
@@ -1030,7 +1031,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 		// remove the file from the project
 		IFile fileInWS = getFileInWorkspace(project, qualifier);
-		fileInWS.delete(IResource.NONE, getMonitor());
+		fileInWS.delete(IResource.NONE, createTestMonitor());
 		assertTrue("3.0", !fileInWS.exists());
 		assertTrue("3.1", !fileInFS.exists());
 		IEclipsePreferences projectNode = (IEclipsePreferences) service.getRootNode().node(ProjectScope.SCOPE).node(project.getName());
@@ -1046,7 +1047,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 				}
 			}
 		}
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		// ensure that the resource changes happen
 		waitForBuild();
 
@@ -1085,8 +1086,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1094,7 +1095,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1102,7 +1103,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode("");
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode("");
 		String[] childrenNames = node.childrenNames();
@@ -1113,8 +1114,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(1, childrenNames.length);
 		assertEquals(nodeB, childrenNames[0]);
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testChildrenNamesAgainstLoad() throws BackingStoreException, CoreException {
@@ -1124,8 +1125,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1133,7 +1134,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1141,15 +1142,15 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA);
 		String[] childrenNames = node.childrenNames();
 		assertEquals(1, childrenNames.length);
 		assertEquals(nodeB, childrenNames[0]);
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testClear() throws BackingStoreException, CoreException {
@@ -1159,8 +1160,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1168,7 +1169,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1176,15 +1177,15 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node(nodeB);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		node.clear();
 		assertEquals(0, node.keys().length);
 		assertNull(node.get(key, null));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testGet() throws BackingStoreException, CoreException {
@@ -1194,8 +1195,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1203,7 +1204,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1211,13 +1212,13 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node(nodeB);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		assertEquals(value, node.get(key, null));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testKeys() throws BackingStoreException, CoreException {
@@ -1227,8 +1228,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1236,7 +1237,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1244,15 +1245,15 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node(nodeB);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		String[] keys = node.keys();
 		assertEquals(1, keys.length);
 		assertEquals(key, keys[0]);
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testNodeExistsAgainstInitialize() throws BackingStoreException, CoreException {
@@ -1262,8 +1263,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1271,7 +1272,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1279,15 +1280,15 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode("nodeC");
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode("");
 		assertTrue(node.nodeExists(nodeA));
 		node = node.node(nodeA);
 		assertTrue(node.nodeExists(nodeB));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testNodeExistsAgainstLoad() throws BackingStoreException, CoreException {
@@ -1297,8 +1298,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1306,7 +1307,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1314,13 +1315,13 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node("nodeC");
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA);
 		assertTrue(node.nodeExists(nodeB));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testPut() throws BackingStoreException, CoreException {
@@ -1331,8 +1332,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String anotherValue = "anotherValue";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1340,7 +1341,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1348,14 +1349,14 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node(nodeB);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		node.put(key, anotherValue);
 		assertEquals(anotherValue, node.get(key, null));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testRemove() throws BackingStoreException, CoreException {
@@ -1365,8 +1366,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		prefs1.put(key, value);
@@ -1374,7 +1375,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals(value, prefs1.get(key, null));
 
 		IProject project2 = getProject(getUniqueString());
-		project1.move(project2.getFullPath(), IResource.NONE, getMonitor());
+		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
 		assertEquals(value, prefs2.get(key, null));
@@ -1382,14 +1383,14 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// this will trigger the creation of "phantom" preferences node for the now-missing project
 		new ProjectScope(project1).getNode(nodeA).node(nodeB);
 
-		project2.move(project1.getFullPath(), IResource.NONE, getMonitor());
+		project2.move(project1.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		node.remove(key);
 		assertNull(node.get(key, null));
 
-		project1.delete(true, getMonitor());
-		project2.delete(true, getMonitor());
+		project1.delete(true, createTestMonitor());
+		project2.delete(true, createTestMonitor());
 	}
 
 	public void testDeleteOnFilesystemAndLoad() throws CoreException, BackingStoreException {
@@ -1398,8 +1399,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		Preferences prefs1 = new ProjectScope(project1).getNode(nodeA);
 		prefs1.put(key, value);
@@ -1425,8 +1426,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 
 		IProject project1 = getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		// create the project settings folder on disk, it will be out of sync with the workspace
 		// see bug#522214

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
@@ -81,7 +82,7 @@ public class ProjectReferencesTest extends ResourceTest {
 	private void setUpVariants(IProject project) throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[] {bc0, bc1});
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 	public void testAddReferencesToNonExistantConfigs() throws CoreException {
@@ -91,7 +92,7 @@ public class ProjectReferencesTest extends ResourceTest {
 				!project0.hasBuildConfig(nonExistentBC));
 
 		desc.setBuildConfigReferences(nonExistentBC, new IBuildConfiguration[] {project1v0});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		assertThat("project '" + project0 + "' has unexpected build config: " + nonExistentBC,
 				!project0.hasBuildConfig(nonExistentBC));
@@ -114,7 +115,7 @@ public class ProjectReferencesTest extends ResourceTest {
 		// Set some references
 		desc.setBuildConfigReferences(project0v0.getName(), refs);
 		desc.setBuildConfigReferences(project0v1.getName(), refs2);
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		// Check build configa
 		desc = project0.getDescription();
@@ -122,21 +123,21 @@ public class ProjectReferencesTest extends ResourceTest {
 		assertThat(desc.getBuildConfigReferences(project0v1.getName()), is(refs2));
 		// Resetting the build configs doesn't change anything
 		desc.setBuildConfigs(new String[] {project0v0.getName(), project0v1.getName()});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		desc = project0.getDescription();
 		assertThat(desc.getBuildConfigReferences(project0v0.getName()), is(refs));
 		assertThat(desc.getBuildConfigReferences(project0v1.getName()), is(refs2));
 		// Removing a build configuration removes the references
 		desc.setBuildConfigs(new String[] {project0v0.getName()});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		desc = project0.getDescription();
 		assertThat(desc.getBuildConfigReferences(project0v0.getName()), is(refs));
 		assertThat(desc.getBuildConfigReferences(project0v1.getName()), emptyArray());
 		// Re-adding a build configuration doesn't make references re-appear
 		desc.setBuildConfigs(new String[] {project0v0.getName()});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		desc = project0.getDescription();
 		assertThat(desc.getBuildConfigReferences(project0v0.getName()), is(refs));
@@ -151,7 +152,7 @@ public class ProjectReferencesTest extends ResourceTest {
 		// Set project variant references
 		IProjectDescription desc = project0.getDescription();
 		desc.setDynamicReferences(new IProject[] {project1, project3});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		// Check getters
 		desc = project0.getDescription();
@@ -165,7 +166,7 @@ public class ProjectReferencesTest extends ResourceTest {
 
 		// Now set dynamic references on config1
 		desc.setBuildConfigReferences(project0v0.getName(), new IBuildConfiguration[] {project3v1, project2v0, project1v0});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		// Check references
 		// This is deterministic as config0 is listed first, so we expect its config order to trump cofig1's
@@ -185,22 +186,22 @@ public class ProjectReferencesTest extends ResourceTest {
 		IProjectDescription desc = project0.getDescription();
 		desc.setReferencedProjects(new IProject[] {project3, project1});
 		desc.setDynamicReferences(new IProject[] {project1, project2});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		desc = project1.getDescription();
 		desc.setReferencedProjects(new IProject[] {project0});
 		desc.setDynamicReferences(new IProject[] {});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		desc = project2.getDescription();
 		desc.setReferencedProjects(new IProject[] {});
 		desc.setDynamicReferences(new IProject[] {});
-		project2.setDescription(desc, getMonitor());
+		project2.setDescription(desc, createTestMonitor());
 
 		desc = project3.getDescription();
 		desc.setReferencedProjects(new IProject[] {});
 		desc.setDynamicReferences(new IProject[] {project0});
-		project3.setDescription(desc, getMonitor());
+		project3.setDescription(desc, createTestMonitor());
 
 		// Test getters
 		desc = project0.getDescription();
@@ -224,18 +225,18 @@ public class ProjectReferencesTest extends ResourceTest {
 		// config level references
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {project2v0, project1v0});
 		desc.setBuildConfigReferences(bc1, new IBuildConfiguration[] {project2v0});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		desc = project1.getDescription();
 		desc.setReferencedProjects(new IProject[] {project0});
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {project0v1});
 		desc.setBuildConfigReferences(bc1, new IBuildConfiguration[] {});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 
 		desc = project3.getDescription();
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {project0v1});
 		desc.setBuildConfigReferences(bc1, new IBuildConfiguration[] {});
-		project3.setDescription(desc, getMonitor());
+		project3.setDescription(desc, createTestMonitor());
 
 		// Check getters
 		desc = project0.getDescription();
@@ -255,7 +256,7 @@ public class ProjectReferencesTest extends ResourceTest {
 	public void testReferencesToActiveConfigs() throws CoreException {
 		IProjectDescription desc = project0.getDescription();
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {getRef(project1)});
-		project0.setDescription(desc, getMonitor());
+		project0.setDescription(desc, createTestMonitor());
 
 		assertThat(desc.getBuildConfigReferences(bc0), arrayContaining(getRef(project1)));
 		assertThat(project0.getReferencedBuildConfigs(project0v0.getName(), true),

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,7 +57,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 		final IProject project = getWorkspace().getRoot().getProject("testEndRuleInWorkspaceOperation");
 		assertThrows(RuntimeException.class,
 				() -> getWorkspace().run((IWorkspaceRunnable) monitor -> Job.getJobManager().endRule(project), project,
-						IResource.NONE, getMonitor()));
+						IResource.NONE, createTestMonitor()));
 	}
 
 	/**
@@ -143,7 +144,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 		};
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			// noop
-		}, rule, IResource.NONE, getMonitor());
+		}, rule, IResource.NONE, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -18,6 +18,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -183,10 +184,10 @@ public class CharsetTest extends ResourceTest {
 		try {
 			final IFile file = project.getFile("file.txt");
 			ensureExistsInWorkspace(file, true);
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			workspace.run((IWorkspaceRunnable) monitor -> {
 				assertEquals("0.9", "FOO", file.getCharset());
-				file.setCharset("BAR", getMonitor());
+				file.setCharset("BAR", createTestMonitor());
 				assertEquals("1.0", "BAR", file.getCharset());
 				file.move(project.getFullPath().append("file2.txt"), IResource.NONE, monitor);
 				IFile file2 = project.getFile("file2.txt");
@@ -205,11 +206,11 @@ public class CharsetTest extends ResourceTest {
 		try {
 			final IFile file = project.getFile("file.txt");
 			ensureExistsInWorkspace(file, true);
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			assertEquals("Setting up Projects default charset was successful", "FOO", file.getCharset());
-			file.setCharset("BAR", getMonitor());
+			file.setCharset("BAR", createTestMonitor());
 			assertEquals("Setting up file's explicit charset was successful", "BAR", file.getCharset());
-			file.move(project.getFullPath().append("file2.txt"), IResource.NONE, getMonitor());
+			file.move(project.getFullPath().append("file2.txt"), IResource.NONE, createTestMonitor());
 			IFile file2 = project.getFile("file2.txt");
 			assertExistsInWorkspace(file2);
 			assertEquals("The file's charset was correctly copied while coying the file", "BAR", file2.getCharset());
@@ -227,9 +228,9 @@ public class CharsetTest extends ResourceTest {
 			ensureExistsInWorkspace(project, false);
 			final IFile file = project.getFile("file.txt");
 			ensureExistsInWorkspace(file, true);
-			file.setCharset("FOO", getMonitor());
+			file.setCharset("FOO", createTestMonitor());
 			assertEquals("File charset correctly set", file.getCharset(true), "FOO");
-			file.copy(project.getFullPath().append("file2.txt"), IResource.NONE, getMonitor());
+			file.copy(project.getFullPath().append("file2.txt"), IResource.NONE, createTestMonitor());
 			final IFile copiedFile = project.getFile("file2.txt");
 			assertEquals("File with explicitly set charset keeps charset", copiedFile.getCharset(true), "FOO");
 		} finally {
@@ -258,13 +259,13 @@ public class CharsetTest extends ResourceTest {
 			}
 			switch (resource.getType()) {
 				case IResource.FILE :
-					((IFile) resource).setCharset(null, getMonitor());
+					((IFile) resource).setCharset(null, createTestMonitor());
 					break;
 				case IResource.ROOT :
 					// do nothing
 					break;
 				default :
-					((IContainer) resource).setDefaultCharset(null, getMonitor());
+					((IContainer) resource).setDefaultCharset(null, createTestMonitor());
 			}
 			return true;
 		};
@@ -341,10 +342,10 @@ public class CharsetTest extends ResourceTest {
 			IFile file = project.getFile("file.txt");
 			IFolder folder = project.getFolder("folder");
 			ensureExistsInWorkspace(new IResource[] {file, folder}, true);
-			file.setCharset("FOO", getMonitor());
-			folder.setDefaultCharset("BAR", getMonitor());
-			project.setDefaultCharset("PROJECT_CHARSET", getMonitor());
-			getWorkspace().getRoot().setDefaultCharset("ROOT_CHARSET", getMonitor());
+			file.setCharset("FOO", createTestMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
+			project.setDefaultCharset("PROJECT_CHARSET", createTestMonitor());
+			getWorkspace().getRoot().setDefaultCharset("ROOT_CHARSET", createTestMonitor());
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -405,7 +406,7 @@ public class CharsetTest extends ResourceTest {
 			IWorkspace workspace = getWorkspace();
 			project = workspace.getRoot().getProject("MyProject");
 			ensureExistsInWorkspace(project, true);
-			project.setDefaultCharset("BAR", getMonitor());
+			project.setDefaultCharset("BAR", createTestMonitor());
 
 			IFolder folder = project.getFolder(getUniqueString());
 			IFile file = folder.getFile(getUniqueString());
@@ -414,7 +415,7 @@ public class CharsetTest extends ResourceTest {
 			ensureExistsInWorkspace(folder, true);
 			assertEquals("2.0", "BAR", file.getCharset(true));
 
-			folder.setDerived(true, getMonitor());
+			folder.setDerived(true, createTestMonitor());
 			assertEquals("3.0", "BAR", file.getCharset(true));
 
 			setDerivedEncodingStoredSeparately(project, true);
@@ -456,7 +457,7 @@ public class CharsetTest extends ResourceTest {
 		// returns the correct value.
 
 		// 1) first set the content type to ascii
-		file.setContents(new ByteArrayInputStream(ascii.getBytes("ascii")), IResource.FORCE, getMonitor());
+		file.setContents(new ByteArrayInputStream(ascii.getBytes("ascii")), IResource.FORCE, createTestMonitor());
 		assertTrue("4.0", file.getCharset().equals("ascii"));
 		assertTrue("4.1", file.getContentDescription().getCharset().equals("ascii"));
 
@@ -474,7 +475,7 @@ public class CharsetTest extends ResourceTest {
 
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 		// Prime the cache...
 		assertTrue("4.6", file.getCharset().equals("ascii"));
 
@@ -489,7 +490,7 @@ public class CharsetTest extends ResourceTest {
 		assertTrue("5.5", file.getContentDescription().getCharset().equals("UTF-8"));
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 		// #getCharset will now have noticed that the file has changed.
 		assertTrue("5.6", file.getCharset().equals("UTF-8"));
 
@@ -504,7 +505,7 @@ public class CharsetTest extends ResourceTest {
 		assertTrue("6.8", file.getContentDescription().getCharset().equals("ascii"));
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 		assertTrue("6.9", file.getCharset().equals("ascii"));
 	}
 
@@ -523,7 +524,7 @@ public class CharsetTest extends ResourceTest {
 			ensureExistsInWorkspace(new IResource[] {project1, a1, b1, a}, true);
 			verifier.reset();
 			verifier.addExpectedChange(b1, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
-			b1.setDerived(true, getMonitor());
+			b1.setDerived(true, createTestMonitor());
 			verifier.waitForEvent(10000);
 			IFile regularPrefs = getResourcesPreferenceFile(project1, false);
 			IFile derivedPrefs = getResourcesPreferenceFile(project1, true);
@@ -545,7 +546,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.reset();
 			verifier.addExpectedChange(a, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			a.setCharset("UTF-8", getMonitor());
+			a.setCharset("UTF-8", createTestMonitor());
 			assertTrue("2.1", verifier.waitForEvent(10000));
 			assertTrue("2.2 " + verifier.getMessage(), verifier.isDeltaValid());
 			assertExistsInWorkspace(regularPrefs);
@@ -553,7 +554,7 @@ public class CharsetTest extends ResourceTest {
 
 			//3 - setting derived == 'true' for file
 			// TODO update the test when bug 345271 is fixed
-			a.setDerived(true, getMonitor());
+			a.setDerived(true, createTestMonitor());
 			//wait for all resource deltas
 			// Thread.sleep(500);
 			waitForCharsetManagerJob();
@@ -563,7 +564,7 @@ public class CharsetTest extends ResourceTest {
 
 			//4 - setting derived == 'false' for file
 			// TODO update the test when bug 345271 is fixed
-			a.setDerived(false, getMonitor());
+			a.setDerived(false, createTestMonitor());
 			//wait for all resource deltas
 			// Thread.sleep(500);
 			waitForCharsetManagerJob();
@@ -576,7 +577,7 @@ public class CharsetTest extends ResourceTest {
 			backgroundVerifier.reset();
 			backgroundVerifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.ADDED, 0);
-			a.move(destination.getFullPath(), true, getMonitor());
+			a.move(destination.getFullPath(), true, createTestMonitor());
 			a = destination;
 			waitForCharsetManagerJob();
 			assertTrue("5.1", backgroundVerifier.waitForAllDeltas(10000, 15000));
@@ -779,9 +780,9 @@ public class CharsetTest extends ResourceTest {
 			IFile file1 = project1.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2, project2}, true);
-			project1.setDefaultCharset("FOO", getMonitor());
-			project2.setDefaultCharset("ZOO", getMonitor());
-			folder.setDefaultCharset("BAR", getMonitor());
+			project1.setDefaultCharset("FOO", createTestMonitor());
+			project2.setDefaultCharset("ZOO", createTestMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
 			// move a folder to another project and ensure its encoding is
 			// preserved
 			folder.move(project2.getFullPath().append("folder"), false, false, null);
@@ -808,9 +809,9 @@ public class CharsetTest extends ResourceTest {
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2}, true);
-			project.setDefaultCharset("FOO", getMonitor());
-			file1.setCharset("FRED", getMonitor());
-			folder.setDefaultCharset("BAR", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
+			file1.setCharset("FRED", createTestMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
 			// move a folder inside the project and ensure its encoding is
 			// preserved
 			folder.move(project.getFullPath().append("folder2"), false, false, null);
@@ -842,9 +843,9 @@ public class CharsetTest extends ResourceTest {
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2}, true);
-			project.setDefaultCharset("FOO", getMonitor());
-			file1.setCharset("FRED", getMonitor());
-			folder.setDefaultCharset("BAR", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
+			file1.setCharset("FRED", createTestMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
 			project.close(null);
 			// now reopen the project and ensure the settings were not forgotten
 			IProject projectB = workspace.getRoot().getProject(project.getName());
@@ -867,7 +868,7 @@ public class CharsetTest extends ResourceTest {
 		IProject project = workspace.getRoot().getProject("MyProject");
 		try {
 			ensureExistsInWorkspace(project, true);
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
 			assertEquals("0.9", "FOO", project.getDefaultCharset());
 			// content-based encoding is BAR
@@ -915,7 +916,7 @@ public class CharsetTest extends ResourceTest {
 			IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertEquals("No missing encoding marker should be set", 0, markers.length);
 
-			project.setDefaultCharset(null, getMonitor());
+			project.setDefaultCharset(null, createTestMonitor());
 			assertEquals(null, project.getDefaultCharset(false));
 
 			waitForEncodingRelatedJobs();
@@ -929,7 +930,7 @@ public class CharsetTest extends ResourceTest {
 			assertCharsetIs("1.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
 
 			// sets workspace default charset
-			workspace.getRoot().setDefaultCharset("FOO", getMonitor());
+			workspace.getRoot().setDefaultCharset("FOO", createTestMonitor());
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertEquals("Missing encoding marker should be still set", 1, markers.length);
 
@@ -937,7 +938,7 @@ public class CharsetTest extends ResourceTest {
 			assertCharsetIs("2.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
 
 			// sets project default charset
-			project.setDefaultCharset("BAR", getMonitor());
+			project.setDefaultCharset("BAR", createTestMonitor());
 			waitForEncodingRelatedJobs();
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
@@ -947,34 +948,34 @@ public class CharsetTest extends ResourceTest {
 			assertCharsetIs("3.1", null, new IResource[] {file1, folder1, file2, folder2, file3}, false);
 			assertCharsetIs("3.2", "FOO", new IResource[] {workspace.getRoot()}, true);
 			// sets folder1 default charset
-			folder1.setDefaultCharset("FRED", getMonitor());
+			folder1.setDefaultCharset("FRED", createTestMonitor());
 			assertCharsetIs("4.0", "FRED", new IResource[] {folder1, file2, folder2, file3}, true);
 			assertCharsetIs("4.1", null, new IResource[] {file2, folder2, file3}, false);
 			assertCharsetIs("4.2", "BAR", new IResource[] {project, file1}, true);
 			// sets folder2 default charset
-			folder2.setDefaultCharset("ZOO", getMonitor());
+			folder2.setDefaultCharset("ZOO", createTestMonitor());
 			assertCharsetIs("5.0", "ZOO", new IResource[] {folder2, file3}, true);
 			assertCharsetIs("5.1", null, new IResource[] {file3}, false);
 			assertCharsetIs("5.2", "FRED", new IResource[] {folder1, file2}, true);
 			// sets file3 charset
-			file3.setCharset("ZIT", getMonitor());
+			file3.setCharset("ZIT", createTestMonitor());
 			assertCharsetIs("6.0", "ZIT", new IResource[] {file3}, false);
-			folder2.setDefaultCharset(null, getMonitor());
+			folder2.setDefaultCharset(null, createTestMonitor());
 			assertCharsetIs("7.0", folder2.getParent().getDefaultCharset(), new IResource[] {folder2}, true);
 			assertCharsetIs("7.1", null, new IResource[] {folder2}, false);
 			assertCharsetIs("7.2", "ZIT", new IResource[] {file3}, false);
-			folder1.setDefaultCharset(null, getMonitor());
+			folder1.setDefaultCharset(null, createTestMonitor());
 			assertCharsetIs("8.0", folder1.getParent().getDefaultCharset(), new IResource[] {folder1, file2, folder2}, true);
 			assertCharsetIs("8.1", null, new IResource[] {folder1, file2, folder2}, false);
 			assertCharsetIs("8.2", "ZIT", new IResource[] {file3}, false);
-			project.setDefaultCharset(null, getMonitor());
+			project.setDefaultCharset(null, createTestMonitor());
 			assertCharsetIs("9.0", project.getParent().getDefaultCharset(), new IResource[] {project, file1, folder1, file2, folder2}, true);
 			assertCharsetIs("9.1", null, new IResource[] {project, file1, folder1, file2, folder2}, false);
 			assertCharsetIs("9.2", "ZIT", new IResource[] {file3}, false);
-			workspace.getRoot().setDefaultCharset(null, getMonitor());
+			workspace.getRoot().setDefaultCharset(null, createTestMonitor());
 			assertCharsetIs("10.0", project.getParent().getDefaultCharset(), new IResource[] {project, file1, folder1, file2, folder2}, true);
 			assertCharsetIs("10.1", "ZIT", new IResource[] {file3}, false);
-			file3.setCharset(null, getMonitor());
+			file3.setCharset(null, createTestMonitor());
 			assertCharsetIs("11.0", ResourcesPlugin.getEncoding(), new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
 		} finally {
 			ResourcesPlugin.getPlugin().getPluginPreferences().setValue(ResourcesPlugin.PREF_ENCODING, originalCharset);
@@ -1002,9 +1003,9 @@ public class CharsetTest extends ResourceTest {
 			IFile file3 = project.getFile("file3.resources-mc");
 			IFile file4 = project.getFile("file4.resources-mc");
 			ensureExistsInWorkspace(new IResource[] {file1, file2, file3, file4}, true);
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			// even files with a user-set charset will appear in the delta
-			file4.setCharset("BAR", getMonitor());
+			file4.setCharset("BAR", createTestMonitor());
 			// configure verifier
 			backgroundVerifier.reset();
 			backgroundVerifier.addExpectedChange(new IResource[] {file2, file3, file4}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
@@ -1053,7 +1054,7 @@ public class CharsetTest extends ResourceTest {
 			assertTrue("0.9", resourcesPrefs.exists());
 			String prefsContent = Files.readString(resourcesPrefs.getLocation().toFile().toPath());
 			assertTrue(prefsContent.contains(ResourcesPlugin.getEncoding()));
-			file1.setCharset("CHARSET1", getMonitor());
+			file1.setCharset("CHARSET1", createTestMonitor());
 			assertTrue("1.1", resourcesPrefs.exists());
 			waitForCharsetManagerJob();
 
@@ -1064,7 +1065,7 @@ public class CharsetTest extends ResourceTest {
 			backgroundVerifier.addExpectedChange(new IResource[] {project, folder1, file1, file2, resourcesPrefs, resourcesPrefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			// cause a resource change event without actually changing contents
 			InputStream contents = new ByteArrayInputStream(prefsContent.getBytes());
-			resourcesPrefs.setContents(contents, 0, getMonitor());
+			resourcesPrefs.setContents(contents, 0, createTestMonitor());
 			assertTrue("2.1", backgroundVerifier.waitForEvent(10000));
 			assertTrue("2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
 
@@ -1078,7 +1079,7 @@ public class CharsetTest extends ResourceTest {
 			backgroundVerifier.addExpectedChange(new IResource[] { folder1, file1, file2, resourcesPrefs.getParent() },
 					IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			// delete the preferences file
-			resourcesPrefs.delete(true, getMonitor());
+			resourcesPrefs.delete(true, createTestMonitor());
 			waitForCharsetManagerJob();
 			waitForEncodingRelatedJobs();
 
@@ -1110,7 +1111,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(folder1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(new IResource[] { prefs.getParent() }, IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(new IResource[] { prefs }, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset("new_charset", getMonitor());
+			folder1.setDefaultCharset("new_charset", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("1.1.");
 
 			// folder with children
@@ -1122,17 +1123,17 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(new IResource[] {folder1, folder2, file1, file2}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset("a_charset", getMonitor());
+			folder1.setDefaultCharset("a_charset", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("2.1.");
 
 			// folder w. children, some with non-inherited values
 			// set the child to have a non-inherited value
-			folder2.setDefaultCharset("non-Default", getMonitor());
+			folder2.setDefaultCharset("non-Default", createTestMonitor());
 			verifier.reset();
 			verifier.addExpectedChange(new IResource[] {folder1, file1}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset("newOne", getMonitor());
+			folder1.setDefaultCharset("newOne", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("3.2.");
 
 			// change from non-default to another non-default
@@ -1140,7 +1141,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(new IResource[] {folder1, file1}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset("newTwo", getMonitor());
+			folder1.setDefaultCharset("newTwo", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("4.2.");
 
 			// change to default (clear it)
@@ -1148,7 +1149,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(new IResource[] {folder1, file1}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset(null, getMonitor());
+			folder1.setDefaultCharset(null, createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("5.1.");
 
 			// change to default (equal to it but it doesn't inherit)
@@ -1156,7 +1157,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(new IResource[] {folder1, file1}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			folder1.setDefaultCharset(project.getDefaultCharset(), getMonitor());
+			folder1.setDefaultCharset(project.getDefaultCharset(), createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("6.1.");
 
 			// clear all the encoding info before we start working with the project
@@ -1164,7 +1165,7 @@ public class CharsetTest extends ResourceTest {
 			verifier.reset();
 			verifier.addExpectedChange(new IResource[] {project, folder1, folder2, file1, file2, prefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs, IResourceDelta.ADDED, 0);
-			project.setDefaultCharset("foo", getMonitor());
+			project.setDefaultCharset("foo", createTestMonitor());
 			waitForEncodingRelatedJobs();
 			verifier.assertExpectedDeltasWereReceived("7.2.");
 
@@ -1172,7 +1173,7 @@ public class CharsetTest extends ResourceTest {
 			clearAllEncodings(project);
 			verifier.reset();
 			verifier.addExpectedChange(new IResource[] {project, folder1, folder2, file1, file2, prefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			getWorkspace().getRoot().setDefaultCharset("foo", getMonitor());
+			getWorkspace().getRoot().setDefaultCharset("foo", createTestMonitor());
 			waitForEncodingRelatedJobs();
 			verifier.assertExpectedDeltasWereReceived("8.2.");
 		} finally {
@@ -1202,34 +1203,34 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(new IResource[] { prefs.getParent() }, IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(new IResource[] { prefs }, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			file1.setCharset("FOO", getMonitor());
+			file1.setCharset("FOO", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("1.0.1");
 
 			// change to default (clear it)
 			verifier.reset();
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			file1.setCharset(null, getMonitor());
+			file1.setCharset(null, createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("1.1.1");
 
 			// change to default (equal to it but it doesn't inherit)
 			verifier.reset();
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			file1.setCharset(project.getDefaultCharset(), getMonitor());
+			file1.setCharset(project.getDefaultCharset(), createTestMonitor());
 
 			verifier.assertExpectedDeltasWereReceived("1.2.1");
 
 			// change from non-default to another non-default
 			// sets to a non-default value first
-			file1.setCharset("FOO", getMonitor());
+			file1.setCharset("FOO", createTestMonitor());
 
 			verifier.reset();
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			// sets to another non-defauilt value
-			file1.setCharset("BAR", getMonitor());
+			file1.setCharset("BAR", createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("1.3.2");
 
 			// multiple files (same operation)
@@ -1240,9 +1241,9 @@ public class CharsetTest extends ResourceTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				file1.setCharset("FOO", getMonitor());
-				file2.setCharset("FOO", getMonitor());
-			}, getMonitor());
+				file1.setCharset("FOO", createTestMonitor());
+				file2.setCharset("FOO", createTestMonitor());
+			}, createTestMonitor());
 			verifier.assertExpectedDeltasWereReceived("1.4.1");
 		} finally {
 			verifier.removeResourceChangeListeners();
@@ -1259,17 +1260,17 @@ public class CharsetTest extends ResourceTest {
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2}, true);
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
-			project.setDefaultCharset(null, getMonitor());
+			project.setDefaultCharset(null, createTestMonitor());
 			assertDoesNotExistInWorkspace(getResourcesPreferenceFile(project, false));
-			file1.setCharset("FRED", getMonitor());
+			file1.setCharset("FRED", createTestMonitor());
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
-			folder.setDefaultCharset("BAR", getMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
-			file1.setCharset(null, getMonitor());
+			file1.setCharset(null, createTestMonitor());
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
-			folder.setDefaultCharset(null, getMonitor());
+			folder.setDefaultCharset(null, createTestMonitor());
 			assertDoesNotExistInWorkspace(getResourcesPreferenceFile(project, false));
 		} finally {
 			clearAllEncodings(project);
@@ -1294,8 +1295,8 @@ public class CharsetTest extends ResourceTest {
 			IFile newRandomFile = project.getFile("newFile." + (long) (Math.random() * (Long.MAX_VALUE)));
 			ensureExistsInWorkspace(oldFile, SAMPLE_XML_DEFAULT_ENCODING);
 			// sets project default charset
-			project.setDefaultCharset("BAR", getMonitor());
-			oldFile.setCharset("FOO", getMonitor());
+			project.setDefaultCharset("BAR", createTestMonitor());
+			oldFile.setCharset("FOO", createTestMonitor());
 			// project and non-existing file share the same encoding
 			assertCharsetIs("0.1", "BAR", new IResource[] {project, newXMLFile, newTXTFile, newRandomFile}, true);
 			// existing file has encoding determined by user
@@ -1309,7 +1310,7 @@ public class CharsetTest extends ResourceTest {
 			assertEquals("2.0", xml.getDefaultCharset(), newXMLFile.getCharsetFor(getTextContents("")));
 			assertEquals("2.1", xml.getDefaultCharset(), newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
 			assertEquals("2.2", "US-ASCII", newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
-			oldFile.setCharset(null, getMonitor());
+			oldFile.setCharset(null, createTestMonitor());
 			assertEquals("2.3", xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents("")));
 			assertEquals("2.4", xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
 			assertEquals("2.5", "US-ASCII", oldFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
@@ -1335,8 +1336,8 @@ public class CharsetTest extends ResourceTest {
 			IFile file1 = project1.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
 			ensureExistsInWorkspace(new IResource[] {file1, file2}, true);
-			project1.setDefaultCharset("FOO", getMonitor());
-			folder.setDefaultCharset("BAR", getMonitor());
+			project1.setDefaultCharset("FOO", createTestMonitor());
+			folder.setDefaultCharset("BAR", createTestMonitor());
 
 			assertEquals("1.0", "BAR", folder.getDefaultCharset());
 			assertEquals("1.1", "BAR", file2.getCharset());
@@ -1368,17 +1369,17 @@ public class CharsetTest extends ResourceTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("MyProject");
 		try {
-			CoreException e = assertThrows(CoreException.class, () -> project.setDefaultCharset("FOO", getMonitor()));
+			CoreException e = assertThrows(CoreException.class, () -> project.setDefaultCharset("FOO", createTestMonitor()));
 			assertEquals("project should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
 			ensureExistsInWorkspace(project, true);
-			project.setDefaultCharset("FOO", getMonitor());
+			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
 			assertDoesNotExistInWorkspace(file);
 			assertEquals("2.2", "FOO", file.getCharset());
-			e = assertThrows(CoreException.class, () -> file.setCharset("BAR", getMonitor()));
+			e = assertThrows(CoreException.class, () -> file.setCharset("BAR", createTestMonitor()));
 			assertEquals("file should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
 			ensureExistsInWorkspace(file, true);
-			file.setCharset("BAR", getMonitor());
+			file.setCharset("BAR", createTestMonitor());
 			assertEquals("2.8", "BAR", file.getCharset());
 			file.delete(IResource.NONE, null);
 			assertDoesNotExistInWorkspace(file);
@@ -1407,12 +1408,12 @@ public class CharsetTest extends ResourceTest {
 		Job.getJobManager().addJobChangeListener(listener);
 		try {
 			String otherCharset = getOtherCharset(workspace.getRoot().getDefaultCharset());
-			project.setDefaultCharset(otherCharset, getMonitor());
+			project.setDefaultCharset(otherCharset, createTestMonitor());
 			assertEquals(otherCharset, project.getDefaultCharset());
-			project.delete(false, getMonitor());
+			project.delete(false, createTestMonitor());
 			Thread.sleep(100); // leave some time for CharsetDeltaJob.to be scheduled;
 			Job.getJobManager().wakeUp(CharsetDeltaJob.FAMILY_CHARSET_DELTA);
-			Job.getJobManager().join(CharsetDeltaJob.FAMILY_CHARSET_DELTA, getMonitor());
+			Job.getJobManager().join(CharsetDeltaJob.FAMILY_CHARSET_DELTA, createTestMonitor());
 			assertTrue(listener.getResult().isOK());
 		} finally {
 			Job.getJobManager().removeJobChangeListener(listener);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -181,7 +182,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 
 		// originally, project description has no natures
 		try (InputStream input = projectDescriptionWithNatures(project.getName(), new String[0])) {
-			descFile.setContents(input, IResource.FORCE, getMonitor());
+			descFile.setContents(input, IResource.FORCE, createTestMonitor());
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
@@ -190,7 +191,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 
 		// change project description to include one of the natures
 		try (InputStream input = projectDescriptionWithNatures(project.getName(), new String[] { CONTENT_TYPE_RELATED_NATURE1 })) {
-			descFile.setContents(input, IResource.FORCE, getMonitor());
+			descFile.setContents(input, IResource.FORCE, createTestMonitor());
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
@@ -200,7 +201,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		// change project description to include the other nature
 		try (InputStream input = projectDescriptionWithNatures(project.getName(),
 				new String[] { CONTENT_TYPE_RELATED_NATURE2 })) {
-			descFile.setContents(input, IResource.FORCE, getMonitor());
+			descFile.setContents(input, IResource.FORCE, createTestMonitor());
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
@@ -210,7 +211,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		// change project description to include both of the natures
 		try (InputStream input = projectDescriptionWithNatures(project.getName(),
 				new String[] { CONTENT_TYPE_RELATED_NATURE1, CONTENT_TYPE_RELATED_NATURE2  })) {
-			descFile.setContents(input, IResource.FORCE, getMonitor());
+			descFile.setContents(input, IResource.FORCE, createTestMonitor());
 		}
 		waitForCacheFlush();
 
@@ -220,7 +221,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 
 		// back to no natures
 		descFile.setContents(projectDescriptionWithNatures(project.getName(), new String[0]), IResource.FORCE,
-				getMonitor());
+				createTestMonitor());
 		waitForCacheFlush();
 		description = file.getContentDescription();
 		assertNotNull("5.2", description);
@@ -241,7 +242,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		ensureExistsInWorkspace(txtFile, "");
 		ensureExistsInWorkspace(xmlFile, "");
 
-		project.setDefaultCharset("FOO", getMonitor());
+		project.setDefaultCharset("FOO", createTestMonitor());
 		assertEquals("1.0", "FOO", txtFile.getCharset());
 		assertEquals("1.1", "UTF-8", xmlFile.getCharset());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -72,7 +73,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 	protected void doCleanup() throws Exception {
 		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject}, true);
-		closedProject.close(getMonitor());
+		closedProject.close(createTestMonitor());
 		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
 		resolve(localFolder).toFile().mkdirs();
 		createFileInFileSystem(resolve(localFile), getRandomContents());
@@ -126,18 +127,18 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo");
 		IFile bar = existingFolderInExistingProject.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 
@@ -163,18 +164,18 @@ public class FilteredResourceTest extends ResourceTest {
 	public void testCreateFilterOnProject() throws CoreException {
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FOLDERS,
-				matcherDescription, 0, getMonitor());
+				matcherDescription, 0, createTestMonitor());
 
 		IFolder foo = existingProject.getFolder("foo");
 		IFolder bar = existingProject.getFolder("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 		IResourceFilterDescription[] filters = existingProject.getFilters();
 
 		assertEquals("1.4", filters.length, 1);
@@ -205,22 +206,22 @@ public class FilteredResourceTest extends ResourceTest {
 		IFolder folder = nonExistingFolderInExistingProject;
 
 		//try to create without the flag (should fail)
-		assertThrows(CoreException.class, () -> folder.createLink(location, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> folder.createLink(location, IResource.NONE, createTestMonitor()));
 
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
-				matcherDescription, 0, getMonitor());
+				matcherDescription, 0, createTestMonitor());
 
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 
 		IResourceFilterDescription[] filters = folder.getFilters();
 
@@ -248,16 +249,16 @@ public class FilteredResourceTest extends ResourceTest {
 		IPath location = existingFolderInExistingFolder.getLocation();
 		IFolder folder = nonExistingFolderInExistingProject;
 
-		folder.createLink(location, IResource.NONE, getMonitor());
+		folder.createLink(location, IResource.NONE, createTestMonitor());
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.cpp");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.h");
 
 		folder.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES,
-				matcherDescription1, 0, getMonitor());
+				matcherDescription1, 0, createTestMonitor());
 		IResourceFilterDescription filterDescription2 = existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IResource members[] = folder.members();
 		assertEquals("1.2", members.length, 0);
@@ -268,7 +269,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile newFile = existingFolderInExistingFolder.getFile("foo.cpp");
 		assertTrue("1.5", newFile.getLocation().toFile().createNewFile());
 
-		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("1.9", members.length, 1);
 		assertEquals("2.0", members[0].getType(), IResource.FILE);
@@ -280,7 +281,7 @@ public class FilteredResourceTest extends ResourceTest {
 		newFile = existingFolderInExistingFolder.getFile("foo.h");
 		assertTrue("2.5", newFile.getLocation().toFile().createNewFile());
 
-		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", members.length, 1);
 		assertEquals("3.0", members[0].getType(), IResource.FILE);
@@ -289,7 +290,7 @@ public class FilteredResourceTest extends ResourceTest {
 		members = folder.members();
 		assertEquals("3.3", members.length, 0);
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("3.9", members.length, 1);
 		assertEquals("4.0", members[0].getType(), IResource.FILE);
@@ -304,7 +305,7 @@ public class FilteredResourceTest extends ResourceTest {
 		newFile = existingFolderInExistingFolder.getFile("foo.text");
 		assertTrue("5.5", newFile.getLocation().toFile().createNewFile());
 
-		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("5.9", members.length, 2);
 		assertEquals("6.0", members[0].getType(), IResource.FILE);
@@ -320,7 +321,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("6.9", members[1].getName(), "foo.text");
 
 		// delete the common file
-		newFile.delete(true, getMonitor());
+		newFile.delete(true, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("7.2", members.length, 1);
 		assertEquals("7.3", members[0].getType(), IResource.FILE);
@@ -332,7 +333,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("7.8", members[0].getName(), "foo.h");
 
 		// remove the first filter
-		filterDescription2.delete(0, getMonitor());
+		filterDescription2.delete(0, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("8.2", members.length, 2);
 		assertEquals("8.3", members[0].getType(), IResource.FILE);
@@ -348,7 +349,7 @@ public class FilteredResourceTest extends ResourceTest {
 		// add the filter again
 		existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("9.2", members.length, 1);
 		assertEquals("9.3", members[0].getType(), IResource.FILE);
@@ -364,12 +365,12 @@ public class FilteredResourceTest extends ResourceTest {
 		IFolder folder = existingFolderInExistingProject.getFolder("virtual_folder.txt");
 		IFile file = existingFolderInExistingProject.getFile("linked_file.txt");
 
-		folder.create(IResource.VIRTUAL, true, getMonitor());
-		file.createLink(existingFileInExistingProject.getLocation(), 0, getMonitor());
+		folder.create(IResource.VIRTUAL, true, createTestMonitor());
+		file.createLink(existingFileInExistingProject.getLocation(), 0, createTestMonitor());
 
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.txt");
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL, matcherDescription, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IWorkspace workspace = existingProject.getWorkspace();
 		assertTrue("1.0", workspace.validateFiltered(folder).isOK());
@@ -386,16 +387,16 @@ public class FilteredResourceTest extends ResourceTest {
 		final IPath location = existingFolderInExistingFolder.getLocation();
 		final IFolder folder = nonExistingFolderInExistingProject;
 
-		folder.createLink(location, IResource.NONE, getMonitor());
+		folder.createLink(location, IResource.NONE, createTestMonitor());
 
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.h");
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.cpp");
 
 		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
-				matcherDescription1, 0, getMonitor());
+				matcherDescription1, 0, createTestMonitor());
 		existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
 
 		// Create 'foo.cpp' in existingFolder...
@@ -426,7 +427,7 @@ public class FilteredResourceTest extends ResourceTest {
 		assertEquals("3.0", IResource.FILE, members[0].getType());
 		assertEquals("3.1", "foo.cpp", members[0].getName());
 		// And refreshing doesn't change things
-		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingFolderInExistingFolder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingFolder.members();
 		assertEquals("2.9", 1, members.length);
 		assertEquals("3.0", IResource.FILE, members[0].getType());
@@ -479,11 +480,11 @@ public class FilteredResourceTest extends ResourceTest {
 		// Filter out all children from existingFolderInExistingProject
 		IResourceFilterDescription filterDescription1 = folder1.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
-		folder1.createLink(parentLoc, IResource.NONE, getMonitor());
-		folder2.createLink(childLoc, IResource.NONE, getMonitor());
-		existingProject.close(getMonitor());
+		folder1.createLink(parentLoc, IResource.NONE, createTestMonitor());
+		folder2.createLink(childLoc, IResource.NONE, createTestMonitor());
+		existingProject.close(createTestMonitor());
 
 		assertTrue("12.0", folder1.exists());
 		assertTrue("12.2", folder2.exists());
@@ -498,7 +499,7 @@ public class FilteredResourceTest extends ResourceTest {
 		// reconcileLinks will never be called...
 		Workspace workspace = ((Workspace) ResourcesPlugin.getWorkspace());
 		try {
-			workspace.prepareOperation(project, getMonitor());
+			workspace.prepareOperation(project, createTestMonitor());
 			workspace.beginOperation(true);
 
 			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
@@ -507,12 +508,12 @@ public class FilteredResourceTest extends ResourceTest {
 			workspace.endOperation(project, true);
 		}
 
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertTrue("3.1", !project.isOpen());
 		// Create a file under existingFolderInExistingFolder
 		createFileInFileSystem(childLoc.append("foo"));
 		// Reopen the project
-		project.open(IResource.NONE, getMonitor());
+		project.open(IResource.NONE, createTestMonitor());
 
 		assertTrue("22.0", folder1.exists());
 		assertTrue("22.2", folder2.exists());
@@ -524,19 +525,19 @@ public class FilteredResourceTest extends ResourceTest {
 		assertTrue("22.12", folder2.members().length == 1);
 
 		// Swap the links around, loading may be order independent...
-		folder2.createLink(parentLoc, IResource.REPLACE, getMonitor());
-		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
+		folder2.createLink(parentLoc, IResource.REPLACE, createTestMonitor());
+		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, createTestMonitor());
 
 		// Filter out all children from existingFolderInExistingProject
 		folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
-				matcherDescription1, 0, getMonitor());
-		filterDescription1.delete(0, getMonitor());
+				matcherDescription1, 0, createTestMonitor());
+		filterDescription1.delete(0, createTestMonitor());
 		assertTrue(folder1.getFilters().length == 0);
 
 		// Need to unset M_USED on the project's resource info, or
 		// reconcileLinks will never be called...
 		try {
-			workspace.prepareOperation(project, getMonitor());
+			workspace.prepareOperation(project, createTestMonitor());
 			workspace.beginOperation(true);
 
 			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
@@ -545,9 +546,9 @@ public class FilteredResourceTest extends ResourceTest {
 			workspace.endOperation(project, true);
 		}
 
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertTrue("3.1", !project.isOpen());
-		project.open(IResource.NONE, getMonitor());
+		project.open(IResource.NONE, createTestMonitor());
 
 		assertTrue("32.0", folder1.exists());
 		assertTrue("32.2", folder2.exists());
@@ -586,11 +587,11 @@ public class FilteredResourceTest extends ResourceTest {
 		// Filter out all children from existingFolderInExistingProject
 		IResourceFilterDescription filterDescription1 = folder1.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
-		folder1.createLink(parentLoc, IResource.NONE, getMonitor());
-		folder2.createLink(childLoc, IResource.NONE, getMonitor());
-		existingProject.close(getMonitor());
+		folder1.createLink(parentLoc, IResource.NONE, createTestMonitor());
+		folder2.createLink(childLoc, IResource.NONE, createTestMonitor());
+		existingProject.close(createTestMonitor());
 
 		assertTrue("12.0", folder1.exists());
 		assertTrue("12.2", folder2.exists());
@@ -605,7 +606,7 @@ public class FilteredResourceTest extends ResourceTest {
 		// reconcileLinks will never be called...
 		Workspace workspace = ((Workspace) ResourcesPlugin.getWorkspace());
 		try {
-			workspace.prepareOperation(project, getMonitor());
+			workspace.prepareOperation(project, createTestMonitor());
 			workspace.beginOperation(true);
 
 			ResourceInfo ri = ((Resource) project).getResourceInfo(false, true);
@@ -627,13 +628,13 @@ public class FilteredResourceTest extends ResourceTest {
 		assertTrue("22.12", folder2.members().length == 1);
 
 		// Swap the links around, loading may be order independent...
-		folder2.createLink(parentLoc, IResource.REPLACE | IResource.NONE, getMonitor());
-		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, getMonitor());
+		folder2.createLink(parentLoc, IResource.REPLACE | IResource.NONE, createTestMonitor());
+		folder1.createLink(childLoc, IResource.REPLACE | IResource.FORCE, createTestMonitor());
 
 		// Filter out all children from existingFolderInExistingProject
 		folder2.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
-				matcherDescription1, 0, getMonitor());
-		filterDescription1.delete(0, getMonitor());
+				matcherDescription1, 0, createTestMonitor());
+		filterDescription1.delete(0, createTestMonitor());
 		assertTrue(folder1.getFilters().length == 0);
 
 		assertTrue("32.0", folder1.exists());
@@ -658,19 +659,19 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 
 		folder.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES,
-				matcherDescription1, 0, getMonitor());
-		folder.createLink(location, IResource.NONE, getMonitor());
+				matcherDescription1, 0, createTestMonitor());
+		folder.createLink(location, IResource.NONE, createTestMonitor());
 
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 
 		IResourceFilterDescription[] filters = folder.getFilters();
 
@@ -693,24 +694,24 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		IResourceFilterDescription filterDescription = existingFolderInExistingFolder
 				.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES
-						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
+						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 
-		filterDescription.delete(0, getMonitor());
+		filterDescription.delete(0, createTestMonitor());
 
 		//close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingFolder.getFilters();
 
@@ -731,15 +732,15 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		IResourceFilterDescription filterDescription = existingFolderInExistingFolder
 				.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES
-						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, getMonitor());
+						| IResourceFilterDescription.FOLDERS, matcherDescription1, 0, createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar}, true);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		filterDescription.delete(0, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		filterDescription.delete(0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingFolder.getFilters();
 		assertEquals("1.6", filters.length, 0);
@@ -760,14 +761,14 @@ public class FilteredResourceTest extends ResourceTest {
 
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFile file = existingFolderInExistingProject.getFile("file.c");
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingProject.members();
 		assertEquals("2.0", members.length, 2);
@@ -779,9 +780,9 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*\\.c");
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingFolderInExistingProject.members();
 		assertEquals("3.3", members.length, 2);
 		assertEquals("3.4", members[0].getType(), IResource.FILE);
@@ -798,7 +799,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFile file = existingFolderInExistingFolder.getFile("file.c");
@@ -806,7 +807,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 2);
@@ -818,8 +819,8 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
-				getMonitor());
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+				createTestMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		members = existingFolderInExistingFolder.members();
 		assertEquals("3.3", members.length, 1);
@@ -836,10 +837,10 @@ public class FilteredResourceTest extends ResourceTest {
 
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFile file = existingFolderInExistingProject.getFile("file.c");
@@ -847,7 +848,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingProject.members();
 		assertEquals("2.0", members.length, 1);
@@ -863,10 +864,10 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription2 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 
 		existingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.INHERITABLE
-				| IResourceFilterDescription.FILES, matcherDescription1, 0, getMonitor());
+				| IResourceFilterDescription.FILES, matcherDescription1, 0, createTestMonitor());
 		existingFolderInExistingFolder.createFilter(IResourceFilterDescription.EXCLUDE_ALL
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFile file = existingFolderInExistingFolder.getFile("file.c");
@@ -874,7 +875,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
 		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
@@ -889,13 +890,13 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
@@ -910,13 +911,13 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
 		assertEquals("2.0", members.length, 1);
@@ -931,16 +932,16 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
-		existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
+		existingFolderInExistingProject.move(destination.getFullPath(), 0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
@@ -960,16 +961,16 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
-		existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
+		existingFolderInExistingProject.copy(destination.getFullPath(), 0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 1);
@@ -993,17 +994,17 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
-		existingFolderInExistingProject.copy(destination.getFullPath(), 0, getMonitor());
+		existingFolderInExistingProject.copy(destination.getFullPath(), 0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 1);
@@ -1027,17 +1028,17 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription1 = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo.*");
 		existingFolderInExistingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
-		existingFolderInExistingProject.move(destination.getFullPath(), 0, getMonitor());
+		existingFolderInExistingProject.move(destination.getFullPath(), 0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
@@ -1059,19 +1060,19 @@ public class FilteredResourceTest extends ResourceTest {
 
 		existingFolderInExistingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES, matcherDescription1, 0,
-				getMonitor());
+				createTestMonitor());
 		existingFolderInExistingFolder.createFilter(
 				IResourceFilterDescription.INCLUDE_ONLY | IResourceFilterDescription.FILES, matcherDescription2, 0,
-				getMonitor());
+				createTestMonitor());
 
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
 		ensureExistsInWorkspace(new IResource[] {foo, food}, true);
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject}, true);
-		existingFolderInExistingProject.delete(0, getMonitor());
+		existingFolderInExistingProject.delete(0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 		assertEquals("1.4", filters.length, 0);
@@ -1093,11 +1094,11 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, "foo");
 		existingFolderInExistingProject.createFilter(IResourceFilterDescription.INCLUDE_ONLY
 				| IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS, matcherDescription, 0,
-				getMonitor());
+				createTestMonitor());
 
 		// close and reopen the project
-		existingProject.close(getMonitor());
-		existingProject.open(getMonitor());
+		existingProject.close(createTestMonitor());
+		existingProject.open(createTestMonitor());
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
 
 		// check that filters are recreated when the project is reopened
@@ -1125,18 +1126,18 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile file = folder.getFile("bar.txt");
 		ensureExistsInWorkspace(file, "content");
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
 		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
-				matcherDescription, 0, getMonitor());
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+				matcherDescription, 0, createTestMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingProject.members();
 		assertEquals("1.5", 2, members.length);
 		assertEquals("1.6", ".project", members[0].getName());
 		assertEquals("1.7", existingFileInExistingProject.getName(), members[1].getName());
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		members = existingProject.members();
 		assertEquals("2.2", 2, members.length);
 		assertEquals("2.3", ".project", members[0].getName());
@@ -1157,23 +1158,23 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile file = folder.getFile("bar.txt");
 		ensureExistsInWorkspace(file, "content");
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
 		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS,
-				matcherDescription, 0, getMonitor());
+				matcherDescription, 0, createTestMonitor());
 		assertEquals(1, existingProject.getFilters().length);
 
-		existingProject.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IPath newPath = existingProject.getFullPath().removeLastSegments(1).append(existingProject.getName() + "_moved");
-		existingProject.move(newPath, true, getMonitor());
+		existingProject.move(newPath, true, createTestMonitor());
 
 		IProject newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(existingProject.getName() + "_moved");
 		assertTrue(newProject.exists());
 		assertEquals(1, newProject.getFilters().length);
 
 		newPath = newProject.getFullPath().removeLastSegments(1).append(newProject.getName() + "_copy");
-		newProject.copy(newPath, true, getMonitor());
+		newProject.copy(newPath, true, createTestMonitor());
 
 		newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(newProject.getName() + "_copy");
 		assertTrue(newProject.exists());
@@ -1193,7 +1194,7 @@ public class FilteredResourceTest extends ResourceTest {
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER,
 				"a\\.txt");
 		existingProject.createFilter(IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FILES
-				| IResourceFilterDescription.INHERITABLE, matcherDescription, 0, getMonitor());
+				| IResourceFilterDescription.INHERITABLE, matcherDescription, 0, createTestMonitor());
 
 		assertFalse("2.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
 
@@ -1204,7 +1205,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 		assertFalse("4.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertFalse("6.0", file_a_txt.exists());
 		assertFalse("7.0", existingProject.getWorkspace().validateFiltered(file_a_txt).isOK());
@@ -1226,7 +1227,7 @@ public class FilteredResourceTest extends ResourceTest {
 		existingProject.createFilter(
 				IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.FOLDERS
 						| IResourceFilterDescription.FILES | IResourceFilterDescription.INHERITABLE,
-				matcherDescription, 0, getMonitor());
+				matcherDescription, 0, createTestMonitor());
 
 		IPath fileLocation = subProjectLocation.append("file.txt");
 
@@ -1253,7 +1254,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IProjectDescription newProjectDescription = getWorkspace().newProjectDescription(subProjectName);
 		newProjectDescription.setLocation(subProjectLocation);
 
-		subProject.create(newProjectDescription, getMonitor());
+		subProject.create(newProjectDescription, createTestMonitor());
 		result = root.getFileForLocation(fileLocation);
 
 		assertTrue("3.0", result != null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IContainer;
@@ -47,7 +48,7 @@ public class HiddenResourceTest extends ResourceTest {
 		try {
 			setHidden(folder, true, IResource.DEPTH_ZERO);
 			ensureOutOfSync(subFile);
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
 		} finally {
 			removeResourceChangeListener(listener);
@@ -271,7 +272,7 @@ public class HiddenResourceTest extends ResourceTest {
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// copy the project
 		int flags = IResource.FORCE;
-		project.copy(destProject.getFullPath(), flags, getMonitor());
+		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -280,7 +281,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
-		folder.copy(destFolder.getFullPath(), flags, getMonitor());
+		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
@@ -289,7 +290,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		project.copy(destProject.getFullPath(), flags, getMonitor());
+		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -298,7 +299,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		folder.copy(destFolder.getFullPath(), flags, getMonitor());
+		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
@@ -324,7 +325,7 @@ public class HiddenResourceTest extends ResourceTest {
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// move the project
 		int flags = IResource.FORCE;
-		project.move(destProject.getFullPath(), flags, getMonitor());
+		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -333,7 +334,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
-		folder.move(destFolder.getFullPath(), flags, getMonitor());
+		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
@@ -342,7 +343,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		project.move(destProject.getFullPath(), flags, getMonitor());
+		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -351,7 +352,7 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		folder.move(destFolder.getFullPath(), flags, getMonitor());
+		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
@@ -368,16 +369,16 @@ public class HiddenResourceTest extends ResourceTest {
 		// default behavior with no hidden
 		int flags = IResource.ALWAYS_DELETE_PROJECT_CONTENT | IResource.FORCE;
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
-		file.delete(flags, getMonitor());
+		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
@@ -385,12 +386,12 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
@@ -398,18 +399,18 @@ public class HiddenResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		file.delete(flags, getMonitor());
+		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 	}
@@ -431,7 +432,7 @@ public class HiddenResourceTest extends ResourceTest {
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			addResourceChangeListener(listener);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
 			waitForEncodingRelatedJobs();
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
@@ -452,7 +453,7 @@ public class HiddenResourceTest extends ResourceTest {
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			addResourceChangeListener(listener);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
@@ -471,7 +472,7 @@ public class HiddenResourceTest extends ResourceTest {
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			addResourceChangeListener(listener);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue("3.1." + listener.getMessage(), listener.isDeltaValid());
@@ -594,8 +595,8 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 
 		ensureExistsInWorkspace(project, true);
-		folder.create(IResource.HIDDEN, true, getMonitor());
-		file.create(getRandomContents(), IResource.HIDDEN, getMonitor());
+		folder.create(IResource.HIDDEN, true, createTestMonitor());
+		file.create(getRandomContents(), IResource.HIDDEN, createTestMonitor());
 
 		assertHidden(project, false, IResource.DEPTH_ZERO);
 		assertHidden(folder, true, IResource.DEPTH_ZERO);
@@ -603,8 +604,8 @@ public class HiddenResourceTest extends ResourceTest {
 
 		IProject project2 = getWorkspace().getRoot().getProject(getUniqueString());
 
-		project2.create(null, IResource.HIDDEN, getMonitor());
-		project2.open(getMonitor());
+		project2.create(null, IResource.HIDDEN, createTestMonitor());
+		project2.open(createTestMonitor());
 
 		assertHidden(project2, true, IResource.DEPTH_ZERO);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -101,7 +102,7 @@ public class IFileTest extends ResourceTest {
 			//file in existent folder
 			if (project.exists() && project.isOpen()) {
 				IFolder folder = project.getFolder("ExistingFolder");
-				folder.create(true, true, getMonitor());
+				folder.create(true, true, createTestMonitor());
 				generateInterestingFiles(folder);
 			}
 		}
@@ -163,13 +164,13 @@ public class IFileTest extends ResourceTest {
 
 			//open project
 			IProject openProject = getWorkspace().getRoot().getProject("OpenProject");
-			openProject.create(getMonitor());
-			openProject.open(getMonitor());
+			openProject.create(createTestMonitor());
+			openProject.open(createTestMonitor());
 			projects[0] = openProject;
 
 			//closed project
 			IProject closedProject = getWorkspace().getRoot().getProject("ClosedProject");
-			closedProject.create(getMonitor());
+			closedProject.create(createTestMonitor());
 			projects[1] = closedProject;
 
 			//non-existent project

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IFile;
@@ -45,14 +46,14 @@ public class IFolderTest extends ResourceTest {
 
 		// create the resources and set some content in a file that will be moved.
 		ensureExistsInWorkspace(before, true);
-		beforeFile.create(getRandomContents(), false, getMonitor());
+		beforeFile.create(getRandomContents(), false, createTestMonitor());
 
 		// Be sure the resources exist and then move them.
 		assertExistsInWorkspace(before);
 		assertExistsInWorkspace(beforeFile);
 		assertDoesNotExistInWorkspace(after);
 		assertDoesNotExistInWorkspace(afterFile);
-		before.move(after.getFullPath(), IResource.NONE, getMonitor());
+		before.move(after.getFullPath(), IResource.NONE, createTestMonitor());
 
 		assertDoesNotExistInWorkspace(before);
 		assertDoesNotExistInWorkspace(beforeFile);
@@ -70,7 +71,7 @@ public class IFolderTest extends ResourceTest {
 		ensureDoesNotExistInFileSystem(before);
 
 		// should fail because 'before' does not exist in the filesystem
-		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, getMonitor()));
+		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 		//the destination should not exist, because the source does not exist
 		assertTrue("1.1", !before.exists());
@@ -83,11 +84,11 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(derived);
 
-		derived.create(IResource.DERIVED, true, getMonitor());
+		derived.create(IResource.DERIVED, true, createTestMonitor());
 		assertTrue("1.0", derived.isDerived());
 		assertTrue("1.1", !derived.isTeamPrivateMember());
-		derived.delete(false, getMonitor());
-		derived.create(IResource.NONE, true, getMonitor());
+		derived.delete(false, createTestMonitor());
+		derived.create(IResource.NONE, true, createTestMonitor());
 		assertTrue("2.0", !derived.isDerived());
 		assertTrue("2.1", !derived.isTeamPrivateMember());
 	}
@@ -102,7 +103,7 @@ public class IFolderTest extends ResourceTest {
 
 		verifier.addExpectedChange(derived, IResourceDelta.ADDED, IResource.NONE);
 
-		derived.create(IResource.FORCE | IResource.DERIVED, true, getMonitor());
+		derived.create(IResource.FORCE | IResource.DERIVED, true, createTestMonitor());
 
 		assertTrue("2.0", verifier.isDeltaValid());
 	}
@@ -113,12 +114,12 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
-		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, getMonitor());
+		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, createTestMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
 		assertTrue("1.1", teamPrivate.isDerived());
 
-		teamPrivate.delete(false, getMonitor());
-		teamPrivate.create(IResource.NONE, true, getMonitor());
+		teamPrivate.delete(false, createTestMonitor());
+		teamPrivate.create(IResource.NONE, true, createTestMonitor());
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
@@ -129,12 +130,12 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
-		teamPrivate.create(IResource.TEAM_PRIVATE, true, getMonitor());
+		teamPrivate.create(IResource.TEAM_PRIVATE, true, createTestMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
 		assertTrue("1.1", !teamPrivate.isDerived());
 
-		teamPrivate.delete(false, getMonitor());
-		teamPrivate.create(IResource.NONE, true, getMonitor());
+		teamPrivate.delete(false, createTestMonitor());
+		teamPrivate.create(IResource.NONE, true, createTestMonitor());
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
@@ -146,29 +147,29 @@ public class IFolderTest extends ResourceTest {
 
 		IFolder target = project.getFolder("Folder1");
 		assertTrue("1.0", !target.exists());
-		target.create(true, true, getMonitor());
+		target.create(true, true, createTestMonitor());
 		assertTrue("1.1", target.exists());
 
 		// nested folder creation
 		IFolder nestedTarget = target.getFolder("Folder2");
 		assertTrue("2.0", !nestedTarget.exists());
-		nestedTarget.create(true, true, getMonitor());
+		nestedTarget.create(true, true, createTestMonitor());
 		assertTrue("2.1", nestedTarget.exists());
 
 		// try to create a folder that already exists
 		assertTrue("3.0", target.exists());
 		IFolder folderTarget = target;
-		assertThrows(CoreException.class, () -> folderTarget.create(true, true, getMonitor()));
+		assertThrows(CoreException.class, () -> folderTarget.create(true, true, createTestMonitor()));
 		assertTrue("3.2", target.exists());
 
 		// try to create a folder over a file that exists
 		IFile file = target.getFile("File1");
 		target = target.getFolder("File1");
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 		assertTrue("4.0", file.exists());
 
 		IFolder subfolderTarget = target;
-		assertThrows(CoreException.class, () -> subfolderTarget.create(true, true, getMonitor()));
+		assertThrows(CoreException.class, () -> subfolderTarget.create(true, true, createTestMonitor()));
 		assertTrue("5.1", file.exists());
 		assertTrue("5.2", !target.exists());
 
@@ -178,12 +179,12 @@ public class IFolderTest extends ResourceTest {
 
 		// try to create a folder as a child of a file
 		file = project.getFile("File2");
-		file.create(null, true, getMonitor());
+		file.create(null, true, createTestMonitor());
 
 		target = project.getFolder("File2/Folder4");
 		assertTrue("7.1", !target.exists());
 		IFolder nonexistentSubfolderTarget = target;
-		assertThrows(CoreException.class, () -> nonexistentSubfolderTarget.create(true, true, getMonitor()));
+		assertThrows(CoreException.class, () -> nonexistentSubfolderTarget.create(true, true, createTestMonitor()));
 		assertTrue("7.3", file.exists());
 		assertTrue("7.4", !target.exists());
 
@@ -192,7 +193,7 @@ public class IFolderTest extends ResourceTest {
 		target = folder.getFolder("Folder6");
 		assertTrue("8.0", !folder.exists());
 		IFolder nonexistentFolderTarget = target;
-		assertThrows(CoreException.class, () -> nonexistentFolderTarget.create(true, true, getMonitor()));
+		assertThrows(CoreException.class, () -> nonexistentFolderTarget.create(true, true, createTestMonitor()));
 		assertTrue("8.2", !folder.exists());
 		assertTrue("8.3", !target.exists());
 	}
@@ -203,7 +204,7 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(before, true);
 		//
 		assertExistsInWorkspace(before);
-		project.getFolder("c").delete(true, getMonitor());
+		project.getFolder("c").delete(true, createTestMonitor());
 		assertDoesNotExistInWorkspace(before);
 	}
 
@@ -216,11 +217,11 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(before, true);
 		String content = getRandomString();
 		IFile file = project.getFile(IPath.fromOSString("b/b/z"));
-		file.setContents(getContents(content), true, false, getMonitor());
+		file.setContents(getContents(content), true, false, createTestMonitor());
 
 		// Be sure the resources exist and then move them.
 		assertExistsInWorkspace(before);
-		project.getFolder("b").move(project.getFullPath().append("a"), true, getMonitor());
+		project.getFolder("b").move(project.getFullPath().append("a"), true, createTestMonitor());
 
 		//
 		assertDoesNotExistInWorkspace(before);
@@ -235,7 +236,7 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(existing, true);
 		IFolder target = getWorkspace().getRoot().getFolder(path);
 		assertThrows("Should not be able to create folder over a file", CoreException.class,
-				() -> target.create(true, true, getMonitor()));
+				() -> target.create(true, true, createTestMonitor()));
 		assertTrue("2.0", existing.exists());
 	}
 
@@ -259,7 +260,7 @@ public class IFolderTest extends ResourceTest {
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
 			assertTrue("1.0 " + name, !folder.exists());
-			assertThrows(CoreException.class, () -> folder.create(true, true, getMonitor()));
+			assertThrows(CoreException.class, () -> folder.create(true, true, createTestMonitor()));
 			assertTrue("1.2 " + name, !folder.exists());
 		}
 
@@ -274,7 +275,7 @@ public class IFolderTest extends ResourceTest {
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
 			assertTrue("2.0 " + name, !folder.exists());
-			folder.create(true, true, getMonitor());
+			folder.create(true, true, createTestMonitor());
 			assertTrue("2.2 " + name, folder.exists());
 		}
 	}
@@ -284,7 +285,7 @@ public class IFolderTest extends ResourceTest {
 		IFolder source = project.getFolder("Folder1");
 		ensureExistsInWorkspace(source, true);
 		IFolder dest = project.getFolder("Folder2");
-		source.move(dest.getFullPath(), true, getMonitor());
+		source.move(dest.getFullPath(), true, createTestMonitor());
 		assertExistsInWorkspace(dest);
 		assertDoesNotExistInWorkspace(source);
 	}
@@ -300,7 +301,7 @@ public class IFolderTest extends ResourceTest {
 		ensureExistsInWorkspace(source, true);
 		source.setReadOnly(true);
 		IFolder dest = project.getFolder("Folder2");
-		source.copy(dest.getFullPath(), true, getMonitor());
+		source.copy(dest.getFullPath(), true, createTestMonitor());
 		assertExistsInWorkspace(dest);
 		assertExistsInWorkspace(source);
 		assertTrue("1.2", dest.isReadOnly());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedWriter;
@@ -50,8 +51,8 @@ public class IPathVariableTest extends ResourceTest {
 	protected void setUp() throws Exception {
 		super.setUp();
 		project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		assertTrue("1.4", project.exists());
 		manager = project.getPathVariableManager();
 	}
@@ -587,7 +588,7 @@ public class IPathVariableTest extends ResourceTest {
 
 		ensureExistsInWorkspace(new IResource[] {existingProject}, true);
 
-		existingProject.close(getMonitor());
+		existingProject.close(createTestMonitor());
 		ProjectInfo info = (ProjectInfo) ((Project) existingProject).getResourceInfo(false, false);
 		info.clear(ICoreConstants.M_USED);
 		String dotProjectPath = existingProject.getLocation().append(".project").toOSString();
@@ -595,7 +596,7 @@ public class IPathVariableTest extends ResourceTest {
 		try (BufferedWriter out = new BufferedWriter(fstream)) {
 			out.write(dorProjectContent);
 		}
-		existingProject.open(getMonitor());
+		existingProject.open(createTestMonitor());
 
 		IPathVariableManager pathVariableManager = existingProject.getPathVariableManager();
 		String[] varNames = pathVariableManager.getPathVariableNames();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;
@@ -155,7 +156,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 		IProjectDescription description = project.getDescription();
 		description.setReferencedProjects(new IProject[] {target1});
 		description.setDynamicReferences(new IProject[] {target2});
-		project.setDescription(description, getMonitor());
+		project.setDescription(description, createTestMonitor());
 		IProject[] refs = project.getReferencedProjects();
 		assertEquals("2.1", 2, refs.length);
 		assertEquals("2.2", target1, refs[0]);
@@ -178,10 +179,10 @@ public class IProjectDescriptionTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project2");
 		ensureExistsInWorkspace(project, true);
 
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		IProjectDescription description = project.getDescription();
 		description.setReferencedProjects(new IProject[] {target});
-		project.setDescription(description, getMonitor());
+		project.setDescription(description, createTestMonitor());
 		assertEquals("2.1", 1, target.getReferencingProjects().length);
 
 		//get references for a non-existent project

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -70,7 +71,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 			marker2 = file2.createMarker(IMarker.BOOKMARK);
 			marker3 = file3.createMarker(IMarker.BOOKMARK);
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 	}
 
 	/**
@@ -123,7 +124,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 			marker3.setAttribute("Foo", true);
 		};
 		try {
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -174,7 +175,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 
 		//do the work
 		try {
-			file1.setContents(getRandomContents(), true, true, getMonitor());
+			file1.setContents(getRandomContents(), true, true, createTestMonitor());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -100,7 +101,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	public void testBenchMark_1GBYQEZ() throws Throwable {
 		// start with a clean workspace
 		getWorkspace().removeResourceChangeListener(verifier);
-		getWorkspace().getRoot().delete(false, getMonitor());
+		getWorkspace().getRoot().delete(false, createTestMonitor());
 
 		final AtomicReference<CoreException> exceptionInListener = new AtomicReference<>();
 		// create the listener
@@ -138,21 +139,21 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			IPath contents = root.append("temp/testing");
 			deleteOnTearDown(root.append("temp"));
 			description.setLocation(contents);
-			project.create(description, getMonitor());
-			project.open(getMonitor());
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project.create(description, createTestMonitor());
+			project.open(createTestMonitor());
+			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		// touch all resources (so that they appear in the delta)
 		body = monitor -> {
 			IResourceVisitor visitor = resource -> {
-				resource.touch(getMonitor());
+				resource.touch(createTestMonitor());
 				return true;
 			};
 			getWorkspace().getRoot().accept(visitor);
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		// un-register our listener
 		getWorkspace().removeResourceChangeListener(listener);
@@ -219,14 +220,14 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		project2MetaData = project2.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		// Create and open a project, folder and file
 		IWorkspaceRunnable body = monitor -> {
-			project1.create(getMonitor());
-			project1.open(getMonitor());
-			folder1.create(true, true, getMonitor());
-			file1.create(getRandomContents(), true, getMonitor());
+			project1.create(createTestMonitor());
+			project1.open(createTestMonitor());
+			folder1.create(true, true, createTestMonitor());
+			file1.create(getRandomContents(), true, createTestMonitor());
 		};
 		verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		//ensure all background jobs are done before we reset the delta verifier
 		waitForBuild();
@@ -258,7 +259,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					IResourceDeltaVisitor visitor = delta -> {
 						IResource resource = delta.getResource();
 						try {
-							resource.touch(getMonitor());
+							resource.touch(createTestMonitor());
 						} catch (RuntimeException e) {
 							throw e;
 						}
@@ -267,7 +268,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					};
 					event.getDelta().accept(visitor);
 				};
-				getWorkspace().run(body, getMonitor());
+				getWorkspace().run(body, createTestMonitor());
 			} catch (CoreException e) {
 				listenerInMainThreadCallback.set(() -> {
 					throw e;
@@ -280,7 +281,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			IWorkspaceRunnable body = new IWorkspaceRunnable() {
 				// cause a delta by touching all resources
 				final IResourceVisitor visitor = resource -> {
-					resource.touch(getMonitor());
+					resource.touch(createTestMonitor());
 					return true;
 				};
 
@@ -289,7 +290,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					getWorkspace().getRoot().accept(visitor);
 				}
 			};
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			//wait for autobuild so POST_BUILD will fire
 			try {
 				Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
@@ -314,7 +315,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		// should not have been verified since there was no change
 		assertTrue("Unexpected notification on no change", !verifier.hasBeenNotified());
 	}
@@ -329,14 +330,14 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		// should not have been verified since there was no change
 		assertTrue("Unexpected notification on no change", !verifier.hasBeenNotified());
 	}
 
 	public void testAddFile() throws CoreException {
 		verifier.addExpectedChange(file2, IResourceDelta.ADDED, 0);
-		file2.create(getRandomContents(), true, getMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
 		assertDelta();
 	}
 
@@ -351,20 +352,20 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testAddFolder() throws CoreException {
 		verifier.addExpectedChange(folder2, IResourceDelta.ADDED, 0);
-		folder2.create(true, true, getMonitor());
+		folder2.create(true, true, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testAddProject() throws CoreException {
 		verifier.addExpectedChange(project2, IResourceDelta.ADDED, 0);
 		verifier.addExpectedChange(project2MetaData, IResourceDelta.ADDED, 0);
-		project2.create(getMonitor());
+		project2.create(createTestMonitor());
 		assertDelta();
 	}
 
@@ -382,7 +383,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					IResourceDeltaVisitor visitor = delta -> {
 						IResource resource = delta.getResource();
 						try {
-							resource.touch(getMonitor());
+							resource.touch(createTestMonitor());
 						} catch (RuntimeException e) {
 							throw e;
 						}
@@ -391,7 +392,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					};
 					event.getDelta().accept(visitor);
 				};
-				getWorkspace().run(body, getMonitor());
+				getWorkspace().run(body, createTestMonitor());
 			} catch (CoreException e) {
 				return;
 			}
@@ -403,7 +404,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			IWorkspaceRunnable body = new IWorkspaceRunnable() {
 				// cause a delta by touching all resources
 				final IResourceVisitor visitor = resource -> {
-					resource.touch(getMonitor());
+					resource.touch(createTestMonitor());
 					return true;
 				};
 
@@ -412,7 +413,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					getWorkspace().getRoot().accept(visitor);
 				}
 			};
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 		} finally {
 			// cleanup: ensure that the listener is removed
 			getWorkspace().removeResourceChangeListener(listener);
@@ -437,7 +438,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 				workspace.run((IWorkspaceRunnable) monitor -> {
 					file1.touch(null);
 					workspace.build(trigger, monitor);
-				}, getMonitor());
+				}, createTestMonitor());
 				assertEquals("1.0." + i, workspace, preBuild.source);
 				assertEquals("1.1." + i, workspace, postBuild.source);
 				assertEquals("1.2." + i, workspace, postChange.source);
@@ -447,8 +448,8 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 				workspace.run((IWorkspaceRunnable) monitor -> {
 					file1.touch(null);
-					project1.build(trigger, getMonitor());
-				}, getMonitor());
+					project1.build(trigger, createTestMonitor());
+				}, createTestMonitor());
 				assertEquals("2.0." + i, project1, preBuild.source);
 				assertEquals("2.2." + i, project1, postBuild.source);
 				assertEquals("2.2." + i, workspace, postChange.source);
@@ -480,7 +481,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	public void testChangeFile() throws CoreException {
 		/* change file1's contents */
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		file1.setContents(getRandomContents(), true, false, getMonitor());
+		file1.setContents(getRandomContents(), true, false, createTestMonitor());
 		assertDelta();
 	}
 
@@ -499,7 +500,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			workspace.addResourceChangeListener(preBuild, IResourceChangeEvent.PRE_BUILD);
 			workspace.addResourceChangeListener(postBuild, IResourceChangeEvent.POST_BUILD);
 
-			file1.touch(getMonitor());
+			file1.touch(createTestMonitor());
 
 			// wait for noBuildJob so POST_BUILD will fire
 			((Workspace) getWorkspace()).getBuildManager().waitForAutoBuildOff();
@@ -527,7 +528,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -535,8 +536,8 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		/* change to a folder */
 		verifier.reset();
 		getWorkspace().run((IWorkspaceRunnable) m -> {
-			file1.delete(true, getMonitor());
-			folder3.create(true, true, getMonitor());
+			file1.delete(true, createTestMonitor());
+			folder3.create(true, true, createTestMonitor());
 		}, null);
 		/* now change back to a file and verify */
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED,
@@ -549,21 +550,21 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testChangeProject() throws CoreException {
 		verifier.reset();
 		getWorkspace().run((IWorkspaceRunnable) m -> {
-			project2.create(getMonitor());
-			project2.open(getMonitor());
+			project2.create(createTestMonitor());
+			project2.open(createTestMonitor());
 		}, null);
 		IProjectDescription desc = project2.getDescription();
 		desc.setReferencedProjects(new IProject[] { project1 });
 		verifier.addExpectedChange(project2, IResourceDelta.CHANGED, IResourceDelta.DESCRIPTION);
 		verifier.addExpectedChange(project2MetaData, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		project2.setDescription(desc, IResource.FORCE, getMonitor());
+		project2.setDescription(desc, IResource.FORCE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -579,7 +580,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -594,7 +595,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -615,7 +616,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -643,9 +644,9 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.POST_BUILD);
 		try {
 			getWorkspace().run((IWorkspaceRunnable) monitor -> getWorkspace().getRoot().accept(resource -> {
-				resource.touch(getMonitor());
+				resource.touch(createTestMonitor());
 				return true;
-			}), getMonitor());
+			}), createTestMonitor());
 		} finally {
 			// cleanup: ensure that the listener is removed
 			getWorkspace().removeResourceChangeListener(listener);
@@ -661,7 +662,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	 */
 	public void testDeleteMoveFile() throws CoreException {
 		verifier.reset();
-		file2.create(getRandomContents(), IResource.NONE, getMonitor());
+		file2.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		verifier.reset();
 		int flags = IResourceDelta.REPLACED | IResourceDelta.MOVED_FROM | IResourceDelta.CONTENT;
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, flags, file2.getFullPath(), null);
@@ -674,7 +675,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -703,7 +704,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		Listener1 listener = new Listener1();
 		try {
 			getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.POST_CHANGE);
-			project1.delete(true, false, getMonitor());
+			project1.delete(true, false, createTestMonitor());
 			synchronized (listener) {
 				int i = 0;
 				while (!listener.done) {
@@ -722,18 +723,18 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 	public void testDeleteFolderDuringRefresh() throws Throwable {
 		project1 = getWorkspace().getRoot().getProject(getUniqueString());
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		project2 = getWorkspace().getRoot().getProject(getUniqueString());
-		project2.create(getMonitor());
-		project2.open(getMonitor());
+		project2.create(createTestMonitor());
+		project2.open(createTestMonitor());
 
 		assertTrue("1.0", project1.isOpen());
 		assertTrue("2.0", project2.isOpen());
 
 		final IFolder f = project1.getFolder(getUniqueString());
-		f.create(true, true, getMonitor());
+		f.create(true, true, createTestMonitor());
 
 		// the listener checks if an attempt to modify the tree succeeds if made in a job
 		// that belongs to FAMILY_MANUAL_REFRESH
@@ -752,7 +753,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
 						try {
-							f.delete(true, getMonitor());
+							f.delete(true, createTestMonitor());
 							deletePerformed = true;
 						} catch (Exception e) {
 							exception = e;
@@ -769,7 +770,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		try {
 			getWorkspace().addResourceChangeListener(listener1, IResourceChangeEvent.PRE_REFRESH);
 
-			project2.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project2.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
@@ -849,7 +850,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			getWorkspace().addResourceChangeListener(listener1, IResourceChangeEvent.PRE_REFRESH);
 			getWorkspace().addResourceChangeListener(listener2, IResourceChangeEvent.PRE_REFRESH);
 
-			project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
@@ -895,7 +896,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		try {
 			getWorkspace().addResourceChangeListener(listener1, IResourceChangeEvent.PRE_REFRESH);
 
-			root.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			root.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
@@ -903,7 +904,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			assertEquals("3.0", getWorkspace(), listener1.eventSource);
 			assertEquals("4.0", null, listener1.eventResource);
 
-			project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
@@ -941,7 +942,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(phantomResources);
 		try {
 			//create a phantom folder
-			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFolder, new byte[] {1}), getMonitor());
+			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFolder, new byte[] {1}), createTestMonitor());
 			//create children in phantom folder
 			IFile fileInFolder = phantomFolder.getFile("FileInPrivateFolder");
 			workspace.getSynchronizer().setSyncInfo(partner, fileInFolder, new byte[] {1});
@@ -951,11 +952,11 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			workspace.getSynchronizer().flushSyncInfo(partner, fileInFolder, IResource.DEPTH_INFINITE);
 			//delete phantom folder and change some other file
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				phantomFolder.delete(IResource.NONE, getMonitor());
-				file1.setContents(getRandomContents(), IResource.NONE, getMonitor());
-			}, getMonitor());
+				phantomFolder.delete(IResource.NONE, createTestMonitor());
+				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			}, createTestMonitor());
 			//create phantom file
-			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFile, new byte[] {2}), getMonitor());
+			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFile, new byte[] {2}), createTestMonitor());
 			//modify phantom file
 			workspace.getSynchronizer().setSyncInfo(partner, phantomFile, new byte[] {3});
 			//delete phantom file
@@ -990,30 +991,30 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		try {
 			//create a team private folder
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				teamPrivateFolder.create(true, true, getMonitor());
+				teamPrivateFolder.create(true, true, createTestMonitor());
 				teamPrivateFolder.setTeamPrivateMember(true);
-			}, getMonitor());
+			}, createTestMonitor());
 			//create children in team private folder
 			IFile fileInFolder = teamPrivateFolder.getFile("FileInPrivateFolder");
-			fileInFolder.create(getRandomContents(), true, getMonitor());
+			fileInFolder.create(getRandomContents(), true, createTestMonitor());
 			//modify children in team private folder
-			fileInFolder.setContents(getRandomContents(), IResource.NONE, getMonitor());
+			fileInFolder.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 			//delete children in team private folder
-			fileInFolder.delete(IResource.NONE, getMonitor());
+			fileInFolder.delete(IResource.NONE, createTestMonitor());
 			//delete team private folder and change some other file
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				teamPrivateFolder.delete(IResource.NONE, getMonitor());
-				file1.setContents(getRandomContents(), IResource.NONE, getMonitor());
-			}, getMonitor());
+				teamPrivateFolder.delete(IResource.NONE, createTestMonitor());
+				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			}, createTestMonitor());
 			//create team private file
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				teamPrivateFile.create(getRandomContents(), true, getMonitor());
+				teamPrivateFile.create(getRandomContents(), true, createTestMonitor());
 				teamPrivateFile.setTeamPrivateMember(true);
-			}, getMonitor());
+			}, createTestMonitor());
 			//modify team private file
-			teamPrivateFile.setContents(getRandomContents(), IResource.NONE, getMonitor());
+			teamPrivateFile.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 			//delete team private file
-			teamPrivateFile.delete(IResource.NONE, getMonitor());
+			teamPrivateFile.delete(IResource.NONE, createTestMonitor());
 		} finally {
 			workspace.removeResourceChangeListener(listener);
 		}
@@ -1029,12 +1030,12 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Creating and moving", 100);
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
-				file1.setContents(getRandomContents(), IResource.NONE, getMonitor());
+				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 				file1.move(file3.getFullPath(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1050,7 +1051,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1068,7 +1069,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1092,7 +1093,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1111,7 +1112,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1125,11 +1126,11 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
 				file1.move(file3.getFullPath(), true, SubMonitor.convert(m, 50));
-				file3.setContents(getRandomContents(), IResource.NONE, getMonitor());
+				file3.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1146,7 +1147,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1168,7 +1169,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1200,7 +1201,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1221,7 +1222,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1241,7 +1242,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		getWorkspace().addResourceChangeListener(listener1, IResourceChangeEvent.POST_CHANGE);
 		getWorkspace().addResourceChangeListener(listener2, IResourceChangeEvent.POST_BUILD);
 		try {
-			project1.touch(getMonitor());
+			project1.touch(createTestMonitor());
 			int i = 0;
 			while (!(listener1.done && listener2.done)) {
 				// timeout if the listeners are never called
@@ -1310,7 +1311,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			assertTrue(waitUntil(() -> reg1.getReference().getUsingBundles() != null));
 			assertTrue(waitUntil(() -> reg2.getReference().getUsingBundles() != null));
 			assertTrue(waitUntil(() -> reg3.getReference().getUsingBundles() != null));
-			project1.touch(getMonitor());
+			project1.touch(createTestMonitor());
 			assertTrue(waitUntil(
 					() -> listener1.done && listener2.done && listener3.done && (loggy.done || reader == null)));
 		} finally {
@@ -1365,7 +1366,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.addExpectedChange(project1MetaData, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		IProjectDescription description = project1.getDescription();
 		description.setComment("new comment");
-		project1.setDescription(description, IResource.NONE, getMonitor());
+		project1.setDescription(description, IResource.NONE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1374,7 +1375,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.addExpectedChange(project1, IResourceDelta.CHANGED, IResourceDelta.DESCRIPTION);
 		IProjectDescription description = project1.getDescription();
 		description.setDynamicReferences(new IProject[] { project2 });
-		project1.setDescription(description, IResource.NONE, getMonitor());
+		project1.setDescription(description, IResource.NONE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1384,7 +1385,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.addExpectedChange(project1MetaData, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		IProjectDescription description = project1.getDescription();
 		description.setNatureIds(new String[] { NATURE_SIMPLE });
-		project1.setDescription(description, IResource.NONE, getMonitor());
+		project1.setDescription(description, IResource.NONE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1394,20 +1395,20 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.addExpectedChange(project1MetaData, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		IProjectDescription description = project1.getDescription();
 		description.setReferencedProjects(new IProject[] { project2 });
-		project1.setDescription(description, IResource.NONE, getMonitor());
+		project1.setDescription(description, IResource.NONE, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testRemoveFile() throws CoreException {
 		verifier.addExpectedChange(file1, IResourceDelta.REMOVED, 0);
-		file1.delete(true, getMonitor());
+		file1.delete(true, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testRemoveFileAndFolder() throws CoreException {
 		verifier.addExpectedChange(folder1, IResourceDelta.REMOVED, 0);
 		verifier.addExpectedChange(file1, IResourceDelta.REMOVED, 0);
-		folder1.delete(true, getMonitor());
+		folder1.delete(true, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1422,7 +1423,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1451,18 +1452,18 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
 	public void testSetLocal() throws CoreException {
 		verifier.reset();
 		// set local on a file that is already local -- should be no change
-		file1.setLocal(true, IResource.DEPTH_INFINITE, getMonitor());
+		file1.setLocal(true, IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("Unexpected notification on no change", !verifier.hasBeenNotified());
 		// set non-local, still shouldn't appear in delta
 		verifier.reset();
-		file1.setLocal(false, IResource.DEPTH_INFINITE, getMonitor());
+		file1.setLocal(false, IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("Unexpected notification on no change", !verifier.hasBeenNotified());
 	}
 
@@ -1489,7 +1490,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1514,7 +1515,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1529,52 +1530,52 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.reset();
 		verifier.addExpectedChange(teamPrivateFolder, IResourceDelta.ADDED, 0);
 		workspace.run((IWorkspaceRunnable) monitor -> {
-			teamPrivateFolder.create(true, true, getMonitor());
+			teamPrivateFolder.create(true, true, createTestMonitor());
 			teamPrivateFolder.setTeamPrivateMember(true);
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// create children in team private folder
 		IFile fileInFolder = teamPrivateFolder.getFile("FileInPrivateFolder");
 		verifier.addExpectedChange(fileInFolder, IResourceDelta.ADDED, 0);
-		fileInFolder.create(getRandomContents(), true, getMonitor());
+		fileInFolder.create(getRandomContents(), true, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// modify children in team private folder
 		verifier.addExpectedChange(fileInFolder, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		fileInFolder.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		fileInFolder.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// delete children in team private folder
 		verifier.addExpectedChange(fileInFolder, IResourceDelta.REMOVED, 0);
-		fileInFolder.delete(IResource.NONE, getMonitor());
+		fileInFolder.delete(IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// delete team private folder and change some other file
 		verifier.addExpectedChange(teamPrivateFolder, IResourceDelta.REMOVED, 0);
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		workspace.run((IWorkspaceRunnable) monitor -> {
-			teamPrivateFolder.delete(IResource.NONE, getMonitor());
-			file1.setContents(getRandomContents(), IResource.NONE, getMonitor());
-		}, getMonitor());
+			teamPrivateFolder.delete(IResource.NONE, createTestMonitor());
+			file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		}, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// create team private file
 		verifier.addExpectedChange(teamPrivateFile, IResourceDelta.ADDED, 0);
 		workspace.run((IWorkspaceRunnable) monitor -> {
-			teamPrivateFile.create(getRandomContents(), true, getMonitor());
+			teamPrivateFile.create(getRandomContents(), true, createTestMonitor());
 			teamPrivateFile.setTeamPrivateMember(true);
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// modify team private file
 		verifier.addExpectedChange(teamPrivateFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		teamPrivateFile.setContents(getRandomContents(), IResource.NONE, getMonitor());
+		teamPrivateFile.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// delete team private file
 		verifier.addExpectedChange(teamPrivateFile, IResourceDelta.REMOVED, 0);
-		teamPrivateFile.delete(IResource.NONE, getMonitor());
+		teamPrivateFile.delete(IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 	}
@@ -1590,7 +1591,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			} finally {
 				m.done();
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1600,19 +1601,19 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		path.toFile().createNewFile();
 
 		IFile linkedFile = project1.getFile(getUniqueString());
-		linkedFile.createLink(path, IResource.NONE, getMonitor());
+		linkedFile.createLink(path, IResource.NONE, createTestMonitor());
 
 		// check the delta when underlying file is removed
 		verifier.addExpectedChange(linkedFile, IResourceDelta.CHANGED, IResourceDelta.LOCAL_CHANGED);
 		path.toFile().delete();
-		project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertDelta();
 
 		// check the delta when underlying file is recreated
 		verifier.addExpectedChange(linkedFile, IResourceDelta.CHANGED, IResourceDelta.LOCAL_CHANGED | IResourceDelta.CONTENT);
 		path.toFile().createNewFile();
 
-		project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1622,18 +1623,18 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 		path.toFile().mkdir();
 		IFolder linkedFolder = project1.getFolder(getUniqueString());
-		linkedFolder.createLink(path, IResource.NONE, getMonitor());
+		linkedFolder.createLink(path, IResource.NONE, createTestMonitor());
 
 		// check the delta when underlying folder is removed
 		verifier.addExpectedChange(linkedFolder, IResourceDelta.CHANGED, IResourceDelta.LOCAL_CHANGED);
 		path.toFile().delete();
-		project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertDelta();
 
 		// check the delta when underlying folder is recreated
 		verifier.addExpectedChange(linkedFolder, IResourceDelta.CHANGED, IResourceDelta.LOCAL_CHANGED);
 		path.toFile().mkdir();
-		project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertDelta();
 	}
 
@@ -1643,14 +1644,14 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 		path.toFile().mkdir();
 		IFolder linkedFolder = project1.getFolder(getUniqueString());
-		linkedFolder.createLink(path, IResource.NONE, getMonitor());
+		linkedFolder.createLink(path, IResource.NONE, createTestMonitor());
 
 		IFolder regularFolder = project1.getFolder(getUniqueString());
-		regularFolder.create(true, true, getMonitor());
+		regularFolder.create(true, true, createTestMonitor());
 
 		// check the delta when underlying folder is removed
 		verifier.addExpectedChange(regularFolder, IResourceDelta.REMOVED, 0);
-		regularFolder.delete(true, getMonitor());
+		regularFolder.delete(true, createTestMonitor());
 		assertDelta();
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -63,7 +64,7 @@ public class IResourceDeltaTest extends ResourceTest {
 
 		// Create and open the resources
 		IWorkspaceRunnable body = monitor -> ensureExistsInWorkspace(allResources, true);
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 	}
 
 	/**
@@ -109,12 +110,12 @@ public class IResourceDeltaTest extends ResourceTest {
 
 		//do the work
 		IWorkspaceRunnable body = monitor -> {
-			file1.setContents(getRandomContents(), true, true, getMonitor());
-			folder2.delete(true, getMonitor());
-			file4.create(getRandomContents(), true, getMonitor());
+			file1.setContents(getRandomContents(), true, true, createTestMonitor());
+			folder2.delete(true, createTestMonitor());
+			file4.create(getRandomContents(), true, createTestMonitor());
 		};
 		try {
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -477,7 +478,7 @@ public class IResourceTest extends ResourceTest {
 			// Reinitialize projects if necessary
 			if (reinitializeOnCleanup) {
 				waitForBuild();
-				getWorkspace().getRoot().delete(true, true, getMonitor());
+				getWorkspace().getRoot().delete(true, true, createTestMonitor());
 				IResourceTest.this.initializeProjects();
 				reinitializeOnCleanup = false;
 			}
@@ -491,7 +492,7 @@ public class IResourceTest extends ResourceTest {
 			throws OperationCanceledException, InterruptedException, CoreException {
 		// Wait for any outstanding refresh to finish
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		if (addVerifier) {
 			/* install the verifier */
@@ -772,8 +773,8 @@ public class IResourceTest extends ResourceTest {
 		 * Add a project in the file system, but not in the workspace */
 
 		IProject project1 = getWorkspace().getRoot().getProject("Project");
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		IProject project2 = getWorkspace().getRoot().getProject("NewProject");
 
@@ -781,8 +782,8 @@ public class IResourceTest extends ResourceTest {
 		deleteOnTearDown(projectPath);
 		projectPath.toFile().mkdirs();
 
-		project1.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		project2.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		project2.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("1.1", project1.exists());
 		assertTrue("1.2", project1.isSynchronized(IResource.DEPTH_INFINITE));
 		assertFalse("1.3", project2.exists());
@@ -1041,7 +1042,7 @@ public class IResourceTest extends ResourceTest {
 		try {
 			logListener = new LogListener();
 			Platform.addLogListener(logListener);
-			sourceProj.copy(desc, IResource.NONE, getMonitor());
+			sourceProj.copy(desc, IResource.NONE, createTestMonitor());
 		} finally {
 			Platform.removeLogListener(logListener);
 		}
@@ -1060,8 +1061,8 @@ public class IResourceTest extends ResourceTest {
 	private IProject createProject(boolean applyResFilter) throws CoreException {
 		IProject sourceProj = getWorkspace().getRoot().getProject(getName());
 		// create source project and apply resource filter.
-		sourceProj.create(getMonitor());
-		sourceProj.open(getMonitor());
+		sourceProj.create(createTestMonitor());
+		sourceProj.open(createTestMonitor());
 		// create a new filter.
 		if (applyResFilter) {
 			String MULTI_FILT_ID = "org.eclipse.ui.ide.multiFilter";
@@ -1069,7 +1070,7 @@ public class IResourceTest extends ResourceTest {
 			FileInfoMatcherDescription filterDesc = new FileInfoMatcherDescription(MULTI_FILT_ID, FILT_ARG);
 			int EXCL_FILE_GT = IResourceFilterDescription.EXCLUDE_ALL + IResourceFilterDescription.FILES
 					+ IResourceFilterDescription.INHERITABLE;
-			sourceProj.createFilter(EXCL_FILE_GT, filterDesc, IResource.BACKGROUND_REFRESH, getMonitor());
+			sourceProj.createFilter(EXCL_FILE_GT, filterDesc, IResource.BACKGROUND_REFRESH, createTestMonitor());
 		}
 		return sourceProj;
 	}
@@ -1209,10 +1210,10 @@ public class IResourceTest extends ResourceTest {
 		IProject project = root.getProject("Project");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("target");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		folder.create(true, true, getMonitor());
-		file.create(getRandomContents(), true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		folder.create(true, true, createTestMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
@@ -1298,7 +1299,7 @@ public class IResourceTest extends ResourceTest {
 		verifier.reset();
 
 		/* remove trash */
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 
 		// isDerived should return false when resource does not exist
 		assertFalse("8.1", project.isDerived());
@@ -1320,10 +1321,10 @@ public class IResourceTest extends ResourceTest {
 		IProject project = root.getProject("Project");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("target");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		folder.create(true, true, getMonitor());
-		file.create(getRandomContents(), true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		folder.create(true, true, createTestMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		// all resources have independent derived flag; all non-derived by
 		// default; check each type
@@ -1381,7 +1382,7 @@ public class IResourceTest extends ResourceTest {
 		assertFalse("5.2.4", file.isDerived());
 
 		/* remove trash */
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 
 		// isDerived should return false when resource does not exist
 		assertFalse("8.1", project.isDerived());
@@ -1569,7 +1570,7 @@ public class IResourceTest extends ResourceTest {
 
 	public void testGetModificationStamp() throws CoreException {
 		// cleanup auto-created resources
-		getWorkspace().getRoot().delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		getWorkspace().getRoot().delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 
 		// setup
 		IResource[] resources = buildResources(getWorkspace().getRoot(), new String[] {"/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1"});
@@ -1587,7 +1588,7 @@ public class IResourceTest extends ResourceTest {
 		IProject project;
 		for (IProject project2 : projects) {
 			project = project2;
-			project.create(getMonitor());
+			project.create(createTestMonitor());
 			assertEquals("2.1." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
 		}
 
@@ -1596,7 +1597,7 @@ public class IResourceTest extends ResourceTest {
 		for (IProject project2 : projects) {
 			project = project2;
 			assertEquals("3.1." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 			assertNotEquals("3.3." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
 			// cache the value for later use
 			table.put(project.getFullPath(), Long.valueOf(project.getModificationStamp()));
@@ -1614,7 +1615,7 @@ public class IResourceTest extends ResourceTest {
 		// close the projects. now all resources should have a null stamp again
 		for (IProject project2 : projects) {
 			project = project2;
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 		}
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
@@ -1625,7 +1626,7 @@ public class IResourceTest extends ResourceTest {
 		// re-open the projects. all resources should have the same stamps
 		for (IProject project2 : projects) {
 			project = project2;
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 		}
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.PROJECT) {
@@ -1640,7 +1641,7 @@ public class IResourceTest extends ResourceTest {
 		final Map<IPath, Long> tempTable = new HashMap<>(resources.length);
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
-				resource.touch(getMonitor());
+				resource.touch(createTestMonitor());
 				long stamp = resource.getModificationStamp();
 				Object v = table.get(resource.getFullPath());
 				assertNotNull("6.0." + resource.getFullPath(), v);
@@ -1655,7 +1656,7 @@ public class IResourceTest extends ResourceTest {
 
 		// mark all resources as non-local. all non-local resources have a null
 		// stamp
-		getWorkspace().getRoot().setLocal(false, IResource.DEPTH_INFINITE, getMonitor());
+		getWorkspace().getRoot().setLocal(false, IResource.DEPTH_INFINITE, createTestMonitor());
 		IResourceVisitor visitor = resource -> {
 			//projects and root are always local
 			if (resource.getType() == IResource.ROOT || resource.getType() == IResource.PROJECT) {
@@ -1670,7 +1671,7 @@ public class IResourceTest extends ResourceTest {
 		// mark all resources as local. none should have a null stamp and it
 		// should be different than
 		// the last one
-		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, getMonitor());
+		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, createTestMonitor());
 		tempTable.clear();
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
@@ -1687,7 +1688,7 @@ public class IResourceTest extends ResourceTest {
 		table.putAll(tempTable);
 		//set local on resources that are already local, this should not
 		// affect the modification stamp
-		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, getMonitor());
+		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, createTestMonitor());
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
 				long newStamp = resource.getModificationStamp();
@@ -1700,7 +1701,7 @@ public class IResourceTest extends ResourceTest {
 		}
 
 		// delete all the resources so we can start over.
-		getWorkspace().getRoot().delete(true, getMonitor());
+		getWorkspace().getRoot().delete(true, createTestMonitor());
 
 		// none of the resources exist yet so all the modification stamps
 		// should be null
@@ -1726,7 +1727,7 @@ public class IResourceTest extends ResourceTest {
 			}
 		}
 		// now make all resources local and re-check stamps
-		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, getMonitor());
+		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, createTestMonitor());
 		visitor = resource -> {
 			if (resource.getType() != IResource.ROOT) {
 				assertNotEquals("12.1." + resource.getFullPath(), IResource.NULL_STAMP,
@@ -1750,9 +1751,9 @@ public class IResourceTest extends ResourceTest {
 
 		// Remove and re-create the file in a workspace operation
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			file.delete(false, getMonitor());
+			file.delete(false, createTestMonitor());
 			create(file, true);
-		}, getMonitor());
+		}, createTestMonitor());
 
 		assertNotEquals("1.0", modificationStamp, file.getModificationStamp());
 	}
@@ -1785,7 +1786,7 @@ public class IResourceTest extends ResourceTest {
 		assertEquals("2.2", workspaceLocation.append(topFile.getFullPath()), topFile.getRawLocation());
 		assertEquals("2.3", workspaceLocation.append(deepFile.getFullPath()), deepFile.getRawLocation());
 
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		//closed project
 		assertNull("3.0", project.getRawLocation());
 		//resource in closed project
@@ -1805,10 +1806,10 @@ public class IResourceTest extends ResourceTest {
 		IPathVariableManager varMan = getWorkspace().getPathVariableManager();
 		try {
 			varMan.setValue(variableName, variableLocation);
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 			IProjectDescription description = project.getDescription();
 			description.setLocation(projectLocation);
-			project.move(description, IResource.NONE, getMonitor());
+			project.move(description, IResource.NONE, createTestMonitor());
 
 			//open project not in default location
 			assertEquals("4.0", projectLocation, project.getRawLocation());
@@ -1817,7 +1818,7 @@ public class IResourceTest extends ResourceTest {
 			assertEquals("4.2", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
 			assertEquals("4.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 
 			//closed project not in default location
 			assertEquals("5.0", projectLocation, project.getRawLocation());
@@ -1826,13 +1827,13 @@ public class IResourceTest extends ResourceTest {
 			assertEquals("5.2", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
 			assertEquals("5.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 			ensureDoesNotExistInWorkspace(topFolder);
 			ensureDoesNotExistInWorkspace(topFile);
 			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(fileLocation));
 			folderLocation.toFile().mkdirs();
-			topFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-			topFile.createLink(fileLocation, IResource.NONE, getMonitor());
+			topFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
+			topFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
 			ensureExistsInWorkspace(deepFile, true);
 
 			//linked file
@@ -1842,7 +1843,7 @@ public class IResourceTest extends ResourceTest {
 			//resource below linked folder
 			assertEquals("6.2", folderLocation.append(deepFile.getName()), deepFile.getRawLocation());
 
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 
 			//linked file in closed project (should default to project
 			// location)
@@ -1852,15 +1853,15 @@ public class IResourceTest extends ResourceTest {
 			//resource below linked folder in closed project
 			assertEquals("7.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 			IPath variableFolderLocation = IPath.fromOSString(variableName).append("/VarFolderName");
 			IPath variableFileLocation = IPath.fromOSString(variableName).append("/VarFileName");
 			ensureDoesNotExistInWorkspace(topFolder);
 			ensureDoesNotExistInWorkspace(topFile);
 			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(varMan.resolvePath(variableFileLocation)));
 			varMan.resolvePath(variableFolderLocation).toFile().mkdirs();
-			topFolder.createLink(variableFolderLocation, IResource.NONE, getMonitor());
-			topFile.createLink(variableFileLocation, IResource.NONE, getMonitor());
+			topFolder.createLink(variableFolderLocation, IResource.NONE, createTestMonitor());
+			topFile.createLink(variableFileLocation, IResource.NONE, createTestMonitor());
 			ensureExistsInWorkspace(deepFile, true);
 
 			//linked file with variable
@@ -1870,7 +1871,7 @@ public class IResourceTest extends ResourceTest {
 			//resource below linked folder with variable
 			assertEquals("8.3", varMan.resolvePath(variableFolderLocation).append(deepFile.getName()), deepFile.getRawLocation());
 
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 
 			//linked file in closed project with variable
 			assertEquals("9.0", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
@@ -1901,7 +1902,7 @@ public class IResourceTest extends ResourceTest {
 		assertEquals(true, b.isConflicting(multi));
 		assertEquals(true, multi.isConflicting(b));
 
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 
 	public void testIsConflicting2() throws CoreException {
@@ -1936,14 +1937,14 @@ public class IResourceTest extends ResourceTest {
 		assertEquals(true, wrapper.isConflicting(project));
 		assertEquals(true, multi.isConflicting(project));
 
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 
 	/**
 	 * This method tests the IResource.isSynchronized() operation */
 	public void testIsSynchronized() throws Exception {
 		//don't need auto-created resources
-		getWorkspace().getRoot().delete(true, true, getMonitor());
+		getWorkspace().getRoot().delete(true, true, createTestMonitor());
 
 		interestingResources = buildInterestingResources();
 		Object[][] inputs = { interestingResources, interestingResources, interestingStates(), interestingDepths() };
@@ -2080,18 +2081,18 @@ public class IResourceTest extends ResourceTest {
 		for (IResource resource : resources) {
 			switch (resource.getType()) {
 			case IResource.FILE:
-				((IFile) resource).create(null, false, getMonitor());
+				((IFile) resource).create(null, false, createTestMonitor());
 				break;
 			case IResource.FOLDER:
-				((IFolder) resource).create(false, true, getMonitor());
+				((IFolder) resource).create(false, true, createTestMonitor());
 				break;
 			case IResource.PROJECT:
-				((IProject) resource).create(getMonitor());
+				((IProject) resource).create(createTestMonitor());
 				break;
 			}
 		}
 		assertExistsInWorkspace(resources);
-		project.delete(true, false, getMonitor());
+		project.delete(true, false, createTestMonitor());
 	}
 
 	/**
@@ -2199,9 +2200,9 @@ public class IResourceTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
 		IFile file = project.getFile("target");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		file.create(getRandomContents(), true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		// file
 		assertFalse("1.0", file.isReadOnly());
@@ -2222,7 +2223,7 @@ public class IResourceTest extends ResourceTest {
 	 * This method tests the IResource.refreshLocal() operation */
 	public void testRefreshLocal() throws Exception {
 		//don't need auto-created resources
-		getWorkspace().getRoot().delete(true, true, getMonitor());
+		getWorkspace().getRoot().delete(true, true, createTestMonitor());
 
 		interestingResources = buildInterestingResources();
 		Object[][] inputs = { interestingResources, interestingResources, interestingStates(), interestingDepths() };
@@ -2244,7 +2245,7 @@ public class IResourceTest extends ResourceTest {
 					return null;
 				}
 				setupBeforeState(receiver, target, state, depth, true);
-				receiver.refreshLocal(depth, getMonitor());
+				receiver.refreshLocal(depth, createTestMonitor());
 				return Boolean.TRUE;
 			}
 
@@ -2271,16 +2272,16 @@ public class IResourceTest extends ResourceTest {
 	public void testRefreshLocalWithDepth() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder folder = project.getFolder("Folder");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		folder.create(true, true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		String[] hierarchy = {"Folder/", "Folder/Folder/", "Folder/Folder/Folder/", "Folder/Folder/Folder/Folder/"};
 		IResource[] resources = buildResources(folder, hierarchy);
 		ensureExistsInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
 
-		folder.refreshLocal(IResource.DEPTH_ONE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());
 
 		assertExistsInWorkspace(folder.getFolder("Folder"));
 		assertDoesNotExistInWorkspace(folder.getFolder("Folder/Folder"));
@@ -2294,15 +2295,15 @@ public class IResourceTest extends ResourceTest {
 		 * file, when neither of them exist in the workspace.
 		 */
 		IProject project1 = getWorkspace().getRoot().getProject("Project");
-		project1.create(getMonitor());
-		project1.open(getMonitor());
+		project1.create(createTestMonitor());
+		project1.open(createTestMonitor());
 
 		IFolder folder = project1.getFolder("Folder");
 		IFile file = folder.getFile("File");
 
 		ensureExistsInFileSystem(file);
 
-		file.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		file.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 	}
 
 	/**
@@ -2338,7 +2339,7 @@ public class IResourceTest extends ResourceTest {
 			}
 		}
 		//should fail for non-existent resources
-		getWorkspace().getRoot().delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		getWorkspace().getRoot().delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		for (IResource resource : resources) {
 			//should fail except for root
 			ThrowingRunnable revertOperation = () -> resource.revertModificationStamp(1);
@@ -2354,7 +2355,7 @@ public class IResourceTest extends ResourceTest {
 	 * This method tests the IResource.setLocalTimeStamp() operation */
 	public void testSetLocalTimeStamp() throws Exception {
 		//don't need auto-created resources
-		getWorkspace().getRoot().delete(true, true, getMonitor());
+		getWorkspace().getRoot().delete(true, true, createTestMonitor());
 
 		interestingResources = buildInterestingResources();
 		Long[] interestingTimes = { Long.valueOf(-1), Long.valueOf(System.currentTimeMillis() - 1000),
@@ -2409,10 +2410,10 @@ public class IResourceTest extends ResourceTest {
 		IProject project = root.getProject("Project");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("target");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		folder.create(true, true, getMonitor());
-		file.create(getRandomContents(), true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		folder.create(true, true, createTestMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		// all resources have independent team private member flag
 		// all non-TPM by default; check each type
@@ -2470,7 +2471,7 @@ public class IResourceTest extends ResourceTest {
 		assertFalse("5.2.4", file.isTeamPrivateMember());
 
 		/* remove trash */
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 
 		// isTeamPrivateMember should return false when resource does not exist
 		assertFalse("8.1", project.isTeamPrivateMember());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.DataInputStream;
@@ -146,11 +147,11 @@ public class ISynchronizerTest extends ResourceTest {
 			for (IProject project : projects) {
 				IResource[] children = project.members();
 				for (IResource element : children) {
-					element.delete(false, getMonitor());
+					element.delete(false, createTestMonitor());
 				}
 			}
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		// sync info should remain for the resources since they are now phantoms
 		visitor = resource -> {
@@ -168,7 +169,7 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// delete the projects
 		for (IProject project : projects) {
-			project.delete(false, getMonitor());
+			project.delete(false, createTestMonitor());
 		}
 
 		// sync info should be gone since projects can't become phantoms
@@ -219,12 +220,12 @@ public class ISynchronizerTest extends ResourceTest {
 			for (IProject project : projects) {
 				for (IResource element : project.members()) {
 					if (!element.getName().equals(IProjectDescription.DESCRIPTION_FILE_NAME)) {
-						element.delete(false, getMonitor());
+						element.delete(false, createTestMonitor());
 					}
 				}
 			}
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		// sync info should remain for the resources since they are now phantoms
 		visitor = resource -> {
@@ -248,7 +249,7 @@ public class ISynchronizerTest extends ResourceTest {
 				}
 			}
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		// there should be no sync info for any resources except the project
 		visitor = resource -> {
@@ -271,7 +272,7 @@ public class ISynchronizerTest extends ResourceTest {
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
 
 		// cleanup auto-created resources
-		getWorkspace().getRoot().delete(true, getMonitor());
+		getWorkspace().getRoot().delete(true, createTestMonitor());
 
 		// setup
 		IResource[] testResources = buildResources(getWorkspace().getRoot(), new String[] { "/Foo", "/Foo/file.txt" });
@@ -287,7 +288,7 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// move the file
 		IFile destination = project.getFile("newFile.txt");
-		source.move(destination.getFullPath(), true, getMonitor());
+		source.move(destination.getFullPath(), true, createTestMonitor());
 
 		// check sync info
 		byte[] old = synchronizer.getSyncInfo(qname, source);
@@ -301,7 +302,7 @@ public class ISynchronizerTest extends ResourceTest {
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
 
 		// cleanup auto-created resources
-		getWorkspace().getRoot().delete(true, getMonitor());
+		getWorkspace().getRoot().delete(true, createTestMonitor());
 
 		// setup
 		IResource[] toTest = buildResources(getWorkspace().getRoot(), new String[] {"/Foo", "/Foo/file.txt"});
@@ -318,7 +319,7 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// move the file
 		IFile destFile = sourceProject.getFile("newFile.txt");
-		sourceFile.move(destFile.getFullPath(), true, getMonitor());
+		sourceFile.move(destFile.getFullPath(), true, createTestMonitor());
 
 		// check sync info
 		byte[] old = synchronizer.getSyncInfo(qname, sourceFile);
@@ -327,7 +328,7 @@ public class ISynchronizerTest extends ResourceTest {
 		assertNull("4.2", synchronizer.getSyncInfo(qname, destFile));
 
 		// move the file back
-		destFile.move(sourceFile.getFullPath(), true, getMonitor());
+		destFile.move(sourceFile.getFullPath(), true, createTestMonitor());
 
 		// check the sync info
 		old = synchronizer.getSyncInfo(qname, sourceFile);
@@ -337,7 +338,7 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// rename the file and ensure that the sync info is moved with it
 		IProject destProject = getWorkspace().getRoot().getProject("newProject");
-		sourceProject.move(destProject.getFullPath(), true, getMonitor());
+		sourceProject.move(destProject.getFullPath(), true, createTestMonitor());
 		assertNull("7.1", synchronizer.getSyncInfo(qname, sourceProject));
 		assertNull("7.2", synchronizer.getSyncInfo(qname, sourceFile));
 		old = synchronizer.getSyncInfo(qname, destProject.getFile(sourceFile.getName()));
@@ -447,7 +448,7 @@ public class ISynchronizerTest extends ResourceTest {
 						throw wrappedException;
 					}
 				};
-				getWorkspace().run(body, getMonitor());
+				getWorkspace().run(body, createTestMonitor());
 			}
 		}
 
@@ -723,7 +724,7 @@ public class ISynchronizerTest extends ResourceTest {
 		assertTrue("1.1", file1.exists());
 		assertTrue("1.2", !file1.isPhantom());
 		// deletes file
-		file1.delete(true, getMonitor());
+		file1.delete(true, createTestMonitor());
 		// file is now a phantom resource
 		assertTrue("2.1", !file1.exists());
 		assertTrue("2.2", file1.isPhantom());
@@ -739,7 +740,7 @@ public class ISynchronizerTest extends ResourceTest {
 		assertTrue("4.3", file2.exists());
 		assertTrue("4.4", !file2.isPhantom());
 		// deletes the folder and its only child
-		folder.delete(true, getMonitor());
+		folder.delete(true, createTestMonitor());
 		// both resources are now phantom resources
 		assertTrue("5.1", !folder.exists());
 		assertTrue("5.2", folder.isPhantom());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -62,7 +63,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		fileLocationLower = fileLocationLower.setDevice(fileLocationLower.getDevice().toLowerCase());
 		IPath fileLocationUpper = fileLocationLower.setDevice(fileLocationLower.getDevice().toUpperCase());
 		//create the link with lower case device
-		link.createLink(fileLocationLower, IResource.NONE, getMonitor());
+		link.createLink(fileLocationLower, IResource.NONE, createTestMonitor());
 
 		//try to find the file using the upper case device
 		IFile[] files = getWorkspace().getRoot().findFilesForLocation(fileLocationUpper);
@@ -112,7 +113,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IFolder parent = p2.getFolder("parent");
 		IFolder link = parent.getFolder("link");
 		ensureExistsInWorkspace(new IResource[] {p1, p2, parent}, true);
-		link.createLink(p1.getLocationURI(), IResource.NONE, getMonitor());
+		link.createLink(p1.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertResources("2.0", p1, link, root.findContainersForLocation(p1.getLocation()));
 
 		//existing folder
@@ -137,8 +138,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IFolder otherLink = p1.getFolder("otherLink");
 		IFileStore linkStore = getTempStore();
 		URI location = linkStore.toURI();
-		linkStore.mkdir(EFS.NONE, getMonitor());
-		otherLink.createLink(location, IResource.NONE, getMonitor());
+		linkStore.mkdir(EFS.NONE, createTestMonitor());
+		otherLink.createLink(location, IResource.NONE, createTestMonitor());
 		result = root.findContainersForLocationURI(location);
 		assertResources("5.1", otherLink, result);
 
@@ -218,8 +219,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IFolder link = project.getFolder("link");
 		IFileStore linkStore = getTempStore();
 		URI location = linkStore.toURI();
-		linkStore.mkdir(EFS.NONE, getMonitor());
-		link.createLink(location, IResource.NONE, getMonitor());
+		linkStore.mkdir(EFS.NONE, createTestMonitor());
+		link.createLink(location, IResource.NONE, createTestMonitor());
 		IFile child = link.getFile("link-child.txt");
 		URI childLocation = linkStore.getChild(child.getName()).toURI();
 		result = root.findFilesForLocationURI(childLocation);
@@ -301,17 +302,17 @@ public class IWorkspaceRootTest extends ResourceTest {
 		final IWorkspaceRoot root = getWorkspace().getRoot();
 		final String value = "this is a test property value";
 		final QualifiedName name = new QualifiedName("test", "testProperty");
-		getWorkspace().run((IWorkspaceRunnable) monitor -> root.setPersistentProperty(name, value), getMonitor());
+		getWorkspace().run((IWorkspaceRunnable) monitor -> root.setPersistentProperty(name, value), createTestMonitor());
 
 		final String[] storedValue = new String[1];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> storedValue[0] = root.getPersistentProperty(name),
-				getMonitor());
+				createTestMonitor());
 		assertEquals("2.0", value, storedValue[0]);
 
 		final QualifiedName name2 = new QualifiedName("test", "testNonProperty");
 		final String[] changedStoredValue = new String[1];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> changedStoredValue[0] = root.getPersistentProperty(name2),
-				getMonitor());
+				createTestMonitor());
 		assertEquals("3.0", null, changedStoredValue[0]);
 	}
 
@@ -320,9 +321,9 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");
 		ensureExistsInWorkspace(project, true);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		//refreshing the root shouldn't fail
-		root.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		root.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 	}
 
 	@Test
@@ -330,11 +331,11 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
 		ensureDoesNotExistInWorkspace(hiddenProject);
-		hiddenProject.create(null, IResource.HIDDEN, getMonitor());
-		hiddenProject.open(getMonitor());
+		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
+		hiddenProject.open(createTestMonitor());
 
 		IFolder folder = hiddenProject.getFolder("foo");
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		IContainer[] containers = root.findContainersForLocationURI(folder.getLocationURI());
 		assertEquals("2.0", 0, containers.length);
@@ -348,11 +349,11 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(getUniqueString());
 		ensureDoesNotExistInWorkspace(hiddenProject);
-		hiddenProject.create(null, IResource.HIDDEN, getMonitor());
-		hiddenProject.open(getMonitor());
+		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
+		hiddenProject.open(createTestMonitor());
 
 		IFile file = hiddenProject.getFile("foo");
-		file.create(new ByteArrayInputStream("foo".getBytes()), true, getMonitor());
+		file.create(new ByteArrayInputStream("foo".getBytes()), true, createTestMonitor());
 
 		IFile[] files = root.findFilesForLocationURI(file.getLocationURI());
 		assertEquals("3.0", 0, files.length);
@@ -391,7 +392,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IProjectDescription newProjectDescription = getWorkspace().newProjectDescription(subProjectName);
 		newProjectDescription.setLocation(subProjectLocation);
 
-		subProject.create(newProjectDescription, getMonitor());
+		subProject.create(newProjectDescription, createTestMonitor());
 
 		file = root.getFileForLocation(fileLocation);
 		assertNotNull("2.0", file);
@@ -421,8 +422,8 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IProject project = root.getProject(getUniqueString());
 		ensureDoesNotExistInWorkspace(project);
 
-		project.create(null, IResource.NONE, getMonitor());
-		project.open(getMonitor());
+		project.create(null, IResource.NONE, createTestMonitor());
+		project.open(createTestMonitor());
 
 		// a team private folder
 		IFolder teamFolder = createFolder(project, IResource.TEAM_PRIVATE, false);
@@ -487,13 +488,13 @@ public class IWorkspaceRootTest extends ResourceTest {
 		if (linked) {
 			IPath path = getTempDir().append(getUniqueString());
 			path.toFile().createNewFile();
-			file.createLink(URIUtil.toURI(path), updateFlags, getMonitor());
+			file.createLink(URIUtil.toURI(path), updateFlags, createTestMonitor());
 			if ((updateFlags & IResource.TEAM_PRIVATE) == IResource.TEAM_PRIVATE) {
 				file.setTeamPrivateMember(true);
 			}
 		} else {
 			try (ByteArrayInputStream inputStream = new ByteArrayInputStream("content".getBytes())) {
-				file.create(inputStream, updateFlags, getMonitor());
+				file.create(inputStream, updateFlags, createTestMonitor());
 			}
 		}
 		return file;
@@ -504,12 +505,12 @@ public class IWorkspaceRootTest extends ResourceTest {
 		if (linked) {
 			IPath path = getTempDir().append(getUniqueString());
 			path.toFile().mkdir();
-			folder.createLink(URIUtil.toURI(path), updateFlags, getMonitor());
+			folder.createLink(URIUtil.toURI(path), updateFlags, createTestMonitor());
 			if ((updateFlags & IResource.TEAM_PRIVATE) == IResource.TEAM_PRIVATE) {
 				folder.setTeamPrivateMember(true);
 			}
 		} else {
-			folder.create(updateFlags, true, getMonitor());
+			folder.create(updateFlags, true, createTestMonitor());
 		}
 		return folder;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -31,6 +31,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getVa
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -95,7 +96,7 @@ public class IWorkspaceTest extends ResourceTest {
 	public void testCancelRunnable() {
 		assertThrows(OperationCanceledException.class, () -> getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			throw new OperationCanceledException();
-		}, getMonitor()));
+		}, createTestMonitor()));
 	}
 
 	/**
@@ -119,58 +120,58 @@ public class IWorkspaceTest extends ResourceTest {
 
 		// project not open
 		assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { file }, folder.getFullPath(), false, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { file }, folder.getFullPath(), false, createTestMonitor()));
 
 		ensureResourceHierarchyExist();
 
 		//copy to bogus destination
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file },
-				folder2.getFullPath().append("figment"), false, getMonitor()));
+				folder2.getFullPath().append("figment"), false, createTestMonitor()));
 
 		//copy to non-existent destination
 		assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, createTestMonitor()));
 
 		//create the destination
-		folder2.create(false, true, getMonitor());
+		folder2.create(false, true, createTestMonitor());
 
 		//source file doesn't exist
 		assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { file2 }, folder2.getFullPath(), false, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { file2 }, folder2.getFullPath(), false, createTestMonitor()));
 
 		//some source files don't exist
 		assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor()));
 
 		//make sure the first copy worked
 		assertTrue("1.5", fileCopy.exists());
-		fileCopy.delete(true, getMonitor());
+		fileCopy.delete(true, createTestMonitor());
 
 		// create the files
 		IFile projectFile = project.getFile("ProjectPhile");
-		file2.create(getRandomContents(), false, getMonitor());
-		file3.create(getRandomContents(), false, getMonitor());
-		projectFile.create(getRandomContents(), false, getMonitor());
+		file2.create(getRandomContents(), false, createTestMonitor());
+		file3.create(getRandomContents(), false, createTestMonitor());
+		projectFile.create(getRandomContents(), false, createTestMonitor());
 
 		//source files aren't siblings
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file, projectFile },
-				folder2.getFullPath(), false, getMonitor()));
+				folder2.getFullPath(), false, createTestMonitor()));
 
 		//source files contains duplicates
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file, file2, file },
-				folder2.getFullPath(), false, getMonitor()));
+				folder2.getFullPath(), false, createTestMonitor()));
 
 		//source can't be prefix of destination
 		assertThrows(CoreException.class, () -> {
 			IFolder folder3 = folder2.getFolder("Folder3");
-			folder3.create(false, true, getMonitor());
-			getWorkspace().copy(new IResource[] { folder2 }, folder3.getFullPath(), false, getMonitor());
+			folder3.create(false, true, createTestMonitor());
+			getWorkspace().copy(new IResource[] { folder2 }, folder3.getFullPath(), false, createTestMonitor());
 		});
 
 		//target exists
 		assertThrows(CoreException.class, () -> {
-			file2Copy.create(getRandomContents(), false, getMonitor());
-			getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, getMonitor());
+			file2Copy.create(getRandomContents(), false, createTestMonitor());
+			getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
 		});
 		ensureDoesNotExistInWorkspace(file2Copy);
 		ensureDoesNotExistInFileSystem(file2Copy);
@@ -178,28 +179,28 @@ public class IWorkspaceTest extends ResourceTest {
 		//make sure the first copy worked
 		fileCopy = folder2.getFile("File");
 		assertTrue("2.2", fileCopy.exists());
-		fileCopy.delete(true, getMonitor());
+		fileCopy.delete(true, createTestMonitor());
 
 		//resource out of sync with filesystem
 		ensureOutOfSync(file);
 		assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, createTestMonitor()));
 
 		// make sure "file" is in sync.
 		file.refreshLocal(IResource.DEPTH_ZERO, null);
 		/********** NON FAILURE CASES ***********/
 
 		//empty resource list
-		getWorkspace().copy(new IResource[] {}, folder2.getFullPath(), false, getMonitor());
+		getWorkspace().copy(new IResource[] {}, folder2.getFullPath(), false, createTestMonitor());
 
 		//copy single file
-		getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, getMonitor());
+		getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.2", fileCopy.exists());
 		ensureDoesNotExistInWorkspace(fileCopy);
 		ensureDoesNotExistInFileSystem(fileCopy);
 
 		//copy two files
-		getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, getMonitor());
+		getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.4", fileCopy.exists());
 		assertTrue("3.5", file2Copy.exists());
 		ensureDoesNotExistInWorkspace(fileCopy);
@@ -208,7 +209,7 @@ public class IWorkspaceTest extends ResourceTest {
 		ensureDoesNotExistInFileSystem(file2Copy);
 
 		//copy a folder
-		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, getMonitor());
+		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.7", folderCopy.exists());
 		assertTrue("3.8", folderCopy.members().length > 0);
 		ensureDoesNotExistInWorkspace(folderCopy);
@@ -226,24 +227,24 @@ public class IWorkspaceTest extends ResourceTest {
 		IFile file = (IFile) resources[3];
 
 		//delete non-existent resources
-		assertTrue(getWorkspace().delete(new IResource[] {project, folder, file}, false, getMonitor()).isOK());
-		assertTrue(getWorkspace().delete(new IResource[] {file}, false, getMonitor()).isOK());
-		assertTrue(getWorkspace().delete(new IResource[] {}, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(new IResource[] {project, folder, file}, false, createTestMonitor()).isOK());
+		assertTrue(getWorkspace().delete(new IResource[] {file}, false, createTestMonitor()).isOK());
+		assertTrue(getWorkspace().delete(new IResource[] {}, false, createTestMonitor()).isOK());
 		ensureResourceHierarchyExist();
 
 		//delete existing resources
 		resources = new IResource[] {file, project, folder};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
 		ensureResourceHierarchyExist();
 		resources = new IResource[] {file};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		file.create(getRandomContents(), false, getMonitor());
+		file.create(getRandomContents(), false, createTestMonitor());
 		resources = new IResource[] {};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
 		ensureResourceHierarchyExist();
@@ -252,17 +253,17 @@ public class IWorkspaceTest extends ResourceTest {
 		IProject fakeProject = getWorkspace().getRoot().getProject("pigment");
 		IFolder fakeFolder = fakeProject.getFolder("ligament");
 		resources = new IResource[] {file, folder, fakeFolder, project, fakeProject};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
 		ensureResourceHierarchyExist();
 		resources = new IResource[] {fakeProject, file};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		file.create(getRandomContents(), false, getMonitor());
+		file.create(getRandomContents(), false, createTestMonitor());
 		resources = new IResource[] {fakeProject};
-		assertTrue(getWorkspace().delete(resources, false, getMonitor()).isOK());
+		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
 		ensureResourceHierarchyExist();
@@ -498,7 +499,7 @@ public class IWorkspaceTest extends ResourceTest {
 
 		/* normal case */
 		IResource[] resources = {file, anotherFile, oneMoreFile};
-		getWorkspace().move(resources, folder.getFullPath(), true, getMonitor());
+		getWorkspace().move(resources, folder.getFullPath(), true, createTestMonitor());
 		assertFalse("1.1", file.exists());
 		assertFalse("1.2", anotherFile.exists());
 		assertFalse("1.3", oneMoreFile.exists());
@@ -508,7 +509,7 @@ public class IWorkspaceTest extends ResourceTest {
 
 		/* test duplicates */
 		resources = new IResource[] {folder.getFile(file.getName()), folder.getFile(anotherFile.getName()), folder.getFile(oneMoreFile.getName()), folder.getFile(oneMoreFile.getName())};
-		IStatus status = getWorkspace().move(resources, project.getFullPath(), true, getMonitor());
+		IStatus status = getWorkspace().move(resources, project.getFullPath(), true, createTestMonitor());
 		assertTrue("2.1", status.isOK());
 		assertTrue("2.3", file.exists());
 		assertTrue("2.4", anotherFile.exists());
@@ -520,7 +521,7 @@ public class IWorkspaceTest extends ResourceTest {
 		/* test no simblings */
 		IResource[] resources2 = new IResource[] { file, anotherFile, oneMoreFile, project };
 		CoreException ex = assertThrows(CoreException.class,
-				() -> getWorkspace().move(resources2, folder.getFullPath(), true, getMonitor()));
+				() -> getWorkspace().move(resources2, folder.getFullPath(), true, createTestMonitor()));
 		assertFalse("3.1", ex.getStatus().isOK());
 		assertEquals("3.2", 1, ex.getStatus().getChildren().length);
 		assertFalse("3.3", file.exists());
@@ -535,7 +536,7 @@ public class IWorkspaceTest extends ResourceTest {
 				folder.getFile(anotherFile.getName()), folder.getFile("inexisting"),
 				folder.getFile(oneMoreFile.getName()) };
 		CoreException ex2 = assertThrows(CoreException.class,
-				() -> getWorkspace().move(resources3, project.getFullPath(), true, getMonitor()));
+				() -> getWorkspace().move(resources3, project.getFullPath(), true, createTestMonitor()));
 		assertFalse("4.1", ex2.getStatus().isOK());
 		assertTrue("4.3", file.exists());
 		assertTrue("4.4", anotherFile.exists());
@@ -569,7 +570,7 @@ public class IWorkspaceTest extends ResourceTest {
 
 		/* normal case */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile};
-		getWorkspace().copy(resources, folder.getFullPath(), true, getMonitor());
+		getWorkspace().copy(resources, folder.getFullPath(), true, createTestMonitor());
 		assertTrue("1.1", file1.exists());
 		assertTrue("1.2", anotherFile.exists());
 		assertTrue("1.3", oneMoreFile.exists());
@@ -585,7 +586,7 @@ public class IWorkspaceTest extends ResourceTest {
 
 		/* test duplicates */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile, file1};
-		getWorkspace().copy(resources, folder.getFullPath(), true, getMonitor());
+		getWorkspace().copy(resources, folder.getFullPath(), true, createTestMonitor());
 		assertTrue("2.2", file1.exists());
 		assertTrue("2.3", anotherFile.exists());
 		assertTrue("2.4", oneMoreFile.exists());
@@ -602,7 +603,7 @@ public class IWorkspaceTest extends ResourceTest {
 		/* test no siblings */
 		IResource[] resources2 = new IResource[] { file1, anotherFile, oneMoreFile, project };
 		CoreException e = assertThrows(CoreException.class,
-				() -> getWorkspace().copy(resources2, folder.getFullPath(), true, getMonitor()));
+				() -> getWorkspace().copy(resources2, folder.getFullPath(), true, createTestMonitor()));
 		IStatus status = e.getStatus();
 		assertFalse("3.1", status.isOK());
 		assertEquals("3.2", 1, status.getChildren().length);
@@ -622,7 +623,7 @@ public class IWorkspaceTest extends ResourceTest {
 		/* inexisting resource */
 		IResource[] resources3 = new IResource[] { file1, anotherFile, project.getFile("inexisting"), oneMoreFile };
 		CoreException ex = assertThrows(CoreException.class,
-				() -> getWorkspace().copy(resources3, folder.getFullPath(), true, getMonitor()));
+				() -> getWorkspace().copy(resources3, folder.getFullPath(), true, createTestMonitor()));
 		status = ex.getStatus();
 		assertFalse("4.1", status.isOK());
 		assertTrue("4.2", file1.exists());
@@ -635,7 +636,7 @@ public class IWorkspaceTest extends ResourceTest {
 		/* copy projects should not be allowed */
 		IResource destination = getWorkspace().getRoot().getProject("destination");
 		CoreException ex2 = assertThrows(CoreException.class,
-				() -> getWorkspace().copy(new IResource[] { project }, destination.getFullPath(), true, getMonitor()));
+				() -> getWorkspace().copy(new IResource[] { project }, destination.getFullPath(), true, createTestMonitor()));
 		status = ex2.getStatus();
 		assertFalse("5.1", status.isOK());
 		assertEquals("5.2", 1, status.getChildren().length);
@@ -651,18 +652,18 @@ public class IWorkspaceTest extends ResourceTest {
 			for (IResource resource : resources) {
 				switch (resource.getType()) {
 					case IResource.FILE :
-						((IFile) resource).create(null, false, getMonitor());
+						((IFile) resource).create(null, false, createTestMonitor());
 						break;
 					case IResource.FOLDER :
-						((IFolder) resource).create(false, true, getMonitor());
+						((IFolder) resource).create(false, true, createTestMonitor());
 						break;
 					case IResource.PROJECT :
-						((IProject) resource).create(getMonitor());
+						((IProject) resource).create(createTestMonitor());
 						break;
 				}
 			}
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 		assertExistsInWorkspace(project);
 		assertExistsInWorkspace(resources);
 	}
@@ -673,7 +674,7 @@ public class IWorkspaceTest extends ResourceTest {
 		ensureExistsInWorkspace(before, true);
 		//
 		assertExistsInWorkspace(before);
-		getWorkspace().delete(before, true, getMonitor());
+		getWorkspace().delete(before, true, createTestMonitor());
 		assertDoesNotExistInWorkspace(before);
 	}
 
@@ -729,7 +730,7 @@ public class IWorkspaceTest extends ResourceTest {
 		TestingSupport.waitForSnapshot();
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		descriptionFile.delete(IResource.NONE, null);
-		IStatus result = getWorkspace().save(true, getMonitor());
+		IStatus result = getWorkspace().save(true, createTestMonitor());
 		assertEquals("1.0", IStatus.WARNING, result.getSeverity());
 	}
 
@@ -1031,7 +1032,7 @@ public class IWorkspaceTest extends ResourceTest {
 			//indirect test: setting the project description may validate location, which shouldn't complain
 			IProjectDescription desc = open.getDescription();
 			desc.setReferencedProjects(new IProject[] {project});
-			open.setDescription(desc, IResource.FORCE, getMonitor());
+			open.setDescription(desc, IResource.FORCE, createTestMonitor());
 
 			assertFalse("9.1", workspace.validateProjectLocation(project, openProjectLocation).isOK());
 			assertFalse("9.2", workspace.validateProjectLocation(project, closedProjectLocation).isOK());
@@ -1044,7 +1045,7 @@ public class IWorkspaceTest extends ResourceTest {
 			linkLocation.toFile().mkdirs();
 			assertTrue("10.1", workspace.validateProjectLocation(open, linkLocation).isOK());
 			IFolder link = open.getFolder("link");
-			link.createLink(linkLocation, IResource.NONE, getMonitor());
+			link.createLink(linkLocation, IResource.NONE, createTestMonitor());
 			assertFalse("10.2", workspace.validateProjectLocation(open, linkLocation).isOK());
 			assertFalse("10.3", workspace.validateProjectLocation(open, linkLocation.append("sub")).isOK());
 
@@ -1060,8 +1061,8 @@ public class IWorkspaceTest extends ResourceTest {
 			Workspace.clear(linkLocation.toFile());
 			//make sure we clean up project directories
 			try {
-				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
-				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
+				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 			} catch (CoreException e) {
 			}
 			ensureDoesNotExistInFileSystem(openProjectLocation.toFile());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -88,10 +89,10 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void testFileLinkedToNonExistent_Deep() throws CoreException {
 		IFile fileLink = existingProject.getFile(getUniqueString());
 		IPath fileLocation = getRandomLocation();
-		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		CoreException exception = assertThrows(CoreException.class, () -> fileLink
-				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, getMonitor()));
+				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, createTestMonitor()));
 		assertEquals("1.2", IResourceStatus.NOT_FOUND_LOCAL, exception.getStatus().getCode());
 
 		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
@@ -101,13 +102,13 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		deleteOnTearDown(fileLocation);
 
 		exception = assertThrows(CoreException.class, () -> fileLink
-				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, getMonitor()));
+				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, createTestMonitor()));
 		assertEquals("2.2", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, false);
 
-		fileLink.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		fileLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("5.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, true);
@@ -116,7 +117,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void testFileLinkedToNonExistent_Shallow() throws CoreException {
 		IFile fileLink = existingProject.getFile(getUniqueString());
 		IPath fileLocation = getRandomLocation();
-		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
@@ -127,7 +128,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 
-		fileLink.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		fileLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("5.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
@@ -136,7 +137,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void testFolderLinkedToNonExistent_Deep() throws CoreException {
 		IFolder folderLink = existingProject.getFolder(getUniqueString());
 		IPath folderLocation = getRandomLocation();
-		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, false);
@@ -147,7 +148,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, true);
 
-		folderLink.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folderLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("5.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, true);
@@ -156,7 +157,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void testFolderLinkedToNonExistent_Shallow() throws CoreException {
 		IFolder folderLink = existingProject.getFolder(getUniqueString());
 		IPath folderLocation = getRandomLocation();
-		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("2.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
@@ -167,7 +168,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
 
-		folderLink.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folderLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("5.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
@@ -179,22 +180,22 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void testMoveFolderWithLinksToNonExisitngLocations_withShallow() throws CoreException {
 		// create a folder
 		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
-		folderWithLinks.create(true, true, getMonitor());
+		folderWithLinks.create(true, true, createTestMonitor());
 
 		// non-exisitng location
 		IPath fileLocation = getRandomLocation();
 
 		// create a linked file in the folder
 		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
-		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// move the folder
 		folderWithLinks.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.SHALLOW,
-				getMonitor());
+				createTestMonitor());
 
 		// move the folder
 		assertThrows(CoreException.class, () -> folderWithLinks
-				.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, getMonitor()));
+				.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should not exist
 		assertFalse("5.0", folderWithLinks.exists());
@@ -207,21 +208,21 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	public void _testCopyFolderWithLinksToNonExisitngLocations_withShallow() throws CoreException {
 		// create a folder
 		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
-		folderWithLinks.create(true, true, getMonitor());
+		folderWithLinks.create(true, true, createTestMonitor());
 
 		// non-exisitng location
 		IPath fileLocation = getRandomLocation();
 
 		// create a linked file in the folder
 		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
-		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// copy the folder
 		folderWithLinks.copy(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.SHALLOW,
-				getMonitor());
+				createTestMonitor());
 
 		assertThrows(CoreException.class, () -> folderWithLinks
-				.copy(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, getMonitor()));
+				.copy(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should exist
 		assertTrue("5.0", folderWithLinks.exists());
@@ -235,7 +236,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IFile fileLinkInFolder = folder.getFile(getUniqueString());
 
 		IPath fileLocation = getRandomLocation();
-		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
@@ -246,7 +247,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, true);
@@ -259,7 +260,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IFile fileLinkInFolder = folder.getFile(getUniqueString());
 
 		IPath fileLocation = getRandomLocation();
-		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
@@ -270,7 +271,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
@@ -283,7 +284,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IFolder folderLinkInFolder = folder.getFolder(getUniqueString());
 
 		IPath folderLocation = getRandomLocation();
-		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
@@ -294,7 +295,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, true);
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, true);
@@ -307,7 +308,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IFolder folderLinkInFolder = folder.getFolder(getUniqueString());
 
 		IPath folderLocation = getRandomLocation();
-		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
@@ -318,7 +319,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
 
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
@@ -335,7 +336,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 
 		URI relativeLocation = existingProject.getPathVariableManager().convertToRelative(URIUtil.toURI(fileLocation),
 				true, ProjectLocationVariableResolver.NAME);
-		fileLink.createLink(relativeLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		fileLink.createLink(relativeLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		IProject destination = getWorkspace().getRoot().getProject("DestProject");
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
@@ -343,7 +344,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(destination);
 		// without the fix, this call will cause an infinite loop in
 		// PathVariableUtil.getUniqueVariableName()
-		existingProject.move(description, IResource.SHALLOW, getMonitor());
+		existingProject.move(description, IResource.SHALLOW, createTestMonitor());
 		IProject destProject = ResourcesPlugin.getWorkspace().getRoot().getProject("DestProject");
 		assertExistsInWorkspace(destProject);
 		assertExistsInWorkspace(destProject.getFile(linkName));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -81,7 +82,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		if (toSetWritable != null) {
 			IFileInfo info = toSetWritable.fetchInfo();
 			info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, false);
-			toSetWritable.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+			toSetWritable.putInfo(info, EFS.SET_ATTRIBUTES, createTestMonitor());
 			toSetWritable = null;
 		}
 		getWorkspace().getPathVariableManager().setValue(VARIABLE_NAME, null);
@@ -244,8 +245,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 
 		//refresh local - should not fail or make the link disappear
-		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		file.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertExistsInWorkspace(file);
 
@@ -299,8 +300,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 
 		// refresh local - should not fail or make the link disappear
-		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		file.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertExistsInWorkspace(file);
 
@@ -475,7 +476,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		IFile newFile = nonExistingFileInOtherExistingProject;
 		// moves the variable - the location will be undefined (null)
-		file.move(newFile.getFullPath(), IResource.SHALLOW, getMonitor());
+		file.move(newFile.getFullPath(), IResource.SHALLOW, createTestMonitor());
 		assertExistsInWorkspace(newFile);
 		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
 		assertTrue("3,3", newFile.getRawLocation().equals(variableBasedLocation));
@@ -510,8 +511,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 
 		// refresh local - should not fail or make the link disappear
-		file.refreshLocal(IResource.DEPTH_ONE, getMonitor());
-		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		file.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());
+		file.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertExistsInWorkspace(file);
 
@@ -556,7 +557,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		childFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
@@ -570,23 +571,23 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(folder);
 
 		//refresh local - should not fail but should cause link's children to disappear
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(folder);
 		assertDoesNotExistInWorkspace(childFile);
 
 		//try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
 		assertThrows(CoreException.class,
-				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
+				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 		assertTrue("3.6", !destination.exists());
 
 		//try to create a sub-file
-		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, createTestMonitor()));
 
 		//try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
-		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, getMonitor()));
+		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, createTestMonitor()));
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
@@ -607,7 +608,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem(childFile);
 
 		// refresh should recreate the child
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(folder);
 		assertExistsInWorkspace(childFile);
 	}
@@ -637,21 +638,21 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// Close the project, and convert line endings
 		IFileStore projFile = projStore.getChild(".project");
-		proj.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
+		proj.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
 		IFileStore projNew = projStore.getChild(".project.new");
-		convertLineEndings(projFile, projNew, getMonitor());
+		convertLineEndings(projFile, projNew, createTestMonitor());
 
 		// Set the project read-only
-		projNew.move(projFile, EFS.OVERWRITE, getMonitor());
-		IFileInfo info = projFile.fetchInfo(EFS.NONE, getMonitor());
+		projNew.move(projFile, EFS.OVERWRITE, createTestMonitor());
+		IFileInfo info = projFile.fetchInfo(EFS.NONE, createTestMonitor());
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-		projFile.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+		projFile.putInfo(info, EFS.SET_ATTRIBUTES, createTestMonitor());
 		toSetWritable = projFile; /* for cleanup */
 
 		// Bug 210664: Open project with wrong line endings and non-existing path
 		// variable
 		proj.create(null);
-		proj.open(IResource.NONE, getMonitor());
+		proj.open(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -672,7 +673,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		childFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		childFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
@@ -687,23 +688,23 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// refresh local - should not fail but should cause link's children to
 		// disappear
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(folder);
 		assertDoesNotExistInWorkspace(childFile);
 
 		// try to copy a file to the folder
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
 		assertThrows(CoreException.class,
-				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
+				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 		assertTrue("3.6", !destination.exists());
 
 		// try to create a sub-file
-		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, createTestMonitor()));
 
 		// try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
-		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, getMonitor()));
+		assertThrows(CoreException.class, () -> subFolder.create(IResource.NONE, true, createTestMonitor()));
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
@@ -724,7 +725,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInFileSystem(childFile);
 
 		// refresh should recreate the child
-		folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(folder);
 		assertExistsInWorkspace(childFile);
 	}
@@ -739,47 +740,47 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IFolder testFolder = existingProject.getFolder("UndefinedVarTest");
 
 		//should fail to create links
-		assertThrows(CoreException.class, () -> testFile.createLink(fileLocation, IResource.NONE, getMonitor()));
-		assertThrows(CoreException.class, () -> testFolder.createLink(folderLocation, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFile.createLink(fileLocation, IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.createLink(folderLocation, IResource.NONE, createTestMonitor()));
 
 		//validate method should return warning
 		assertTrue("1.2", getWorkspace().validateLinkLocation(testFolder, folderLocation).getSeverity() == IStatus.WARNING);
 		assertTrue("1.3", getWorkspace().validateLinkLocation(testFile, fileLocation).getSeverity() == IStatus.WARNING);
 
 		//should succeed with ALLOW_MISSING_LOCAL
-		testFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		testFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		testFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
+		testFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		//copy should fail
 		IPath copyFileDestination = existingProject.getFullPath().append("CopyFileDest");
 		IPath copyFolderDestination = existingProject.getFullPath().append("CopyFolderDest");
 
-		assertThrows(CoreException.class, () -> testFile.copy(copyFileDestination, IResource.NONE, getMonitor()));
-		assertThrows(CoreException.class, () -> testFolder.copy(copyFolderDestination, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFile.copy(copyFileDestination, IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.copy(copyFolderDestination, IResource.NONE, createTestMonitor()));
 
 		//move should fail
 		IPath moveFileDestination = existingProject.getFullPath().append("MoveFileDest");
 		IPath moveFolderDestination = existingProject.getFullPath().append("MoveFolderDest");
 
-		assertThrows(CoreException.class, () -> testFile.move(moveFileDestination, IResource.NONE, getMonitor()));
-		assertThrows(CoreException.class, () -> testFolder.move(moveFolderDestination, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> testFile.move(moveFileDestination, IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> testFolder.move(moveFolderDestination, IResource.NONE, createTestMonitor()));
 
 		//refresh local should succeed
-		testFile.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		testFolder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		testFile.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-		testFolder.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-		existingProject.refreshLocal(IResource.NONE, getMonitor());
+		testFile.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		testFolder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
+		testFile.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
+		testFolder.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
+		existingProject.refreshLocal(IResource.NONE, createTestMonitor());
 
 		//renaming the project shallow is ok
 		IProject project = testFolder.getProject();
 		IProjectDescription desc = project.getDescription();
 		desc.setName("moveDest");
-		project.move(desc, IResource.SHALLOW | IResource.FORCE, getMonitor());
+		project.move(desc, IResource.SHALLOW | IResource.FORCE, createTestMonitor());
 
 		//delete should succeed
-		testFile.delete(IResource.NONE, getMonitor());
-		testFolder.delete(IResource.NONE, getMonitor());
+		testFile.delete(IResource.NONE, createTestMonitor());
+		testFolder.delete(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -799,8 +800,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
 
-		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
+		file.setContents(getContents("contents for a file"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -814,7 +815,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
-				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
+				() -> file.setContents(getContents("new contents"), IResource.NONE, createTestMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
@@ -822,7 +823,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
+		file.setContents(getContents("contents in different location"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem(file);
@@ -864,8 +865,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
 
-		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		file.setContents(getContents("contents for a file"), IResource.FORCE, getMonitor());
+		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
+		file.setContents(getContents("contents for a file"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -879,7 +880,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
-				() -> file.setContents(getContents("new contents"), IResource.NONE, getMonitor()));
+				() -> file.setContents(getContents("new contents"), IResource.NONE, createTestMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
@@ -887,7 +888,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		file.setContents(getContents("contents in different location"), IResource.FORCE, getMonitor());
+		file.setContents(getContents("contents in different location"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem(file);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -162,7 +163,7 @@ public class MarkerTest extends ResourceTest {
 			for (int i = 0; i < hosts.length; i++) {
 				result[i] = hosts[i].createMarker(type);
 			}
-		}, getMonitor());
+		}, createTestMonitor());
 		return result;
 	}
 
@@ -215,7 +216,7 @@ public class MarkerTest extends ResourceTest {
 		IResource child = ((IProject) resource).members()[0];
 		markers[1] = child.createMarker(IMarker.TASK);
 		listener.reset();
-		resource.move(destination, false, getMonitor());
+		resource.move(destination, false, createTestMonitor());
 		IResource destinationResource = getWorkspace().getRoot().findMember(destination);
 		markers[2] = destinationResource.getMarker(markers[0].getId());
 		IResource destinationChild = ((IProject) destinationResource).findMember(child.getName());
@@ -233,7 +234,7 @@ public class MarkerTest extends ResourceTest {
 				.append(resource.getFullPath().lastSegment() + "copy");
 		resource.createMarker(IMarker.BOOKMARK);
 		listener.reset();
-		resource.copy(destination, false, getMonitor());
+		resource.copy(destination, false, createTestMonitor());
 		listener.assertNumberOfAffectedResources(0);
 
 		// delete all markers for a clean run next time
@@ -649,7 +650,7 @@ public class MarkerTest extends ResourceTest {
 		resource.deleteMarkers(null, true, IResource.DEPTH_INFINITE);
 		IMarker marker = resource.createMarker(IMarker.BOOKMARK);
 		listener.reset();
-		resource.delete(true, getMonitor());
+		resource.delete(true, createTestMonitor());
 		assertMarkerDoesNotExist(marker);
 		listener.assertChanges(resource, null, new IMarker[] { marker }, null);
 	}
@@ -671,7 +672,7 @@ public class MarkerTest extends ResourceTest {
 			markers[2].setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
 			markers[2].setAttribute(IMarker.MESSAGE, "Hello");
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 
 		//create the attribute change listener
 		MarkerAttributeChangeListener listener = new MarkerAttributeChangeListener();
@@ -702,7 +703,7 @@ public class MarkerTest extends ResourceTest {
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			markers[1].setAttribute(IMarker.CHAR_START, 5);
 			markers[1].setAttribute(IMarker.CHAR_END, 10);
-		}, getMonitor());
+		}, createTestMonitor());
 		listener.verifyChanges();
 
 		// change+remove same marker
@@ -710,7 +711,7 @@ public class MarkerTest extends ResourceTest {
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			markers[1].setAttribute(IMarker.CHAR_START, 5);
 			markers[1].setAttribute(IMarker.CHAR_START, null);
-		}, getMonitor());
+		}, createTestMonitor());
 		listener.verifyChanges();
 
 		// change multiple markers
@@ -719,7 +720,7 @@ public class MarkerTest extends ResourceTest {
 			markers[0].setAttribute(IMarker.CHAR_START, 5);
 			markers[1].setAttribute(IMarker.CHAR_START, 10);
 			markers[2].setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_LOW);
-		}, getMonitor());
+		}, createTestMonitor());
 		listener.verifyChanges();
 	}
 
@@ -747,7 +748,7 @@ public class MarkerTest extends ResourceTest {
 			};
 			getWorkspace().getRoot().accept(visitor);
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 		listener.reset();
 
 		// copy all non-project resources
@@ -756,7 +757,7 @@ public class MarkerTest extends ResourceTest {
 			IResource[] children = project.members();
 			for (IResource element : children) {
 				IPath destination = IPath.fromOSString(element.getName() + "copy");
-				element.copy(destination, true, getMonitor());
+				element.copy(destination, true, createTestMonitor());
 			}
 		}
 
@@ -780,7 +781,7 @@ public class MarkerTest extends ResourceTest {
 				marker.delete();
 				assertMarkerDoesNotExist(marker);
 			};
-			getWorkspace().run(addAndRemoveOperation, getMonitor());
+			getWorkspace().run(addAndRemoveOperation, createTestMonitor());
 			listener.assertNumberOfAffectedResources(0);
 			listener.assertChanges(resource, null, null, null);
 
@@ -795,7 +796,7 @@ public class MarkerTest extends ResourceTest {
 				addAndChangeMarker.get().setAttribute(IMarker.MESSAGE, "my message text");
 				assertMarkerHasAttributeValue(addAndChangeMarker.get(), IMarker.MESSAGE, "my message text");
 			};
-			getWorkspace().run(addAndChangeOperation, getMonitor());
+			getWorkspace().run(addAndChangeOperation, createTestMonitor());
 			listener.assertNumberOfAffectedResources(1);
 			listener.assertChanges(resource, new IMarker[] { addAndChangeMarker.get() }, null, null);
 
@@ -835,7 +836,7 @@ public class MarkerTest extends ResourceTest {
 				assertMarkerHasAttributeValue(changeAndChangeMarker, IMarker.PRIORITY,
 						IMarker.PRIORITY_HIGH);
 			};
-			getWorkspace().run(changeAndChangeOperation, getMonitor());
+			getWorkspace().run(changeAndChangeOperation, createTestMonitor());
 			listener.assertNumberOfAffectedResources(1);
 			listener.assertChanges(resource, null, null, new IMarker[] { changeAndChangeMarker });
 
@@ -849,7 +850,7 @@ public class MarkerTest extends ResourceTest {
 				changeAndRemoveMarker.delete();
 				assertMarkerDoesNotExist(changeAndRemoveMarker);
 			};
-			getWorkspace().run(changeAndRemoveOperation, getMonitor());
+			getWorkspace().run(changeAndRemoveOperation, createTestMonitor());
 			listener.assertNumberOfAffectedResources(1);
 			listener.assertChanges(resource, null, new IMarker[] { changeAndRemoveMarker }, null);
 
@@ -883,7 +884,7 @@ public class MarkerTest extends ResourceTest {
 		listener = new MarkersChangeListener();
 		setResourceChangeListener(listener);
 		// move the files
-		folder.move(destFolder.getFullPath(), IResource.FORCE, getMonitor());
+		folder.move(destFolder.getFullPath(), IResource.FORCE, createTestMonitor());
 
 		// verify marker deltas
 		listener.assertChanges(folder, null, new IMarker[] { folderMarker }, null);
@@ -921,8 +922,8 @@ public class MarkerTest extends ResourceTest {
 		listener.reset();
 
 		// move the files
-		file.move(destFile.getFullPath(), IResource.FORCE, getMonitor());
-		subFile.move(destSubFile.getFullPath(), IResource.FORCE, getMonitor());
+		file.move(destFile.getFullPath(), IResource.FORCE, createTestMonitor());
+		subFile.move(destSubFile.getFullPath(), IResource.FORCE, createTestMonitor());
 
 		// verify marker deltas
 		listener.assertChanges(file, null, new IMarker[] { fileMarker }, null);
@@ -960,14 +961,14 @@ public class MarkerTest extends ResourceTest {
 			};
 			getWorkspace().getRoot().accept(visitor);
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 		listener.reset();
 
 		// move all resources
 		IProject[] projects = getWorkspace().getRoot().getProjects();
 		for (IProject project : projects) {
 			IPath destination = IPath.fromOSString(project.getName() + "move");
-			project.move(destination, true, getMonitor());
+			project.move(destination, true, createTestMonitor());
 		}
 
 		// verify marker deltas
@@ -1049,7 +1050,7 @@ public class MarkerTest extends ResourceTest {
 						throw new IllegalStateException("failed reading markers", e);
 					}
 				};
-				getWorkspace().run(body, getMonitor());
+				getWorkspace().run(body, createTestMonitor());
 			}
 		}
 
@@ -1137,7 +1138,7 @@ public class MarkerTest extends ResourceTest {
 						throw new IllegalStateException("Failed reading markers", e);
 					}
 				};
-				getWorkspace().run(body, getMonitor());
+				getWorkspace().run(body, createTestMonitor());
 			}
 		}
 
@@ -1166,10 +1167,10 @@ public class MarkerTest extends ResourceTest {
 		IMarker marker = project.createMarker(IMarker.BOOKMARK);
 		assertMarkerExists(marker);
 
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertMarkerDoesNotExist(marker);
 
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		assertMarkerExists(marker);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -40,7 +41,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 	protected IFileStore createFolderStore(String name) throws CoreException {
 		IFileSystem system = getFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
-		store.mkdir(EFS.NONE, getMonitor());
+		store.mkdir(EFS.NONE, createTestMonitor());
 		return store;
 	}
 
@@ -66,21 +67,21 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		//copy to linked destination should succeed
-		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 		//copy to local destination should succeed
-		sourceFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(localFile.getFullPath(), IResource.NONE, createTestMonitor());
 		//copy from local to non local
 		ensureDoesNotExistInWorkspace(destinationFile);
 		//copy from local to non local
-		localFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		localFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//copy to self should fail
-		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
 	public void testCopyFolder() throws CoreException {
@@ -92,23 +93,23 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		parentFolder.create(IResource.NONE, true, getMonitor());
-		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
+		parentFolder.create(IResource.NONE, true, createTestMonitor());
+		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 
 		//shallow copy to destination should succeed
-		source.copy(destination.getFullPath(), IResource.SHALLOW, getMonitor());
+		source.copy(destination.getFullPath(), IResource.SHALLOW, createTestMonitor());
 		assertTrue("1.1", destination.exists());
 
 		//deep copy to destination should succeed
-		destination.delete(IResource.NONE, getMonitor());
-		source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
+		destination.delete(IResource.NONE, createTestMonitor());
+		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("2.1", destination.exists());
 
 		//should fail when destination is occupied
-		assertThrows(CoreException.class, () -> source.copy(destination.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 
 		//copy to self should fail
-		assertThrows(CoreException.class, () -> source.copy(source.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> source.copy(source.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
 	public void testMoveFile() throws CoreException {
@@ -123,24 +124,24 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		//move to linked destination should succeed
-		sourceFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.move(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 		//move back to source location
 		//move to linked destination should succeed
-		destinationFile.move(sourceFile.getFullPath(), IResource.NONE, getMonitor());
+		destinationFile.move(sourceFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//move to local destination should succeed
-		sourceFile.move(localFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.move(localFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//movefrom local to non local
-		localFile.move(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		localFile.move(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//copy to self should fail
-		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
 	// Test for Bug 342060 - Renaming a project failing with custom EFS
@@ -153,20 +154,20 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFile sourceFile = source.getFile("file.txt");
 		//setup initial resources
 		ensureExistsInWorkspace(project, true);
-		source.createLink(sourceStore.toURI(), IResource.NONE, getMonitor());
-		destination.createLink(destinationStore.toURI(), IResource.NONE, getMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, getMonitor());
+		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
+		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
+		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
 
 		//move to linked destination should succeed
-		project.move(IPath.fromPortableString("movedProject"), IResource.NONE, getMonitor());
+		project.move(IPath.fromPortableString("movedProject"), IResource.NONE, createTestMonitor());
 	}
 
 	protected IFileStore createBogusFolderStore(String name) throws CoreException {
 		IFileSystem system = getBogusFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
 		deleteOnTearDown(
-					IPath.fromOSString(system.getStore(IPath.ROOT).toLocalFile(EFS.NONE, getMonitor()).getPath()));
-		store.mkdir(EFS.NONE, getMonitor());
+					IPath.fromOSString(system.getStore(IPath.ROOT).toLocalFile(EFS.NONE, createTestMonitor()).getPath()));
+		store.mkdir(EFS.NONE, createTestMonitor());
 		return store;
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.core.internal.resources.PreferenceInitializer;
@@ -154,7 +155,7 @@ public class ProjectEncodingTest extends ResourceTest {
 		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY, value);
 		node.flush();
 		Job.getJobManager().wakeUp(ValidateProjectEncoding.class);
-		Job.getJobManager().join(ValidateProjectEncoding.class, getMonitor());
+		Job.getJobManager().join(ValidateProjectEncoding.class, createTestMonitor());
 	}
 
 	private void whenProjectIsCreated() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.File;
 import org.eclipse.core.filesystem.EFS;
@@ -159,7 +160,7 @@ public class ResourceAttributeTest extends ResourceTest {
 	public void testClosedProject() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		ensureExistsInWorkspace(project, true);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertNull("1.0", project.getResourceAttributes());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -197,7 +198,7 @@ public abstract class ResourceTest extends CoreTest {
 		final IFileStore[] toDelete = storesToDelete.toArray(new IFileStore[0]);
 		storesToDelete.clear();
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			getWorkspace().getRoot().delete(true, true, getMonitor());
+			getWorkspace().getRoot().delete(true, true, createTestMonitor());
 			//clear stores in workspace runnable to avoid interaction with resource jobs
 			for (IFileStore store : toDelete) {
 				store.delete(EFS.NONE, null);
@@ -252,14 +253,14 @@ public abstract class ResourceTest extends CoreTest {
 		}
 		switch (resource.getType()) {
 			case IResource.FILE :
-				((IFile) resource).create(local ? new ByteArrayInputStream(new byte[0]) : null, true, getMonitor());
+				((IFile) resource).create(local ? new ByteArrayInputStream(new byte[0]) : null, true, createTestMonitor());
 				break;
 			case IResource.FOLDER :
-				((IFolder) resource).create(true, local, getMonitor());
+				((IFolder) resource).create(true, local, createTestMonitor());
 				break;
 			case IResource.PROJECT :
-				((IProject) resource).create(getMonitor());
-				((IProject) resource).open(getMonitor());
+				((IProject) resource).create(createTestMonitor());
+				((IProject) resource).open(createTestMonitor());
 				break;
 		}
 	}
@@ -328,7 +329,7 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public void ensureDoesNotExistInWorkspace(IResource resource) throws CoreException {
 		if (resource.exists()) {
-			resource.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+			resource.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -27,12 +27,17 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
 
 /**
  * Utilities for resource tests.
  */
 public final class ResourceTestUtil {
 	private ResourceTestUtil() {
+	}
+
+	public static IProgressMonitor createTestMonitor() {
+		return new FussyProgressMonitor();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -49,7 +50,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		try {
 			setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 			ensureOutOfSync(subFile);
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
@@ -271,7 +272,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		// copy the project
 		int flags = IResource.FORCE;
-		project.copy(destProject.getFullPath(), flags, getMonitor());
+		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -280,7 +281,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
-		folder.copy(destFolder.getFullPath(), flags, getMonitor());
+		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
@@ -289,7 +290,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		project.copy(destProject.getFullPath(), flags, getMonitor());
+		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -298,7 +299,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		folder.copy(destFolder.getFullPath(), flags, getMonitor());
+		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
@@ -324,7 +325,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		// move the project
 		int flags = IResource.FORCE;
-		project.move(destProject.getFullPath(), flags, getMonitor());
+		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -333,7 +334,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
-		folder.move(destFolder.getFullPath(), flags, getMonitor());
+		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 
@@ -342,7 +343,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(destResources);
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		project.move(destProject.getFullPath(), flags, getMonitor());
+		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		assertExistsInWorkspace(destResources);
 
@@ -351,7 +352,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		ensureExistsInWorkspace(destProject, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		folder.move(destFolder.getFullPath(), flags, getMonitor());
+		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
@@ -368,16 +369,16 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		// default behaviour with no team private members
 		int flags = IResource.ALWAYS_DELETE_PROJECT_CONTENT | IResource.FORCE;
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
-		file.delete(flags, getMonitor());
+		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
@@ -385,12 +386,12 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
@@ -398,18 +399,18 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
-		project.delete(flags, getMonitor());
+		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		file.delete(flags, getMonitor());
+		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
 		ensureExistsInWorkspace(resources, true);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
-		folder.delete(flags, getMonitor());
+		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 	}
@@ -432,7 +433,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
 			ensureDoesNotExistInWorkspace(resources);
@@ -451,7 +452,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
 			ensureDoesNotExistInWorkspace(resources);
 		} finally {
@@ -469,7 +470,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
-			getWorkspace().run(body, getMonitor());
+			getWorkspace().run(body, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
 			ensureDoesNotExistInWorkspace(resources);
 		} finally {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -18,6 +18,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -44,7 +45,7 @@ public class VirtualFolderTest extends ResourceTest {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingVirtualFolderInExistingProject = existingProject.getFolder("existingVirtualFolderInExistingProject");
 		ensureExistsInWorkspace(new IResource[] { existingProject }, true);
-		existingVirtualFolderInExistingProject.create(IResource.VIRTUAL, true, getMonitor());
+		existingVirtualFolderInExistingProject.create(IResource.VIRTUAL, true, createTestMonitor());
 	}
 
 	/**
@@ -53,13 +54,13 @@ public class VirtualFolderTest extends ResourceTest {
 	public void testCreateVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
 
-		virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
+		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 
 		assertTrue("2.0", virtualFolder.exists());
 		assertTrue("3.0", virtualFolder.isVirtual());
 
 		// delete should succeed
-		virtualFolder.delete(IResource.NONE, getMonitor());
+		virtualFolder.delete(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -91,7 +92,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertTrue("3.0", virtualFolder.isVirtual());
 
 		// delete should succeed
-		virtualFolder.delete(IResource.NONE, getMonitor());
+		virtualFolder.delete(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -102,7 +103,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath location = getRandomLocation();
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("2.0", linkedFolder.exists());
 		assertEquals("3.0", location, linkedFolder.getLocation());
@@ -112,7 +113,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertEquals("5.0", 0, linkedFolder.members().length);
 
 		// delete should succeed
-		linkedFolder.delete(IResource.NONE, getMonitor());
+		linkedFolder.delete(IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -123,14 +124,14 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath location = getRandomLocation();
 		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
 
-		file.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		file.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("2.0", file.exists());
 		assertEquals("3.0", location, file.getLocation());
 		assertTrue("4.0", !location.toFile().exists());
 
 		// delete should succeed
-		file.delete(IResource.NONE, getMonitor());
+		file.delete(IResource.NONE, createTestMonitor());
 	}
 
 	public void testCopyProjectWithVirtualFolder() throws CoreException {
@@ -145,12 +146,12 @@ public class VirtualFolderTest extends ResourceTest {
 		createFileInFileSystem(fileLocation, getRandomContents());
 		folderLocation.toFile().mkdir();
 
-		linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-		linkedFile.createLink(fileLocation, IResource.NONE, getMonitor());
+		linkedFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
+		linkedFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
 		// copy the project
 		IProject destinationProject = getWorkspace().getRoot().getProject("CopyTargetProject");
-		existingProject.copy(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
+		existingProject.copy(destinationProject.getFullPath(), IResource.SHALLOW, createTestMonitor());
 
 		IFile newFile = destinationProject.getFile(linkedFile.getProjectRelativePath());
 		assertTrue("3.0", newFile.isLinked());
@@ -163,8 +164,8 @@ public class VirtualFolderTest extends ResourceTest {
 		assertTrue("4.2", newFolder.getParent().isVirtual());
 
 		// test project deep copy
-		destinationProject.delete(IResource.NONE, getMonitor());
-		existingProject.copy(destinationProject.getFullPath(), IResource.NONE, getMonitor());
+		destinationProject.delete(IResource.NONE, createTestMonitor());
+		existingProject.copy(destinationProject.getFullPath(), IResource.NONE, createTestMonitor());
 
 		assertTrue("5.1", newFile.isLinked());
 		assertEquals("5.2", linkedFile.getLocation(), newFile.getLocation());
@@ -173,7 +174,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertEquals("5.5", linkedFolder.getLocation(), newFolder.getLocation());
 		assertTrue("5.6", newFolder.getParent().isVirtual());
 
-		destinationProject.delete(IResource.NONE, getMonitor());
+		destinationProject.delete(IResource.NONE, createTestMonitor());
 	}
 
 	public void testMoveProjectWithVirtualFolder() throws CoreException {
@@ -192,16 +193,16 @@ public class VirtualFolderTest extends ResourceTest {
 		createFileInFileSystem(fileLocation);
 		folderLocation.toFile().mkdir();
 
-		folder.createLink(folderLocation, IResource.NONE, getMonitor());
-		file.createLink(fileLocation, IResource.NONE, getMonitor());
+		folder.createLink(folderLocation, IResource.NONE, createTestMonitor());
+		file.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
-		childFile.create(getRandomContents(), true, getMonitor());
+		childFile.create(getRandomContents(), true, createTestMonitor());
 
 		// move the project
 		IProject destinationProject = getWorkspace().getRoot().getProject("MoveTargetProject");
 		assertDoesNotExistInWorkspace(destinationProject);
 
-		existingProject.move(destinationProject.getFullPath(), IResource.SHALLOW, getMonitor());
+		existingProject.move(destinationProject.getFullPath(), IResource.SHALLOW, createTestMonitor());
 
 		IFile newFile = destinationProject.getFile(file.getProjectRelativePath());
 		IFolder newFolder = destinationProject.getFolder(folder.getProjectRelativePath());
@@ -224,13 +225,13 @@ public class VirtualFolderTest extends ResourceTest {
 		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
 
 		virtualFolder.create(IResource.VIRTUAL, true, null);
-		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
-		existingProject.create(getMonitor());
+		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
+		existingProject.create(createTestMonitor());
 
 		// virtual folder should not exist until the project is open
 		assertTrue("2.0", !virtualFolder.exists());
 
-		existingProject.open(getMonitor());
+		existingProject.open(createTestMonitor());
 
 		// virtual folder should now exist
 		assertTrue("4.0", virtualFolder.exists());
@@ -246,15 +247,15 @@ public class VirtualFolderTest extends ResourceTest {
 
 		folderLocation.toFile().mkdir();
 		virtualFolder.create(IResource.VIRTUAL, true, null);
-		linkedFolder.createLink(folderLocation, IResource.NONE, getMonitor());
-		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, getMonitor());
-		existingProject.create(getMonitor());
+		linkedFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
+		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
+		existingProject.create(createTestMonitor());
 
 		// virtual folder should not exist until the project is open
 		assertTrue("2.0", !virtualFolder.exists());
 		assertTrue("3.0", !linkedFolder.exists());
 
-		existingProject.open(getMonitor());
+		existingProject.open(createTestMonitor());
 
 		// virtual folder should now exist
 		assertTrue("5.0", virtualFolder.exists());
@@ -271,7 +272,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath folderLocation = getRandomLocation();
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
 
-		folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		assertTrue("2.0", folder.exists());
 		assertEquals("3.0", folderLocation, folder.getLocation());
@@ -309,8 +310,8 @@ public class VirtualFolderTest extends ResourceTest {
 
 		// create the structure in the workspace
 		ensureExistsInWorkspace(topFolder, true);
-		linkedFolder.createLink(linkedFolderLocation, IResource.NONE, getMonitor());
-		virtualFolder.create(IResource.VIRTUAL, true, getMonitor());
+		linkedFolder.createLink(linkedFolderLocation, IResource.NONE, createTestMonitor());
+		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 
 		// assert locations
 		assertEquals("2.0", linkedFolderLocation, linkedFolder.getLocation());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IMarker;
@@ -168,7 +169,7 @@ public class BenchWorkspace extends ResourceTest {
 				}
 			}.run(BenchWorkspace.this, 10, 10);
 		};
-		workspace.run(runnable, getMonitor());
+		workspace.run(runnable, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
 import org.eclipse.core.resources.ICommand;
@@ -47,10 +48,10 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 			desc.setBuildSpec(new ICommand[] { createCommand(desc, "Builder1"), createCommand(desc, "Builder2"),
 					createCommand(desc, "Builder3"), createCommand(desc, "Builder4"),
 					createCommand(desc, "Builder5") });
-			project.create(desc, getMonitor());
-			project.open(getMonitor());
+			project.create(desc, createTestMonitor());
+			project.open(createTestMonitor());
 			createFolder(folder, totalResources);
-		}, getMonitor());
+		}, createTestMonitor());
 	}
 
 	/**
@@ -108,7 +109,7 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 				try {
 					for (int repeats = 0; repeats < REPEAT; repeats++) {
 						for (IProject project : projects) {
-							project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+							project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 						}
 					}
 				} catch (CoreException e) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
@@ -13,8 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.util.Set;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.tests.harness.CoreTest;
@@ -61,14 +67,14 @@ public class ContentDescriptionPerformanceTest extends ResourceTest {
 		// create a project with thousands of files
 		IProject bigProject = ResourcesPlugin.getWorkspace().getRoot().getProject("bigproject");
 		assertTrue("1.0", !bigProject.exists());
-		bigProject.create(getMonitor());
-		bigProject.open(getMonitor());
+		bigProject.create(createTestMonitor());
+		bigProject.open(createTestMonitor());
 		for (int i = 0; i < SUBDIRS; i++) {
 			IFolder folder = bigProject.getFolder("folder_" + i);
-			folder.create(false, true, getMonitor());
+			folder.create(false, true, createTestMonitor());
 			for (int j = 0; j < TOTAL_FILES / SUBDIRS; j++) {
 				IFile file = folder.getFile("file_" + j + getFileName(j));
-				file.create(getContents(getContents(j)), false, getMonitor());
+				file.create(getContents(getContents(j)), false, createTestMonitor());
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
@@ -38,7 +39,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
 public class LocalHistoryPerformanceTest extends ResourceTest {
 
 	void cleanHistory() {
-		((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore().clean(getMonitor());
+		((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore().clean(createTestMonitor());
 	}
 
 	/**
@@ -61,14 +62,14 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 						ensureExistsInWorkspace(file, getRandomContents());
 						try {
 							for (int k = 0; k < statesPerFile; k++) {
-								file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+								file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 							}
 						} catch (CoreException ce) {
 							fail("0.5", ce);
 						}
 					}
 				}
-			}, workspace.getRuleFactory().modifyRule(workspace.getRoot()), IWorkspace.AVOID_UPDATE, getMonitor());
+			}, workspace.getRuleFactory().modifyRule(workspace.getRoot()), IWorkspace.AVOID_UPDATE, createTestMonitor());
 		} catch (CoreException e) {
 			fail("#createTree at : " + base.getFullPath(), e);
 		}
@@ -85,7 +86,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		HistoryStoreTest.wipeHistoryStore(getMonitor());
+		HistoryStoreTest.wipeHistoryStore(createTestMonitor());
 	}
 
 	public void testAddState() throws CoreException {
@@ -101,8 +102,8 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void tearDown() {
 				try {
-					file.clearHistory(getMonitor());
-					file.delete(IResource.FORCE, getMonitor());
+					file.clearHistory(createTestMonitor());
+					file.delete(IResource.FORCE, createTestMonitor());
 				} catch (CoreException e) {
 					fail("1.0", e);
 				}
@@ -111,7 +112,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+					file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 				} catch (CoreException e) {
 					fail("", e);
 				}
@@ -132,10 +133,10 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			protected void setUp() throws CoreException {
 				ensureExistsInWorkspace(new IResource[] {project, folder1, folder2}, true);
 				try {
-					file1.create(getRandomContents(), IResource.FORCE, getMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+					file1.create(getRandomContents(), IResource.FORCE, createTestMonitor());
+					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 				} catch (CoreException e) {
 					fail("0.0", e);
 				}
@@ -148,7 +149,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 					IHistoryStore store = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 					// Remove all the entries from the history store index.  Note that
 					// this does not cause the history store states to be removed.
-					store.remove(IPath.ROOT, getMonitor());
+					store.remove(IPath.ROOT, createTestMonitor());
 					// Now make sure all the states are really removed.
 					store.removeGarbage();
 				} catch (Exception e) {
@@ -159,8 +160,8 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					file1.move(file2.getFullPath(), true, true, getMonitor());
-					file2.move(file1.getFullPath(), true, true, getMonitor());
+					file1.move(file2.getFullPath(), true, true, createTestMonitor());
+					file2.move(file1.getFullPath(), true, true, createTestMonitor());
 				} catch (CoreException e) {
 					fail("1.0", e);
 				}
@@ -195,7 +196,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					base.clearHistory(getMonitor());
+					base.clearHistory(createTestMonitor());
 				} catch (CoreException e) {
 					fail("", e);
 				}
@@ -227,7 +228,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				try {
 					String newProjectName = getUniqueString();
 					IProject newProject = getWorkspace().getRoot().getProject(newProjectName);
-					tmpProject[0].copy(newProject.getFullPath(), true, getMonitor());
+					tmpProject[0].copy(newProject.getFullPath(), true, createTestMonitor());
 					tmpProject[0] = newProject;
 				} catch (CoreException e) {
 					fail("", e);
@@ -259,7 +260,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					tmpProject.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+					tmpProject.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 				} catch (CoreException e) {
 					fail("", e);
 				}
@@ -284,13 +285,13 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		final IFile file = project.getFile("file.txt");
 		ensureExistsInWorkspace(file, getRandomContents());
 		for (int i = 0; i < 100; i++) {
-			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 		}
 		new PerformanceTestRunner() {
 			@Override
 			protected void test() {
 				try {
-					file.getHistory(getMonitor());
+					file.getHistory(createTestMonitor());
 				} catch (CoreException e) {
 					fail("", e);
 				}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -48,7 +49,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 	IFolder copyFolder() {
 		IFolder destination = testProject.getFolder("CopyDestination");
 		try {
-			testFolder.copy(destination.getFullPath(), IResource.NONE, getMonitor());
+			testFolder.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		} catch (CoreException e) {
 			fail("Failed to copy project in performance test", e);
 		}
@@ -61,10 +62,10 @@ public class WorkspacePerformanceTest extends ResourceTest {
 	void createAndPopulateProject(final int totalResources) {
 		try {
 			getWorkspace().run((IWorkspaceRunnable) monitor -> {
-				testProject.create(getMonitor());
-				testProject.open(getMonitor());
+				testProject.create(createTestMonitor());
+				testProject.open(createTestMonitor());
 				createFolder(testFolder, totalResources);
-			}, getMonitor());
+			}, createTestMonitor());
 		} catch (CoreException e) {
 			fail("Failed to create project in performance test", e);
 		}
@@ -80,7 +81,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 	 * Creates and returns a folder with lots of contents
 	 */
 	IFolder createFolder(IFolder topFolder, int totalResources) throws CoreException {
-		topFolder.create(IResource.NONE, true, getMonitor());
+		topFolder.create(IResource.NONE, true, createTestMonitor());
 		//tree depth is log of total resource count with the width as the log base
 		int depth = (int) (Math.log(totalResources) / Math.log(TREE_WIDTH));
 		recursiveCreateChildren(topFolder, depth - 1);
@@ -112,7 +113,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 	IFolder moveFolder() {
 		IFolder destination = testFolder.getProject().getFolder("MoveDestination");
 		try {
-			testFolder.move(destination.getFullPath(), IResource.NONE, getMonitor());
+			testFolder.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		} catch (CoreException e) {
 			fail("Failed to move folder during performance test", e);
 		}
@@ -126,7 +127,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 		//create TREE_WIDTH files
 		for (int i = 0; i < TREE_WIDTH; i++) {
 			IFile file = parentFolder.getFile(createString(10));
-			file.create(new ByteArrayInputStream(createBytes(5000)), IResource.NONE, getMonitor());
+			file.create(new ByteArrayInputStream(createBytes(5000)), IResource.NONE, createTestMonitor());
 		}
 		if (depth <= 0) {
 			return;
@@ -134,7 +135,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 		//create TREE_WIDTH folders
 		for (int i = 0; i < TREE_WIDTH; i++) {
 			IFolder folder = parentFolder.getFolder(createString(6));
-			folder.create(IResource.NONE, true, getMonitor());
+			folder.create(IResource.NONE, true, createTestMonitor());
 			recursiveCreateChildren(folder, depth - 1);
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.refresh;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.emptyArray;
@@ -75,10 +76,10 @@ public class RefreshProviderTest extends ResourceTest {
 		// ensure we currently have just the project being monitored
 		TestRefreshProvider provider = TestRefreshProvider.getInstance();
 		assertEquals("1.0", 1, provider.getMonitoredResources().length);
-		link.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		link.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.1", 2, provider.getMonitoredResources().length);
-		link.delete(IResource.FORCE, getMonitor());
+		link.delete(IResource.FORCE, createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.2", 1, provider.getMonitoredResources().length);
 		ensureDoesNotExistInWorkspace(project);
@@ -101,10 +102,10 @@ public class RefreshProviderTest extends ResourceTest {
 		// ensure we currently have just the project being monitored
 		TestRefreshProvider provider = TestRefreshProvider.getInstance();
 		assertEquals("1.0", 1, provider.getMonitoredResources().length);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.1", 0, provider.getMonitoredResources().length);
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.2", 1, provider.getMonitoredResources().length);
 		ensureDoesNotExistInWorkspace(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -53,7 +54,7 @@ public class Bug_025457 extends ResourceTest {
 		try (InputStream stream = sourceFile.getContents()) {
 			//try to rename the file (should fail)
 			assertThrows(CoreException.class,
-					() -> sourceFile.move(destFile.getFullPath(), IResource.NONE, getMonitor()));
+					() -> sourceFile.move(destFile.getFullPath(), IResource.NONE, createTestMonitor()));
 		}
 		//ensure source still exists and has same content
 		assertTrue("2.0", source.exists());
@@ -84,7 +85,7 @@ public class Bug_025457 extends ResourceTest {
 		try (InputStream stream = sourceFile.getContents()) {
 			//try to rename the project (should fail)
 			assertThrows(CoreException.class,
-					() -> sourceFolder.move(destFolder.getFullPath(), IResource.NONE, getMonitor()));
+					() -> sourceFolder.move(destFolder.getFullPath(), IResource.NONE, createTestMonitor()));
 			//ensure source still exists
 			assertTrue("2.0", source.exists());
 			assertTrue("2.1", sourceFolder.exists());
@@ -112,7 +113,7 @@ public class Bug_025457 extends ResourceTest {
 		try (InputStream stream = sourceFile.getContents()) {
 			//try to rename the project (should fail)
 			assertThrows(CoreException.class,
-					() -> source.move(destination.getFullPath(), IResource.NONE, getMonitor()));
+					() -> source.move(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 
 			//ensure source does not exist
 			assertTrue("2.0", !source.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -70,7 +71,7 @@ public class Bug_026294 extends ResourceTest {
 			assertTrue("1.2", projectFile.exists());
 			assertTrue("1.3", projectFile.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertThrows(CoreException.class, () -> project.delete(IResource.FORCE, getMonitor()));
+			assertThrows(CoreException.class, () -> project.delete(IResource.FORCE, createTestMonitor()));
 
 			// Delete is best-case so check all the files.
 			// Do a check on disk and in the workspace in case something is out of sync.
@@ -102,7 +103,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
-		project.delete(IResource.FORCE, getMonitor());
+		project.delete(IResource.FORCE, createTestMonitor());
 		assertTrue("5.1", !project.exists());
 		assertTrue("5.2", !file1.exists());
 		assertTrue("5.3", file1.isSynchronized(IResource.DEPTH_INFINITE));
@@ -137,7 +138,7 @@ public class Bug_026294 extends ResourceTest {
 			assertTrue("1.2", projectFile.exists());
 			assertTrue("1.3", projectFile.isSynchronized(IResource.DEPTH_INFINITE));
 
-			assertThrows(CoreException.class, () -> project.delete(IResource.FORCE, getMonitor()));
+			assertThrows(CoreException.class, () -> project.delete(IResource.FORCE, createTestMonitor()));
 			assertTrue("2.1", project.exists());
 			assertTrue("2.2", file1.exists());
 			assertTrue("2.3", !file2.exists());
@@ -151,7 +152,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
-		project.delete(IResource.FORCE, getMonitor());
+		project.delete(IResource.FORCE, createTestMonitor());
 		assertTrue("5.1", !project.exists());
 		assertTrue("5.2", !file1.exists());
 		assertTrue("5.3", file1.isSynchronized(IResource.DEPTH_INFINITE));
@@ -182,16 +183,16 @@ public class Bug_026294 extends ResourceTest {
 
 		// opens a file so it cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 			assertThrows(CoreException.class,
-					() -> project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor()));
+					() -> project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor()));
 			assertTrue("2.1", project.exists());
 			assertTrue("2.7", project.isSynchronized(IResource.DEPTH_INFINITE));
 			assertExistsInFileSystem(projectFile);
 
 		}
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
-		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		assertTrue("5.1", !project.exists());
 		assertTrue("5.3", project.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("6.0", !projectRoot.toFile().exists());
@@ -224,22 +225,22 @@ public class Bug_026294 extends ResourceTest {
 			// marks folder as read-only so its files cannot be removed on Linux
 			setReadOnly(folder, true);
 
-			project.close(getMonitor());
+			project.close(createTestMonitor());
 			assertThrows(CoreException.class,
-					() -> project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor()));
+					() -> project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor()));
 
 			assertTrue("3.0", project.exists());
 			assertTrue("3.1", project.isSynchronized(IResource.DEPTH_INFINITE));
 			assertExistsInFileSystem(projectFile);
 
-			project.open(getMonitor());
+			project.open(createTestMonitor());
 		} finally {
 			if (folder.exists()) {
 				setReadOnly(folder, false);
 			}
 		}
 
-		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, getMonitor());
+		project.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		assertTrue("6.0", !project.exists());
 		assertTrue("6.1", project.isSynchronized(IResource.DEPTH_INFINITE));
 		assertTrue("6.2", !projectRoot.toFile().exists());
@@ -267,7 +268,7 @@ public class Bug_026294 extends ResourceTest {
 
 		// opens a file so it cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
-			assertThrows(CoreException.class, () -> folder.delete(IResource.FORCE, getMonitor()));
+			assertThrows(CoreException.class, () -> folder.delete(IResource.FORCE, createTestMonitor()));
 			assertTrue("2.2", file1.exists());
 			assertTrue("2.4", !file3.exists());
 			assertTrue("2.5", folder.exists());
@@ -275,7 +276,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
-		folder.delete(IResource.FORCE, getMonitor());
+		folder.delete(IResource.FORCE, createTestMonitor());
 		assertTrue("5.1", !file1.exists());
 		assertTrue("5.2", !folder.exists());
 		assertTrue("5.3", file1.isSynchronized(IResource.DEPTH_INFINITE));
@@ -306,7 +307,7 @@ public class Bug_026294 extends ResourceTest {
 			// marks sub-folder as read-only so its files cannot be removed on Linux
 			setReadOnly(subFolder, true);
 
-			assertThrows(CoreException.class, () -> folder.delete(IResource.FORCE, getMonitor()));
+			assertThrows(CoreException.class, () -> folder.delete(IResource.FORCE, createTestMonitor()));
 			assertTrue("2.2", file1.exists());
 			assertTrue("2.3", subFolder.exists());
 			assertTrue("2.4", !file3.exists());
@@ -319,7 +320,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		assertTrue("3.5", project.isSynchronized(IResource.DEPTH_INFINITE));
-		folder.delete(IResource.FORCE, getMonitor());
+		folder.delete(IResource.FORCE, createTestMonitor());
 		assertTrue("5.1", !file1.exists());
 		assertTrue("5.2", !subFolder.exists());
 		assertTrue("5.3", !folder.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029116.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029116.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_29116;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -30,13 +31,13 @@ public class Bug_029116 extends ResourceTest {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");
 		// Create and open a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_29116 });
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -50,7 +51,7 @@ public class Bug_029671 extends ResourceTest {
 			IFolder targetFolder = project.getFolder("target");
 			IFile targetFile = targetFolder.getFile(file.getName());
 
-			folder.move(targetFolder.getFullPath(), false, false, getMonitor());
+			folder.move(targetFolder.getFullPath(), false, false, createTestMonitor());
 			assertTrue("3.0", folder.isPhantom());
 			assertTrue("4.0", file.isPhantom());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -63,7 +64,7 @@ public class Bug_032076 extends ResourceTest {
 		// opens the file so it cannot be removed on Windows
 		try (InputStream input = sourceFile.getContents()) {
 			assertThrows(CoreException.class,
-					() -> sourceFile.move(destinationFile.getFullPath(), IResource.FORCE, getMonitor()));
+					() -> sourceFile.move(destinationFile.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 			// the source parent is in sync
 			assertTrue("3.0", sourceParent.isSynchronized(IResource.DEPTH_INFINITE));
@@ -83,7 +84,7 @@ public class Bug_032076 extends ResourceTest {
 			assertTrue("4.2", sourceFile.isSynchronized(IResource.DEPTH_ZERO));
 
 			// refresh the source parent
-			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 			// file is still found in source tree
 			assertTrue("4.7", sourceFile.exists());
@@ -120,7 +121,7 @@ public class Bug_032076 extends ResourceTest {
 		// opens a file so it (and its parent) cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
 			assertThrows(CoreException.class,
-					() -> folder.move(destinationFolder.getFullPath(), IResource.FORCE, getMonitor()));
+					() -> folder.move(destinationFolder.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 			// the source parent is in sync
 			assertTrue("3.0", sourceParent.isSynchronized(IResource.DEPTH_INFINITE));
@@ -144,7 +145,7 @@ public class Bug_032076 extends ResourceTest {
 			assertTrue("4.3", !file2.exists());
 
 			// refresh the source parent
-			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 			// non-removable resources still in source tree
 			assertTrue("4.6", folder.exists());
@@ -181,7 +182,7 @@ public class Bug_032076 extends ResourceTest {
 		try (InputStream input = file1.getContents()) {
 
 			assertThrows(CoreException.class,
-					() -> sourceProject.move(destinationProject.getFullPath(), IResource.FORCE, getMonitor()));
+					() -> sourceProject.move(destinationProject.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 			// the source does not exist
 			assertTrue("3.0", !sourceProject.exists());
@@ -236,7 +237,7 @@ public class Bug_032076 extends ResourceTest {
 			// mark sub-folder as read-only so its immediate children cannot be removed on Linux
 			setReadOnly(roFolder, true);
 			assertThrows(CoreException.class,
-					() -> sourceFile.move(destinationFile.getFullPath(), IResource.FORCE, getMonitor()));
+					() -> sourceFile.move(destinationFile.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 			// the source parent is out-of-sync
 			assertTrue("3.0", !sourceParent.isSynchronized(IResource.DEPTH_INFINITE));
@@ -255,7 +256,7 @@ public class Bug_032076 extends ResourceTest {
 			assertTrue("4.1", !sourceFile.exists());
 
 			// refresh the source parent
-			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 			// non-removable file now reappear in the resource tree
 			assertTrue("4.7", sourceFile.exists());
@@ -301,7 +302,7 @@ public class Bug_032076 extends ResourceTest {
 			setReadOnly(roFolder, true);
 
 			assertThrows(CoreException.class, () -> roFolder
-					.move(destinationParent.getFullPath().append(roFolder.getName()), IResource.FORCE, getMonitor()));
+					.move(destinationParent.getFullPath().append(roFolder.getName()), IResource.FORCE, createTestMonitor()));
 
 			// the source parent is out-of-sync
 			assertTrue("3.0", !sourceParent.isSynchronized(IResource.DEPTH_INFINITE));
@@ -329,7 +330,7 @@ public class Bug_032076 extends ResourceTest {
 			assertTrue("4.3", !file2.exists());
 
 			// refresh the source parent
-			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			sourceParent.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 			// non-removed resources now reappear in the resource tree
 			assertTrue("4.5", roFolder.exists());
@@ -361,8 +362,8 @@ public class Bug_032076 extends ResourceTest {
 		IProjectDescription destinationDescription = workspace.newProjectDescription(destinationProject.getName());
 
 		// create and open the source project at a non-default location
-		sourceProject.create(sourceDescription, getMonitor());
-		sourceProject.open(getMonitor());
+		sourceProject.create(sourceDescription, createTestMonitor());
+		sourceProject.open(createTestMonitor());
 		deleteOnTearDown(sourceProject.getLocation());
 
 		IFile file1 = sourceProject.getFile("file1.txt");
@@ -382,7 +383,7 @@ public class Bug_032076 extends ResourceTest {
 			setReadOnly(projectParentStore, true);
 
 			assertThrows(CoreException.class,
-					() -> sourceProject.move(destinationDescription, IResource.FORCE, getMonitor()));
+					() -> sourceProject.move(destinationDescription, IResource.FORCE, createTestMonitor()));
 			deleteOnTearDown(destinationProject.getLocation());
 
 			// the source does not exist

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
@@ -64,11 +65,11 @@ public class Bug_044106 extends ResourceTest {
 		assertExistsInFileSystem(linkedFile);
 
 		// do a refresh and ensure that the resources are in the workspace
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(linkedFile);
 
 		// delete the file
-		linkedFile.delete(deleteFlags, getMonitor());
+		linkedFile.delete(deleteFlags, createTestMonitor());
 
 		// ensure that the folder and file weren't deleted in the filesystem
 		assertDoesNotExistInWorkspace(linkedFile);
@@ -103,15 +104,15 @@ public class Bug_044106 extends ResourceTest {
 		assertExistsInFileSystem(linkedFile);
 
 		// do a refresh and ensure that the resources are in the workspace
-		linkedFolder.getProject().refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		linkedFolder.getProject().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInWorkspace(linkedFolder);
 		assertExistsInWorkspace(linkedFile);
 
 		// delete the folder or project
 		if (deleteParent) {
-			linkedFolder.getParent().delete(deleteFlags, getMonitor());
+			linkedFolder.getParent().delete(deleteFlags, createTestMonitor());
 		} else {
-			linkedFolder.delete(deleteFlags, getMonitor());
+			linkedFolder.delete(deleteFlags, createTestMonitor());
 		}
 
 		// ensure that the folder and file weren't deleted in the filesystem

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
@@ -48,39 +49,39 @@ public class Bug_079398 extends ResourceTest {
 		getWorkspace().setDescription(description);
 		ensureExistsInWorkspace(file1, getRandomContents());
 		for (int i = 0; i < 10; i++) {
-			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}
 
-		IFileState[] sourceStates = file1.getHistory(getMonitor());
+		IFileState[] sourceStates = file1.getHistory(createTestMonitor());
 		// just make sure our assumptions are valid
 		assertEquals("0.4", 10, sourceStates.length);
 
 		// copy the file - the history should be shared, but the destination
 		// will conform to the policy
-		file1.copy(file2.getFullPath(), true, getMonitor());
+		file1.copy(file2.getFullPath(), true, createTestMonitor());
 
 		assertExistsInWorkspace(file2);
-		sourceStates = file1.getHistory(getMonitor());
+		sourceStates = file1.getHistory(createTestMonitor());
 		// the source is unaffected so far
 		assertEquals("1.2", 10, sourceStates.length);
-		IFileState[] destinationStates = file2.getHistory(getMonitor());
+		IFileState[] destinationStates = file2.getHistory(createTestMonitor());
 		// but the destination conforms to the policy
 		assertEquals("1.4", description.getMaxFileStates(), destinationStates.length);
 
 		// now cause the destination to have many more states
 		for (int i = 0; i <= description.getMaxFileStates(); i++) {
-			file2.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, getMonitor());
+			file2.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}
 		IHistoryStore history = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 		// clean history
-		history.clean(getMonitor());
+		history.clean(createTestMonitor());
 
-		destinationStates = file2.getHistory(getMonitor());
+		destinationStates = file2.getHistory(createTestMonitor());
 		// cleaning will remove any states the destination had in common
 		// with the source since they don't fit into the policy
 		assertEquals("1.7", description.getMaxFileStates(), destinationStates.length);
 
-		sourceStates = file1.getHistory(getMonitor());
+		sourceStates = file1.getHistory(createTestMonitor());
 		// the source should have any extra states removed as well,
 		// but the ones left should still exist
 		assertEquals("1.7", description.getMaxFileStates(), sourceStates.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IProject;
@@ -32,7 +33,7 @@ public class Bug_098740 extends ResourceTest {
 	public void testBug() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Bug98740");
 		ensureExistsInWorkspace(project, true);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertThrows(CoreException.class, () -> project.members());
 		IResourceVisitor visitor = resource -> true;
 		assertThrows(CoreException.class, () -> project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -35,15 +36,15 @@ public class Bug_126104 extends ResourceTest {
 		ensureExistsInWorkspace(source, true);
 		IFolder link = project.getFolder("link");
 		IFileStore location = getTempStore();
-		link.createLink(location.toURI(), IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		link.createLink(location.toURI(), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		IFile destination = link.getFile(source.getName());
-		source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
+		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("1.0", destination.exists());
 
 		//try the same thing with move
 		ensureDoesNotExistInWorkspace(destination);
-		location.delete(EFS.NONE, getMonitor());
-		source.move(destination.getFullPath(), IResource.NONE, getMonitor());
+		location.delete(EFS.NONE, createTestMonitor());
+		source.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("3.0", !source.exists());
 		assertTrue("3.1", destination.exists());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -33,7 +34,7 @@ public class Bug_127562 extends ResourceTest {
 		ensureExistsInWorkspace(project, true);
 		IProjectDescription description = project.getDescription();
 		description.setComment("Foo");
-		getWorkspace().run((IWorkspaceRunnable) monitor -> project.setDescription(description, getMonitor()),
-				getWorkspace().getRoot(), IResource.NONE, getMonitor());
+		getWorkspace().run((IWorkspaceRunnable) monitor -> project.setDescription(description, createTestMonitor()),
+				getWorkspace().getRoot(), IResource.NONE, createTestMonitor());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -73,8 +74,8 @@ public class Bug_147232 extends AbstractBuilderTest implements IResourceChangeLi
 		file = project.getFile("file.txt");
 		getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE | IResourceChangeEvent.PRE_BUILD | IResourceChangeEvent.POST_BUILD);
 		setAutoBuilding(false);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		addBuilder(project, ClearMarkersBuilder.BUILDER_NAME);
 		setAutoBuilding(true);
 		//create a file in the project to trigger a build

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -46,7 +47,7 @@ public class Bug_160251 extends ResourceTest {
 		//move the project (should succeed)
 		IProjectDescription description = source.getDescription();
 		description.setLocationURI(destination.toURI());
-		source.move(description, IResource.NONE, getMonitor());
+		source.move(description, IResource.NONE, createTestMonitor());
 
 		//ensure project still exists
 		assertTrue("2.0", source.exists());
@@ -66,12 +67,12 @@ public class Bug_160251 extends ResourceTest {
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
 		ensureExistsInWorkspace(source, true);
 		ensureExistsInWorkspace(sourceFile, true);
-		destination.mkdir(EFS.NONE, getMonitor());
+		destination.mkdir(EFS.NONE, createTestMonitor());
 
 		//move the project (should succeed)
 		IProjectDescription description = source.getDescription();
 		description.setLocationURI(destination.toURI());
-		source.move(description, IResource.NONE, getMonitor());
+		source.move(description, IResource.NONE, createTestMonitor());
 
 		//ensure project still exists
 		assertTrue("2.0", source.exists());
@@ -91,13 +92,13 @@ public class Bug_160251 extends ResourceTest {
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
 		ensureExistsInWorkspace(source, true);
 		ensureExistsInWorkspace(sourceFile, true);
-		destination.mkdir(EFS.NONE, getMonitor());
+		destination.mkdir(EFS.NONE, createTestMonitor());
 		createFileInFileSystem(destinationFile, getRandomContents());
 
 		//move the project (should fail)
 		IProjectDescription description = source.getDescription();
 		description.setLocationURI(destination.toURI());
-		assertThrows(CoreException.class, () -> source.move(description, IResource.NONE, getMonitor()));
+		assertThrows(CoreException.class, () -> source.move(description, IResource.NONE, createTestMonitor()));
 
 		//ensure project still exists in old location
 		assertTrue("2.0", source.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -46,7 +47,7 @@ public class Bug_165892 extends ResourceTest {
 		sourceFile.setPersistentProperty(name, sourceValue);
 
 		//copy the file
-		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
 		assertEquals("2.0", sourceValue, sourceFile.getPersistentProperty(name));
@@ -72,23 +73,23 @@ public class Bug_165892 extends ResourceTest {
 		ensureExistsInWorkspace(sourceFile, true);
 
 		// modify the source file so it has some history
-		sourceFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+		sourceFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 		// check that the source file has the expected history
-		assertEquals("1.0", 1, sourceFile.getHistory(getMonitor()).length);
+		assertEquals("1.0", 1, sourceFile.getHistory(createTestMonitor()).length);
 
 		//copy the file
-		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, getMonitor());
+		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the history was copied
-		assertEquals("2.0", 1, sourceFile.getHistory(getMonitor()).length);
-		assertEquals("2.1", 1, destinationFile.getHistory(getMonitor()).length);
+		assertEquals("2.0", 1, sourceFile.getHistory(createTestMonitor()).length);
+		assertEquals("2.1", 1, destinationFile.getHistory(createTestMonitor()).length);
 
 		//modify the destination to change its history
-		destinationFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+		destinationFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 
 		//make sure the history is correct
-		assertEquals("2.0", 1, sourceFile.getHistory(getMonitor()).length);
-		assertEquals("2.1", 2, destinationFile.getHistory(getMonitor()).length);
+		assertEquals("2.0", 1, sourceFile.getHistory(createTestMonitor()).length);
+		assertEquals("2.1", 2, destinationFile.getHistory(createTestMonitor()).length);
 	}
 
 	/**
@@ -110,7 +111,7 @@ public class Bug_165892 extends ResourceTest {
 		sourceFile.setPersistentProperty(name, sourceValue);
 
 		//copy the folder
-		sourceFolder.copy(destinationFolder.getFullPath(), IResource.NONE, getMonitor());
+		sourceFolder.copy(destinationFolder.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
 		assertEquals("2.0", sourceValue, source.getPersistentProperty(name));
@@ -152,7 +153,7 @@ public class Bug_165892 extends ResourceTest {
 		sourceFile.setPersistentProperty(name, sourceValue);
 
 		//copy the project
-		source.copy(destination.getFullPath(), IResource.NONE, getMonitor());
+		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
 		assertEquals("2.0", sourceValue, source.getPersistentProperty(name));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -31,7 +33,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.tests.resources.ResourceTest;
-
 
 /**
  * Test cases for symbolic links in projects.
@@ -92,7 +93,7 @@ public class Bug_185247_LinuxTests extends ResourceTest {
 	private void importProjectAndRefresh(String projectName) throws Exception {
 		if (IS_LINUX) {
 			IProject project = importTestProject(projectName);
-			project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		}
 	}
 
@@ -103,8 +104,8 @@ public class Bug_185247_LinuxTests extends ResourceTest {
 		projectDescription.setName(projectName);
 		String projectRoot = String.join(File.separator, testCasesLocation.toOSString(), "bug185247", projectName);
 		projectDescription.setLocationURI(URI.create(projectRoot));
-		testProject.create(projectDescription, getMonitor());
-		testProject.open(getMonitor());
+		testProject.create(projectDescription, createTestMonitor());
+		testProject.open(createTestMonitor());
 		assertTrue("expected project to be open: " + projectName, testProject.isAccessible());
 		return testProject;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_recursiveLinks.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_recursiveLinks.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -24,7 +26,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.resources.ResourceTest;
-
 
 /**
  * Tests for recursive symbolic links in projects.
@@ -190,7 +191,7 @@ public class Bug_185247_recursiveLinks extends ResourceTest {
 
 	private void importProjectAndRefresh(String projectName, URI projectRootLocation) throws Exception {
 		IProject project = importTestProject(projectName, projectRootLocation);
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 	}
 
 	private IProject importTestProject(String projectName, URI projectRootLocation) throws Exception {
@@ -199,8 +200,8 @@ public class Bug_185247_recursiveLinks extends ResourceTest {
 		IProjectDescription projectDescription = new ProjectDescription();
 		projectDescription.setName(projectName);
 		projectDescription.setLocationURI(projectRootLocation);
-		testProject.create(projectDescription, getMonitor());
-		testProject.open(getMonitor());
+		testProject.create(projectDescription, createTestMonitor());
+		testProject.open(createTestMonitor());
 		assertTrue("expected project to be open: " + projectName, testProject.isAccessible());
 		return testProject;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
@@ -13,11 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.eclipse.core.filesystem.EFS;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
 import org.eclipse.core.tests.internal.filesystem.remote.RemoteFileSystem;
@@ -72,12 +81,12 @@ public class Bug_192631 extends ResourceTest {
 		IProject projectA = workspace.getRoot().getProject("projectA");
 		ensureExistsInWorkspace(projectA, true);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
-		linkA.createLink(commonA, IResource.NONE, getMonitor());
+		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
 		ensureExistsInWorkspace(projectB, true);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
-		linkB.createLink(commonB, IResource.NONE, getMonitor());
+		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
@@ -91,8 +100,8 @@ public class Bug_192631 extends ResourceTest {
 		assertTrue("2.1", toVisit.isEmpty());
 		assertEquals("2.2", 0, toVisitCount[0]);
 
-		projectA.delete(true, getMonitor());
-		projectB.delete(true, getMonitor());
+		projectA.delete(true, createTestMonitor());
+		projectB.delete(true, createTestMonitor());
 	}
 
 	public void testCompareUserInfo() throws CoreException, URISyntaxException {
@@ -117,12 +126,12 @@ public class Bug_192631 extends ResourceTest {
 		IProject projectA = workspace.getRoot().getProject("projectA");
 		ensureExistsInWorkspace(projectA, true);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
-		linkA.createLink(commonA, IResource.NONE, getMonitor());
+		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
 		ensureExistsInWorkspace(projectB, true);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
-		linkB.createLink(commonB, IResource.NONE, getMonitor());
+		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
@@ -136,8 +145,8 @@ public class Bug_192631 extends ResourceTest {
 		assertTrue("2.1", toVisit.isEmpty());
 		assertEquals("2.2", 0, toVisitCount[0]);
 
-		projectA.delete(true, getMonitor());
-		projectB.delete(true, getMonitor());
+		projectA.delete(true, createTestMonitor());
+		projectB.delete(true, createTestMonitor());
 	}
 
 	public void testComparePort() throws CoreException, URISyntaxException {
@@ -162,12 +171,12 @@ public class Bug_192631 extends ResourceTest {
 		IProject projectA = workspace.getRoot().getProject("projectA");
 		ensureExistsInWorkspace(projectA, true);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
-		linkA.createLink(commonA, IResource.NONE, getMonitor());
+		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
 		ensureExistsInWorkspace(projectB, true);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
-		linkB.createLink(commonB, IResource.NONE, getMonitor());
+		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
@@ -181,7 +190,7 @@ public class Bug_192631 extends ResourceTest {
 		assertTrue("2.1", toVisit.isEmpty());
 		assertEquals("2.2", 0, toVisitCount[0]);
 
-		projectA.delete(true, getMonitor());
-		projectB.delete(true, getMonitor());
+		projectA.delete(true, createTestMonitor());
+		projectB.delete(true, createTestMonitor());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -62,7 +64,7 @@ public class Bug_231301 extends ResourceTest {
 		try {
 			workspace.addResourceChangeListener(projectClosingChangeListener, IResourceChangeEvent.PRE_CLOSE);
 			// close project
-			project1.close(getMonitor());
+			project1.close(createTestMonitor());
 			job.join();
 		} finally {
 			workspace.removeResourceChangeListener(projectClosingChangeListener);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.IFileStore;
@@ -37,7 +38,7 @@ public class Bug_233939 extends ResourceTest {
 	 */
 	protected void symLinkAndRefresh(IContainer container, String linkName, IPath linkTarget) throws CoreException {
 		createSymLink(container.getLocation().toFile(), linkName, linkTarget.toOSString(), false);
-		container.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		container.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		IResource theLink = container.findMember(linkName);
 		assertExistsInWorkspace(theLink);
 		assertTrue("2.2", theLink.getResourceAttributes().isSymbolicLink());
@@ -64,8 +65,8 @@ public class Bug_233939 extends ResourceTest {
 		IFile file = project.getFile(fileName);
 
 		// create a project
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// create a file: getTempStore() will be cleaned up in tearDown()
 		IFileStore tempFileStore = getTempStore().getChild(fileName);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_297635.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_297635.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -66,11 +67,11 @@ public class Bug_297635 extends ResourceTest {
 	}
 
 	private void saveFull() throws CoreException {
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	private void saveSnapshot(SaveManager saveManager) throws CoreException {
-		saveManager.save(ISaveContext.SNAPSHOT, true, null, getMonitor());
+		saveManager.save(ISaveContext.SNAPSHOT, true, null, createTestMonitor());
 	}
 
 	private void executeWithSaveManagerSpy(Consumer<SaveManager> executeOnSpySaveManager) throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -77,7 +78,7 @@ public class Bug_303517 extends ResourceTest {
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// Core.resources should be aware that the file no longer exists...
 		assertFalse("1.4", f.exists());
@@ -102,7 +103,7 @@ public class Bug_303517 extends ResourceTest {
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// File is now in sync.
 		try (InputStream in = f.getContents(false)) {
@@ -124,7 +125,7 @@ public class Bug_303517 extends ResourceTest {
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// File is now in sync.
 		try (InputStream in = f.getContents()) {
@@ -154,7 +155,7 @@ public class Bug_303517 extends ResourceTest {
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// File is now in sync.
 		assertTrue("1.3", f.isSynchronized(IResource.DEPTH_ONE));
@@ -181,7 +182,7 @@ public class Bug_303517 extends ResourceTest {
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
-		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, getMonitor());
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// File is no longer a file - i.e. still out-of-sync
 		assertFalse("1.3", f.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -36,7 +38,7 @@ public class Bug_329836 extends ResourceTest {
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
 		IFileInfo info = fileStore.fetchInfo();
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, createTestMonitor());
 
 		// read the info again
 		info = fileStore.fetchInfo();
@@ -50,7 +52,7 @@ public class Bug_329836 extends ResourceTest {
 		// unset EFS.ATTRIBUTE_READ_ONLY which also unsets EFS.IMMUTABLE on Mac
 
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, false);
-		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, createTestMonitor());
 
 		// read the info again
 		info = fileStore.fetchInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.eclipse.core.resources.IFolder;
@@ -39,7 +41,7 @@ public class Bug_331445 extends ResourceTest {
 
 		project.getPathVariableManager().setURIValue(variableName, new URI(variablePath));
 		IFolder folder = project.getFolder(getUniqueString());
-		folder.createLink(IPath.fromOSString(rawLinkFolderLocation), IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		folder.createLink(IPath.fromOSString(rawLinkFolderLocation), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		assertNull("3.0", folder.getLocation());
 		assertEquals("4.0", IPath.fromOSString(rawLinkFolderLocation), folder.getRawLocation());
 		assertEquals("5.0", new URI(linkFolderLocation), folder.getLocationURI());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedOutputStream;
@@ -103,27 +104,27 @@ public class Bug_332543 extends ResourceTest {
 		desc.setLocationURI(proj_uri);
 		// Create the project on the wrapped file system
 		IProject project = root.getProject(desc.getName());
-		project.create(desc, getMonitor());
+		project.create(desc, createTestMonitor());
 
 		// Create a file in the project
 		IFile file = project.getFile("foo.txt");
 		ensureExistsInFileSystem(file);
 
 		// Now open the project
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		// Set our evil IOException on close() fs.
 		WrapperFileSystem.setCustomFileStore(IOErrOnCloseFileStore.class);
 
 		// Try #setContents on an existing file
 		assertThrows(CoreException.class, () -> file.setContents(wrap.apply(new ByteArrayInputStream("Random".getBytes())),
-				false, true, getMonitor()));
+				false, true, createTestMonitor()));
 
 		// Try create on a non-existent file
 		IFile nonExistentFile = project.getFile("foo1.txt");
 		assertThrows(CoreException.class,
 				() -> nonExistentFile.create(wrap.apply(new ByteArrayInputStream("Random".getBytes())), false,
-						getMonitor()));
+						createTestMonitor()));
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.concurrent.Semaphore;
 import org.eclipse.core.resources.ICommand;
@@ -89,7 +90,7 @@ public class Bug_378156 extends ResourceTest {
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 		ensureExistsInWorkspace(file, getRandomContents());
 		//build may not be triggered immediately
 		Thread.sleep(2000);
@@ -131,7 +132,7 @@ public class Bug_378156 extends ResourceTest {
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
-		project1.setDescription(desc, getMonitor());
+		project1.setDescription(desc, createTestMonitor());
 		ensureExistsInWorkspace(file, getRandomContents());
 		waitForBuild();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
@@ -24,7 +25,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
-
 
 /**
  * Test for Bug 530868: millisecond resolution of file timestamps with native
@@ -40,8 +40,8 @@ public class Bug_530868 extends ResourceTest {
 		super.setUp();
 
 		testProject = getWorkspace().getRoot().getProject(Bug_530868.class + "TestProject");
-		testProject.create(getMonitor());
-		testProject.open(getMonitor());
+		testProject.create(createTestMonitor());
+		testProject.open(createTestMonitor());
 		testFile = testProject.getFile(getName());
 
 	}
@@ -84,9 +84,9 @@ public class Bug_530868 extends ResourceTest {
 	private void setTestFileContents(String contents) throws Exception {
 		ByteArrayInputStream contentsStream = new ByteArrayInputStream(String.valueOf(contents).getBytes());
 		if (testFile.exists()) {
-			testFile.delete(true, getMonitor());
+			testFile.delete(true, createTestMonitor());
 		}
-		testFile.create(contentsStream, true, getMonitor());
+		testFile.create(contentsStream, true, createTestMonitor());
 	}
 
 	private long getLastModificationTimestamp() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IFile;
@@ -63,7 +64,7 @@ public class IFileTest extends ResourceTest {
 			folder.setReadOnly(true);
 			assertTrue(folder.isReadOnly());
 			CoreException exception = assertThrows(CoreException.class,
-					() -> file.create(getRandomContents(), true, getMonitor()));
+					() -> file.create(getRandomContents(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.FAILED_WRITE_LOCAL, exception.getStatus().getCode());
 		} finally {
 			folder.setReadOnly(false);
@@ -95,7 +96,7 @@ public class IFileTest extends ResourceTest {
 			folder.setReadOnly(true);
 			assertTrue(folder.isReadOnly());
 			CoreException exception = assertThrows(CoreException.class,
-					() -> file.create(getRandomContents(), true, getMonitor()));
+					() -> file.create(getRandomContents(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.PARENT_READ_ONLY, exception.getStatus().getCode());
 		} finally {
 			folder.setReadOnly(false);
@@ -121,6 +122,6 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.0", descFile.isSynchronized(IResource.DEPTH_ZERO));
 
 		// try setting the description -- shouldn't fail
-		project.setDescription(desc, getMonitor());
+		project.setDescription(desc, createTestMonitor());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -58,7 +59,7 @@ public class IFolderTest extends ResourceTest {
 		try {
 			parentFolder.setReadOnly(true);
 			assertTrue(parentFolder.isReadOnly());
-			CoreException exception = assertThrows(CoreException.class, () -> folder.create(true, true, getMonitor()));
+			CoreException exception = assertThrows(CoreException.class, () -> folder.create(true, true, createTestMonitor()));
 			assertEquals(IResourceStatus.PARENT_READ_ONLY, exception.getStatus().getCode());
 		} finally {
 			parentFolder.setReadOnly(false);
@@ -84,19 +85,19 @@ public class IFolderTest extends ResourceTest {
 
 		// now create the resources in the local file system and refresh
 		ensureExistsInFileSystem(file);
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("2.1", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("2.2", !folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("2.3", !subFile.isLocal(IResource.DEPTH_ZERO));
 
 		folder.getLocation().toFile().mkdir();
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("3.1", folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.2", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.3", !subFile.isLocal(IResource.DEPTH_ZERO));
 
 		ensureExistsInFileSystem(subFile);
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("4.1", subFile.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("4.2", folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("4.3", file.isLocal(IResource.DEPTH_ZERO));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.ICommand;
@@ -57,20 +58,20 @@ public class IProjectTest extends AbstractBuilderTest {
 		/* test */
 		project.accept(renameVisitor);
 		// cleanup
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 
 	public void test_1G5I6PV() throws CoreException {
 		/* common objects */
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		/* test */
-		project.setLocal(true, IResource.DEPTH_ZERO, getMonitor());
+		project.setLocal(true, IResource.DEPTH_ZERO, createTestMonitor());
 
 		// cleanup
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 
 	/**
@@ -88,8 +89,8 @@ public class IProjectTest extends AbstractBuilderTest {
 		ICommand command = prjDescription.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		prjDescription.setBuildSpec(new ICommand[] { command });
-		projectONE.create(prjDescription, getMonitor());
-		projectONE.open(getMonitor());
+		projectONE.create(prjDescription, createTestMonitor());
+		projectONE.open(createTestMonitor());
 
 		// create project with a builder
 		IProject projectTWO = getWorkspace().getRoot().getProject("Project_TWO");
@@ -97,14 +98,14 @@ public class IProjectTest extends AbstractBuilderTest {
 		command = prjDescription.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		prjDescription.setBuildSpec(new ICommand[] { command });
-		projectTWO.create(prjDescription, getMonitor());
-		projectTWO.open(getMonitor());
+		projectTWO.create(prjDescription, createTestMonitor());
+		projectTWO.open(createTestMonitor());
 
 		// set auto build ON
 		description = getWorkspace().getDescription();
 		description.setAutoBuilding(true);
 		getWorkspace().setDescription(description);
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		waitForBuild();
 
 		SignaledBuilder projectONEbuilder = SignaledBuilder.getInstance(projectONE);
@@ -152,8 +153,8 @@ public class IProjectTest extends AbstractBuilderTest {
 		createFileInFileSystem(location.append(file1.getName()));
 
 		// create
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// verify discovery
 		assertTrue("2.0", project.isAccessible());
@@ -167,8 +168,8 @@ public class IProjectTest extends AbstractBuilderTest {
 	 */
 	public void testDelete_1GDW1RX() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		String[] paths = new String[] {"/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1"};
 		IResource[] resources = buildResources(project, paths);
@@ -180,10 +181,10 @@ public class IProjectTest extends AbstractBuilderTest {
 		IFile file = folder.getFile("MyFile");
 		ensureExistsInFileSystem(file);
 
-		assertThrows(CoreException.class, () -> project.delete(false, getMonitor()));
+		assertThrows(CoreException.class, () -> project.delete(false, createTestMonitor()));
 
 		// clean up
-		project.delete(true, true, getMonitor());
+		project.delete(true, true, createTestMonitor());
 	}
 
 	public void testRefreshDotProject() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -79,7 +80,7 @@ public class IResourceTest extends ResourceTest {
 		ensureExistsInWorkspace(new IResource[] {project, outputFolder}, true);
 
 		assertTrue("0.0", description.exists());
-		description.copy(destination.getFullPath(), IResource.NONE, getMonitor());
+		description.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("0.1", destination.exists());
 	}
 
@@ -97,7 +98,7 @@ public class IResourceTest extends ResourceTest {
 		file.setResourceAttributes(attributes);
 		assertTrue("1.0", !file.getResourceAttributes().isArchive());
 		// modify the file
-		file.setContents(getRandomContents(), IResource.KEEP_HISTORY, getMonitor());
+		file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 
 		//now the archive bit should be set
 		assertTrue("2.0", file.getResourceAttributes().isArchive());
@@ -169,7 +170,7 @@ public class IResourceTest extends ResourceTest {
 				ISynchronizer synchronizer = getWorkspace().getSynchronizer();
 				synchronizer.flushSyncInfo(name, file, IResource.DEPTH_INFINITE);
 				synchronizer.setSyncInfo(name, file, new byte[] { 1 });
-			}, null, IWorkspace.AVOID_UPDATE, getMonitor());
+			}, null, IWorkspace.AVOID_UPDATE, createTestMonitor());
 			// ensure file was only seen by phantom listener
 			assertTrue("1.0", !seen[0]);
 			assertTrue("1.0", phantomSeen[0]);
@@ -187,7 +188,7 @@ public class IResourceTest extends ResourceTest {
 		IFolder folder = project.getFolder("f");
 		ensureExistsInWorkspace(project, true);
 		ensureExistsInWorkspace(folder, true);
-		folder.setLocal(false, IResource.DEPTH_ZERO, getMonitor());
+		folder.setLocal(false, IResource.DEPTH_ZERO, createTestMonitor());
 		// non-local resource is never synchronized because it doesn't exist on disk
 		assertTrue("1.0", !project.isSynchronized(IResource.DEPTH_INFINITE));
 	}
@@ -212,14 +213,14 @@ public class IResourceTest extends ResourceTest {
 	public void testCopy_1GA6QJP() throws CoreException, InterruptedException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile source = project.getFile("file1");
-		project.create(getMonitor());
-		project.open(getMonitor());
-		source.create(getContents("abc"), true, getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		source.create(getContents("abc"), true, createTestMonitor());
 
 		Thread.sleep(2000);
 
 		IPath destinationPath = IPath.fromOSString("copy of file");
-		source.copy(destinationPath, true, getMonitor());
+		source.copy(destinationPath, true, createTestMonitor());
 
 		IFile destination = project.getFile(destinationPath);
 		long expected = source.getLocation().toFile().lastModified();
@@ -271,7 +272,7 @@ public class IResourceTest extends ResourceTest {
 		}
 
 		// test refreshLocal
-		ThrowingRunnable refresh = () -> anotherFile.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
+		ThrowingRunnable refresh = () -> anotherFile.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
 		if (caseSensitive) {
 			refresh.run();
 		} else {
@@ -322,7 +323,7 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("MyFile");
 		ensureExistsInFileSystem(file);
 
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 	}
 
 	/*
@@ -349,7 +350,7 @@ public class IResourceTest extends ResourceTest {
 		assertTrue("2.0", file.isReadOnly());
 
 		// doit
-		assertThrows(CoreException.class, () -> file.delete(false, getMonitor()));
+		assertThrows(CoreException.class, () -> file.delete(false, createTestMonitor()));
 
 		// cleanup
 		attributes = file.getResourceAttributes();
@@ -371,7 +372,7 @@ public class IResourceTest extends ResourceTest {
 		ensureOutOfSync(file);
 
 		// doit
-		CoreException exception = assertThrows(CoreException.class, () -> file.delete(false, getMonitor()));
+		CoreException exception = assertThrows(CoreException.class, () -> file.delete(false, createTestMonitor()));
 		IStatus status = exception.getStatus();
 		if (status.isMultiStatus()) {
 			IStatus[] children = status.getChildren();
@@ -404,15 +405,15 @@ public class IResourceTest extends ResourceTest {
 	 */
 	public void testFindMember_1GA6QYV() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		IFolder folder1 = project.getFolder("Folder1");
 		IFolder folder2 = folder1.getFolder("Folder2");
 		IFolder folder3 = folder2.getFolder("Folder3");
-		folder1.create(true, true, getMonitor());
-		folder2.create(true, true, getMonitor());
-		folder3.create(true, true, getMonitor());
+		folder1.create(true, true, createTestMonitor());
+		folder2.create(true, true, createTestMonitor());
+		folder3.create(true, true, createTestMonitor());
 
 		IPath targetPath = IPath.fromOSString("Folder2/Folder3");
 		IFolder target = (IFolder) folder1.findMember(targetPath);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -35,35 +36,35 @@ public class IWorkspaceTest extends ResourceTest {
 	public void testMultiMove_1GDKIHD() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// test file (force = true)
 		IFile file1 = project.getFile("file.txt");
 		IFolder folder = project.getFolder("folder");
 		IResource[] allResources = new IResource[] {file1, folder};
-		folder.create(true, true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		IFileState[] states = file1.getHistory(getMonitor());
+		folder.create(true, true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		IFileState[] states = file1.getHistory(createTestMonitor());
 		assertEquals("1.0", 3, states.length);
-		getWorkspace().delete(allResources, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(allResources, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 
 		// test file (force = false)
-		folder.create(true, true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), false, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		states = file1.getHistory(getMonitor());
+		folder.create(true, true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), false, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		states = file1.getHistory(createTestMonitor());
 		assertEquals("2.0", 3, states.length);
-		getWorkspace().delete(allResources, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(allResources, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 	}
 
 	/**
@@ -72,59 +73,59 @@ public class IWorkspaceTest extends ResourceTest {
 	public void testMultiDelete_1GDGRIZ() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// test file (force = true)
 		IFile file1 = project.getFile("file.txt");
-		file1.create(getRandomContents(), true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().delete(new IFile[] { file1 }, true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		IFileState[] states = file1.getHistory(getMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().delete(new IFile[] { file1 }, true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		IFileState[] states = file1.getHistory(createTestMonitor());
 		assertEquals("1.0", 3, states.length);
-		getWorkspace().delete(new IResource[] { file1 }, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 
 		// test file (force = false)
-		file1.create(getRandomContents(), true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().delete(new IFile[] { file1 }, false, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		states = file1.getHistory(getMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().delete(new IFile[] { file1 }, false, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		states = file1.getHistory(createTestMonitor());
 		assertEquals("2.0", 3, states.length);
-		getWorkspace().delete(new IResource[] { file1 }, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 
 		// test folder (force = true)
 		IFolder folder = project.getFolder("folder");
 		IFile file2 = folder.getFile("file2.txt");
-		folder.create(true, true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
-		file2.setContents(getRandomContents(), true, true, getMonitor());
-		file2.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().delete(new IResource[] { folder }, true, getMonitor());
-		folder.create(true, true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
-		states = file2.getHistory(getMonitor());
+		folder.create(true, true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
+		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().delete(new IResource[] { folder }, true, createTestMonitor());
+		folder.create(true, true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
+		states = file2.getHistory(createTestMonitor());
 		assertEquals("3.0", 3, states.length);
-		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 
 		// test folder (force = false)
-		folder.create(true, true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
-		file2.setContents(getRandomContents(), true, true, getMonitor());
-		file2.setContents(getRandomContents(), true, true, getMonitor());
-		getWorkspace().delete(new IResource[] { folder }, false, getMonitor());
-		folder.create(true, true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
-		states = file2.getHistory(getMonitor());
+		folder.create(true, true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
+		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		getWorkspace().delete(new IResource[] { folder }, false, createTestMonitor());
+		folder.create(true, true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
+		states = file2.getHistory(createTestMonitor());
 		assertEquals("4.0", 3, states.length);
-		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, getMonitor());
-		project.clearHistory(getMonitor());
+		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());
+		project.clearHistory(createTestMonitor());
 	}
 
 	public void test_8974() throws CoreException {
@@ -135,7 +136,7 @@ public class IWorkspaceTest extends ResourceTest {
 		IProjectDescription oneDescription = getWorkspace().newProjectDescription(one.getName());
 		oneDescription.setLocation(oneLocation);
 
-		one.create(oneDescription, getMonitor());
+		one.create(oneDescription, createTestMonitor());
 
 		IProject two = getWorkspace().getRoot().getProject("Two");
 		IPath twoLocation = oneLocation.removeLastSegments(1).append(oneLocation.lastSegment().toLowerCase());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources.regression;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,13 +78,13 @@ public class NLTest extends ResourceTest {
 
 	public void testFileNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("project");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		String[] files = getFileNames(Locale.ENGLISH.getLanguage());
 		IResource[] resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 		ensureDoesNotExistInWorkspace(resources);
@@ -91,7 +92,7 @@ public class NLTest extends ResourceTest {
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);
 		ensureExistsInWorkspace(resources, true);
-		project.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.resources.IFile;
@@ -90,7 +91,7 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 				monitor.done();
 			}
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 		assertDelta();
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -31,8 +32,8 @@ public class PR_1GH2B0N_Test extends ResourceTest {
 		IPath projectLocation = path.append(project.getName());
 		deleteOnTearDown(projectLocation);
 		description.setLocation(projectLocation);
-		project.create(description, getMonitor());
-		project.open(getMonitor());
+		project.create(description, createTestMonitor());
+		project.open(createTestMonitor());
 
 		IProject project2 = getWorkspace().getRoot().getProject("MyProject2");
 		IStatus status = getWorkspace().validateProjectLocation(project2, project.getLocation().append(project2.getName()));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -37,16 +38,16 @@ public class PR_1GHOM0N_Test extends ResourceTest {
 		ICommand command = description.newCommand();
 		command.setBuilderName(SimpleBuilder.BUILDER_ID);
 		description.setBuildSpec(new ICommand[] { command });
-		project.create(description, getMonitor());
-		project.open(getMonitor());
+		project.create(description, createTestMonitor());
+		project.open(createTestMonitor());
 
 		// try and reproduce the error (there are problems when calling an incremental
 		// build from within an operation...it leaves the tree immutable)
 		IWorkspaceRunnable body = monitor -> {
-			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 			IFile file = project.getFile("test.txt");
-			file.create(getRandomContents(), true, getMonitor());
+			file.create(getRandomContents(), true, createTestMonitor());
 		};
-		getWorkspace().run(body, getMonitor());
+		getWorkspace().run(body, createTestMonitor());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.util.Map;
@@ -70,12 +71,12 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 		IProjectDescription description = project1.getDescription();
 		description.setBuildSpec(new ICommand[] { createCommand(description, "Project1Build1"),
 				createCommand(description, "Project1Build2") });
-		project1.setDescription(description, getMonitor());
+		project1.setDescription(description, createTestMonitor());
 
 		// initial build -- created sortedFile1
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	protected ICommand createCommand(IProjectDescription description, String builderId) {
@@ -92,7 +93,7 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 	 * about changes made by Builder2 during the last build phase.
 	 */
 	public void test2() throws CoreException {
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		//Only builder1 should have been built
 		SortBuilder[] builders = SortBuilder.allInstances();
 		assertEquals("1.0", 2, builders.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -52,11 +53,11 @@ public class Bug_266907 extends WorkspaceSessionTest {
 
 		final IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_NAME);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		IFile f = project.getFile(FILE_NAME);
-		f.create(getContents("content"), true, getMonitor());
+		f.create(getContents("content"), true, createTestMonitor());
 
 		IMarker marker = f.createMarker(IMarker.BOOKMARK);
 		marker.setAttribute(MARKER_ATTRIBUTE_NAME, MARKER_ATTRIBUTE);
@@ -64,7 +65,7 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		// remember the location of .project to delete is at the end
 		File dotProject = project.getFile(".project").getLocation().toFile();
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 
 		// move .project to a temp location
 		File dotProjectCopy = getTempDir().append("dotProjectCopy").toFile();
@@ -88,7 +89,7 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		transferStreams(new FileInputStream(dotProjectCopy), new FileOutputStream(dotProject), null);
 		dotProjectCopy.delete();
 
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		assertThat("project should be accessible", project.isAccessible(), is(true));
 
 		IFile file = project.getFile(FILE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -62,186 +63,186 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 	}
 
 	private void saveWorkspace() throws CoreException {
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	public void test1() throws Exception {
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.1", 0, df.length);
 
 		// test that a deleted file can be found
 		// create and delete a file
-		pfile.create(getRandomContents(), true, getMonitor());
-		pfile.delete(true, true, getMonitor());
+		pfile.create(getRandomContents(), true, createTestMonitor());
+		pfile.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
 	}
 
 	public void test2() throws Exception {
 		// the deleted file should show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.1", 1, df.length);
 		assertEquals("0.2", pfile, df[0]);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("0.3", 1, df.length);
 		assertEquals("0.4", pfile, df[0]);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("0.5", 0, df.length);
 
 		// the deleted file should show up as a deleted member of workspace root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.5.1", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("0.5.2", 1, df.length);
 		assertEquals("0.5.3", pfile, df[0]);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("0.5.4", 0, df.length);
 
 		// recreate the file
-		pfile.create(getRandomContents(), true, getMonitor());
+		pfile.create(getRandomContents(), true, createTestMonitor());
 
 		saveWorkspace();
 	}
 
 	public void test3() throws Exception {
 		// the deleted file should no longer show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.6", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("0.7", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("0.8", 0, df.length);
 
 		// the deleted file should no longer show up as a deleted member of ws root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.8.1", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("0.8.2", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("0.8.3", 0, df.length);
 
 		// scrub the project
-		project.delete(true, getMonitor());
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.delete(true, createTestMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("0.9", 0, df.length);
 
 		// test folder
 		// create and delete a file in a folder
-		folder.create(true, true, getMonitor());
-		file.create(getRandomContents(), true, getMonitor());
-		file.delete(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
+		file.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
 	}
 
 	public void test4() throws Exception {
 		// the deleted file should show up as a deleted member
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("1.1", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("1.2", 1, df.length);
 		assertEquals("1.3", file, df[0]);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("1.4", 0, df.length);
 
 		// recreate the file
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 
 		// the recreated file should no longer show up as a deleted member
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("1.5", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("1.6", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("1.7", 0, df.length);
 
 		// deleting the folder should bring it back into history
-		folder.delete(true, true, getMonitor());
+		folder.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
 	}
 
 	public void test5() throws Exception {
 		// the deleted file should show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("1.8", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("1.9", 1, df.length);
 		assertEquals("1.10", file, df[0]);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("1.11", 0, df.length);
 
 		// create and delete a file where the folder was
-		folderAsFile.create(getRandomContents(), true, getMonitor());
-		folderAsFile.delete(true, true, getMonitor());
-		folder.create(true, true, getMonitor());
+		folderAsFile.create(getRandomContents(), true, createTestMonitor());
+		folderAsFile.delete(true, true, createTestMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("1.12", 1, df.length);
 		assertEquals("1.13", folderAsFile, df[0]);
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("1.14", 2, df.length);
 		List<IFile> dfList = Arrays.asList(df);
 		assertTrue("1.15", dfList.contains(file));
 		assertTrue("1.16", dfList.contains(folderAsFile));
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("1.17", 2, df.length);
 		dfList = Arrays.asList(df);
 		assertTrue("1.18", dfList.contains(file));
 		assertTrue("1.19", dfList.contains(folderAsFile));
 
 		// scrub the project
-		project.delete(true, getMonitor());
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.delete(true, createTestMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("1.50", 0, df.length);
 
 		// test a bunch of deletes
 		// create and delete a file in a folder
-		folder.create(true, true, getMonitor());
-		folder2.create(true, true, getMonitor());
-		file1.create(getRandomContents(), true, getMonitor());
-		file2.create(getRandomContents(), true, getMonitor());
-		file3.create(getRandomContents(), true, getMonitor());
-		folder.delete(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
+		folder2.create(true, true, createTestMonitor());
+		file1.create(getRandomContents(), true, createTestMonitor());
+		file2.create(getRandomContents(), true, createTestMonitor());
+		file3.create(getRandomContents(), true, createTestMonitor());
+		folder.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
 	}
 
 	public void test6() throws Exception {
 		// under root
-		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("3.1", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("3.2", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("3.3", 3, df.length);
 		List<IFile> dfList = Arrays.asList(df);
 		assertTrue("3.3.1", dfList.contains(file1));
@@ -249,13 +250,13 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertTrue("3.3.3", dfList.contains(file3));
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("3.4", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("3.5", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("3.6", 3, df.length);
 		dfList = Arrays.asList(df);
 		assertTrue("3.6.1", dfList.contains(file1));
@@ -263,26 +264,26 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertTrue("3.6.3", dfList.contains(file3));
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("3.7", 0, df.length);
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("3.8", 2, df.length);
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("3.9", 3, df.length);
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("3.10", 0, df.length);
 
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("3.11", 1, df.length);
 
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("3.12", 1, df.length);
 
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 
 		saveWorkspace();
 	}
@@ -290,43 +291,43 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 	public void test7() throws Exception {
 		// once the project is gone, so is all the history for that project
 		// under root
-		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("4.1", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("4.2", 0, df.length);
 
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("4.3", 0, df.length);
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("4.4", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("4.5", 0, df.length);
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("4.6", 0, df.length);
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("4.7", 0, df.length);
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("4.8", 0, df.length);
 
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("4.9", 0, df.length);
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
 		assertEquals("4.10", 0, df.length);
 
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
 		assertEquals("4.11", 0, df.length);
 
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, getMonitor());
+		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("4.12", 0, df.length);
 
 		saveWorkspace();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectDescriptionDynamicTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectDescriptionDynamicTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
@@ -81,15 +82,15 @@ public class ProjectDescriptionDynamicTest extends WorkspaceSessionTest {
 	 */
 	public void test1() throws Exception {
 		// Projects to references -- needn't exist
-		proj.create(getMonitor());
-		proj.open(getMonitor());
+		proj.create(createTestMonitor());
+		proj.open(createTestMonitor());
 
 		IProjectDescription desc = proj.getDescription();
 		desc.setBuildConfigs(configNames);
 		desc.setDynamicReferences(dynRefs);
-		proj.setDescription(desc, getMonitor());
+		proj.setDescription(desc, createTestMonitor());
 
-		ResourcesPlugin.getWorkspace().save(true, getMonitor());
+		ResourcesPlugin.getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -108,9 +109,9 @@ public class ProjectDescriptionDynamicTest extends WorkspaceSessionTest {
 		desc.setBuildConfigReferences(configs[1].getName(), configRefs);
 		// Change the active configuration
 		desc.setActiveBuildConfig(configs[1].getName());
-		proj.setDescription(desc, getMonitor());
+		proj.setDescription(desc, createTestMonitor());
 
-		ResourcesPlugin.getWorkspace().save(true, getMonitor());
+		ResourcesPlugin.getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.concurrent.atomic.AtomicReference;
 import junit.framework.Test;
@@ -41,7 +42,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	}
 
 	private void saveWorkspace() throws Exception {
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/*
@@ -82,7 +83,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		};
 		try {
 			Platform.addLogListener(listener);
-			project.delete(IResource.NONE, getMonitor());
+			project.delete(IResource.NONE, createTestMonitor());
 		} finally {
 			Platform.removeLogListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1G1N9GZ.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1G1N9GZ.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
@@ -43,7 +44,7 @@ public class Test1G1N9GZ extends WorkspaceSerializationTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.getArguments().put(TestBuilder.BUILD_ID, "P1Build1");
 		desc.setBuildSpec(new ICommand[] {command});
-		p1.setDescription(desc, getMonitor());
+		p1.setDescription(desc, createTestMonitor());
 
 		/* create P2 and set a builder */
 		IProject p2 = workspace.getRoot().getProject("p2");
@@ -54,14 +55,14 @@ public class Test1G1N9GZ extends WorkspaceSerializationTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.getArguments().put(TestBuilder.BUILD_ID, "P2Build1");
 		desc.setBuildSpec(new ICommand[] {command});
-		p1.setDescription(desc, getMonitor());
+		p1.setDescription(desc, createTestMonitor());
 
 		/* PR test case */
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test3() throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.filesystem.EFS;
@@ -49,14 +50,14 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 		ensureExistsInWorkspace(project, true);
 		IFileStore parent = EFS.getStore(location.toFile().toURI());
 		IFileStore child = parent.getChild(linkChild.getName());
-		parent.mkdir(EFS.NONE, getMonitor());
-		child.openOutputStream(EFS.NONE, getMonitor()).close();
-		link.createLink(location, IResource.NONE, getMonitor());
+		parent.mkdir(EFS.NONE, createTestMonitor());
+		child.openOutputStream(EFS.NONE, createTestMonitor()).close();
+		link.createLink(location, IResource.NONE, createTestMonitor());
 
 		assertTrue("1.0", link.exists());
 		assertTrue("1.1", linkChild.exists());
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -66,7 +67,7 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 		IProject project = workspace.getRoot().getProject("Project1");
 		IFolder link = project.getFolder("link");
 		IFile linkChild = link.getFile("child.txt");
-		link.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
+		link.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("1.0", link.exists());
 		assertTrue("1.1", linkChild.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -33,11 +34,11 @@ public class TestBug12575 extends WorkspaceSerializationTest {
 	 */
 	public void test1() throws CoreException {
 		IProject project = workspace.getRoot().getProject(projectName);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		dotProject.delete(IResource.NONE, getMonitor());
-		workspace.save(true, getMonitor());
+		dotProject.delete(IResource.NONE, createTestMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	/**
@@ -48,7 +49,7 @@ public class TestBug12575 extends WorkspaceSerializationTest {
 		IProject other = workspace.getRoot().getProject("Other");
 		IProjectDescription desc = project.getDescription();
 		desc.setReferencedProjects(new IProject[] { other });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		//creating a project will cause a snapshot
 		ensureExistsInWorkspace(other, true);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
 import junit.framework.Test;
@@ -51,12 +52,12 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
 		command.setArguments(args);
 		description.setBuildSpec(new ICommand[] { command });
-		project.setDescription(description, getMonitor());
+		project.setDescription(description, createTestMonitor());
 
 		//initial build
-		workspace.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -66,8 +67,8 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 		IProject project = workspace.getRoot().getProject("Project1");
 		IProjectDescription desc = project.getDescription();
 		desc.setName("MovedProject");
-		project.move(desc, IResource.NONE, getMonitor());
-		workspace.save(true, getMonitor());
+		project.move(desc, IResource.NONE, createTestMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	/**
@@ -80,7 +81,7 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 		assertTrue("1.0", !oldLocation.exists());
 		assertTrue("1.0", newLocation.exists());
 		assertTrue("1.1", newLocation.isOpen());
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
@@ -33,10 +34,10 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
 		ensureExistsInWorkspace(project, true);
-		project.setDefaultCharset("UTF-8", getMonitor());
+		project.setDefaultCharset("UTF-8", createTestMonitor());
 		assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
-		project.close(getMonitor());
-		workspace.save(true, getMonitor());
+		project.close(createTestMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void testStartWithClosedProject() throws CoreException {
@@ -46,10 +47,10 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		// project is closed so it is not possible to read correct encoding
 		assertNull("2.0", project.getDefaultCharset(false));
 		// opening the project should initialize ProjectPreferences
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 		// correct values should be available after initialization
 		assertEquals("5.0", "UTF-8", project.getDefaultCharset(false));
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void testStartWithOpenProject() throws CoreException {
@@ -68,7 +69,7 @@ public class TestBug202384 extends WorkspaceSessionTest {
 			TestUtil.waitForJobs(getName(), 500, 1000);
 		}
 		assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -77,7 +78,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 
 		// make sure we do not have .snap file
 		TestingSupport.waitForSnapshot();
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 
 		return project;
 	}
@@ -98,7 +99,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 		// move project using IProjectDescription
 		IProjectDescription description = project.getDescription();
 		description.setName(PROJECT_NEW_NAME);
-		project.move(description, true, getMonitor());
+		project.move(description, true, createTestMonitor());
 
 		// wait for the snapshot job to run
 		TestingSupport.waitForSnapshot();
@@ -116,7 +117,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 		IProject project = createProject();
 
 		// move project using IPath
-		project.move(project.getFullPath().removeLastSegments(1).append(PROJECT_NEW_NAME), true, getMonitor());
+		project.move(project.getFullPath().removeLastSegments(1).append(PROJECT_NEW_NAME), true, createTestMonitor());
 
 		// wait for the snapshot job to run
 		TestingSupport.waitForSnapshot();
@@ -134,7 +135,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 		IProject project = createProject();
 
 		// delete project
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 
 		// wait for the snapshot job to run
 		TestingSupport.waitForSnapshot();
@@ -162,7 +163,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 		getWorkspace().addResourceChangeListener(selfDeregisteringExistingChangeListener, IResourceChangeEvent.POST_CHANGE);
 
 		// delete project
-		project.delete(true, getMonitor());
+		project.delete(true, createTestMonitor());
 	}
 
 	public void testDeleteWithoutWaitingForSnapshot_02() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
@@ -47,10 +48,10 @@ public class TestBug30015 extends WorkspaceSessionTest {
 		IProjectDescription description = getWorkspace().newProjectDescription(PROJECT_NAME);
 		description.setLocation(rawLocation);
 		//create the project
-		project.create(description, getMonitor());
-		project.open(getMonitor());
+		project.create(description, createTestMonitor());
+		project.open(createTestMonitor());
 		//save and shutdown
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
@@ -35,7 +36,7 @@ public class TestBug316182 extends WorkspaceSessionTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project_TestBug316182");
 		ensureExistsInWorkspace(project, true);
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 		// reset last caught exception
 		CAUGHT_EXCEPTION = null;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.File;
 import junit.framework.Test;
@@ -43,11 +44,11 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
 		IFileInfo info = fileStore.fetchInfo();
 		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, getMonitor());
+		fileStore.putInfo(info, EFS.SET_ATTRIBUTES, createTestMonitor());
 
 		// create a cached file
 		File cachedFile = null;
-		cachedFile = fileStore.toLocalFile(EFS.CACHE, getMonitor());
+		cachedFile = fileStore.toLocalFile(EFS.CACHE, createTestMonitor());
 
 		IFileInfo cachedFileInfo = new LocalFile(cachedFile).fetchInfo();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -37,9 +38,9 @@ public class TestBug369177 extends WorkspaceSessionTest {
 		ensureExistsInWorkspace(project, true);
 
 		IFile link = project.getFile("link_to_file");
-		link.createLink(new URI("bug369177:/dummy_path.txt"), IResource.ALLOW_MISSING_LOCAL, getMonitor());
+		link.createLink(new URI("bug369177:/dummy_path.txt"), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test02_startWorkspace() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
 import junit.framework.Test;
@@ -47,8 +48,8 @@ public class TestBug6995 extends WorkspaceSessionTest {
 
 		//create a project and configure builder
 		IProject project = workspace.getRoot().getProject("Project");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		IProjectDescription description = project.getDescription();
 		ICommand command = description.newCommand();
@@ -57,13 +58,13 @@ public class TestBug6995 extends WorkspaceSessionTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.setArguments(args);
 		description.setBuildSpec(new ICommand[] { command });
-		project.setDescription(description, getMonitor());
+		project.setDescription(description, createTestMonitor());
 
 		//do an initial build
-		project.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		//save the workspace
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	/**
@@ -73,13 +74,13 @@ public class TestBug6995 extends WorkspaceSessionTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("Project");
 		//snapshot
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		//build
 		//make a change so build doesn't get short-circuited
 		IFile file = project.getFile("File");
-		file.create(getRandomContents(), true, getMonitor());
-		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
+		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		//make sure an incremental build occurred
 		SortBuilder builder = SortBuilder.getInstance();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ContentDescriptionManager;
@@ -69,7 +70,7 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		ContentDescriptionManagerTest.waitForCacheFlush();
 		assertEquals("4.0", ContentDescriptionManager.USED_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2ndSession() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.setArguments(args);
 		description.setBuildSpec(new ICommand[] { command });
-		project1.setDescription(description, getMonitor());
+		project1.setDescription(description, createTestMonitor());
 
 		// configure builder for project2
 		description = project1.getDescription();
@@ -95,12 +96,12 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		command.setArguments(args);
 		description.setBuildSpec(new ICommand[] { command });
-		project2.setDescription(description, getMonitor());
+		project2.setDescription(description, createTestMonitor());
 
 		// initial build -- created sortedFile1 and sortedFile2
-		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -108,7 +109,7 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 	 * about changes made by Builder2 during the last build phase.
 	 */
 	public void test2() throws CoreException {
-		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		//Only builder1 should have been built
 		SortBuilder[] builders = SortBuilder.allInstances();
 		assertEquals("1.0", 2, builders.length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -30,12 +31,12 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = workspace.getRoot().getProject(PROJECT);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IFolder folder = project.getFolder(FOLDER);
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 		IFile file = folder.getFile(FILE);
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(getRandomContents(), true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -40,13 +41,13 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 		IFile file = project.getFile(FILE);
 		IProjectDescription desc = workspace.newProjectDescription(PROJECT);
 		desc.setLocation(location);
-		project.create(desc, getMonitor());
-		project.open(getMonitor());
+		project.create(desc, createTestMonitor());
+		project.open(createTestMonitor());
 		ensureExistsInWorkspace(file, true);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 		assertEquals("1.1", location, project.getLocation());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ProjectDescription;
@@ -36,10 +37,10 @@ public class TestCreateLinkedResourceInHiddenProject extends WorkspaceSerializat
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IProjectDescription desc = new ProjectDescription();
 		desc.setName(PROJECT);
-		project.create(desc, IResource.HIDDEN, getMonitor());
-		project.open(getMonitor());
+		project.create(desc, IResource.HIDDEN, createTestMonitor());
+		project.open(createTestMonitor());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {
@@ -49,7 +50,7 @@ public class TestCreateLinkedResourceInHiddenProject extends WorkspaceSerializat
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFolder folder = project.getFolder(getUniqueString());
 
-		folder.createLink(path, IResource.NONE, getMonitor());
+		folder.createLink(path, IResource.NONE, createTestMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -79,12 +80,12 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		command.setBuilderName(DeltaVerifierBuilder.BUILDER_NAME);
 		command.setArguments(args);
 		description.setBuildSpec(new ICommand[] { command });
-		project1.setDescription(description, getMonitor());
+		project1.setDescription(description, createTestMonitor());
 
 		// initial build requesting no projects
-		project1.build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -94,8 +95,8 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
 		builder.requestDeltas(new IProject[] {project1, project2, project4});
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		ArrayList<IProject> received = builder.getReceivedDeltas();
 
 		// should have received only a delta for project1
@@ -107,7 +108,7 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		assertEquals("1.2", 0, empty.size());
 
 		// save
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -117,12 +118,12 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
 		// dirty projects 1, 2, 3
-		file1.setContents(getRandomContents(), true, true, getMonitor());
-		file2.setContents(getRandomContents(), true, true, getMonitor());
-		file3.setContents(getRandomContents(), true, true, getMonitor());
+		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		file3.setContents(getRandomContents(), true, true, createTestMonitor());
 
 		// build
-		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, getMonitor());
+		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		ArrayList<IProject> received = builder.getReceivedDeltas();
 
 		// should have received deltas for 1, 2, and 4
@@ -138,7 +139,7 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		assertTrue("1.3", empty.contains(project4));
 
 		// save
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SNOW;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_WATER;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -67,7 +68,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		//wait for background build to complete
 		waitForBuild();
 		//remove the water nature, thus invalidating snow nature
@@ -75,14 +76,14 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		builder.reset();
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		// setting description file will also trigger build
-		descFile.setContents(projectFileWithoutWater(), IResource.FORCE, getMonitor());
+		descFile.setContents(projectFileWithoutWater(), IResource.FORCE, createTestMonitor());
 		//assert that builder was skipped
 		builder.assertLifecycleEvents();
 
 		//assert that the builder is still in the build spec
 		assertTrue(hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -96,13 +97,13 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		assertTrue(hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
 		//perform a build and ensure snow builder isn't called
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		SnowBuilder builder = SnowBuilder.getInstance();
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
 		builder.assertLifecycleEvents();
 
-		getWorkspace().save(true, getMonitor());
+		getWorkspace().save(true, createTestMonitor());
 	}
 
 	/**
@@ -116,7 +117,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		assertTrue("1.0", hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
 		//perform a build and ensure snow builder isn't called
-		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, getMonitor());
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		SnowBuilder builder = SnowBuilder.getInstance();
 		builder.addExpectedLifecycleEvent(TestBuilder.SET_INITIALIZATION_DATA);
 		builder.addExpectedLifecycleEvent(TestBuilder.STARTUP_ON_INITIALIZE);
@@ -128,7 +129,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		builder.addExpectedLifecycleEvent(SnowBuilder.SNOW_BUILD_EVENT);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
-		project.setDescription(desc, IResource.FORCE, getMonitor());
+		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		builder.assertLifecycleEvents();
 		assertTrue(builder.wasDeltaNull());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -35,25 +36,25 @@ public class TestMultiSnap extends WorkspaceSerializationTest {
 
 		/* create some resource handles */
 		IProject project = getWorkspace().getRoot().getProject(PROJECT);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		/* snapshot */
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		/* do more stuff */
 		IFolder folder = project.getFolder(FOLDER);
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		/* do even more stuff */
 		IFile file = folder.getFile(FILE);
 		byte[] bytes = "Test bytes".getBytes();
 		java.io.ByteArrayInputStream in = new java.io.ByteArrayInputStream(bytes);
-		file.create(in, true, getMonitor());
+		file.create(in, true, createTestMonitor());
 
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		//exit without saving
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
@@ -31,10 +32,10 @@ public class TestSave extends WorkspaceSerializationTest {
 	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
@@ -30,10 +31,10 @@ public class TestSaveCreateProject extends WorkspaceSerializationTest {
 	public void test1() throws CoreException {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 	}
 
 	public void test2() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
@@ -34,28 +35,28 @@ public class TestSaveSnap extends WorkspaceSerializationTest {
 	public void test1() throws Exception {
 		/* create some resource handles */
 		IProject project = getWorkspace().getRoot().getProject(PROJECT);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		/* full save */
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 
 		/* do more stuff */
 		IFolder folder = project.getFolder(FOLDER);
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		//snapshot
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		/* do even more stuff */
 		IFile file = folder.getFile(FILE);
 		byte[] bytes = "Test bytes".getBytes();
 		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
-			file.create(in, true, getMonitor());
+			file.create(in, true, createTestMonitor());
 		}
 
 		//snapshot
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		//exit without saving
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -30,12 +31,12 @@ public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
 		/* create some resource handles */
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFile file = project.getFile(FILE);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		file.create(getRandomContents(), true, null);
-		project.close(getMonitor());
+		project.close(createTestMonitor());
 
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {
@@ -46,7 +47,7 @@ public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
 		assertTrue("1.1", !project.isOpen());
 		assertTrue("1.2", !file.exists());
 
-		project.open(getMonitor());
+		project.open(createTestMonitor());
 
 		assertTrue("2.0", project.isOpen());
 		assertTrue("2.1", file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
 import junit.framework.Test;
@@ -36,26 +37,26 @@ public class TestSnapSaveSnap extends WorkspaceSerializationTest {
 		IProject project = getWorkspace().getRoot().getProject(PROJECT);
 		IFolder folder = project.getFolder(FOLDER);
 		IFile file = folder.getFile(FILE);
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 
 		// snapshot
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 
 		/* do more stuff */
-		folder.create(true, true, getMonitor());
+		folder.create(true, true, createTestMonitor());
 
 		// full save
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 
 		/* do even more stuff */
 		byte[] bytes = "Test bytes".getBytes();
 		try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
-			file.create(in, true, getMonitor());
+			file.create(in, true, createTestMonitor());
 		}
 
 		// snapshot
-		workspace.save(false, getMonitor());
+		workspace.save(false, createTestMonitor());
 		//exit without saving
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IWorkspace;
@@ -46,8 +47,8 @@ public class TestWorkspaceEncodingNewWorkspace extends WorkspaceSessionTest {
 		// Should be default
 		assertEquals("UTF-8", charset);
 		// Set something else
-		workspace.getRoot().setDefaultCharset(CHARSET, getMonitor());
-		workspace.save(true, getMonitor());
+		workspace.getRoot().setDefaultCharset(CHARSET, createTestMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void testExpectedEncoding2() throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -48,7 +49,7 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 		desc.setMaxFileStateSize(MAX_FILE_SIZE);
 		desc.setSnapshotInterval(SNAPSHOT_INTERVAL);
 		workspace.setDescription(desc);
-		workspace.save(true, getMonitor());
+		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -26,8 +27,8 @@ public class HistoryStorePerformanceTest extends ResourceTest {
 	@Override
 	public void setUp() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		project.create(getMonitor());
-		project.open(getMonitor());
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
 		IWorkspaceDescription description = getWorkspace().getDescription();
 		description.setFileStateLongevity(1000 * 3600 * 24); // 1 day
 		description.setMaxFileStates(10000);
@@ -38,7 +39,7 @@ public class HistoryStorePerformanceTest extends ResourceTest {
 	@Override
 	protected void tearDown() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		project.clearHistory(getMonitor());
+		project.clearHistory(createTestMonitor());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.ICommand;
@@ -39,10 +40,10 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 				throw new IllegalArgumentException(exceptionToThrow);
 			}
 			if (triggerBuild) {
-				project.touch(getMonitor());
+				project.touch(createTestMonitor());
 			}
 			if (nestedOperation != null) {
-				getWorkspace().run(nestedOperation, getMonitor());
+				getWorkspace().run(nestedOperation, createTestMonitor());
 			}
 		};
 	}
@@ -54,8 +55,8 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 		ICommand command = prjDescription.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		prjDescription.setBuildSpec(new ICommand[] { command });
-		project.create(prjDescription, getMonitor());
-		project.open(getMonitor());
+		project.create(prjDescription, createTestMonitor());
+		project.open(createTestMonitor());
 		waitForBuild();
 		SignaledBuilder builder = SignaledBuilder.getInstance(project);
 
@@ -65,7 +66,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 			IWorkspaceRunnable op2 = createRunnable(project, op1, false, null);
 			IWorkspaceRunnable op3 = createRunnable(project, op2, false, null);
 			builder.reset();
-			getWorkspace().run(op3, getMonitor());
+			getWorkspace().run(op3, createTestMonitor());
 			waitForBuild();
 			assertTrue("1.1", builder.wasExecuted());
 		}
@@ -76,7 +77,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 			IWorkspaceRunnable op2 = createRunnable(project, op1, true, null);
 			IWorkspaceRunnable op3 = createRunnable(project, op2, true, null);
 			builder.reset();
-			assertThrows(OperationCanceledException.class, () -> getWorkspace().run(op3, getMonitor()));
+			assertThrows(OperationCanceledException.class, () -> getWorkspace().run(op3, createTestMonitor()));
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
 			assertTrue("2.2", !builder.wasExecuted());
@@ -88,7 +89,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 			IWorkspaceRunnable op2 = createRunnable(project, op1, true, null);
 			IWorkspaceRunnable op3 = createRunnable(project, op2, true, null);
 			builder.reset();
-			CoreException exception = assertThrows(CoreException.class, () -> getWorkspace().run(op3, getMonitor()));
+			CoreException exception = assertThrows(CoreException.class, () -> getWorkspace().run(op3, createTestMonitor()));
 			assertEquals(Status.CANCEL_STATUS, exception.getStatus());
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
@@ -101,7 +102,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 			IWorkspaceRunnable op2 = createRunnable(project, op1, false, null);
 			IWorkspaceRunnable op3 = createRunnable(project, op2, false, null);
 			builder.reset();
-			getWorkspace().run(op3, getMonitor());
+			getWorkspace().run(op3, createTestMonitor());
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
 			assertTrue("4.1", !builder.wasExecuted());

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/CoreTest.java
@@ -278,7 +278,7 @@ public class CoreTest extends TestCase {
 		return new ByteArrayInputStream(text.getBytes());
 	}
 
-	public IProgressMonitor getMonitor() {
+	public static IProgressMonitor getMonitor() {
 		return new FussyProgressMonitor();
 	}
 


### PR DESCRIPTION
The getMonitor() method in CoreTest is actually a factory method creating a monitor upon each call. It is not tied to an instance of CoreTest. This change adds an according method with a name indicating the creation behavior to the ResourceTestUtil and updates calls to that method within the resource tests. This is part of the cleanup for the ResourceTest inheritance hierarchy in order to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903