### PR TITLE
Remove ResourceTest#ensureExistsInWorkspace taking stream #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -207,7 +207,7 @@ public class BasicAliasTest extends ResourceTest {
 		location.toFile().mkdirs();
 		deleteOnTearDown(location);
 		link.createLink(location, IResource.NONE, createTestMonitor());
-		ensureExistsInWorkspace(child, getRandomContents());
+		ensureExistsInWorkspace(child, getRandomString());
 		// move the link (rename)
 		IFolder movedLink = project.getFolder("MovedLink");
 		link.move(movedLink.getFullPath(), IResource.SHALLOW, createTestMonitor());
@@ -249,7 +249,7 @@ public class BasicAliasTest extends ResourceTest {
 		sub2.open(createTestMonitor());
 		IFile sub2File = sub2.getFile("file.txt");
 		IFile topFile = top.getFolder(sub2.getName()).getFile(sub2File.getName());
-		ensureExistsInWorkspace(sub2File, getRandomContents());
+		ensureExistsInWorkspace(sub2File, getRandomString());
 		assertTrue("1.0", topFile.exists());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -857,7 +857,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
 		project.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(input, getRandomContents());
+		ensureExistsInWorkspace(input, getRandomString());
 
 		waitForBuild();
 		assertTrue("1.0", output.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import java.io.ByteArrayInputStream;
 import java.lang.Thread.State;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -316,7 +315,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				tb.setStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
 				try {
-					ensureExistsInWorkspace(foo, new ByteArrayInputStream(new byte[0]));
+					ensureExistsInWorkspace(foo);
 				} catch (CoreException e) {
 					errorInWorkspaceChangingJob.set(e);
 				}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -362,7 +362,7 @@ public class CharsetTest extends ResourceTest {
 		assertNotNull("0.5", anotherXML);
 		ensureExistsInWorkspace(project);
 		IFile file = project.getFile("file.xml");
-		ensureExistsInWorkspace(file, new ByteArrayInputStream(SAMPLE_SPECIFIC_XML.getBytes(StandardCharsets.UTF_8)));
+		ensureExistsInWorkspace(file, SAMPLE_SPECIFIC_XML);
 		IContentDescription description = file.getContentDescription();
 		assertNotNull("1.0", description);
 		assertEquals("1.1", anotherXML, description.getContentType());
@@ -764,13 +764,13 @@ public class CharsetTest extends ResourceTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project1 = workspace.getRoot().getProject("Project1");
 		IFile file = project1.getFile("file1.xml");
-		ensureExistsInWorkspace(file, new ByteArrayInputStream(SAMPLE_XML_ISO_8859_1_ENCODING.getBytes(StandardCharsets.ISO_8859_1)));
+		ensureExistsInWorkspace(file, SAMPLE_XML_ISO_8859_1_ENCODING);
 		ContentDescriptionManagerTest.waitForCacheFlush();
 		assertEquals("1.0", "ISO-8859-1", file.getCharset());
 
 		//delete and recreate the file with different contents
 		ensureDoesNotExistInWorkspace(file);
-		ensureExistsInWorkspace(file, new ByteArrayInputStream(SAMPLE_XML_DEFAULT_ENCODING.getBytes(StandardCharsets.UTF_8)));
+		ensureExistsInWorkspace(file, SAMPLE_XML_DEFAULT_ENCODING);
 		assertEquals("2.0", "UTF-8", file.getCharset());
 	}
 
@@ -875,7 +875,7 @@ public class CharsetTest extends ResourceTest {
 			IFile file = project.getFile("file.xml");
 			assertEquals("0.9", "FOO", project.getDefaultCharset());
 			// content-based encoding is BAR
-			ensureExistsInWorkspace(file, new ByteArrayInputStream(SAMPLE_XML_US_ASCII_ENCODING.getBytes(StandardCharsets.UTF_8)));
+			ensureExistsInWorkspace(file, SAMPLE_XML_US_ASCII_ENCODING);
 			assertEquals("1.0", "US-ASCII", file.getCharset());
 			// content-based encoding is FRED
 			file.setContents(new ByteArrayInputStream(SAMPLE_XML_ISO_8859_1_ENCODING.getBytes(StandardCharsets.ISO_8859_1)), false, false, null);
@@ -1200,7 +1200,7 @@ public class CharsetTest extends ResourceTest {
 			// File:
 			// single file
 			final IFile file1 = project.getFile("file1.txt");
-			ensureExistsInWorkspace(file1, getRandomContents());
+			ensureExistsInWorkspace(file1, getRandomString());
 			// change from default
 			verifier.reset();
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
@@ -1239,7 +1239,7 @@ public class CharsetTest extends ResourceTest {
 			// multiple files (same operation)
 			verifier.reset();
 			final IFile file2 = project.getFile("file2.txt");
-			ensureExistsInWorkspace(file2, getRandomContents());
+			ensureExistsInWorkspace(file2, getRandomString());
 			verifier.addExpectedChange(new IResource[] {file1, file2}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -76,8 +76,8 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		String newExtension = "xml_bug_79151";
 		IFile file1 = project.getFile("file.xml");
 		IFile file2 = project.getFile("file." + newExtension);
-		ensureExistsInWorkspace(file1, getContents(CharsetTest.SAMPLE_XML_ISO_8859_1_ENCODING));
-		ensureExistsInWorkspace(file2, getContents(CharsetTest.SAMPLE_XML_US_ASCII_ENCODING));
+		ensureExistsInWorkspace(file1, CharsetTest.SAMPLE_XML_ISO_8859_1_ENCODING);
+		ensureExistsInWorkspace(file2, CharsetTest.SAMPLE_XML_US_ASCII_ENCODING);
 		// ensure we start in a known state
 		((Workspace) workspace).getContentDescriptionManager().invalidateCache(true, null);
 		// wait for cache flush to finish

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -68,7 +68,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// file bit is set already for a new file
 		assertTrue("1.0", file.getResourceAttributes().isArchive());
@@ -92,7 +92,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isExecutable());
@@ -117,7 +117,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isHidden());
@@ -141,7 +141,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isReadOnly());
@@ -205,7 +205,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("testRefreshExecutableOnFolder");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// folder is executable initially and the file should exist
 		assertTrue("1.0", project.getResourceAttributes().isExecutable());
@@ -232,7 +232,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile link = project.getFile("link");
-		ensureExistsInWorkspace(link, getRandomContents());
+		ensureExistsInWorkspace(link, getRandomString());
 
 		// attempts to set the symbolic link attribute wont't affect
 		// the resource and the underlying file
@@ -274,7 +274,7 @@ public class ResourceAttributeTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFile file = project.getFile(createUniqueString());
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		for (int attribute : attributes) {
 			// only activate this test on platforms that support it

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -318,27 +317,21 @@ public abstract class ResourceTest extends CoreTest {
 	/**
 	 * Create the given file in the workspace resource info tree.
 	 */
-	public void ensureExistsInWorkspace(final IFile resource, final InputStream contents) throws CoreException {
+	public void ensureExistsInWorkspace(IFile resource, String contents) throws CoreException {
+		InputStream contentStream = getContents(contents);
 		if (resource == null) {
 			return;
 		}
 		IWorkspaceRunnable body;
 		if (resource.exists()) {
-			body = monitor -> resource.setContents(contents, true, false, null);
+			body = monitor -> resource.setContents(contentStream, true, false, null);
 		} else {
 			body = monitor -> {
 				createInWorkspace(resource.getParent());
-				resource.create(contents, true, null);
+				resource.create(contentStream, true, null);
 			};
 		}
 		getWorkspace().run(body, null);
-	}
-
-	/**
-	 * Create the given file in the workspace resource info tree.
-	 */
-	public void ensureExistsInWorkspace(IFile resource, String contents) throws CoreException {
-		ensureExistsInWorkspace(resource, new ByteArrayInputStream(contents.getBytes()));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -60,7 +60,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				for (IFolder folder : folders) {
 					for (int j = 0; j < filesPerFolder; j++) {
 						IFile file = folder.getFile("file" + j);
-						ensureExistsInWorkspace(file, getRandomContents());
+						ensureExistsInWorkspace(file, getRandomString());
 						try {
 							for (int k = 0; k < statesPerFile; k++) {
 								file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
@@ -97,7 +97,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				ensureExistsInWorkspace(file, getRandomContents());
+				ensureExistsInWorkspace(file, getRandomString());
 			}
 
 			@Override
@@ -284,7 +284,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	public void testGetHistory() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFile file = project.getFile("file.txt");
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 		for (int i = 0; i < 100; i++) {
 			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -56,7 +56,7 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		for (IFolder folder : folders) {
 			for (int j = 0; j < filesPerFolder; j++) {
 				IFile file = folder.getFile("file" + j);
-				ensureExistsInWorkspace(file, getRandomContents());
+				ensureExistsInWorkspace(file, getRandomString());
 				resources.add(file);
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -47,7 +47,7 @@ public class Bug_079398 extends ResourceTest {
 		// max size of file = 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
 		getWorkspace().setDescription(description);
-		ensureExistsInWorkspace(file1, getRandomContents());
+		ensureExistsInWorkspace(file1, getRandomString());
 		for (int i = 0; i < 10; i++) {
 			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -92,7 +92,7 @@ public class Bug_378156 extends ResourceTest {
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 		//build may not be triggered immediately
 		Thread.sleep(2000);
 		waitForBuild();
@@ -134,7 +134,7 @@ public class Bug_378156 extends ResourceTest {
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 		waitForBuild();
 
 		//initialize the builder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -41,7 +41,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 
 		// create a project with a file
 		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 
 		// save the workspace
 		workspace.save(true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -57,7 +57,7 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		IFile file = project.getFile("foo.txt");
 		assertDoesNotExistInWorkspace(file);
-		ensureExistsInWorkspace(file, getRandomContents());
+		ensureExistsInWorkspace(file, getRandomString());
 		// this will also cause the cache flush job to be scheduled
 		file.getContentDescription();
 		// after waiting cache flushing, cache should be new


### PR DESCRIPTION
The ResourceTest class contains two ensureExistsInWorkspace() methods taking content for the resource to create, one accepting a stream and one accepting a string. Since all consumers of the method accepting a stream perform the wrapping of a string into a stream as done by the method accepting a string on their own, these callers can be simplified and removed.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903