### PR TITLE
Move build resources method from ResourceTest to utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -29,6 +29,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 
 /**

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -31,6 +31,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager3Test.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.saveparticipant;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.internal.resources.ICoreConstants;
@@ -128,7 +129,7 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		file = project.getFolder(IPath.fromOSString("file"));
 		folder = project.getFile(IPath.fromOSString("folder"));
 		createInFileSystem(file);
-		createInFileSystem((IFile) folder);
+		createInFileSystem(folder);
 
 		// run synchronize
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.mapping;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.ArrayList;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.mapping;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -31,6 +31,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getVa
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertNotEquals;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -42,7 +42,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -145,34 +144,6 @@ public abstract class ResourceTest extends CoreTest {
 	@After
 	public final void after() throws Exception {
 		tearDown();
-	}
-
-	/**
-	 * Return a collection of resources for the given hierarchy at
-	 * the given root.
-	 */
-	public IResource[] buildResources(IContainer root, String[] hierarchy) throws CoreException {
-		IResource[] result = new IResource[hierarchy.length];
-		for (int i = 0; i < hierarchy.length; i++) {
-			IPath path = IPath.fromOSString(hierarchy[i]);
-			IPath fullPath = root.getFullPath().append(path);
-			switch (fullPath.segmentCount()) {
-				case 0 :
-					result[i] = getWorkspace().getRoot();
-					break;
-				case 1 :
-					result[i] = getWorkspace().getRoot().getProject(fullPath.segment(0));
-					break;
-				default :
-					if (hierarchy[i].charAt(hierarchy[i].length() - 1) == IPath.SEPARATOR) {
-						result[i] = root.getFolder(path);
-					} else {
-						result[i] = root.getFile(path);
-					}
-					break;
-			}
-		}
-		return result;
 	}
 
 	private void cleanup() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.core.internal.resources.CharsetDeltaJob;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourceAttributes;
@@ -252,6 +253,34 @@ public final class ResourceTestUtil {
 		assertNotNull("tried to set read only for null attributes", attributes);
 		attributes.setReadOnly(value);
 		target.setResourceAttributes(attributes);
+	}
+
+	/**
+	 * Return a collection of resources for the given hierarchy at
+	 * the given root.
+	 */
+	public static IResource[] buildResources(IContainer root, String[] hierarchy) throws CoreException {
+		IResource[] result = new IResource[hierarchy.length];
+		for (int i = 0; i < hierarchy.length; i++) {
+			IPath path = IPath.fromOSString(hierarchy[i]);
+			IPath fullPath = root.getFullPath().append(path);
+			switch (fullPath.segmentCount()) {
+				case 0 :
+					result[i] = getWorkspace().getRoot();
+					break;
+				case 1 :
+					result[i] = getWorkspace().getRoot().getProject(fullPath.segment(0));
+					break;
+				default :
+					if (hierarchy[i].charAt(hierarchy[i].length() - 1) == IPath.SEPARATOR) {
+						result[i] = root.getFolder(path);
+					} else {
+						result[i] = root.getFile(path);
+					}
+					break;
+			}
+		}
+		return result;
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -18,6 +18,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.util.ArrayList;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources.regression;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.ArrayList;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.usecase;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources.usecase;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.usecase;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.compare.tests;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -84,7 +85,7 @@ public class WorkspaceTest extends ResourceTest {
 	 */
 	protected IProject createProject(String prefix, String[] resources) throws CoreException {
 		IProject project = getUniqueTestProject(prefix);
-		buildResources(project, resources, true);
+		buildResourcesWithContainer(project, resources);
 		return project;
 	}
 
@@ -103,13 +104,11 @@ public class WorkspaceTest extends ResourceTest {
 	 * Creates filesystem 'resources' with the given names and fills them with random text.
 	 * @param container An object that can hold the newly created resources.
 	 * @param hierarchy A list of files &amp; folder names to use as resources
-	 * @param includeContainer A flag that controls whether the container is included in the list of resources.
 	 * @return IResource[] An array of resources filled with variable amounts of random text
 	 */
-	public IResource[] buildResources(IContainer container, String[] hierarchy, boolean includeContainer) throws CoreException {
+	public IResource[] buildResourcesWithContainer(IContainer container, String[] hierarchy) throws CoreException {
 		List<IResource> resources = new ArrayList<>(hierarchy.length + 1);
-		if (includeContainer)
-			resources.add(container);
+		resources.add(container);
 		resources.addAll(Arrays.asList(buildResources(container, hierarchy)));
 		IResource[] result = resources.toArray(new IResource[resources.size()]);
 		createInWorkspace(result);

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -347,7 +349,7 @@ public class RepositoryProviderTests extends TeamTest {
 
 	public void testMapSuccess() throws CoreException, TeamException {
 		IProject project = getUniqueTestProject("testLinkSuccess");
-		buildResources(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" }, true);
+		buildResourcesWithContainer(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" });
 
 		// Test shallow link when URI not allowed
 		IFolder folder = project.getFolder("link");
@@ -377,7 +379,7 @@ public class RepositoryProviderTests extends TeamTest {
 
 	public void testLinkSuccess() throws CoreException, TeamException {
 		IProject project = getUniqueTestProject("testLinkSuccess");
-		buildResources(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" }, true);
+		buildResourcesWithContainer(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" });
 		RepositoryProviderWithLinking.setCanHandleLinking(true);
 		RepositoryProviderWithLinking.setCanHandleLinkedURI(false);
 		RepositoryProvider.map(project, RepositoryProviderWithLinking.TYPE_ID);
@@ -397,7 +399,7 @@ public class RepositoryProviderTests extends TeamTest {
 
 	public void testMapFailure() throws CoreException, TeamException {
 		IProject project = getUniqueTestProject("testMapFailure");
-		buildResources(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" }, true);
+		buildResourcesWithContainer(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" });
 		IFolder folder = project.getFolder("link");
 		folder.createLink(getRandomLocation(), IResource.ALLOW_MISSING_LOCAL, null);
 		RepositoryProviderWithLinking.setCanHandleLinking(false);
@@ -451,7 +453,7 @@ public class RepositoryProviderTests extends TeamTest {
 
 	public void testLinkFailure() throws CoreException, TeamException {
 		IProject project = getUniqueTestProject("testLinkFailure");
-		buildResources(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" }, true);
+		buildResourcesWithContainer(project, new String[] { "changed.txt", "deleted.txt", "folder1/", "folder1/a.txt" });
 		RepositoryProviderWithLinking.setCanHandleLinking(false);
 		RepositoryProviderWithLinking.setCanHandleLinkedURI(false);
 		RepositoryProvider.map(project, RepositoryProviderWithLinking.TYPE_ID);


### PR DESCRIPTION
This change moves the buildResources() utility method for creating a resource hierarchy from a string description in the ResourceTest class to the dedicated ResourceTestUtil utility class. It prepares for removing the ResourceTest inheritance hierarchy to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903