### PR TITLE
Remove ResourceTest#transferStreams() #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -863,8 +864,8 @@ public class BuilderTest extends AbstractBuilderTest {
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			input.setContents(new ByteArrayInputStream(new byte[] { 5, 4, 3, 2, 1 }), IResource.NONE, createTestMonitor());
 			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-			try {
-				transferStreams(output.getContents(), out, null);
+			try (InputStream inputStream = output.getContents()) {
+				inputStream.transferTo(out);
 			} catch (IOException e) {
 				exception.set(e);
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -42,7 +42,6 @@ import org.eclipse.core.internal.resources.CharsetDeltaJob;
 import org.eclipse.core.internal.resources.Resource;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -96,18 +95,6 @@ public abstract class ResourceTest extends CoreTest {
 			getWorkspace().setDescription(storedWorkspaceDescription);
 		}
 		storedWorkspaceDescription = null;
-	}
-
-	/**
-	 * Convenience method to copy contents from one stream to another.
-	 */
-	public static void transferStreams(InputStream source, OutputStream destination, String path) throws IOException {
-		try {
-			source.transferTo(destination);
-		}finally {
-			FileUtil.safeClose(source);
-			FileUtil.safeClose(destination);
-		}
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -22,6 +22,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -70,7 +72,10 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		// move .project to a temp location
 		File dotProjectCopy = getTempDir().append("dotProjectCopy").toFile();
 		dotProjectCopy.createNewFile();
-		transferStreams(new FileInputStream(dotProject), new FileOutputStream(dotProjectCopy), null);
+		try (InputStream input = new FileInputStream(dotProject);
+				OutputStream output = new FileOutputStream(dotProjectCopy)) {
+			input.transferTo(output);
+		}
 		dotProject.delete();
 	}
 
@@ -86,7 +91,10 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		File dotProjectCopy = getTempDir().append("dotProjectCopy").toFile();
 
 		dotProject.createNewFile();
-		transferStreams(new FileInputStream(dotProjectCopy), new FileOutputStream(dotProject), null);
+		try (InputStream input = new FileInputStream(dotProjectCopy);
+				OutputStream output = new FileOutputStream(dotProject)) {
+			input.transferTo(output);
+		}
 		dotProjectCopy.delete();
 
 		project.open(createTestMonitor());


### PR DESCRIPTION
The ResourceTest class provides the convenience method transferStreams() to copy an input stream to an output stream and close them. First, this method has only few consumers. At most places, this kind of stream content transfer is implemented ordinarily. Second, the only benefit of this method is that the streams are closed automatically, which makes the consumers hard to comprehend as the auto-closing of passed streams is not obvious.

This change removes the method and makes stream closing explicit at the existing consumers.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903