### PR TITLE
Unify method names for file creation in ResourceTest #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -526,7 +526,7 @@ public class FileStoreTest extends LocalStoreTest {
 	}
 
 	@Test
-	public void testReadOnly() throws CoreException {
+	public void testReadOnly() throws Exception {
 		testAttribute(EFS.ATTRIBUTE_READ_ONLY);
 	}
 
@@ -557,7 +557,7 @@ public class FileStoreTest extends LocalStoreTest {
 	}
 
 	@Test
-	public void testPermissions() throws CoreException {
+	public void testPermissions() throws Exception {
 		testAttribute(EFS.ATTRIBUTE_OWNER_READ);
 		testAttribute(EFS.ATTRIBUTE_OWNER_WRITE);
 		testAttribute(EFS.ATTRIBUTE_OWNER_EXECUTE);
@@ -569,7 +569,7 @@ public class FileStoreTest extends LocalStoreTest {
 		testAttribute(EFS.ATTRIBUTE_OTHER_EXECUTE);
 	}
 
-	private void testAttribute(int attribute) throws CoreException {
+	private void testAttribute(int attribute) throws Exception {
 		Assume.assumeTrue(isAttributeSupported(attribute));
 
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -258,7 +258,7 @@ public class BasicAliasTest extends ResourceTest {
 	 * used in the locations map of AliasManager.
 	 */
 	@Test
-	public void testBug198571() throws CoreException {
+	public void testBug198571() throws Exception {
 		Assume.assumeTrue(OS.isWindows());
 
 		/* look for the adequate environment */
@@ -292,7 +292,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		// new folder in one of the projects
 		IFolder folder = testProject2.getFolder("NewFolder");
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 
 		testProject2.refreshLocal(IResource.DEPTH_INFINITE, null);
 		IResource[] resources = aliasManager.computeAliases(folder, ((Folder) folder).getStore());
@@ -429,7 +429,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	@Test
-	public void testBug258987() throws CoreException {
+	public void testBug258987() throws Exception {
 		// Create the directory to which you will link. The directory needs a single file.
 		IFileStore dirStore = getTempStore();
 		dirStore.mkdir(EFS.NONE, createTestMonitor());
@@ -667,7 +667,7 @@ public class BasicAliasTest extends ResourceTest {
 	}
 
 	@Test
-	public void testDeepLink() throws CoreException {
+	public void testDeepLink() throws Exception {
 		IFolder folder = pNoOverlap.getFolder("folder");
 		IFile folderChild = folder.getFile("Child.txt");
 		final IFolder linkParent = pLinked.getFolder("LinkParent");
@@ -708,7 +708,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		// delete the project that contains the links
 		IFile fileInLinkedProject = pLinked.getFile("fileInLinkedProject.txt");
-		createFileInFileSystem(((Resource) fileInLinkedProject).getStore(), getRandomContents());
+		createFileInFileSystem(((Resource) fileInLinkedProject).getStore());
 		// failure expected here because it is out of sync
 		assertThrows(CoreException.class, () -> getWorkspace().getRoot().delete(IResource.NONE, createTestMonitor()));
 		waitForRefresh();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -333,7 +333,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		assertTrue(herringRouge.exists());
 	}
 
-	public void testRefreshLocalFile1() throws CoreException {
+	public void testRefreshLocalFile1() throws Exception {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
@@ -347,7 +347,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a file in the local file system with the same name but different casing
 		ensureDoesNotExistInFileSystem(file);
-		ensureExistsInFileSystem(herringRouge);
+		createInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
@@ -356,7 +356,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		assertTrue(herringRouge.exists());
 	}
 
-	public void testRefreshLocalFolder2() throws CoreException {
+	public void testRefreshLocalFolder2() throws Exception {
 		String name = "test31415";
 		IProject project = getWorkspace().getRoot().getProjects()[0];
 
@@ -370,7 +370,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a file in the local file system with the same name but different casing
 		ensureDoesNotExistInFileSystem(folder);
-		ensureExistsInFileSystem(herringRouge);
+		createInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -42,9 +42,9 @@ public class CopyTest extends LocalStoreTest {
 		IFolder folder = testProjects[0].getFolder("folder");
 		IFile file = folder.getFile("file.txt");
 		ensureExistsInWorkspace(folder);
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		/* add some properties to file (server, local and session) */
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
 		String[] propValues = new String[numberOfProperties];
@@ -93,9 +93,9 @@ public class CopyTest extends LocalStoreTest {
 		/* test flag force = false */
 		testProjects[0].refreshLocal(IResource.DEPTH_INFINITE, null);
 		IFolder subfolder = folder.getFolder("subfolder");
-		ensureExistsInFileSystem(subfolder);
+		createInFileSystem(subfolder);
 		IFile anotherFile = folder.getFile("new file");
-		ensureExistsInFileSystem(anotherFile);
+		createInFileSystem(anotherFile);
 		IFolder destinationFolder = testProjects[0].getFolder("destination");
 		CoreException exception = assertThrows(CoreException.class,
 				() -> folder.copy(destinationFolder.getFullPath(), false, null));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.IPath;
 
 public class DeleteTest extends LocalStoreTest {
 
-	public void testDeleteOpenProject() throws CoreException {
+	public void testDeleteOpenProject() throws Exception {
 		IProject project = projects[0];
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
@@ -142,8 +142,8 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* initialize common objects */
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(folder);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(folder);
+		createInFileSystem(file);
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 		projectLocation = project.getLocation();
@@ -287,7 +287,7 @@ public class DeleteTest extends LocalStoreTest {
 		IFile fileUnsync = folder.getFile("fileUnsync");
 		ensureExistsInWorkspace(fileUnsync);
 		IFile fileCreated = folder.getFile("fileCreated");
-		ensureExistsInFileSystem(fileCreated); // create only in file system
+		createInFileSystem(fileCreated); // create only in file system
 		IFolder subfolderSync = folder.getFolder("subfolderSync");
 		ensureExistsInWorkspace(subfolderSync);
 		IFolder deletedfolderSync = subfolderSync.getFolder("deletedfolderSync");
@@ -327,7 +327,7 @@ public class DeleteTest extends LocalStoreTest {
 		ensureExistsInWorkspace(fileUnsync);
 		//
 		fileCreated = recreatedFolder.getFile("fileCreated");
-		ensureExistsInFileSystem(fileCreated); // create only in file system
+		createInFileSystem(fileCreated); // create only in file system
 		//
 		subfolderSync = recreatedFolder.getFolder("subfolderSync");
 		ensureExistsInWorkspace(subfolderSync);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -207,20 +207,20 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	}
 
 	@Test
-	public void testSynchronizeProject() throws CoreException {
+	public void testSynchronizeProject() throws Exception {
 		/* test DEPTH parameter */
 		/* DEPTH_ZERO */
 		IFile file = projects[0].getFile("file");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projects[0].refreshLocal(IResource.DEPTH_ZERO, null);
 		assertFalse(file.exists());
 		/* DEPTH_ONE */
 		IFolder folder = projects[0].getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		ensureExistsInFileSystem(folder);
-		ensureExistsInFileSystem(subfolder);
-		ensureExistsInFileSystem(subfile);
+		createInFileSystem(folder);
+		createInFileSystem(subfolder);
+		createInFileSystem(subfile);
 		projects[0].refreshLocal(IResource.DEPTH_ONE, null);
 		assertTrue(file.exists());
 		assertTrue(folder.exists());
@@ -236,7 +236,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* closed project */
 		file = projects[0].getFile("closed");
 		projects[0].close(null);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projects[0].open(null);
 		assertFalse(file.exists());
 		projects[0].refreshLocal(IResource.DEPTH_INFINITE, null);
@@ -338,7 +338,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	}
 
 	@Test
-	public void testWriteFolder() throws CoreException {
+	public void testWriteFolder() throws Exception {
 		/* initialize common objects */
 		IProject project = projects[0];
 		IFolder folder = project.getFolder("testWriteFolder");
@@ -347,7 +347,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* existing file on destination */
 		ensureDoesNotExistInFileSystem(folder);
 		IFile file = project.getFile("testWriteFolder");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		/* force = true */
 		assertThrows(CoreException.class, () -> write(folder, true, null));
 		/* force = false */
@@ -355,7 +355,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		ensureDoesNotExistInFileSystem(file);
 
 		/* existing folder on destination */
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 		/* force = true */
 		write(folder, true, null);
 		assertTrue(folder.getLocation().toFile().isDirectory());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -298,7 +299,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("3.5", 0, states.length);
 	}
 
-	public void testBug28238() throws CoreException {
+	public void testBug28238() throws Exception {
 		// paths to mimic files in the workspace
 		IProject project = getWorkspace().getRoot().getProject("myproject28238");
 		IFolder folder = project.getFolder("myfolder");
@@ -1070,8 +1071,8 @@ public class HistoryStoreTest extends ResourceTest {
 			fileInfo.setLastModified(myLong);
 			historyStore.addState(file.getFullPath(), ((Resource) file).getStore(), fileInfo, true);
 			contents = "This file has some contents in testGetContents.";
-			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
-				createFileInFileSystem(file.getLocation(), is);
+			try (FileOutputStream output = new FileOutputStream(file.getLocation().toFile())) {
+				getContents(contents).transferTo(output);
 			}
 			file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
@@ -1082,8 +1083,8 @@ public class HistoryStoreTest extends ResourceTest {
 			fileInfo.setLastModified(myLong);
 			historyStore.addState(secondValidFile.getFullPath(), ((Resource) secondValidFile).getStore(), fileInfo, true);
 			contents = "A file with some other contents in testGetContents.";
-			try (InputStream is = new ByteArrayInputStream(contents.getBytes())) {
-				createFileInFileSystem(secondValidFile.getLocation(), is);
+			try (FileOutputStream output = new FileOutputStream(secondValidFile.getLocation().toFile())) {
+				getContents(contents).transferTo(output);
 			}
 			secondValidFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -127,8 +127,8 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 
 		file = project.getFolder(IPath.fromOSString("file"));
 		folder = project.getFile(IPath.fromOSString("folder"));
-		ensureExistsInFileSystem(file);
-		ensureExistsInFileSystem((IFile) folder);
+		createInFileSystem(file);
+		createInFileSystem((IFile) folder);
 
 		// run synchronize
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -434,9 +434,9 @@ public class MoveTest extends LocalStoreTest {
 		/* test flag force = false */
 		testProjects[0].refreshLocal(IResource.DEPTH_INFINITE, null);
 		IFolder subfolder = folder.getFolder("aaa");
-		ensureExistsInFileSystem(subfolder);
+		createInFileSystem(subfolder);
 		IFile anotherFile = folder.getFile("bbb");
-		ensureExistsInFileSystem(anotherFile);
+		createInFileSystem(anotherFile);
 		IFolder folderDestination = testProjects[0].getFolder("destination");
 		assertThrows(CoreException.class, () -> folder.move(folderDestination.getFullPath(), false, null));
 		assertThrows(CoreException.class, () -> folder.move(folderDestination.getFullPath(), false, null));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -121,9 +121,9 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		IFolder folder = project.getFolder("Folder");
 		IFile file = folder.getFile("File");
 
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 		ensureDoesNotExistInWorkspace(folder);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		ensureDoesNotExistInWorkspace(file);
 
 		assertFalse(file.exists());
@@ -137,9 +137,9 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		//try again with deleted project
 		project.delete(IResource.FORCE, createTestMonitor());
 
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 		ensureDoesNotExistInWorkspace(folder);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		ensureDoesNotExistInWorkspace(file);
 
 		assertFalse(file.exists());
@@ -179,7 +179,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		ensureDoesNotExistInFileSystem(folder);
 		//
 		IFile file = project.getFile("folder");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		//
 		assertTrue(folder.exists());
 		folder.refreshLocal(IResource.DEPTH_ZERO, null);
@@ -219,7 +219,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 
 		/* test creation of a child */
 		file = project.getFile("file");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		assertFalse(file.exists());
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue(file.exists());
@@ -230,7 +230,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		IFolder folder = project.getFolder("folder");
 		folder.create(true, true, null);
 		file = folder.getFile("file");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		assertTrue(folder.exists());
 		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
 		assertFalse(file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -27,8 +27,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -329,8 +329,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(workspace);
 		// Write out the project description file
 		ensureDoesNotExistInFileSystem(location.toFile());
-		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
+			getContents(invalidProjectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = reader.read(location);
 		assertThat(projDesc, nullValue());
 	}
@@ -340,8 +341,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		IFileStore store = getTempStore();
 		// Write out the project description file
-		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
+			getContents(invalidProjectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = readDescription(store);
 		assertThat(projDesc, not(nullValue()));
 		assertThat(projDesc.getName(), nullValue());
@@ -358,8 +360,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		IFileStore store = getTempStore();
 		// Write out the project description file
-		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
+			getContents(invalidProjectDescription).transferTo(output);
+		}
 
 		ProjectDescription projDesc = readDescription(store);
 		assertThat(projDesc, not(nullValue()));
@@ -377,8 +380,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		IFileStore store = getTempStore();
 		// Write out the project description file
-		InputStream stream = new ByteArrayInputStream(invalidProjectDescription.getBytes());
-		createFileInFileSystem(store, stream);
+		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
+			getContents(invalidProjectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = readDescription(store);
 		assertThat(projDesc, not(nullValue()));
 		assertThat(projDesc.getName(), is("abc"));
@@ -404,8 +408,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
 		ensureDoesNotExistInFileSystem(location.toFile());
-		InputStream stream = new ByteArrayInputStream(longProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
+			getContents(longProjectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = reader.read(location);
 		ensureDoesNotExistInFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
@@ -425,8 +430,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(ResourcesPlugin.getWorkspace());
 		// Write out the project description file
 		ensureDoesNotExistInFileSystem(location.toFile());
-		InputStream stream = new ByteArrayInputStream(longProjectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
+			getContents(longProjectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = reader.read(location);
 		ensureDoesNotExistInFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
@@ -453,11 +459,12 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		// Write out the project description file
 		ensureDoesNotExistInFileSystem(multiLocation.toFile());
 		ensureDoesNotExistInFileSystem(singleLocation.toFile());
-		InputStream multiStream = new ByteArrayInputStream(multiLineProjectDescription.getBytes());
-		InputStream singleStream = new ByteArrayInputStream(singleLineProjectDescription.getBytes());
-
-		createFileInFileSystem(multiLocation, multiStream);
-		createFileInFileSystem(singleLocation, singleStream);
+		try (FileOutputStream output = new FileOutputStream(multiLocation.toFile())) {
+			getContents(multiLineProjectDescription).transferTo(output);
+		}
+		try (FileOutputStream output = new FileOutputStream(singleLocation.toFile())) {
+			getContents(singleLineProjectDescription).transferTo(output);
+		}
 		ProjectDescription multiDesc = reader.read(multiLocation);
 		ProjectDescription singleDesc = reader.read(singleLocation);
 		compareProjectDescriptions(1, multiDesc, singleDesc);
@@ -675,8 +682,9 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
 		ensureDoesNotExistInFileSystem(location.toFile());
-		InputStream stream = new ByteArrayInputStream(projectDescription.getBytes());
-		createFileInFileSystem(location, stream);
+		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
+			getContents(projectDescription).transferTo(output);
+		}
 		ProjectDescription projDesc = reader.read(location);
 		assertThat(projDesc, not(nullValue()));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -451,7 +451,7 @@ public class CharsetTest extends ResourceTest {
 		assertTrue(file.getLocation().toFile().delete());
 		file.getCharset(true);
 
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		ensureOutOfSync(file);
 		//getCharset uses a cached value, so it will still pass
 		file.getCharset(true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -77,7 +77,7 @@ public class FilteredResourceTest extends ResourceTest {
 		closedProject.close(createTestMonitor());
 		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
 		resolve(localFolder).toFile().mkdirs();
-		createFileInFileSystem(resolve(localFile), getRandomContents());
+		createFileInFileSystem(resolve(localFile));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -148,7 +148,7 @@ public class IFileTest extends ResourceTest {
 	 * Returns some interesting files.  These files are created
 	 * during setup.
 	 */
-	public IFile[] interestingFiles() throws CoreException {
+	public IFile[] interestingFiles() throws Exception {
 		refreshFiles();
 		IFile[] result = new IFile[allFiles.size()];
 		allFiles.toArray(result);
@@ -213,12 +213,12 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Makes sure file requirements are met (out of sync, workspace only, etc).
 	 */
-	public void refreshFile(IFile file) throws CoreException {
+	public void refreshFile(IFile file) throws CoreException, IOException {
 		if (file.getName().equals(LOCAL_ONLY)) {
 			ensureDoesNotExistInWorkspace(file);
 			//project must exist to access file system store.
 			if (file.getProject().exists()) {
-				ensureExistsInFileSystem(file);
+				createInFileSystem(file);
 			}
 			return;
 		}
@@ -249,7 +249,7 @@ public class IFileTest extends ResourceTest {
 	/**
 	 * Makes sure file requirements are met (out of sync, workspace only, etc).
 	 */
-	public void refreshFiles() throws CoreException {
+	public void refreshFiles() throws CoreException, IOException {
 		for (IFile file : allFiles) {
 			refreshFile(file);
 		}
@@ -279,7 +279,7 @@ public class IFileTest extends ResourceTest {
 	}
 
 	@Test
-	public void testAppendContents2() throws CoreException {
+	public void testAppendContents2() throws Exception {
 		IFile file = projects[0].getFile("file1");
 		ensureDoesNotExistInWorkspace(file);
 
@@ -293,7 +293,7 @@ public class IFileTest extends ResourceTest {
 		monitor.assertUsedUp();
 		assertTrue("1.0", !file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("1.1", !file.getLocation().toFile().exists());
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		assertTrue("1.2", !file.isLocal(IResource.DEPTH_ZERO));
 
 		monitor.prepare();
@@ -330,7 +330,7 @@ public class IFileTest extends ResourceTest {
 		monitor.assertUsedUp();
 		assertTrue("3.0", !file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.1", !file.getLocation().toFile().exists());
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		assertTrue("3.2", !file.isLocal(IResource.DEPTH_ZERO));
 
 		monitor.prepare();
@@ -366,7 +366,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testCreate") {
 			@Override
-			public void cleanUp(Object[] args, int count) throws CoreException {
+			public void cleanUp(Object[] args, int count) throws Exception {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}
@@ -724,7 +724,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles()};
 		new TestPerformer("IFileTest.testGetContents") {
 			@Override
-			public void cleanUp(Object[] args, int count) throws CoreException {
+			public void cleanUp(Object[] args, int count) throws Exception {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}
@@ -866,7 +866,7 @@ public class IFileTest extends ResourceTest {
 		Object[][] inputs = new Object[][] {interestingFiles(), interestingStreams(), TRUE_AND_FALSE, PROGRESS_MONITORS};
 		new TestPerformer("IFileTest.testSetContents1") {
 			@Override
-			public void cleanUp(Object[] args, int count) throws CoreException {
+			public void cleanUp(Object[] args, int count) throws Exception {
 				IFile file = (IFile) args[0];
 				refreshFile(file);
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -846,7 +846,7 @@ public class IProjectTest extends ResourceTest {
 	 * 	- content area is the DEFAULT
 	 * 	- resources are OUT_OF_SYNC with the file system
 	 */
-	public void testProjectDeletionClosedDefaultOutOfSync() throws CoreException {
+	public void testProjectDeletionClosedDefaultOutOfSync() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("myfile.txt");
 		IFile otherFile = project.getFile("myotherfile.txt");
@@ -1214,7 +1214,7 @@ public class IProjectTest extends ResourceTest {
 	 * 	- content area is USER-DEFINED
 	 * 	- resources are OUT_OF_SYNC with the file system
 	 */
-	public void testProjectDeletionClosedUserDefinedOutOfSync() throws CoreException {
+	public void testProjectDeletionClosedUserDefinedOutOfSync() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("myfile.txt");
 		IFile otherFile = project.getFile("myotherfile.txt");
@@ -1229,7 +1229,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("1.0", project.exists());
@@ -1260,7 +1260,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("2.0", project.exists());
@@ -1289,7 +1289,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("3.0", project.exists());
@@ -1317,7 +1317,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("4.0", project.exists());
@@ -1345,7 +1345,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(new IResource[] {project, file});
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("5.0", project.exists());
@@ -1374,7 +1374,7 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
 		waitForRefresh();
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("6.0", project.exists());
@@ -1519,7 +1519,7 @@ public class IProjectTest extends ResourceTest {
 	 * 	- content area is the DEFAULT
 	 * 	- resources are OUT_OF_SYNC with the file system
 	 */
-	public void testProjectDeletionOpenDefaultOutOfSync() throws CoreException {
+	public void testProjectDeletionOpenDefaultOutOfSync() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("myfile.txt");
 		IFileStore projectStore, fileStore;
@@ -1529,7 +1529,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.0", project.exists());
@@ -1549,7 +1549,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = ALWAYS (always_delete_content over-rides FORCE flag)
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.0", project.exists());
@@ -1567,7 +1567,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = NEVER
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.0", project.exists());
@@ -1587,7 +1587,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = NEVER
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.0", project.exists());
@@ -1607,7 +1607,7 @@ public class IProjectTest extends ResourceTest {
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.0", project.exists());
@@ -1626,7 +1626,7 @@ public class IProjectTest extends ResourceTest {
 		 * =======================================================================*/
 		ensureExistsInWorkspace(project);
 		waitForRefresh();
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.0", project.exists());
@@ -1782,7 +1782,7 @@ public class IProjectTest extends ResourceTest {
 	 * 	- content area is USER-DEFINED
 	 * 	- resources are OUT_OF_SYNC with the file system
 	 */
-	public void testProjectDeletionOpenUserDefinedOutOfSync() throws CoreException {
+	public void testProjectDeletionOpenUserDefinedOutOfSync() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("testProjectDeletionOpenUserDefinedOutOfSync");
 		IFile file = project.getFile("myfile.txt");
 		IFile otherFile = project.getFile("myotherfile.txt");
@@ -1797,7 +1797,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("1.0", project.exists());
@@ -1825,7 +1825,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("2.0", project.exists());
@@ -1851,7 +1851,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("3.0", project.exists());
@@ -1877,7 +1877,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("4.0", project.exists());
@@ -1901,7 +1901,7 @@ public class IProjectTest extends ResourceTest {
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(new IResource[] {project, file});
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("5.0", project.exists());
@@ -1927,7 +1927,7 @@ public class IProjectTest extends ResourceTest {
 		ensureExistsInWorkspace(project, description);
 		ensureExistsInWorkspace(file);
 		waitForRefresh();
-		ensureExistsInFileSystem(otherFile);
+		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
 		assertTrue("6.0", project.exists());
@@ -2349,7 +2349,7 @@ public class IProjectTest extends ResourceTest {
 	 * Tests {@link IResource#move(IProjectDescription, int, IProgressMonitor)}
 	 * in conjunction with {@link IResource#REPLACE}.
 	 */
-	public void testReplaceLocation() throws CoreException {
+	public void testReplaceLocation() throws Exception {
 		IProject target = getWorkspace().getRoot().getProject("testReplaceLocation");
 		ensureExistsInWorkspace(target);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -223,7 +224,7 @@ public class IResourceTest extends ResourceTest {
 		return result;
 	}
 
-	private IResource[] buildSampleResources(IContainer root) throws CoreException {
+	private IResource[] buildSampleResources(IContainer root) throws Exception {
 		// do not change the example resources unless you change references to
 		// specific indices in setUp()
 		IResource[] result = buildResources(root, new String[] {"1/", "1/1/", "1/1/1/", "1/1/1/1", "1/1/2/", "1/1/2/1/", "1/1/2/2/", "1/1/2/3/", "1/2/", "1/2/1", "1/2/2", "1/2/3/", "1/2/3/1", "1/2/3/2", "1/2/3/3", "1/2/3/4", "2", "2"});
@@ -243,7 +244,7 @@ public class IResourceTest extends ResourceTest {
 		unsynchronized = buildResources(root, new String[] {"1/1/2/2/1"});
 		ensureDoesNotExistInWorkspace(unsynchronized);
 		for (IResource resource : unsynchronized) {
-			ensureExistsInFileSystem(resource);
+			createInFileSystem(resource);
 		}
 		unsynchronizedResources.add(unsynchronized[0]);
 		return result;
@@ -428,7 +429,7 @@ public class IResourceTest extends ResourceTest {
 		initializeProjects();
 	}
 
-	private void initializeProjects() throws CoreException {
+	private void initializeProjects() throws Exception {
 		nonExistingResources.clear();
 		// closed project
 		IProject closedProject = getWorkspace().getRoot().getProject("ClosedProject");
@@ -495,7 +496,7 @@ public class IResourceTest extends ResourceTest {
 	/**
 	 * Sets up the workspace and file system for this test. */
 	protected void setupBeforeState(IResource receiver, IResource target, int state, int depth, boolean addVerifier)
-			throws OperationCanceledException, InterruptedException, CoreException {
+			throws OperationCanceledException, InterruptedException, CoreException, IOException {
 		// Wait for any outstanding refresh to finish
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
@@ -526,7 +527,7 @@ public class IResourceTest extends ResourceTest {
 				break;
 			case S_FILESYSTEM_ONLY :
 				ensureDoesNotExistInWorkspace(target);
-				ensureExistsInFileSystem(target);
+				createInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 					// we only get a delta if the receiver of refreshLocal
@@ -566,7 +567,7 @@ public class IResourceTest extends ResourceTest {
 			case S_FOLDER_TO_FILE :
 				ensureExistsInWorkspace(target);
 				ensureDoesNotExistInFileSystem(target);
-				ensureExistsInFileSystem(target);
+				createInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 					// we only get a delta if the receiver of refreshLocal
@@ -1775,7 +1776,7 @@ public class IResourceTest extends ResourceTest {
 	 * Performs black box testing of the following method: IPath
 	 * getRawLocation()
 	 */
-	public void testGetRawLocation() throws CoreException {
+	public void testGetRawLocation() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder topFolder = project.getFolder("TopFolder");
 		IFile topFile = project.getFile("TopFile");
@@ -2282,7 +2283,7 @@ public class IResourceTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
-	public void testRefreshLocalWithDepth() throws CoreException {
+	public void testRefreshLocalWithDepth() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder folder = project.getFolder("Folder");
 		project.create(createTestMonitor());
@@ -2292,7 +2293,7 @@ public class IResourceTest extends ResourceTest {
 		String[] hierarchy = {"Folder/", "Folder/Folder/", "Folder/Folder/Folder/", "Folder/Folder/Folder/Folder/"};
 		IResource[] resources = buildResources(folder, hierarchy);
 		for (IResource resource : resources) {
-			ensureExistsInFileSystem(resource);
+			createInFileSystem(resource);
 		}
 		assertDoesNotExistInWorkspace(resources);
 
@@ -2304,7 +2305,7 @@ public class IResourceTest extends ResourceTest {
 
 	/**
 	 * This method tests the IResource.refreshLocal() operation */
-	public void testRefreshWithMissingParent() throws CoreException {
+	public void testRefreshWithMissingParent() throws Exception {
 		/**
 		 * Add a folder and file to the file system. Call refreshLocal on the
 		 * file, when neither of them exist in the workspace.
@@ -2316,7 +2317,7 @@ public class IResourceTest extends ResourceTest {
 		IFolder folder = project1.getFolder("Folder");
 		IFile file = folder.getFile("File");
 
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 
 		file.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -49,7 +49,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
 	@Test
-	public void testFindFilesNonCanonicalPath() throws CoreException {
+	public void testFindFilesNonCanonicalPath() throws Exception {
 		// this test is for windows only
 		Assume.assumeTrue(OS.isWindows());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -550,7 +550,7 @@ public class IWorkspaceTest extends ResourceTest {
 	/**
 	 * Another test method for IWorkspace.copy().  See also testCopy
 	 */
-	public void testMultiCopy() throws CoreException {
+	public void testMultiCopy() throws Exception {
 		/* create common objects */
 		IResource[] resources = buildResourceHierarchy();
 		IProject project = (IProject) resources[1];
@@ -558,16 +558,16 @@ public class IWorkspaceTest extends ResourceTest {
 
 		/* create folder and file */
 		ensureExistsInWorkspace(folder);
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 		IFile file1 = project.getFile("file.txt");
 		ensureExistsInWorkspace(file1);
-		ensureExistsInFileSystem(file1);
+		createInFileSystem(file1);
 		IFile anotherFile = project.getFile("anotherFile.txt");
 		ensureExistsInWorkspace(anotherFile);
-		ensureExistsInFileSystem(anotherFile);
+		createInFileSystem(anotherFile);
 		IFile oneMoreFile = project.getFile("oneMoreFile.txt");
 		ensureExistsInWorkspace(oneMoreFile);
-		ensureExistsInFileSystem(oneMoreFile);
+		createInFileSystem(oneMoreFile);
 
 		/* normal case */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile};

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -87,7 +87,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		//		}
 	}
 
-	public void testFileLinkedToNonExistent_Deep() throws CoreException {
+	public void testFileLinkedToNonExistent_Deep() throws Exception {
 		IFile fileLink = existingProject.getFile(createUniqueString());
 		IPath fileLocation = getRandomLocation();
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -115,7 +115,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		internalMovedAndCopyTest(fileLink, IResource.NONE, true);
 	}
 
-	public void testFileLinkedToNonExistent_Shallow() throws CoreException {
+	public void testFileLinkedToNonExistent_Shallow() throws Exception {
 		IFile fileLink = existingProject.getFile(createUniqueString());
 		IPath fileLocation = getRandomLocation();
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -230,7 +230,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		assertTrue("6.0", linkedFile.exists());
 	}
 
-	public void testFolderWithFileLinkedToNonExistent_Deep() throws CoreException {
+	public void testFolderWithFileLinkedToNonExistent_Deep() throws Exception {
 		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder);
 
@@ -254,7 +254,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		internalMovedAndCopyTest(folder, IResource.NONE, true);
 	}
 
-	public void testFolderWithFileLinkedToNonExistent_Shallow() throws CoreException {
+	public void testFolderWithFileLinkedToNonExistent_Shallow() throws Exception {
 		IFolder folder = existingProject.getFolder(createUniqueString());
 		ensureExistsInWorkspace(folder);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -103,7 +103,7 @@ public class LinkedResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
 		ensureDoesNotExistInFileSystem(resolve(nonExistingLocation).toFile());
 		resolve(localFolder).toFile().mkdirs();
-		createFileInFileSystem(resolve(localFile), getRandomContents());
+		createFileInFileSystem(resolve(localFile));
 	}
 
 	private byte[] getFileContents(IFile file) throws CoreException, IOException {
@@ -222,11 +222,11 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests case where a resource in the file system cannot be added to the workspace
 	 * because it is blocked by a linked resource of the same name.
 	 */
-	public void testBlockedFolder() throws CoreException {
+	public void testBlockedFolder() throws Exception {
 		//create local folder that will be blocked
-		ensureExistsInFileSystem(nonExistingFolderInExistingProject);
+		createInFileSystem(nonExistingFolderInExistingProject);
 		IFile blockedFile = nonExistingFolderInExistingProject.getFile("BlockedFile");
-		createFileInFileSystem(blockedFile.getLocation(), getRandomContents());
+		createFileInFileSystem(blockedFile.getLocation());
 
 		// link the folder elsewhere
 		nonExistingFolderInExistingProject.createLink(localFolder, IResource.NONE, createTestMonitor());
@@ -267,14 +267,14 @@ public class LinkedResourceTest extends ResourceTest {
 	 * still exist, should have the correct gender, and still be a linked
 	 * resource.
 	 */
-	public void testChangeLinkGender() throws CoreException {
+	public void testChangeLinkGender() throws Exception {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile file = folder.getProject().getFile(folder.getProjectRelativePath());
 		IPath resolvedLocation = resolve(localFolder);
 		folder.createLink(localFolder, IResource.NONE, createTestMonitor());
 
 		ensureDoesNotExistInFileSystem(resolvedLocation.toFile());
-		createFileInFileSystem(resolvedLocation, getRandomContents());
+		createFileInFileSystem(resolvedLocation);
 		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		assertTrue("3.0", !folder.exists());
@@ -542,12 +542,12 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.3", !dest.exists());
 	}
 
-	public void testCopyProjectWithLinks() throws CoreException {
+	public void testCopyProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IFile linkedFile = nonExistingFileInExistingProject;
 		IFolder linkedFolder = nonExistingFolderInExistingProject;
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFileInFileSystem(resolve(fileLocation));
 		linkedFolder.createLink(localFolder, IResource.NONE, createTestMonitor());
 		linkedFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
@@ -607,7 +607,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests creating a linked folder and performing refresh in the background
 	 */
-	public void testCreateFolderInBackground() throws CoreException {
+	public void testCreateFolderInBackground() throws Exception {
 		final IFileStore rootStore = getTempStore();
 		rootStore.mkdir(IResource.NONE, createTestMonitor());
 		IFileStore childStore = rootStore.getChild("file.txt");
@@ -697,7 +697,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("4.0", file.isHidden());
 	}
 
-	public void testDeepMoveProjectWithLinks() throws CoreException {
+	public void testDeepMoveProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IFile file = nonExistingFileInExistingProject;
@@ -1495,7 +1495,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.3", !dest.exists());
 	}
 
-	public void testMoveProjectWithLinks() throws CoreException {
+	public void testMoveProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IFile file = nonExistingFileInExistingProject;
@@ -1543,11 +1543,11 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests bug 117402.
 	 */
-	public void testMoveProjectWithLinks2() throws CoreException {
+	public void testMoveProjectWithLinks2() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IFile linkedFile = existingProject.getFile("(test)");
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFileInFileSystem(resolve(fileLocation));
 		linkedFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
 		// move the project
@@ -1569,7 +1569,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
-		createFileInFileSystem(resolve(fileLocation), getRandomContents());
+		createFileInFileSystem(resolve(fileLocation));
 
 		// create a linked file in the folder
 		IFile linkedFile = folderWithLinks.getFile(createUniqueString());
@@ -1660,7 +1660,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Create a project with a linked resource at depth &gt; 2, and refresh it.
 	 */
-	public void testRefreshDeepLink() throws CoreException {
+	public void testRefreshDeepLink() throws Exception {
 		IFolder link = nonExistingFolderInExistingFolder;
 		IPath linkLocation = localFolder;
 		IPath localChild = linkLocation.append("Child");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -60,16 +60,16 @@ public class ProjectSnapshotTest extends ResourceTest {
 		ensureExistsInWorkspace(projects);
 	}
 
-	private void populateProject(IProject project) throws CoreException {
+	private void populateProject(IProject project) throws Exception {
 		// add files and folders to project
 		IFile file = project.getFile("file");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		IFolder folder = project.getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		ensureExistsInFileSystem(folder);
-		ensureExistsInFileSystem(subfolder);
-		ensureExistsInFileSystem(subfile);
+		createInFileSystem(folder);
+		createInFileSystem(subfolder);
+		createInFileSystem(subfile);
 	}
 
 	private URI getSnapshotLocation(IProject project) {
@@ -224,7 +224,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 		// add two more files to probably provoke a tree delta chain
 		// In SaveManager.writeTree() line 1885, treesToSave.length must be 1
 		IFile file2 = project.getFile("file2");
-		ensureExistsInFileSystem(file2);
+		createInFileSystem(file2);
 		project.getFile("file3");
 		// save project refresh snapshot outside the project
 		URI snapshotLocation = getSnapshotLocation(projects[1]);
@@ -255,7 +255,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 		IProjectDescription description = getWorkspace().newProjectDescription(project.getName());
 		((ProjectDescription) description).setSnapshotLocationURI(URI.create("./relative/uri.zip"));
 		project.create(description, null);
-		ensureExistsInFileSystem(project.getFolder("foo"));
+		createInFileSystem(project.getFolder("foo"));
 		assertFalse("1.0", project.getFolder("foo").exists());
 		// expect to see warning logged, but project open successfully and refresh
 		project.open(null);
@@ -271,7 +271,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 		// create project with non-existing snapshot autoload location
 		((ProjectDescription) description).setSnapshotLocationURI(getTempStore().toURI());
 		project.create(description, null);
-		ensureExistsInFileSystem(project.getFile("foo"));
+		createInFileSystem(project.getFile("foo"));
 		assertFalse("1.0", project.getFile("foo").exists());
 		project.open(null);
 		// expect warning logged but project open and refreshed

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -246,7 +246,7 @@ public class ResourceAttributeTest extends ResourceTest {
 
 		// create the target file in the filesystem
 		IFile target = project.getFile("target");
-		ensureExistsInFileSystem(target);
+		createInFileSystem(target);
 
 		// create a link to the target file and add it to the workspace,
 		// the resource in the workspace should have symbolic link attribute set

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -136,7 +136,7 @@ public class VirtualFolderTest extends ResourceTest {
 		file.delete(IResource.NONE, createTestMonitor());
 	}
 
-	public void testCopyProjectWithVirtualFolder() throws CoreException {
+	public void testCopyProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
@@ -145,7 +145,7 @@ public class VirtualFolderTest extends ResourceTest {
 		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 
-		createFileInFileSystem(fileLocation, getRandomContents());
+		createFileInFileSystem(fileLocation);
 		folderLocation.toFile().mkdir();
 
 		linkedFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
@@ -179,7 +179,7 @@ public class VirtualFolderTest extends ResourceTest {
 		destinationProject.delete(IResource.NONE, createTestMonitor());
 	}
 
-	public void testMoveProjectWithVirtualFolder() throws CoreException {
+	public void testMoveProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
 		deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
@@ -15,15 +15,14 @@ package org.eclipse.core.tests.resources.perf;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.OldCorePerformanceTest;
 
 public class BenchCopyFile extends OldCorePerformanceTest {
 	private static final int COUNT = 5000;
 
-	public void testCopyFile() throws CoreException {
+	public void testCopyFile() throws Exception {
 		IFileStore input = getTempStore();
-		createFileInFileSystem(input, getRandomContents());
+		createFileInFileSystem(input);
 		IFileStore[] output = new IFileStore[COUNT];
 		for (int i = 0; i < output.length; i++) {
 			output[i] = getTempStore();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -85,7 +85,7 @@ public class Bug_160251 extends ResourceTest {
 	/**
 	 * The destination directory exists, and contains an overlapping file. This should fail.
 	 */
-	public void testOccupiedDestination() throws CoreException {
+	public void testOccupiedDestination() throws Exception {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("Important.txt");
 		IFileStore destination = getTempStore();
@@ -93,7 +93,7 @@ public class Bug_160251 extends ResourceTest {
 		ensureExistsInWorkspace(source);
 		ensureExistsInWorkspace(sourceFile);
 		destination.mkdir(EFS.NONE, createTestMonitor());
-		createFileInFileSystem(destinationFile, getRandomContents());
+		createFileInFileSystem(destinationFile);
 
 		//move the project (should fail)
 		IProjectDescription description = source.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -54,7 +54,7 @@ public class Bug_233939 extends ResourceTest {
 		return loc1.equals(loc2);
 	}
 
-	public void testBug() throws CoreException {
+	public void testBug() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
 		if (!canCreateSymLinks()) {
 			return;
@@ -87,7 +87,7 @@ public class Bug_233939 extends ResourceTest {
 		//		assertEquals("6.1", file, files[0]);
 	}
 
-	public void testMultipleLinksToFolder() throws CoreException {
+	public void testMultipleLinksToFolder() throws Exception {
 		// Only activate this test if testing of symbolic links is possible.
 		if (!canCreateSymLinks()) {
 			return;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -54,7 +54,7 @@ public class Bug_264182 extends ResourceTest {
 		super.tearDown();
 	}
 
-	public void testBug() throws CoreException {
+	public void testBug() throws Exception {
 		// create a linked resource
 		final IFile file = project.getFile(createUniqueString());
 		IFileStore tempFileStore = getTempStore();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -21,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSuppo
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -29,7 +28,7 @@ import org.eclipse.core.tests.resources.ResourceTest;
  * Test for bug 329836
  */
 public class Bug_329836 extends ResourceTest {
-	public void testBug() throws CoreException {
+	public void testBug() throws Exception {
 		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
 			return;
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
@@ -94,7 +94,7 @@ public class Bug_332543 extends ResourceTest {
 		});
 	}
 
-	private void testCancel(Function<ByteArrayInputStream, InputStream> wrap) throws CoreException {
+	private void testCancel(Function<ByteArrayInputStream, InputStream> wrap) throws Exception {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 
 		String proj_name = createUniqueString();
@@ -109,7 +109,7 @@ public class Bug_332543 extends ResourceTest {
 
 		// Create a file in the project
 		IFile file = project.getFile("foo.txt");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 
 		// Now open the project
 		project.open(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -71,7 +71,7 @@ public class IFolderTest extends ResourceTest {
 	 * Bug 11510 [resources] Non-local folders do not become local when directory is created.
 	 */
 	@Test
-	public void testBug11510() throws CoreException {
+	public void testBug11510() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("TestProject");
 		IFolder folder = project.getFolder("fold1");
@@ -87,7 +87,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("1.1", !subFile.isLocal(IResource.DEPTH_ZERO));
 
 		// now create the resources in the local file system and refresh
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("2.1", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("2.2", !folder.isLocal(IResource.DEPTH_ZERO));
@@ -99,7 +99,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("3.2", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("3.3", !subFile.isLocal(IResource.DEPTH_ZERO));
 
-		ensureExistsInFileSystem(subFile);
+		createInFileSystem(subFile);
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertTrue("4.1", subFile.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("4.2", folder.isLocal(IResource.DEPTH_ZERO));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -139,7 +139,7 @@ public class IProjectTest extends AbstractBuilderTest {
 	 * Create a project with resources already existing on disk and ensure
 	 * that the resources are automatically discovered and brought into the workspace.
 	 */
-	public void testBug78711() throws CoreException {
+	public void testBug78711() throws Exception {
 		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);
 		IFolder folder = project.getFolder("folder");
@@ -168,7 +168,7 @@ public class IProjectTest extends AbstractBuilderTest {
 	/**
 	 * 1GDW1RX: ITPCORE:ALL - IResource.delete() without force not working correctly
 	 */
-	public void testDelete_1GDW1RX() throws CoreException {
+	public void testDelete_1GDW1RX() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
@@ -178,10 +178,10 @@ public class IProjectTest extends AbstractBuilderTest {
 		ensureExistsInWorkspace(resources);
 
 		IFolder folder = project.getFolder("folder");
-		ensureExistsInFileSystem(folder);
+		createInFileSystem(folder);
 
 		IFile file = folder.getFile("MyFile");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 
 		assertThrows(CoreException.class, () -> project.delete(false, createTestMonitor()));
 
@@ -189,7 +189,7 @@ public class IProjectTest extends AbstractBuilderTest {
 		project.delete(true, true, createTestMonitor());
 	}
 
-	public void testRefreshDotProject() throws CoreException {
+	public void testRefreshDotProject() throws Exception {
 		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
 import static org.junit.Assert.assertThrows;
 
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
@@ -316,13 +317,13 @@ public class IResourceTest extends ResourceTest {
 	 * Ensure that creating a file with force==true doesn't throw
 	 * a CoreException if the resource already exists on disk.
 	 */
-	public void testCreate_1GD7CSU() throws CoreException {
+	public void testCreate_1GD7CSU() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(null);
 		project.open(null);
 
 		IFile file = project.getFile("MyFile");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 
 		file.create(getRandomContents(), true, createTestMonitor());
 	}
@@ -443,7 +444,9 @@ public class IResourceTest extends ResourceTest {
 
 		final String newContents = "some other contents";
 		Thread.sleep(5000);
-		createFileInFileSystem(target.getLocation(), getContents(newContents));
+		try (FileOutputStream output = new FileOutputStream(target.getLocation().toFile())) {
+			getContents(newContents).transferTo(output);
+		}
 
 		final AtomicReference<ThrowingRunnable> listenerInMainThreadCallback = new AtomicReference<>(() -> {
 		});

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -41,7 +41,7 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 
 		/* */
 		IFile file = project.getFile("file");
-		ensureExistsInFileSystem(file);
+		createInFileSystem(file);
 		assertTrue("1.0", !file.exists());
 		file.refreshLocal(IResource.DEPTH_ZERO, null);
 		assertTrue("1.1", file.exists());
@@ -53,8 +53,8 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 	public void test_1FU4TW7() throws Throwable {
 		IFolder folder = projects[0].getFolder("folder");
 		IFile file = folder.getFile("file");
-		ensureExistsInFileSystem(folder);
-		ensureExistsInFileSystem(file);
+		createInFileSystem(folder);
+		createInFileSystem(file);
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue("1.1", folder.exists());
 		assertTrue("1.2", file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -34,7 +34,7 @@ import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
  * Test for bug 323833
  */
 public class TestBug323833 extends WorkspaceSessionTest {
-	public void test1() throws CoreException {
+	public void test1() throws Exception {
 		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
 			return;
 		}


### PR DESCRIPTION
There are two kinds of methods in ResourceTest for creating files in the file system. One of them is called ensureExistsInFileSystem() and the other is called createFileInFileSystem(), but both became very similar, call each other and only accept different parameters. This change unifies the methods to be called create...InFileSystem(). It also removes an unnecessary method for creating a file with a given input stream.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903