### PR TITLE
Remove unnecessary ensure* methods in ResourceTest #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -141,7 +141,8 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* initialize common objects */
 		ensureExistsInWorkspace(project, true);
-		ensureExistsInFileSystem(new IResource[] {folder, file});
+		ensureExistsInFileSystem(folder);
+		ensureExistsInFileSystem(file);
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 		projectLocation = project.getLocation();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -167,7 +167,9 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		IResource[] resources = buildResources(project, new String[] { "/Folder1/", "/Folder1/File1",
 				"/Folder1/Folder2/", "/Folder1/Folder2/File2", "/Folder1/Folder2/Folder3/" });
 		ensureExistsInWorkspace(resources, true);
-		ensureDoesNotExistInFileSystem(resources);
+		for (IResource resource : resources) {
+			ensureDoesNotExistInFileSystem(resource);
+		}
 
 		// exists
 		assertTrue(project.isLocal(IResource.DEPTH_INFINITE)); // test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -120,10 +120,11 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 
 		IFolder folder = project.getFolder("Folder");
 		IFile file = folder.getFile("File");
-		IResource[] both = new IResource[] {folder, file};
 
-		ensureExistsInFileSystem(both);
-		ensureDoesNotExistInWorkspace(both);
+		ensureExistsInFileSystem(folder);
+		ensureDoesNotExistInWorkspace(folder);
+		ensureExistsInFileSystem(file);
+		ensureDoesNotExistInWorkspace(file);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
@@ -136,8 +137,10 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		//try again with deleted project
 		project.delete(IResource.FORCE, createTestMonitor());
 
-		ensureExistsInFileSystem(both);
-		ensureDoesNotExistInWorkspace(both);
+		ensureExistsInFileSystem(folder);
+		ensureDoesNotExistInWorkspace(folder);
+		ensureExistsInFileSystem(file);
+		ensureDoesNotExistInWorkspace(file);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -238,7 +238,9 @@ public class IResourceTest extends ResourceTest {
 		//file system only
 		unsynchronized = buildResources(root, new String[] {"1/1/2/2/1"});
 		ensureDoesNotExistInWorkspace(unsynchronized);
-		ensureExistsInFileSystem(unsynchronized);
+		for (IResource resource : unsynchronized) {
+			ensureExistsInFileSystem(resource);
+		}
 		unsynchronizedResources.add(unsynchronized[0]);
 		return result;
 	}
@@ -2278,7 +2280,9 @@ public class IResourceTest extends ResourceTest {
 
 		String[] hierarchy = {"Folder/", "Folder/Folder/", "Folder/Folder/Folder/", "Folder/Folder/Folder/Folder/"};
 		IResource[] resources = buildResources(folder, hierarchy);
-		ensureExistsInFileSystem(resources);
+		for (IResource resource : resources) {
+			ensureExistsInFileSystem(resource);
+		}
 		assertDoesNotExistInWorkspace(resources);
 
 		folder.refreshLocal(IResource.DEPTH_ONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -306,15 +306,6 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Delete the resources in the array from the local store.
-	 */
-	public void ensureDoesNotExistInFileSystem(IResource[] resources) {
-		for (IResource resource : resources) {
-			ensureDoesNotExistInFileSystem(resource);
-		}
-	}
-
-	/**
 	 * Delete the given resource from the workspace resource tree.
 	 */
 	public void ensureDoesNotExistInWorkspace(IResource resource) throws CoreException {
@@ -337,31 +328,14 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Create the given file in the local store. Use the resource manager
+	 * Create the given file or folder in the local store. Use the resource manager
 	 * to ensure that we have a correct Path -&gt; File mapping.
-	 */
-	public void ensureExistsInFileSystem(IFile file) throws CoreException {
-		createFileInFileSystem(((Resource) file).getStore());
-	}
-
-	/**
-	 * Create the given folder in the local store. Use the resource
-	 * manager to ensure that we have a correct Path -&gt; File mapping.
 	 */
 	public void ensureExistsInFileSystem(IResource resource) throws CoreException {
 		if (resource instanceof IFile file) {
-			ensureExistsInFileSystem(file);
+			createFileInFileSystem(((Resource) file).getStore());
 		} else {
 			((Resource) resource).getStore().mkdir(EFS.NONE, null);
-		}
-	}
-
-	/**
-	 * Create the each resource of the array in the local store.
-	 */
-	public void ensureExistsInFileSystem(IResource[] resources) throws CoreException {
-		for (IResource resource : resources) {
-			ensureExistsInFileSystem(resource);
 		}
 	}
 


### PR DESCRIPTION
Several methods for ensuring file (non-)existence in the ResourceTest class are unnecessary. They are convenience methods to process multiple resources which only have few consumers, which can iterate over the resources on their own. Some of them even wrap two resources into an array to pass to the method instead of calling the method two with single resources. This change clean ups the according functionality.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903