### PR TITLE
Provide unique strings for resource tests via utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -264,7 +265,7 @@ public class BasicAliasTest extends ResourceTest {
 		String[] devices = findAvailableDevices();
 		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
-		String location = getUniqueString();
+		String location = createUniqueString();
 		IProject testProject1 = getWorkspace().getRoot().getProject(location + "1");
 		IProject testProject2 = getWorkspace().getRoot().getProject(location + "2");
 
@@ -402,8 +403,8 @@ public class BasicAliasTest extends ResourceTest {
 		aliasManager.startup(null);
 
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject p1 = root.getProject(getUniqueString());
-		IProject p2 = root.getProject(getUniqueString());
+		IProject p1 = root.getProject(createUniqueString());
+		IProject p2 = root.getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {p1, p2}, true);
 
 		IFileStore tempStore = getTempStore();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertThrows;
 
@@ -48,7 +49,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 
 	@Test
 	public void testBug440110() throws Exception {
-		String projectName = getUniqueString();
+		String projectName = createUniqueString();
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(projectName);
 		IProjectDescription projectDescription = workspace.newProjectDescription(projectName);
@@ -401,7 +402,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	 */
 	@Test
 	public void testBug547691() throws CoreException {
-		String projectName = getUniqueString();
+		String projectName = createUniqueString();
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(projectName);
 		IProjectDescription projectDescription = workspace.newProjectDescription(projectName);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.File;
@@ -60,7 +61,7 @@ public class MoveTest extends LocalStoreTest {
 		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
 		// create common objects
-		String location = getUniqueString();
+		String location = createUniqueString();
 		IProject source = getWorkspace().getRoot().getProject(location + "1");
 		IProject destination = getWorkspace().getRoot().getProject(location + "2");
 		source.create(createTestMonitor());
@@ -162,7 +163,7 @@ public class MoveTest extends LocalStoreTest {
 		Assume.assumeFalse(devices[0] == null || devices[1] == null);
 
 		// create common objects
-		String location = getUniqueString();
+		String location = createUniqueString();
 		IProject source = getWorkspace().getRoot().getProject(location + "1");
 		IProject destination = getWorkspace().getRoot().getProject(location + "2");
 		source.create(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -272,7 +273,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 	}
 
 	public void test368376() throws CoreException, IOException {
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 
 		String filePath = "a/b/c/file.txt";

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -118,9 +119,9 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void testSimple() throws CoreException {
 		IProject project = getProject("foo");
 		String qualifier = "org.eclipse.core.tests.resources";
-		String key = "key" + getUniqueString();
-		String instanceValue = "instance" + getUniqueString();
-		String projectValue = "project" + getUniqueString();
+		String key = "key" + createUniqueString();
+		String instanceValue = "instance" + createUniqueString();
+		String projectValue = "project" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		IScopeContext instanceContext = InstanceScope.INSTANCE;
 		ensureExistsInWorkspace(project, true);
@@ -209,10 +210,10 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 	public void testListener() throws Exception {
 		// setup
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		String qualifier = "org.eclipse.core.tests.resources";
-		String key = "key" + getUniqueString();
-		String value = "value" + getUniqueString();
+		String key = "key" + createUniqueString();
+		String value = "value" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		// create project
 		ensureExistsInWorkspace(project, true);
@@ -235,8 +236,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 
 		// change settings in the file
-		String newKey = "newKey" + getUniqueString();
-		String newValue = "newValue" + getUniqueString();
+		String newKey = "newKey" + createUniqueString();
+		String newValue = "newValue" + createUniqueString();
 		props.put(newKey, newValue);
 
 		// save the file and ensure timestamp is different
@@ -267,12 +268,12 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void testProjectDelete() throws Exception {
 		// create the project
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		// set some settings
-		String qualifier = getUniqueString();
-		String key = getUniqueString();
-		String value = getUniqueString();
+		String qualifier = createUniqueString();
+		String key = createUniqueString();
+		String value = createUniqueString();
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode(qualifier);
 		Preferences parent = node.parent().parent();
@@ -294,13 +295,13 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 	/** See bug 91244, bug 93398 and bug 211006. */
 	public void testProjectMove() throws Exception {
-		IProject project1 = getProject(getUniqueString());
-		IProject project2 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
+		IProject project2 = getProject(createUniqueString());
 
 		ensureExistsInWorkspace(new IResource[] {project1}, true);
-		String qualifier = getUniqueString();
-		String key = getUniqueString();
-		String value = getUniqueString();
+		String qualifier = createUniqueString();
+		String key = createUniqueString();
+		String value = createUniqueString();
 		Preferences node = new ProjectScope(project1).getNode(qualifier);
 		node.put(key, value);
 		node.flush();
@@ -333,9 +334,9 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_60925() throws Exception {
 		// setup
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
-		String qualifier = getUniqueString();
+		String qualifier = createUniqueString();
 		IFile file = getFileInWorkspace(project, qualifier);
 
 		// should be nothing in the file system
@@ -344,8 +345,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 		// store a preference key/value pair
 		IScopeContext context = new ProjectScope(project);
-		String key = getUniqueString();
-		String value = getUniqueString();
+		String key = createUniqueString();
+		String value = createUniqueString();
 		Preferences node = context.getNode(qualifier);
 		node.put(key, value);
 
@@ -363,13 +364,13 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Problems with a dot "." as a key name
 	 */
 	public void test_55410() throws Exception {
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {project1}, true);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES).node("subnode");
 		String key1 = ".";
 		String key2 = "x";
-		String value1 = getUniqueString();
-		String value2 = getUniqueString();
+		String value1 = createUniqueString();
+		String value2 = createUniqueString();
 		node.put(key1, value1);
 		node.put(key2, value2);
 		assertEquals("0.8", value1, node.get(key1, null));
@@ -393,15 +394,15 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * project is moved.
 	 */
 	public void test_61277a() throws Exception {
-		IProject project = getProject(getUniqueString());
-		IProject destProject = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
+		IProject destProject = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		ensureDoesNotExistInWorkspace(destProject);
 		IScopeContext context = new ProjectScope(project);
-		String qualifier = getUniqueString();
+		String qualifier = createUniqueString();
 		Preferences node = context.getNode(qualifier);
-		String key = getUniqueString();
-		String value = getUniqueString();
+		String key = createUniqueString();
+		String value = createUniqueString();
 		node.put(key, value);
 		assertEquals("1.0", value, node.get(key, null));
 
@@ -423,8 +424,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * project is moved.
 	 */
 	public void test_61277b() throws Exception {
-		IProject project1 = getProject(getUniqueString());
-		IProject project2 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {project1}, true);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertTrue("1.0", getFileInWorkspace(project1, ResourcesPlugin.PI_RESOURCES).exists());
@@ -447,21 +448,21 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Problems with a key which is the empty string.
 	 */
 	public void test_61277c() throws Exception {
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {project1}, true);
 		assertTrue("1.0", getFileInWorkspace(project1, ResourcesPlugin.PI_RESOURCES).exists());
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES);
 		String key1 = "key";
 		String emptyKey = "";
-		String value1 = getUniqueString();
-		String value2 = getUniqueString();
+		String value1 = createUniqueString();
+		String value2 = createUniqueString();
 		node.put(key1, value1);
 		node.put(emptyKey, value2);
 		node.flush();
 		assertTrue("1.2", getFileInWorkspace(project1, ResourcesPlugin.PI_RESOURCES).exists());
 
 		// move project and ensures charsets settings are preserved
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), false, null);
 		assertTrue("2.0", getFileInWorkspace(project2, ResourcesPlugin.PI_RESOURCES).exists());
 
@@ -478,8 +479,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_61843() throws Exception {
 		// create the project and manually give it a settings file
-		final String qualifier = getUniqueString();
-		final IProject project = getProject(getUniqueString());
+		final String qualifier = createUniqueString();
+		final IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		IFile settingsFile = getFileInWorkspace(project, qualifier);
 
@@ -522,11 +523,11 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * should be forgotten.
 	 */
 	public void test_65068() throws Exception {
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		String key = "key";
-		String value = getUniqueString();
+		String value = createUniqueString();
 		node.put(key, value);
 		node.flush();
 		assertTrue("1.2", getFileInWorkspace(project, ResourcesPlugin.PI_RESOURCES).exists());
@@ -541,7 +542,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Bug 95052 - external property removals are not detected.
 	 */
 	public void test_95052() throws Exception {
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		node.put("key1", "value1");
@@ -584,7 +585,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Bug 579372 - property removals are not detected.
 	 */
 	public void test_579372() throws Exception {
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		node.put("key1", "value1");
@@ -651,18 +652,18 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * should be updated.
 	 */
 	public void test_256900() throws Exception {
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 
 		// create the destination project and the .settings folder inside
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		ensureExistsInWorkspace(project2, true);
 		ensureExistsInWorkspace(project2.getFolder(DIR_NAME), true);
 
 		// get the pref node for the project and add a sample key/value to it
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		String key = "key";
-		String value = getUniqueString();
+		String value = createUniqueString();
 		node.put(key, value);
 		node.flush();
 
@@ -685,19 +686,19 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Creates property file with various characters on front and verifies that they are written in alphabetical order.
 	 */
 	public void test_325000() throws Exception {
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {project1}, true);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES).node("subnode");
 
 		List<String> keys = new ArrayList<>();
-		keys.add("z" + getUniqueString());
-		keys.add("a" + getUniqueString());
-		keys.add("1" + getUniqueString());
-		keys.add("z" + getUniqueString());
-		keys.add("_" + getUniqueString());
-		keys.add(getUniqueString());
+		keys.add("z" + createUniqueString());
+		keys.add("a" + createUniqueString());
+		keys.add("1" + createUniqueString());
+		keys.add("z" + createUniqueString());
+		keys.add("_" + createUniqueString());
+		keys.add(createUniqueString());
 		for (String key : keys) {
-			node.put(key, getUniqueString());
+			node.put(key, createUniqueString());
 		}
 		node.flush();
 
@@ -733,7 +734,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	}
 
 	public void test_335591() throws Exception {
-		String projectName = getUniqueString();
+		String projectName = createUniqueString();
 		String nodeName = "node";
 		IProject project = getProject(projectName);
 
@@ -812,7 +813,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 			newProjectValue = "\n";
 		}
 
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 
 		Preferences rootNode = Platform.getPreferencesService().getRootNode();
@@ -826,7 +827,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		Preferences node = rootNode.node(ProjectScope.SCOPE).node(project.getName()).node(qualifier);
 		String key = "key";
 		try {
-			node.put(key, getUniqueString());
+			node.put(key, createUniqueString());
 			node.flush();
 			// if there is no preference, OS default line separator should be used
 			assertEquals("1.0", systemValue, getLineSeparatorFromFile(file));
@@ -834,7 +835,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 			instanceNode.put(Platform.PREF_LINE_SEPARATOR, newInstanceValue);
 			instanceNode.flush();
-			node.put(key, getUniqueString());
+			node.put(key, createUniqueString());
 			node.flush();
 			// if there is instance preference then it should be used
 			assertEquals("2.0", newInstanceValue, getLineSeparatorFromFile(file));
@@ -842,7 +843,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 			projectNode.put(Platform.PREF_LINE_SEPARATOR, newProjectValue);
 			projectNode.flush();
-			node.put(key, getUniqueString());
+			node.put(key, createUniqueString());
 			node.flush();
 			// if there is project preference then it should be used
 			String recentlyUsedLineSeparator = getLineSeparatorFromFile(file);
@@ -862,7 +863,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 			}
 			instanceNode.flush();
 			projectNode.flush();
-			node.put(key, getUniqueString());
+			node.put(key, createUniqueString());
 			node.flush();
 			// if the prefs file exists, line delimiter from the existing file should be used
 			assertEquals("4.0", recentlyUsedLineSeparator, getLineSeparatorFromFile(file));
@@ -878,7 +879,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	}
 
 	public void test_336211() throws BackingStoreException, CoreException, IOException {
-		String projectName = getUniqueString();
+		String projectName = createUniqueString();
 		String nodeName = "node";
 		IProject project = getProject(projectName);
 
@@ -908,11 +909,11 @@ public class ProjectPreferencesTest extends ResourceTest {
 	}
 
 	public void testProjectOpenClose() throws Exception {
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
-		String qualifier = getUniqueString();
-		String key = getUniqueString();
-		String value = getUniqueString();
+		String qualifier = createUniqueString();
+		String key = createUniqueString();
+		String value = createUniqueString();
 		Preferences node = new ProjectScope(project).getNode(qualifier);
 		node.put(key, value);
 		node.flush();
@@ -933,10 +934,10 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 	public void testListenerOnChangeFile() throws Exception {
 		// setup
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		String qualifier = "org.eclipse.core.tests.resources";
-		String key = "key" + getUniqueString();
-		String value = "value" + getUniqueString();
+		String key = "key" + createUniqueString();
+		String value = "value" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		// create project
 		ensureExistsInWorkspace(project, true);
@@ -963,8 +964,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// reset the listener
 		tracer.log.setLength(0);
 		// change settings in the file
-		String newKey = "newKey" + getUniqueString();
-		String newValue = "newValue" + getUniqueString();
+		String newKey = "newKey" + createUniqueString();
+		String newValue = "newValue" + createUniqueString();
 		props.put(newKey, newValue);
 
 		// save the file via the IFile API
@@ -1004,7 +1005,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void testLoadIsImport() throws Exception {
 
 		// setup
-		IProject project = getProject(getUniqueString());
+		IProject project = getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		IScopeContext context = new ProjectScope(project);
 		String qualifier = "test.load.is.import";
@@ -1086,7 +1087,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1095,7 +1096,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1125,7 +1126,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1134,7 +1135,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1160,7 +1161,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1169,7 +1170,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1195,7 +1196,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1204,7 +1205,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1228,7 +1229,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1237,7 +1238,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1263,7 +1264,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1272,7 +1273,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1298,7 +1299,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1307,7 +1308,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1332,7 +1333,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value";
 		String anotherValue = "anotherValue";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1341,7 +1342,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1366,7 +1367,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1375,7 +1376,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
 
-		IProject project2 = getProject(getUniqueString());
+		IProject project2 = getProject(createUniqueString());
 		project1.move(project2.getFullPath(), IResource.NONE, createTestMonitor());
 
 		Preferences prefs2 = new ProjectScope(project2).getNode(nodeA).node(nodeB);
@@ -1399,7 +1400,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
@@ -1426,7 +1427,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String key = "key";
 		String value = "value";
 
-		IProject project1 = getProject(getUniqueString());
+		IProject project1 = getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
 import static org.junit.Assert.assertThrows;
 
@@ -338,7 +339,7 @@ public class CharsetTest extends ResourceTest {
 
 	public void testBug59899() throws CoreException {
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		try {
 			IFile file = project.getFile("file.txt");
 			IFolder folder = project.getFolder("folder");
@@ -409,8 +410,8 @@ public class CharsetTest extends ResourceTest {
 			ensureExistsInWorkspace(project, true);
 			project.setDefaultCharset("BAR", createTestMonitor());
 
-			IFolder folder = project.getFolder(getUniqueString());
-			IFile file = folder.getFile(getUniqueString());
+			IFolder folder = project.getFolder(createUniqueString());
+			IFile file = folder.getFile(createUniqueString());
 			assertEquals("1.0", "BAR", file.getCharset(true));
 
 			ensureExistsInWorkspace(folder, true);
@@ -434,7 +435,7 @@ public class CharsetTest extends ResourceTest {
 	public void testBug186984() throws Exception {
 		getResourcesPreferences().putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFile file = project.getFile("file.xml");
 
 		// Test changing content types externally as per bug 186984 Comment 8
@@ -1101,7 +1102,7 @@ public class CharsetTest extends ResourceTest {
 	 */
 	public void testDeltasContainer() throws CoreException {
 		MultipleDeltasCharsetVerifier verifier = new MultipleDeltasCharsetVerifier(CharsetVerifier.IGNORE_BACKGROUND_THREAD);
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
 		try {
 			IFile prefs = getResourcesPreferenceFile(project, false);
@@ -1393,7 +1394,7 @@ public class CharsetTest extends ResourceTest {
 	public void testBug464072() throws CoreException {
 		getResourcesPreferences().putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFile file = project.getFile("file.txt");
 		ensureExistsInWorkspace(file, true);
 		file.getLocation().toFile().delete();
@@ -1403,7 +1404,7 @@ public class CharsetTest extends ResourceTest {
 
 	public void testBug528827() throws CoreException, OperationCanceledException, InterruptedException {
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		JobChangeAdapterExtension listener = new JobChangeAdapterExtension();
 		Job.getJobManager().addJobChangeListener(listener);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -1185,7 +1186,7 @@ public class FilteredResourceTest extends ResourceTest {
 	 * Regression test for bug 328464
 	 */
 	public void test328464() throws CoreException {
-		IFolder folder = existingProject.getFolder(getUniqueString());
+		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
 		IFile file_a_txt = folder.getFile("a.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.junit.Assert.assertThrows;
 
@@ -35,7 +36,7 @@ import org.eclipse.core.runtime.CoreException;
 public class HiddenResourceTest extends ResourceTest {
 	public void testRefreshLocal() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -61,7 +62,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 */
 	public void testFindMember() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -94,7 +95,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * calls unless specifically included by calling #members(IContainer.INCLUDE_HIDDEN)
 	 */
 	public void testMembers() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -180,7 +181,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * resource visitors.
 	 */
 	public void testAccept() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -254,7 +255,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 	public void testCopy() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -307,7 +308,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 	public void testMove() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -360,7 +361,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 	public void testDelete() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -418,7 +419,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 	public void testDeltas() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		final IProject project = root.getProject(getUniqueString());
+		final IProject project = root.getProject(createUniqueString());
 		final IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -507,7 +508,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * in all calls to #exists.
 	 */
 	public void testExists() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -532,7 +533,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * Test the set and get methods for hidden resources.
 	 */
 	public void testSetGet() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
@@ -591,7 +592,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * handles {@link IResource#HIDDEN} flag properly.
 	 */
 	public void testCreateHiddenResources() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 
@@ -603,7 +604,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertHidden(folder, true, IResource.DEPTH_ZERO);
 		assertHidden(file, true, IResource.DEPTH_ZERO);
 
-		IProject project2 = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project2 = getWorkspace().getRoot().getProject(createUniqueString());
 
 		project2.create(null, IResource.HIDDEN, createTestMonitor());
 		project2.open(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertThrows;
 
@@ -494,7 +495,7 @@ public class IProjectTest extends ResourceTest {
 		Preferences instanceNode = rootNode.node(InstanceScope.SCOPE).node(Platform.PI_RUNTIME);
 		String oldInstanceValue = instanceNode.get(Platform.PREF_LINE_SEPARATOR, null);
 
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFile file = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		IProjectDescription description;
 		try {
@@ -611,7 +612,7 @@ public class IProjectTest extends ResourceTest {
 			return;
 		}
 
-		String projectName = getUniqueString() + "a";
+		String projectName = createUniqueString() + "a";
 		IProject project = getWorkspace().getRoot().getProject(projectName);
 
 		project.create(monitor);
@@ -2240,7 +2241,7 @@ public class IProjectTest extends ResourceTest {
 
 	public void testProjectMoveVariations_bug307140() throws CoreException {
 		// Test moving project to its subfolder
-		IProject originalProject = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject originalProject = getWorkspace().getRoot().getProject(createUniqueString());
 		originalProject.create(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
@@ -2248,7 +2249,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.assertUsedUp();
 
 		IPath originalLocation = originalProject.getLocation();
-		IFolder originalProjectSubFolder = originalProject.getFolder(getUniqueString());
+		IFolder originalProjectSubFolder = originalProject.getFolder(createUniqueString());
 
 		assertThrows(CoreException.class, () -> {
 			IProjectDescription originalDescription = originalProject.getDescription();
@@ -2266,7 +2267,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.assertUsedUp();
 
 		// Test moving project to its subfolder - project at non-default location
-		IProject destinationProject = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject destinationProject = getWorkspace().getRoot().getProject(createUniqueString());
 
 		//location outside the workspace
 		IProjectDescription newDescription = getWorkspace().newProjectDescription(destinationProject.getName());
@@ -2279,7 +2280,7 @@ public class IProjectTest extends ResourceTest {
 		monitor.assertUsedUp();
 
 		IPath destinationLocation = destinationProject.getLocation();
-		IFolder destinationProjectSubFolder = destinationProject.getFolder(getUniqueString());
+		IFolder destinationProjectSubFolder = destinationProject.getFolder(createUniqueString());
 
 		assertThrows(CoreException.class, () ->  {
 			IProjectDescription destinationDescription = destinationProject.getDescription();
@@ -2474,7 +2475,7 @@ public class IProjectTest extends ResourceTest {
 	}
 
 	public void testCreateHiddenProject() throws CoreException {
-		IProject hiddenProject = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject hiddenProject = getWorkspace().getRoot().getProject(createUniqueString());
 		ensureDoesNotExistInWorkspace(hiddenProject);
 
 		monitor.prepare();
@@ -2496,11 +2497,11 @@ public class IProjectTest extends ResourceTest {
 	}
 
 	public void testProjectDeletion_Bug347220() throws CoreException {
-		String projectName = getUniqueString();
+		String projectName = createUniqueString();
 
 		IProject project = getWorkspace().getRoot().getProject(projectName);
-		IFolder folder = project.getFolder(getUniqueString());
-		IFile file = folder.getFile(getUniqueString());
+		IFolder folder = project.getFolder(createUniqueString());
+		IFile file = folder.getFile(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {project, folder, file}, true);
 		project.open(monitor);
 		monitor.assertUsedUp();
@@ -2517,7 +2518,7 @@ public class IProjectTest extends ResourceTest {
 		IPath p = ((Workspace) getWorkspace()).getMetaArea().locationFor(project);
 		assertFalse("1.0", p.toFile().exists());
 
-		IProject otherProject = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject otherProject = getWorkspace().getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(new IResource[] {otherProject}, true);
 		monitor.prepare();
 		otherProject.open(monitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -724,18 +725,18 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	public void testDeleteFolderDuringRefresh() throws Throwable {
-		project1 = getWorkspace().getRoot().getProject(getUniqueString());
+		project1 = getWorkspace().getRoot().getProject(createUniqueString());
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 
-		project2 = getWorkspace().getRoot().getProject(getUniqueString());
+		project2 = getWorkspace().getRoot().getProject(createUniqueString());
 		project2.create(createTestMonitor());
 		project2.open(createTestMonitor());
 
 		assertTrue("1.0", project1.isOpen());
 		assertTrue("2.0", project2.isOpen());
 
-		final IFolder f = project1.getFolder(getUniqueString());
+		final IFolder f = project1.getFolder(createUniqueString());
 		f.create(true, true, createTestMonitor());
 
 		// the listener checks if an attempt to modify the tree succeeds if made in a job
@@ -787,11 +788,11 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	public void testRefreshOtherProjectDuringRefresh() throws Throwable {
-		final IProject p = getWorkspace().getRoot().getProject(getUniqueString());
+		final IProject p = getWorkspace().getRoot().getProject(createUniqueString());
 		p.create(null);
 		p.open(null);
 
-		project1 = getWorkspace().getRoot().getProject(getUniqueString());
+		project1 = getWorkspace().getRoot().getProject(createUniqueString());
 		project1.create(null);
 		project1.open(null);
 
@@ -873,7 +874,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	public void testPreRefreshNotification() throws Exception {
 		final IWorkspaceRoot root = getWorkspace().getRoot();
 
-		project1 = root.getProject(getUniqueString());
+		project1 = root.getProject(createUniqueString());
 		project1.create(null);
 		project1.open(null);
 
@@ -1598,11 +1599,11 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	public void testRemoveAndCreateUnderlyingFileForLinkedResource() throws CoreException, IOException {
-		IPath path = getTempDir().addTrailingSeparator().append(getUniqueString());
+		IPath path = getTempDir().addTrailingSeparator().append(createUniqueString());
 		deleteOnTearDown(path);
 		path.toFile().createNewFile();
 
-		IFile linkedFile = project1.getFile(getUniqueString());
+		IFile linkedFile = project1.getFile(createUniqueString());
 		linkedFile.createLink(path, IResource.NONE, createTestMonitor());
 
 		// check the delta when underlying file is removed
@@ -1620,11 +1621,11 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	public void testRemoveAndCreateUnderlyingFolderForLinkedResource() throws CoreException {
-		IPath path = getTempDir().addTrailingSeparator().append(getUniqueString());
+		IPath path = getTempDir().addTrailingSeparator().append(createUniqueString());
 		deleteOnTearDown(path);
 
 		path.toFile().mkdir();
-		IFolder linkedFolder = project1.getFolder(getUniqueString());
+		IFolder linkedFolder = project1.getFolder(createUniqueString());
 		linkedFolder.createLink(path, IResource.NONE, createTestMonitor());
 
 		// check the delta when underlying folder is removed
@@ -1641,14 +1642,14 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	}
 
 	public void testBug228354() throws CoreException {
-		IPath path = getTempDir().addTrailingSeparator().append(getUniqueString());
+		IPath path = getTempDir().addTrailingSeparator().append(createUniqueString());
 		deleteOnTearDown(path);
 
 		path.toFile().mkdir();
-		IFolder linkedFolder = project1.getFolder(getUniqueString());
+		IFolder linkedFolder = project1.getFolder(createUniqueString());
 		linkedFolder.createLink(path, IResource.NONE, createTestMonitor());
 
-		IFolder regularFolder = project1.getFolder(getUniqueString());
+		IFolder regularFolder = project1.getFolder(createUniqueString());
 		regularFolder.create(true, true, createTestMonitor());
 
 		// check the delta when underlying folder is removed

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -695,7 +696,7 @@ public class IResourceTest extends ResourceTest {
 	}
 
 	public void testAcceptDoNotCheckExistence() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder a = project.getFolder("a");
 		ensureExistsInWorkspace(project, true);
 
@@ -729,7 +730,7 @@ public class IResourceTest extends ResourceTest {
 	}
 
 	public void testAcceptProxyVisitorWithDepth() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder a = project.getFolder("a");
 		IFile a1 = a.getFile("a1.txt");
 		IFile a2 = a.getFile("a2.txt");
@@ -1403,7 +1404,7 @@ public class IResourceTest extends ResourceTest {
 	 */
 	public void testDerivedUsingAncestors() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = folder.getFile("file2.txt");
@@ -2201,7 +2202,7 @@ public class IResourceTest extends ResourceTest {
 		if (!isReadOnlySupported()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFile file = project.getFile("target");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -329,7 +330,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	@Test
 	public void testBug234343_folderInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject hiddenProject = root.getProject(getUniqueString());
+		IProject hiddenProject = root.getProject(createUniqueString());
 		ensureDoesNotExistInWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
 		hiddenProject.open(createTestMonitor());
@@ -347,7 +348,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	@Test
 	public void testBug234343_fileInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject hiddenProject = root.getProject(getUniqueString());
+		IProject hiddenProject = root.getProject(createUniqueString());
 		ensureDoesNotExistInWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
 		hiddenProject.open(createTestMonitor());
@@ -419,7 +420,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 
 	public void checkFindMethods(int updateFlags, int[][] results) throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		ensureDoesNotExistInWorkspace(project);
 
 		project.create(null, IResource.NONE, createTestMonitor());
@@ -484,9 +485,9 @@ public class IWorkspaceRootTest extends ResourceTest {
 	}
 
 	private IFile createFile(IContainer parent, int updateFlags, boolean linked) throws Exception {
-		IFile file = parent.getFile(IPath.fromOSString(getUniqueString()));
+		IFile file = parent.getFile(IPath.fromOSString(createUniqueString()));
 		if (linked) {
-			IPath path = getTempDir().append(getUniqueString());
+			IPath path = getTempDir().append(createUniqueString());
 			path.toFile().createNewFile();
 			file.createLink(URIUtil.toURI(path), updateFlags, createTestMonitor());
 			if ((updateFlags & IResource.TEAM_PRIVATE) == IResource.TEAM_PRIVATE) {
@@ -501,9 +502,9 @@ public class IWorkspaceRootTest extends ResourceTest {
 	}
 
 	private IFolder createFolder(IContainer parent, int updateFlags, boolean linked) throws CoreException {
-		IFolder folder = parent.getFolder(IPath.fromOSString(getUniqueString()));
+		IFolder folder = parent.getFolder(IPath.fromOSString(createUniqueString()));
 		if (linked) {
-			IPath path = getTempDir().append(getUniqueString());
+			IPath path = getTempDir().append(createUniqueString());
 			path.toFile().mkdir();
 			folder.createLink(URIUtil.toURI(path), updateFlags, createTestMonitor());
 			if ((updateFlags & IResource.TEAM_PRIVATE) == IResource.TEAM_PRIVATE) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -87,7 +88,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFileLinkedToNonExistent_Deep() throws CoreException {
-		IFile fileLink = existingProject.getFile(getUniqueString());
+		IFile fileLink = existingProject.getFile(createUniqueString());
 		IPath fileLocation = getRandomLocation();
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -115,7 +116,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFileLinkedToNonExistent_Shallow() throws CoreException {
-		IFile fileLink = existingProject.getFile(getUniqueString());
+		IFile fileLink = existingProject.getFile(createUniqueString());
 		IPath fileLocation = getRandomLocation();
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -135,7 +136,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderLinkedToNonExistent_Deep() throws CoreException {
-		IFolder folderLink = existingProject.getFolder(getUniqueString());
+		IFolder folderLink = existingProject.getFolder(createUniqueString());
 		IPath folderLocation = getRandomLocation();
 		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -155,7 +156,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderLinkedToNonExistent_Shallow() throws CoreException {
-		IFolder folderLink = existingProject.getFolder(getUniqueString());
+		IFolder folderLink = existingProject.getFolder(createUniqueString());
 		IPath folderLocation = getRandomLocation();
 		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -179,23 +180,23 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	 */
 	public void testMoveFolderWithLinksToNonExisitngLocations_withShallow() throws CoreException {
 		// create a folder
-		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
+		IFolder folderWithLinks = existingProject.getFolder(createUniqueString());
 		folderWithLinks.create(true, true, createTestMonitor());
 
 		// non-exisitng location
 		IPath fileLocation = getRandomLocation();
 
 		// create a linked file in the folder
-		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
+		IFile linkedFile = folderWithLinks.getFile(createUniqueString());
 		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// move the folder
-		folderWithLinks.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.SHALLOW,
+		folderWithLinks.move(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.SHALLOW,
 				createTestMonitor());
 
 		// move the folder
 		assertThrows(CoreException.class, () -> folderWithLinks
-				.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
+				.move(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should not exist
 		assertFalse("5.0", folderWithLinks.exists());
@@ -207,22 +208,22 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	 */
 	public void _testCopyFolderWithLinksToNonExisitngLocations_withShallow() throws CoreException {
 		// create a folder
-		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
+		IFolder folderWithLinks = existingProject.getFolder(createUniqueString());
 		folderWithLinks.create(true, true, createTestMonitor());
 
 		// non-exisitng location
 		IPath fileLocation = getRandomLocation();
 
 		// create a linked file in the folder
-		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
+		IFile linkedFile = folderWithLinks.getFile(createUniqueString());
 		linkedFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// copy the folder
-		folderWithLinks.copy(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.SHALLOW,
+		folderWithLinks.copy(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.SHALLOW,
 				createTestMonitor());
 
 		assertThrows(CoreException.class, () -> folderWithLinks
-				.copy(otherExistingProject.getFolder(getUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
+				.copy(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should exist
 		assertTrue("5.0", folderWithLinks.exists());
@@ -230,10 +231,10 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderWithFileLinkedToNonExistent_Deep() throws CoreException {
-		IFolder folder = existingProject.getFolder(getUniqueString());
+		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
-		IFile fileLinkInFolder = folder.getFile(getUniqueString());
+		IFile fileLinkInFolder = folder.getFile(createUniqueString());
 
 		IPath fileLocation = getRandomLocation();
 		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -254,10 +255,10 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderWithFileLinkedToNonExistent_Shallow() throws CoreException {
-		IFolder folder = existingProject.getFolder(getUniqueString());
+		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
-		IFile fileLinkInFolder = folder.getFile(getUniqueString());
+		IFile fileLinkInFolder = folder.getFile(createUniqueString());
 
 		IPath fileLocation = getRandomLocation();
 		fileLinkInFolder.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -278,10 +279,10 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderWithFolderLinkedToNonExistent_Deep() throws CoreException {
-		IFolder folder = existingProject.getFolder(getUniqueString());
+		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
-		IFolder folderLinkInFolder = folder.getFolder(getUniqueString());
+		IFolder folderLinkInFolder = folder.getFolder(createUniqueString());
 
 		IPath folderLocation = getRandomLocation();
 		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -302,10 +303,10 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void testFolderWithFolderLinkedToNonExistent_Shallow() throws CoreException {
-		IFolder folder = existingProject.getFolder(getUniqueString());
+		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder, true);
 
-		IFolder folderLinkInFolder = folder.getFolder(getUniqueString());
+		IFolder folderLinkInFolder = folder.getFolder(createUniqueString());
 
 		IPath folderLocation = getRandomLocation();
 		folderLinkInFolder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -326,7 +327,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 	}
 
 	public void test361201() throws CoreException {
-		String linkName = getUniqueString();
+		String linkName = createUniqueString();
 		IFile fileLink = existingProject.getFile(linkName);
 		IFile file = existingProject.getFolder("dir").getFile("foo.txt");
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertThrows;
 
@@ -785,7 +786,7 @@ public class LinkedResourceTest extends ResourceTest {
 	public void testDeleteLink_Bug351823() throws CoreException {
 		IProject project = existingProject;
 
-		IFile link = project.getFile(getUniqueString());
+		IFile link = project.getFile(createUniqueString());
 		link.createLink(localFile, IResource.NONE, createTestMonitor());
 
 		// set .project read-only
@@ -823,8 +824,8 @@ public class LinkedResourceTest extends ResourceTest {
 	public void testDeleteFolderWithLinks() throws CoreException {
 		IProject project = existingProject;
 		IFolder folder = existingFolderInExistingProject;
-		IFile file1 = folder.getFile(getUniqueString());
-		IFile file2 = project.getFile(getUniqueString());
+		IFile file1 = folder.getFile(createUniqueString());
+		IFile file2 = project.getFile(createUniqueString());
 		file1.createLink(localFile, IResource.NONE, createTestMonitor());
 		file2.createLink(localFile, IResource.NONE, createTestMonitor());
 
@@ -1563,7 +1564,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 */
 	public void testMoveFolderWithLinks() throws Exception {
 		// create a folder
-		IFolder folderWithLinks = existingProject.getFolder(getUniqueString());
+		IFolder folderWithLinks = existingProject.getFolder(createUniqueString());
 		folderWithLinks.create(true, true, createTestMonitor());
 
 		IPath fileLocation = getRandomLocation();
@@ -1571,7 +1572,7 @@ public class LinkedResourceTest extends ResourceTest {
 		createFileInFileSystem(resolve(fileLocation), getRandomContents());
 
 		// create a linked file in the folder
-		IFile linkedFile = folderWithLinks.getFile(getUniqueString());
+		IFile linkedFile = folderWithLinks.getFile(createUniqueString());
 		linkedFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
 		// there should be an entry in .project for the linked file
@@ -1579,7 +1580,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("3.0", string.contains(linkedFile.getProjectRelativePath().toString()));
 
 		// move the folder
-		folderWithLinks.move(otherExistingProject.getFolder(getUniqueString()).getFullPath(),
+		folderWithLinks.move(otherExistingProject.getFolder(createUniqueString()).getFullPath(),
 				IResource.SHALLOW | IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// both the folder and link in the source project should not exist

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -429,7 +430,7 @@ public class MarkerTest extends ResourceTest {
 	 * Bug 35300 - ClassCastException if marker transient attribute is set to a non-boolean
 	 */
 	public void test_35300() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 		String MARKER_ID = "foomarker.example.com";
 		int expected = 4;
@@ -461,7 +462,7 @@ public class MarkerTest extends ResourceTest {
 	 */
 	public void test_289811() throws CoreException {
 		String testValue = getRandomString();
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		project.create(null);
 		project.open(null);
 		IFile file = project.getFile("foo.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getInvalidNatureSets;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getValidNatureSets;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
@@ -115,7 +116,7 @@ public class NatureTest extends ResourceTest {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		this.project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
+		this.project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
 	}
 
 	private void assertHasEnabledNature(String nature) throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -160,7 +161,7 @@ public class ProjectEncodingTest extends ResourceTest {
 	}
 
 	private void whenProjectIsCreated() throws CoreException {
-		project = ResourcesPlugin.getWorkspace().getRoot().getProject(getUniqueString());
+		project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
@@ -21,7 +22,7 @@ import org.eclipse.core.resources.ProjectScope;
 public class ProjectScopeTest extends ResourceTest {
 
 	public void testEqualsAndHashCode() {
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		ProjectScope projectScope1 = new ProjectScope(project);
 		ProjectScope projectScope2 = new ProjectScope(project);
 		assertTrue(projectScope1.equals(projectScope2));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 
 import java.io.File;
@@ -269,8 +270,8 @@ public class ResourceAttributeTest extends ResourceTest {
 	public void testAttributes() throws CoreException {
 		int[] attributes = new int[] {EFS.ATTRIBUTE_GROUP_READ, EFS.ATTRIBUTE_GROUP_WRITE, EFS.ATTRIBUTE_GROUP_EXECUTE, EFS.ATTRIBUTE_OTHER_READ, EFS.ATTRIBUTE_OTHER_WRITE, EFS.ATTRIBUTE_OTHER_EXECUTE};
 
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
-		IFile file = project.getFile(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
+		IFile file = project.getFile(createUniqueString());
 		ensureExistsInWorkspace(file, getRandomContents());
 
 		for (int attribute : attributes) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +42,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
-import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -528,11 +528,6 @@ public abstract class ResourceTest extends CoreTest {
 
 	}
 
-	@Override
-	public String getUniqueString() {
-		return new UniversalUniqueIdentifier().toString();
-	}
-
 	/**
 	 * Checks whether the local file system supports accessing and modifying
 	 * the given attribute.
@@ -621,7 +616,7 @@ public abstract class ResourceTest extends CoreTest {
 			java.io.File rootFile = new java.io.File(c + ":\\");
 			if (rootFile.exists() && rootFile.canWrite()) {
 				//sometimes canWrite can return true but we are still not allowed to create a file - see bug 379284.
-				File probe = new File(rootFile, getUniqueString());
+				File probe = new File(rootFile, createUniqueString());
 				try {
 					probe.createNewFile();
 				} catch (IOException e) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.internal.resources.CharsetDeltaJob;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
 import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -42,6 +43,10 @@ public final class ResourceTestUtil {
 
 	public static IProgressMonitor createTestMonitor() {
 		return new FussyProgressMonitor();
+	}
+
+	public static String createUniqueString() {
+		return new UniversalUniqueIdentifier().toString();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.EFS;
@@ -52,7 +53,7 @@ public class VirtualFolderTest extends ResourceTest {
 	 * Tests creating a virtual folder
 	 */
 	public void testCreateVirtualFolder() throws CoreException {
-		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
+		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 
 		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 
@@ -67,7 +68,7 @@ public class VirtualFolderTest extends ResourceTest {
 	 * Tests creating a file under a virtual folder
 	 */
 	public void testCreateFileUnderVirtualFolder() {
-		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
+		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		assertThrows(CoreException.class, () -> create(file, true));
 		assertTrue("2.0", !file.exists());
 	}
@@ -76,7 +77,7 @@ public class VirtualFolderTest extends ResourceTest {
 	 * Tests creating a folder under a virtual folder
 	 */
 	public void testCreateFolderUnderVirtualFolder() {
-		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
+		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		assertThrows(CoreException.class, () -> create(folder, true));
 		assertTrue("2.0", !folder.exists());
 	}
@@ -85,7 +86,7 @@ public class VirtualFolderTest extends ResourceTest {
 	 * Tests creating a virtual folder under a virtual folder
 	 */
 	public void testCreateVirtualFolderUnderVirtualFolder() throws CoreException {
-		IFolder virtualFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
+		IFolder virtualFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		virtualFolder.create(IResource.VIRTUAL, true, null);
 
 		assertTrue("2.0", virtualFolder.exists());
@@ -101,7 +102,7 @@ public class VirtualFolderTest extends ResourceTest {
 	public void testCreateLinkedFolderUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
-		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
+		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 
 		linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -122,7 +123,7 @@ public class VirtualFolderTest extends ResourceTest {
 	public void testCreateLinkedFileUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
-		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
+		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 
 		file.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -140,8 +141,8 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath folderLocation = getRandomLocation();
 		deleteOnTearDown(folderLocation);
 
-		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(getUniqueString());
-		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
+		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(createUniqueString());
+		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 
 		createFileInFileSystem(fileLocation, getRandomContents());
 		folderLocation.toFile().mkdir();
@@ -183,9 +184,9 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath folderLocation = getRandomLocation();
 		deleteOnTearDown(folderLocation);
 
-		IFile file = existingVirtualFolderInExistingProject.getFile(getUniqueString());
-		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
-		IFile childFile = folder.getFile(getUniqueString());
+		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
+		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
+		IFile childFile = folder.getFile(createUniqueString());
 		IResource[] oldResources = new IResource[] {existingProject, file, folder, childFile};
 
 		assertDoesNotExistInWorkspace(new IResource[] { folder, file, childFile });
@@ -222,7 +223,7 @@ public class VirtualFolderTest extends ResourceTest {
 	}
 
 	public void testDeleteProjectWithVirtualFolder() throws CoreException {
-		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
+		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 
 		virtualFolder.create(IResource.VIRTUAL, true, null);
 		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
@@ -242,7 +243,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IPath folderLocation = getRandomLocation();
 		deleteOnTearDown(folderLocation);
 
-		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
+		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 		IFolder linkedFolder = virtualFolder.getFolder("a_link");
 
 		folderLocation.toFile().mkdir();
@@ -270,7 +271,7 @@ public class VirtualFolderTest extends ResourceTest {
 
 	public void testLinkedFolderInVirtualFolder_FileStoreURI() throws CoreException {
 		IPath folderLocation = getRandomLocation();
-		IFolder folder = existingVirtualFolderInExistingProject.getFolder(getUniqueString());
+		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 
 		folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
@@ -287,7 +288,7 @@ public class VirtualFolderTest extends ResourceTest {
 
 	public void testIsVirtual() throws CoreException {
 		// create a virtual folder
-		IFolder virtualFolder = existingProject.getFolder(getUniqueString());
+		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 		virtualFolder.create(IResource.VIRTUAL, true, null);
 		assertTrue("2.0", virtualFolder.isVirtual());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
@@ -226,7 +227,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					String newProjectName = getUniqueString();
+					String newProjectName = createUniqueString();
 					IProject newProject = getWorkspace().getRoot().getProject(newProjectName);
 					tmpProject[0].copy(newProject.getFullPath(), true, createTestMonitor());
 					tmpProject[0] = newProject;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -49,7 +50,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = project.getFile("file2.txt");
@@ -121,7 +122,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = project.getFile("file2.txt");
@@ -170,7 +171,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = project.getFile("file2.txt");
@@ -211,7 +212,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = project.getFile("file2.txt");
@@ -257,7 +258,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file3 = folder.getFile("file3.txt");
@@ -293,7 +294,7 @@ public class Bug_026294 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("a_folder");
 		IFolder subFolder = folder.getFolder("sub-folder");
 		IFile file1 = subFolder.getFile("file1.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,8 +56,8 @@ public class Bug_029851 extends ResourceTest {
 
 	public void test() throws CoreException {
 		createResourceHierarchy();
-		final QualifiedName key = new QualifiedName("local", getUniqueString());
-		final String value = getUniqueString();
+		final QualifiedName key = new QualifiedName("local", createUniqueString());
+		final String value = createUniqueString();
 		IResourceVisitor visitor = resource -> {
 			resource.setPersistentProperty(key, value);
 			return true;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.InputStream;
@@ -43,7 +44,7 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder sourceParent = project.getFolder("source_parent");
 		IFolder destinationParent = project.getFolder("destination_parent");
 		// this file will be made irremovable
@@ -97,7 +98,7 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder sourceParent = project.getFolder("source_parent");
 		IFolder destinationParent = project.getFolder("destination_parent");
 		IFolder folder = sourceParent.getFolder("folder");
@@ -160,8 +161,8 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject sourceProject = workspace.getRoot().getProject(getUniqueString() + ".source");
-		IProject destinationProject = workspace.getRoot().getProject(getUniqueString() + ".dest");
+		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");
+		IProject destinationProject = workspace.getRoot().getProject(createUniqueString() + ".dest");
 		// this file will be made un-removable
 		IFile file1 = sourceProject.getFile("file1.txt");
 		// but not this one
@@ -212,7 +213,7 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder sourceParent = project.getFolder("source_parent");
 		IFolder roFolder = sourceParent.getFolder("sub-folder");
 		IFolder destinationParent = project.getFolder("destination_parent");
@@ -274,7 +275,7 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject project = workspace.getRoot().getProject(getUniqueString());
+		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFolder sourceParent = project.getFolder("source_parent");
 		IFolder roFolder = sourceParent.getFolder("sub-folder");
 		IFolder folder = roFolder.getFolder("folder");
@@ -352,13 +353,13 @@ public class Bug_032076 extends ResourceTest {
 		}
 
 		IWorkspace workspace = getWorkspace();
-		IProject sourceProject = workspace.getRoot().getProject(getUniqueString() + ".source");
+		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");
 		IFileStore projectParentStore = getTempStore();
 		IFileStore projectStore = projectParentStore.getChild(sourceProject.getName());
 		IProjectDescription sourceDescription = workspace.newProjectDescription(sourceProject.getName());
 		sourceDescription.setLocationURI(projectStore.toURI());
 
-		IProject destinationProject = workspace.getRoot().getProject(getUniqueString() + ".dest");
+		IProject destinationProject = workspace.getRoot().getProject(createUniqueString() + ".dest");
 		IProjectDescription destinationDescription = workspace.newProjectDescription(destinationProject.getName());
 
 		// create and open the source project at a non-default location

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
@@ -54,7 +55,7 @@ public class Bug_044106 extends ResourceTest {
 		assertTrue("0.1", linkDestFile.fetchInfo().exists());
 
 		// create some resources in the workspace
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		ensureExistsInWorkspace(project, true);
 
 		// link in the folder
@@ -87,7 +88,7 @@ public class Bug_044106 extends ResourceTest {
 			return;
 		}
 		IFileStore linkDestLocation = getTempStore();
-		IFileStore linkDestFile = linkDestLocation.getChild(getUniqueString());
+		IFileStore linkDestFile = linkDestLocation.getChild(createUniqueString());
 		createFileInFileSystem(linkDestFile);
 		assertTrue("0.1", linkDestLocation.fetchInfo().exists());
 		assertTrue("0.2", linkDestFile.fetchInfo().exists());
@@ -133,7 +134,7 @@ public class Bug_044106 extends ResourceTest {
 		if (!OS.isLinux()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, false, IResource.NONE);
 	}
@@ -142,7 +143,7 @@ public class Bug_044106 extends ResourceTest {
 		if (!OS.isLinux()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.NONE);
 	}
@@ -158,7 +159,7 @@ public class Bug_044106 extends ResourceTest {
 		if (!OS.isLinux()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder parent = project.getFolder("parent");
 		IFolder linkedFolder = parent.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.KEEP_HISTORY);
@@ -168,7 +169,7 @@ public class Bug_044106 extends ResourceTest {
 		if (!OS.isLinux()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, false, IResource.KEEP_HISTORY);
 	}
@@ -177,7 +178,7 @@ public class Bug_044106 extends ResourceTest {
 		if (!OS.isLinux()) {
 			return;
 		}
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.KEEP_HISTORY);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.IFileStore;
@@ -61,7 +62,7 @@ public class Bug_233939 extends ResourceTest {
 		String fileName = "file.txt";
 
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 		IFile file = project.getFile(fileName);
 
 		// create a project
@@ -98,8 +99,8 @@ public class Bug_233939 extends ResourceTest {
 
 		// create two projects with a symlink to the folder each
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject projectA = root.getProject(getUniqueString());
-		IProject projectB = root.getProject(getUniqueString());
+		IProject projectA = root.getProject(createUniqueString());
+		IProject projectB = root.getProject(createUniqueString());
 		create(projectA, true);
 		create(projectB, true);
 		symLinkAndRefresh(projectA, "folderA", tempFolderPath);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.filesystem.IFileStore;
@@ -36,7 +37,7 @@ public class Bug_264182 extends ResourceTest {
 		super.setUp();
 
 		// create a project
-		project = getWorkspace().getRoot().getProject(getUniqueString());
+		project = getWorkspace().getRoot().getProject(createUniqueString());
 		project.create(new NullProgressMonitor());
 		project.open(new NullProgressMonitor());
 
@@ -54,7 +55,7 @@ public class Bug_264182 extends ResourceTest {
 
 	public void testBug() throws CoreException {
 		// create a linked resource
-		final IFile file = project.getFile(getUniqueString());
+		final IFile file = project.getFile(createUniqueString());
 		IFileStore tempFileStore = getTempStore();
 		createFileInFileSystem(tempFileStore);
 		assertThrows(CoreException.class,

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -47,12 +48,12 @@ public class Bug_265810 extends ResourceTest {
 
 	public void testBug() throws Throwable {
 		// create a project
-		IProject project = getWorkspace().getRoot().getProject(getUniqueString());
+		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		project.create(new NullProgressMonitor());
 		project.open(new NullProgressMonitor());
 
 		// create a linked resource
-		final IFile file = project.getFile(getUniqueString());
+		final IFile file = project.getFile(createUniqueString());
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
 		file.createLink(createFolderAtRandomLocation(), IResource.NONE, new NullProgressMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -32,7 +33,7 @@ public class Bug_329836 extends ResourceTest {
 			return;
 		}
 
-		IFileStore fileStore = getTempStore().getChild(getUniqueString());
+		IFileStore fileStore = getTempStore().getChild(createUniqueString());
 		createFileInFileSystem(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -29,18 +30,18 @@ import org.eclipse.core.tests.resources.ResourceTest;
 public class Bug_331445 extends ResourceTest {
 	public void testBug() throws CoreException, URISyntaxException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject project = root.getProject(getUniqueString());
+		IProject project = root.getProject(createUniqueString());
 
 		ensureExistsInWorkspace(project, true);
 
-		String variableName = "a" + getUniqueString();
+		String variableName = "a" + createUniqueString();
 		String variablePath = "mem:/MyProject";
 		String folderName = "MyFolder";
 		String rawLinkFolderLocation = variableName + "/" + folderName;
 		String linkFolderLocation = variablePath + "/" + folderName;
 
 		project.getPathVariableManager().setURIValue(variableName, new URI(variablePath));
-		IFolder folder = project.getFolder(getUniqueString());
+		IFolder folder = project.getFolder(createUniqueString());
 		folder.createLink(IPath.fromOSString(rawLinkFolderLocation), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		assertNull("3.0", folder.getLocation());
 		assertEquals("4.0", IPath.fromOSString(rawLinkFolderLocation), folder.getRawLocation());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedOutputStream;
@@ -96,7 +97,7 @@ public class Bug_332543 extends ResourceTest {
 	private void testCancel(Function<ByteArrayInputStream, InputStream> wrap) throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 
-		String proj_name = getUniqueString();
+		String proj_name = createUniqueString();
 		IPath proj_loc = root.getLocation().append(proj_name);
 		URI proj_uri = WrapperFileSystem.getWrappedURI(URIUtil.toURI(proj_loc));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.junit.Assert.assertThrows;
 
@@ -139,7 +140,7 @@ public class IProjectTest extends AbstractBuilderTest {
 	 * that the resources are automatically discovered and brought into the workspace.
 	 */
 	public void testBug78711() throws CoreException {
-		String name = getUniqueString();
+		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);
 		IFolder folder = project.getFolder("folder");
 		IFile file1 = project.getFile("file1.txt");
@@ -189,7 +190,7 @@ public class IProjectTest extends AbstractBuilderTest {
 	}
 
 	public void testRefreshDotProject() throws CoreException {
-		String name = getUniqueString();
+		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		project.create(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.File;
 import junit.framework.Test;
@@ -38,7 +39,7 @@ public class TestBug323833 extends WorkspaceSessionTest {
 			return;
 		}
 
-		IFileStore fileStore = getTempStore().getChild(getUniqueString());
+		IFileStore fileStore = getTempStore().getChild(createUniqueString());
 		createFileInFileSystem(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCreateLinkedResourceInHiddenProject.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import junit.framework.Test;
 import org.eclipse.core.internal.resources.ProjectDescription;
@@ -44,11 +45,11 @@ public class TestCreateLinkedResourceInHiddenProject extends WorkspaceSerializat
 	}
 
 	public void test2() throws CoreException {
-		IPath path = getTempDir().addTrailingSeparator().append(getUniqueString());
+		IPath path = getTempDir().addTrailingSeparator().append(createUniqueString());
 		path.toFile().mkdir();
 
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
-		IFolder folder = project.getFolder(getUniqueString());
+		IFolder folder = project.getFolder(createUniqueString());
 
 		folder.createLink(path, IResource.NONE, createTestMonitor());
 	}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/Bug_217673.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/Bug_217673.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.team.core.RepositoryProvider;
 import org.eclipse.team.tests.core.TeamTest;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 public class Bug_217673 extends TeamTest {
 
@@ -32,7 +33,7 @@ public class Bug_217673 extends TeamTest {
 
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IProject project = workspace.getRoot().getProject(
-				getUniqueString());
+				createUniqueString());
 		project.create(null);
 		project.open(null);
 		IResource resource = project.getFile(".project");


### PR DESCRIPTION
The getUniqueString() method in CoreTest is actually a factory method creating a unique string upon each call. It is not tied to an instance of CoreTest. This change adds an according method with a name indicating the creation behavior to the ResourceTestUtil and updates calls to that method within the resource tests. This is part of the cleanup for the ResourceTest inheritance hierarchy in order to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903