### PR TITLE
Unify method names for workspace resource creation in ResourceTest #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -143,7 +143,7 @@ public class SaveManager1Test extends SaveManagerTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_1));
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 
@@ -206,7 +206,7 @@ public class SaveManager1Test extends SaveManagerTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_1));
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 
@@ -228,7 +228,7 @@ public class SaveManager1Test extends SaveManagerTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy(PROJECT_2));
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -157,25 +157,25 @@ public class BasicAliasTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		//project with no overlap
 		pNoOverlap = root.getProject("NoOverlap");
-		ensureExistsInWorkspace(pNoOverlap);
-		ensureExistsInWorkspace(buildResources(pNoOverlap, new String[] {"/1/", "/1/1", "/1/2", "/2/", "/2/1"}));
+		createInWorkspace(pNoOverlap);
+		createInWorkspace(buildResources(pNoOverlap, new String[] {"/1/", "/1/1", "/1/2", "/2/", "/2/1"}));
 
 		//project with overlap
 		pOverlap = root.getProject("Overlap");
-		ensureExistsInWorkspace(pOverlap);
+		createInWorkspace(pOverlap);
 		fOverlap = pOverlap.getFolder("fOverlap");
 		IFolder f2 = pOverlap.getFolder("F2");
 		lOverlap = f2.getFile("lOverlap");
 		lChildOverlap = fOverlap.getFile("lChildOverlap");
-		ensureExistsInWorkspace(new IResource[] {fOverlap, f2, lOverlap, lChildOverlap});
+		createInWorkspace(new IResource[] {fOverlap, f2, lOverlap, lChildOverlap});
 		//create some other random child elements
-		ensureExistsInWorkspace(buildResources(pOverlap, new String[] {"/1/", "/1/1", "/1/2"}));
-		ensureExistsInWorkspace(buildResources(f2, new String[] {"/1/", "/1/1", "/1/2"}));
-		ensureExistsInWorkspace(buildResources(fOverlap, new String[] {"/1/", "/1/1", "/1/2"}));
+		createInWorkspace(buildResources(pOverlap, new String[] {"/1/", "/1/1", "/1/2"}));
+		createInWorkspace(buildResources(f2, new String[] {"/1/", "/1/1", "/1/2"}));
+		createInWorkspace(buildResources(fOverlap, new String[] {"/1/", "/1/1", "/1/2"}));
 
 		//create links
 		pLinked = root.getProject("LinkProject");
-		ensureExistsInWorkspace(pLinked);
+		createInWorkspace(pLinked);
 		fLinked = pLinked.getFolder("LinkedFolder");
 		fLinkOverlap1 = pLinked.getFolder("LinkOverlap1");
 		fLinkOverlap2 = pLinked.getFolder("LinkOverlap2");
@@ -183,9 +183,9 @@ public class BasicAliasTest extends ResourceTest {
 		lChildLinked = fLinked.getFile(lChildOverlap.getName());
 		fLinked.createLink(fOverlap.getLocation(), IResource.NONE, null);
 		lLinked.createLink(lOverlap.getLocation(), IResource.NONE, null);
-		ensureExistsInWorkspace(lChildLinked);
-		ensureExistsInWorkspace(buildResources(pLinked, new String[] {"/a/", "/a/a", "/a/b"}));
-		ensureExistsInWorkspace(buildResources(fLinked, new String[] {"/a/", "/a/a", "/a/b"}));
+		createInWorkspace(lChildLinked);
+		createInWorkspace(buildResources(pLinked, new String[] {"/a/", "/a/a", "/a/b"}));
+		createInWorkspace(buildResources(fLinked, new String[] {"/a/", "/a/a", "/a/b"}));
 
 		linkOverlapLocation = getRandomLocation();
 		linkOverlapLocation.toFile().mkdirs();
@@ -207,7 +207,7 @@ public class BasicAliasTest extends ResourceTest {
 		location.toFile().mkdirs();
 		deleteOnTearDown(location);
 		link.createLink(location, IResource.NONE, createTestMonitor());
-		ensureExistsInWorkspace(child, getRandomString());
+		createInWorkspace(child, getRandomString());
 		// move the link (rename)
 		IFolder movedLink = project.getFolder("MovedLink");
 		link.move(movedLink.getFullPath(), IResource.SHALLOW, createTestMonitor());
@@ -238,7 +238,7 @@ public class BasicAliasTest extends ResourceTest {
 		IProject top = getWorkspace().getRoot().getProject("Bug156082_Top");
 		IProject sub1 = getWorkspace().getRoot().getProject("Bug156082_Sub1");
 		IProject sub2 = getWorkspace().getRoot().getProject("Bug156082_Sub2");
-		ensureExistsInWorkspace(top);
+		createInWorkspace(top);
 		IProjectDescription desc1 = getWorkspace().newProjectDescription(sub1.getName());
 		desc1.setLocation(top.getLocation().append(sub1.getName()));
 		IProjectDescription desc2 = getWorkspace().newProjectDescription(sub2.getName());
@@ -249,7 +249,7 @@ public class BasicAliasTest extends ResourceTest {
 		sub2.open(createTestMonitor());
 		IFile sub2File = sub2.getFile("file.txt");
 		IFile topFile = top.getFolder(sub2.getName()).getFile(sub2File.getName());
-		ensureExistsInWorkspace(sub2File, getRandomString());
+		createInWorkspace(sub2File, getRandomString());
 		assertTrue("1.0", topFile.exists());
 	}
 
@@ -405,7 +405,7 @@ public class BasicAliasTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject(createUniqueString());
 		IProject p2 = root.getProject(createUniqueString());
-		ensureExistsInWorkspace(new IResource[] {p1, p2});
+		createInWorkspace(new IResource[] {p1, p2});
 
 		IFileStore tempStore = getTempStore();
 		tempStore.mkdir(EFS.NONE, createTestMonitor());
@@ -485,7 +485,7 @@ public class BasicAliasTest extends ResourceTest {
 	@Test
 	public void testCopyFile() throws CoreException {
 		IFile sourceFile = pNoOverlap.getFile("CopySource");
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(sourceFile);
 
 		// file in linked folder
 		IFile linkDest = fLinked.getFile("CopyDestination");
@@ -535,7 +535,7 @@ public class BasicAliasTest extends ResourceTest {
 	@Test
 	public void testCopyFolder() throws CoreException {
 		IFolder source = pNoOverlap.getFolder("CopyFolder");
-		ensureExistsInWorkspace(source);
+		createInWorkspace(source);
 
 		IFolder destFolder1 = fLinkOverlap1.getFolder(source.getName());
 		IFolder destFolder2 = fLinkOverlap2.getFolder(source.getName());
@@ -651,15 +651,15 @@ public class BasicAliasTest extends ResourceTest {
 		IFile folderChild = folder.getFile("Child.txt");
 		IFolder link = pLinked.getFolder("FolderLink");
 		IFile linkChild = link.getFile(folderChild.getName());
-		ensureExistsInWorkspace(folder);
-		ensureExistsInWorkspace(folderChild);
+		createInWorkspace(folder);
+		createInWorkspace(folderChild);
 		link.createLink(folder.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertTrue("1.0", linkChild.exists());
 		// manipulate file below overlapping folder and make sure alias under link is
 		// updated
 		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.1", linkChild.exists());
-		ensureExistsInWorkspace(folderChild);
+		createInWorkspace(folderChild);
 		assertTrue("1.2", linkChild.exists());
 
 		link.delete(IResource.NONE, createTestMonitor());
@@ -673,7 +673,7 @@ public class BasicAliasTest extends ResourceTest {
 		final IFolder linkParent = pLinked.getFolder("LinkParent");
 		IFolder link = linkParent.getFolder("FolderLink");
 		IFile linkChild = link.getFile(folderChild.getName());
-		ensureExistsInWorkspace(new IResource[] {folder, folderChild, linkParent});
+		createInWorkspace(new IResource[] {folder, folderChild, linkParent});
 		link.createLink(folder.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertTrue("1.0", linkChild.exists());
 
@@ -681,7 +681,7 @@ public class BasicAliasTest extends ResourceTest {
 		// updated
 		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("1.1", linkChild.exists());
-		ensureExistsInWorkspace(folderChild);
+		createInWorkspace(folderChild);
 		assertTrue("1.2", linkChild.exists());
 
 		link.delete(IResource.NONE, createTestMonitor());
@@ -694,7 +694,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("2.1", linkChild.exists());
-		ensureExistsInWorkspace(folderChild);
+		createInWorkspace(folderChild);
 		assertTrue("2.2", linkChild.exists());
 
 		final AliasManager aliasManager = ((Workspace) getWorkspace()).getAliasManager();
@@ -703,7 +703,7 @@ public class BasicAliasTest extends ResourceTest {
 
 		folderChild.delete(IResource.NONE, createTestMonitor());
 		assertFalse("3.1", linkChild.exists());
-		ensureExistsInWorkspace(folderChild);
+		createInWorkspace(folderChild);
 		assertTrue("3.2", linkChild.exists());
 
 		// delete the project that contains the links
@@ -756,7 +756,7 @@ public class BasicAliasTest extends ResourceTest {
 	public void testDeleteProjectUnderProject() throws CoreException {
 		IProject parent = getWorkspace().getRoot().getProject("parent");
 		IProject child = getWorkspace().getRoot().getProject("child");
-		ensureExistsInWorkspace(parent);
+		createInWorkspace(parent);
 
 		IProjectDescription childDesc = getWorkspace().newProjectDescription(child.getName());
 		childDesc.setLocation(parent.getLocation().append(child.getName()));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -60,7 +60,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		file0 = project0.getFile("File0");
 		file1 = project1.getFile("File1");
 		IResource[] resources = {project0, project1, file0, file1};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setAutoBuilding(false);
 		setupProject(project0);
 		setupProject(project1);
@@ -133,7 +133,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		IFile tempFile0 = tempProject.getFile("File0");
 		IFile tempFile1 = tempProject.getFile("File1");
 		IResource[] resources = {tempProject, tempFile0, tempFile1};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setupProject(tempProject);
 
 		ConfigurationBuilder.clearStats();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
@@ -57,7 +57,7 @@ public class BuildContextTest extends AbstractBuilderTest {
 		project1 = root.getProject("BuildContextTests_p1");
 		project2 = root.getProject("BuildContextTests_p2");
 		IResource[] resources = {project0, project1, project2};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setAutoBuilding(false);
 		setupProject(project0);
 		setupProject(project1);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -338,7 +338,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 
 	public void testReuseCachedDelta() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("delta-cache");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IProjectDescription description = project.getDescription();
 		description.setBuildSpec(new ICommand[] { createCommand(description, EmptyDeltaBuilder.BUILDER_NAME, null),

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -44,7 +44,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		IProject before2 = root.getProject("Before2");
 		IProject after1 = root.getProject("After1");
 		IProject after2 = root.getProject("After2");
-		ensureExistsInWorkspace(new IResource[] {project, before1, before2, after1, after2});
+		createInWorkspace(new IResource[] {project, before1, before2, after1, after2});
 
 		setBuildOrder(before1, before2, project, after1, after2);
 		setAutoBuilding(false);
@@ -72,9 +72,9 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		IProject project = root.getProject("Project");
 		IFolder unsorted = project.getFolder(SortBuilder.DEFAULT_UNSORTED_FOLDER);
 		IFile unsortedFile = unsorted.getFile("File.txt");
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(unsorted);
-		ensureExistsInWorkspace(unsortedFile);
+		createInWorkspace(project);
+		createInWorkspace(unsorted);
+		createInWorkspace(unsortedFile);
 
 		//setup so that the sortbuilder and cycle builder are both touching files in the project
 		setAutoBuilding(true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
@@ -58,7 +58,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 		//add the water and snow natures to the project, and ensure
 		//the snow builder gets run
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		SnowBuilder builder = SnowBuilder.getInstance();
 		builder.reset();
 		setAutoBuilding(true);
@@ -78,7 +78,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 	 */
 	public void testDisabledNature() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });
@@ -112,7 +112,7 @@ public class BuilderNatureTest extends AbstractBuilderTest {
 	 */
 	public void testMissingNature() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -857,7 +857,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
 		project.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(input, getRandomString());
+		createInWorkspace(input, getRandomString());
 
 		waitForBuild();
 		assertTrue("1.0", output.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -111,7 +111,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 		file3 = project3.getFile("File3");
 		file4 = project4.getFile("File4");
 		IResource[] resources = {project1, project2, project3, project4, file1, file2, file3, file4};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -345,7 +345,7 @@ public class ParallelBuildChainTest extends AbstractBuilderTest {
 		String projectName = createUniqueProjectName(buildDurationType.toString());
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(projectName);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		configureTimerBuilder(project, buildDurationType.getDurationInMillis(), ruleType);
 		return project;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RelaxedSchedRuleBuilderTest.java
@@ -105,7 +105,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		String projectName = "TestRelaxed";
 		setAutoBuilding(false);
 		final IProject project = getWorkspace().getRoot().getProject(projectName);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		addBuilder(project, EmptyDeltaBuilder.BUILDER_NAME);
 
 		// Ensure the builder is instantiated
@@ -179,7 +179,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		String projectName = "testTwoBuildersRunInOneBuild";
 		setAutoBuilding(false);
 		final IProject project = getWorkspace().getRoot().getProject(projectName);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, "Project1Build1"), createCommand(desc, EmptyDeltaBuilder2.BUILDER_NAME, "Project1Build2")});
@@ -292,7 +292,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		setAutoBuilding(false);
 		final IProject project = getWorkspace().getRoot().getProject(projectName);
 		final IFile foo = project.getFile("foo");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		waitForEncodingRelatedJobs(getName());
 		waitForContentDescriptionUpdate();
@@ -315,7 +315,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				tb.setStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
 				try {
-					ensureExistsInWorkspace(foo);
+					createInWorkspace(foo);
 				} catch (CoreException e) {
 					errorInWorkspaceChangingJob.set(e);
 				}
@@ -431,7 +431,7 @@ public class RelaxedSchedRuleBuilderTest extends AbstractBuilderTest {
 		String projectName = "testBug343256";
 		setAutoBuilding(false);
 		final IProject project = getWorkspace().getRoot().getProject(projectName);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildSpec(new ICommand[] {createCommand(desc, EmptyDeltaBuilder.BUILDER_NAME, "Project1Build1"), createCommand(desc, EmptyDeltaBuilder2.BUILDER_NAME, "Project1Build2")});

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
@@ -136,7 +136,7 @@ public class BuildProjectFromMultipleJobsTest extends ResourceTest {
 		IProject project = getTestProject();
 		assertFalse("Expected test project to not exist at beginning of test", project.exists());
 
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		assertTrue("Expected test project to be open after creation", project.isOpen());
 
 		// add some builder to the project, so that we can run into the concurrency problem

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
@@ -147,7 +147,7 @@ public class BucketTreeTests extends ResourceTest {
 		IFile file1 = proj1.getFile("file1.txt");
 		IFolder folder1 = proj1.getFolder("folder1");
 		IFile file2 = folder1.getFile("file2.txt");
-		ensureExistsInWorkspace(new IResource[] { file1, file2, proj2 });
+		createInWorkspace(new IResource[] { file1, file2, proj2 });
 		IPath[] paths = { IPath.ROOT, proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(),
 				file2.getFullPath(), proj2.getFullPath() };
 		for (IPath path : paths) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -41,9 +41,9 @@ public class CopyTest extends LocalStoreTest {
 		/* create folder and file */
 		IFolder folder = testProjects[0].getFolder("folder");
 		IFile file = folder.getFile("file.txt");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 		createInFileSystem(folder);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(file);
 		/* add some properties to file (server, local and session) */
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -38,7 +38,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* create some resources */
-		ensureExistsInWorkspace(new IResource[] {project, folder, file});
+		createInWorkspace(new IResource[] {project, folder, file});
 		IPath folderPath = folder.getLocation();
 		IPath filePath = file.getLocation();
 		IPath projectLocation = project.getLocation();
@@ -64,7 +64,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * ========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(new IResource[] {project, folder, file});
+		createInWorkspace(new IResource[] {project, folder, file});
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 		projectLocation = project.getLocation();
@@ -89,7 +89,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		folder.create(true, false, createTestMonitor());
 		file.create(null, true, createTestMonitor());
 		folderPath = folder.getLocation();
@@ -115,7 +115,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(new IResource[] {project, folder, file});
+		createInWorkspace(new IResource[] {project, folder, file});
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 
@@ -141,7 +141,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(folder);
 		createInFileSystem(file);
 		folderPath = folder.getLocation();
@@ -173,9 +173,9 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(new IResource[] {project, folder});
+		createInWorkspace(new IResource[] {project, folder});
 		getWorkspace().run(monitor -> file.create(null, true, monitor), createTestMonitor());
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		IPath folderPath = folder.getLocation();
 		IPath filePath = file.getLocation();
 		IPath projectLocation = project.getLocation();
@@ -202,7 +202,7 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(new IResource[] {project, folder, file});
+		createInWorkspace(new IResource[] {project, folder, file});
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 
@@ -225,8 +225,8 @@ public class DeleteTest extends LocalStoreTest {
 		 * =========================================================== */
 
 		/* initialize common objects */
-		ensureExistsInWorkspace(new IResource[] {project, folder});
-		ensureExistsInWorkspace(file);
+		createInWorkspace(new IResource[] {project, folder});
+		createInWorkspace(file);
 		folderPath = folder.getLocation();
 		filePath = file.getLocation();
 		projectLocation = project.getLocation();
@@ -281,25 +281,25 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* create some resources */
 		IFolder folder = projects[0].getFolder("folder");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 		IFile fileSync = folder.getFile("fileSync");
-		ensureExistsInWorkspace(fileSync);
+		createInWorkspace(fileSync);
 		IFile fileUnsync = folder.getFile("fileUnsync");
-		ensureExistsInWorkspace(fileUnsync);
+		createInWorkspace(fileUnsync);
 		IFile fileCreated = folder.getFile("fileCreated");
 		createInFileSystem(fileCreated); // create only in file system
 		IFolder subfolderSync = folder.getFolder("subfolderSync");
-		ensureExistsInWorkspace(subfolderSync);
+		createInWorkspace(subfolderSync);
 		IFolder deletedfolderSync = subfolderSync.getFolder("deletedfolderSync");
-		ensureExistsInWorkspace(deletedfolderSync);
+		createInWorkspace(deletedfolderSync);
 		IFolder subfolderUnsync = folder.getFolder("subfolderUnsync");
-		ensureExistsInWorkspace(subfolderUnsync);
+		createInWorkspace(subfolderUnsync);
 		IFolder subsubfolderUnsync = subfolderUnsync.getFolder("subsubfolderUnsync");
-		ensureExistsInWorkspace(subsubfolderUnsync);
+		createInWorkspace(subsubfolderUnsync);
 		IFile subsubfileSync = subsubfolderUnsync.getFile("subsubfileSync");
-		ensureExistsInWorkspace(subsubfileSync);
+		createInWorkspace(subsubfileSync);
 		IFile subsubfileUnsync = subsubfolderUnsync.getFile("subsubfileUnsync");
-		ensureExistsInWorkspace(subsubfileUnsync);
+		createInWorkspace(subsubfileUnsync);
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);
@@ -318,34 +318,34 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* create some resources */
 		IFolder recreatedFolder = projects[0].getFolder("folder");
-		ensureExistsInWorkspace(recreatedFolder);
+		createInWorkspace(recreatedFolder);
 		//
 		fileSync = recreatedFolder.getFile("fileSync");
-		ensureExistsInWorkspace(fileSync);
+		createInWorkspace(fileSync);
 		//
 		fileUnsync = recreatedFolder.getFile("fileUnsync");
-		ensureExistsInWorkspace(fileUnsync);
+		createInWorkspace(fileUnsync);
 		//
 		fileCreated = recreatedFolder.getFile("fileCreated");
 		createInFileSystem(fileCreated); // create only in file system
 		//
 		subfolderSync = recreatedFolder.getFolder("subfolderSync");
-		ensureExistsInWorkspace(subfolderSync);
+		createInWorkspace(subfolderSync);
 		//
 		deletedfolderSync = subfolderSync.getFolder("deletedfolderSync");
-		ensureExistsInWorkspace(deletedfolderSync);
+		createInWorkspace(deletedfolderSync);
 		//
 		subfolderUnsync = recreatedFolder.getFolder("subfolderUnsync");
-		ensureExistsInWorkspace(subfolderUnsync);
+		createInWorkspace(subfolderUnsync);
 		//
 		subsubfolderUnsync = subfolderUnsync.getFolder("subsubfolderUnsync");
-		ensureExistsInWorkspace(subsubfolderUnsync);
+		createInWorkspace(subsubfolderUnsync);
 		//
 		subsubfileSync = subsubfolderUnsync.getFile("subsubfileSync");
-		ensureExistsInWorkspace(subsubfileSync);
+		createInWorkspace(subsubfileSync);
 		//
 		subsubfileUnsync = subsubfolderUnsync.getFile("subsubfileUnsync");
-		ensureExistsInWorkspace(subsubfileUnsync);
+		createInWorkspace(subsubfileUnsync);
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -168,7 +168,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		// create resources
 		IResource[] resources = buildResources(project, new String[] { "/Folder1/", "/Folder1/File1",
 				"/Folder1/Folder2/", "/Folder1/Folder2/File2", "/Folder1/Folder2/Folder3/" });
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		for (IResource resource : resources) {
 			ensureDoesNotExistInFileSystem(resource);
 		}
@@ -251,7 +251,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* initialize common objects */
 		IProject project = projects[0];
 		IFile file = project.getFile("testWriteFile");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		/* common contents */
 		String originalContent = "this string should not be equal the other";
 		String anotherContent = "and this string should not... well, you know...";
@@ -309,7 +309,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* initialize common objects */
 		IProject project = projects[0];
 		IFile file = project.getFile("testWriteFile");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		String content = "original";
 
 		/* write file for the first time */
@@ -342,7 +342,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		/* initialize common objects */
 		IProject project = projects[0];
 		IFolder folder = project.getFolder("testWriteFolder");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		/* existing file on destination */
 		ensureDoesNotExistInFileSystem(folder);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -337,7 +337,7 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file2 = folder2.getFile(file1.getName());
 
 		// directly deletes history files if project did already existed:
-		ensureExistsInWorkspace(new IResource[] {project, folder1, folder2});
+		createInWorkspace(new IResource[] {project, folder1, folder2});
 		file1.create(getRandomContents(), IResource.FORCE, createTestMonitor());
 		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
@@ -559,7 +559,7 @@ public class HistoryStoreTest extends ResourceTest {
 		String[] contents = {"content0", "content1", "content2", "content3", "content4"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("TestCopyHistoryProject");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFolder folder = project.getFolder("folder1");
 		IFile file = folder.getFile("file1.txt");
@@ -627,7 +627,7 @@ public class HistoryStoreTest extends ResourceTest {
 		String[] contents = {"content0", "content1", "content2", "content3", "content4"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("TestCopyHistoryProject");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFolder folder = project.getFolder("folder1");
 		IFolder folder2 = project.getFolder("folder2");
@@ -667,7 +667,7 @@ public class HistoryStoreTest extends ResourceTest {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("TestCopyHistoryProject");
 		IProject project2 = getWorkspace().getRoot().getProject("TestCopyHistoryProject2");
-		ensureExistsInWorkspace(new IResource[] {project, project2});
+		createInWorkspace(new IResource[] {project, project2});
 
 		IFolder folder = project.getFolder("folder1");
 		IFolder folder2 = project2.getFolder("folder1");
@@ -1054,11 +1054,11 @@ public class HistoryStoreTest extends ResourceTest {
 		/* Create files. */
 		IFile file = project.getFile("getContentsFile.txt");
 		String contents = "This file has some contents in testGetContents.";
-		ensureExistsInWorkspace(file, contents);
+		createInWorkspace(file, contents);
 
 		IFile secondValidFile = project.getFile("secondGetContentsFile.txt");
 		contents = "A file with some other contents in testGetContents.";
-		ensureExistsInWorkspace(secondValidFile, contents);
+		createInWorkspace(secondValidFile, contents);
 
 		IHistoryStore historyStore = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -49,7 +49,7 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		// create resources
 		IResource[] resources = buildResources(project,
 				new String[] { "/File1", "/Folder1/", "/Folder1/File1", "/Folder1/Folder2/" });
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// delete project's default directory
 		Workspace.clear(project.getLocation().toFile());
@@ -90,10 +90,10 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 		IResource folder = project.getFolder(IPath.fromOSString("folder"));
 
 		// add resources to the workspace
-		ensureExistsInWorkspace((IFile) index, "");
-		ensureExistsInWorkspace(toc);
-		ensureExistsInWorkspace((IFile) file, "");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace((IFile) index, "");
+		createInWorkspace(toc);
+		createInWorkspace((IFile) file, "");
+		createInWorkspace(folder);
 
 		// run synchronize
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -117,7 +117,7 @@ public class MoveTest extends LocalStoreTest {
 		// get file instance
 		String fileName = "newFile.txt";
 		IFile file = testProjects[0].getFile(fileName);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 
 		// add some properties to file (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
@@ -220,7 +220,7 @@ public class MoveTest extends LocalStoreTest {
 		// get folder instance
 		String folderName = "newFolder";
 		IFolder folder = testProjects[0].getFolder(folderName);
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		// add some properties to folder (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
@@ -265,14 +265,14 @@ public class MoveTest extends LocalStoreTest {
 		// create the source folder
 		String folderSourceName = "folder source";
 		IFolder folderSource = testPprojects[0].getFolder(folderSourceName);
-		ensureExistsInWorkspace(folderSource);
+		createInWorkspace(folderSource);
 
 		// create hierarchy
 		String[] hierarchy = new String[] { "/", "/file1", "/file2", "/folder1/", "/folder1/file3",
 				"/folder1/file4", "/folder2/", "/folder2/file5", "/folder2/file6", "/folder1/folder3/",
 				"/folder1/folder3/file7", "/folder1/folder3/file8" };
 		IResource[] resources = buildResources(folderSource, hierarchy);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// add some properties to each resource (persistent and session)
 		String[] propNames = new String[numberOfProperties];
@@ -338,14 +338,14 @@ public class MoveTest extends LocalStoreTest {
 		// create the source folder
 		String folderSourceName = "source";
 		IFolder folderSource = testProjects[0].getFolder(folderSourceName);
-		ensureExistsInWorkspace(folderSource);
+		createInWorkspace(folderSource);
 
 		// build hierarchy
 		String[] hierarchy = new String[] { "/", "/file1", "/file2", "/folder1/", "/folder1/file3", "/folder1/file4",
 				"/folder2/", "/folder2/file5", "/folder2/file6", "/folder1/folder3/", "/folder1/folder3/file7",
 				"/folder1/folder3/file8" };
 		IResource[] resources = buildResources(folderSource, hierarchy);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// add some properties to each resource
 		String[] propNames = new String[numberOfProperties];
@@ -405,8 +405,8 @@ public class MoveTest extends LocalStoreTest {
 		/* create folder and file */
 		IFolder folder = projects[0].getFolder("folder");
 		IFile file = folder.getFile("file.txt");
-		ensureExistsInWorkspace(folder);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(folder);
+		createInWorkspace(file);
 
 		/* move to absolute destination */
 		IResource destination = testProjects[0].getFile("file.txt");
@@ -475,7 +475,7 @@ public class MoveTest extends LocalStoreTest {
 		int flags = ((File) ghostFile).getFlags(info);
 		assertTrue(((Resource) ghostFile).exists(flags, true));
 		anotherFile = folder.getFile("anotherFile");
-		ensureExistsInWorkspace(anotherFile);
+		createInWorkspace(anotherFile);
 		anotherFile.move(ghostFile.getFullPath(), true, null);
 		assertTrue(ghostFile.exists());
 	}
@@ -491,7 +491,7 @@ public class MoveTest extends LocalStoreTest {
 		// create a folder
 		String fileName = "file.txt";
 		IFile file = testProjects[0].getFile(fileName);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 
 		// add some properties to file (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];
@@ -543,7 +543,7 @@ public class MoveTest extends LocalStoreTest {
 		// create a folder
 		String folderName = "folder";
 		IFolder folder = testProjects[0].getFolder(folderName);
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		// add some properties to folder (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -42,7 +42,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		IFile file = folder.getFile("file");
 		IFile fileVariant = folderVariant.getFile(file.getName());
 		//create the project, folder, and file
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 
 		//change the case of the folder on disk
 		project.getLocation().append("A").toFile().renameTo((project.getLocation().append("a").toFile()));
@@ -248,7 +248,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* test changes of a child (child is file) */
 		file = project.getFile("file");
 		IFileStore fileStore = ((Resource) file).getStore();
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		assertTrue(file.exists());
 		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
 		assertEquals(fileStore.fetchInfo().getLastModified(),
@@ -270,7 +270,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 
 		/* test root deletion */
 		IFile file = project.getFile("file");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		ensureDoesNotExistInFileSystem(file);
 		assertTrue(file.exists());
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -240,7 +240,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 	 */
 	public void test342968() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("test");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.open(createTestMonitor());
 
 		IProjectDescription description = project.getDescription();
@@ -274,7 +274,7 @@ public class UnifiedTreeTest extends LocalStoreTest {
 
 	public void test368376() throws CoreException, IOException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		String filePath = "a/b/c/file.txt";
 		File javaFile = new File(project.getLocation().toFile(), filePath);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -100,7 +100,7 @@ public class ChangeValidationTest extends ResourceTest {
 		super.setUp();
 		project = getWorkspace().getRoot().getProject("Project");
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/a/", "c/x", "c/b/y", "c/b/z"});
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		assertExistsInWorkspace(before);
 		factory = createEmptyChangeDescription();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
@@ -39,7 +39,7 @@ public class TestProjectDeletion extends ResourceTest {
 		super.setUp();
 		project = getWorkspace().getRoot().getProject("Project");
 		IResource[] resources = buildResources(project, new String[] { "a/", "a/b/", "a/c/", "a/d", "a/b/e", "a/b/f" });
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInWorkspace(resources);
 		factory = ResourceChangeValidator.getValidator().createDeltaFactory();
 		int kind = factory.getDelta().getKind();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -146,8 +146,8 @@ public class PropertyManagerTest extends LocalStoreTest {
 		final int REPEAT = 8;
 		for (int i = 0; i < REPEAT; i++) {
 			// create common objects
-			ensureExistsInWorkspace(projects[0]);
-			ensureExistsInWorkspace(target);
+			createInWorkspace(projects[0]);
+			createInWorkspace(target);
 
 			// prepare keys and values
 			final int N = 50;
@@ -178,7 +178,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		QualifiedName propName = new QualifiedName("test", "prop");
 		String propValue = "this is the property value";
 
-		ensureExistsInWorkspace(new IResource[] { source, sourceFolder, sourceFile });
+		createInWorkspace(new IResource[] { source, sourceFolder, sourceFile });
 
 		System.gc();
 		System.runFinalization();
@@ -205,7 +205,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		int MAX_VALUE_SIZE = 2 * 1024; // PropertyManager2.MAX_VALUE_SIZE
 		String propValue = new String(new byte[MAX_VALUE_SIZE], StandardCharsets.ISO_8859_1);
 
-		ensureExistsInWorkspace(new IResource[] { source, sourceFolder, sourceFile });
+		createInWorkspace(new IResource[] { source, sourceFolder, sourceFile });
 
 		manager.setProperty(source, propName, propValue);
 		manager.setProperty(sourceFolder, propName, propValue);
@@ -265,7 +265,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		QualifiedName propName = new QualifiedName("test", "prop");
 		String propValue = "this is the property value";
 
-		ensureExistsInWorkspace(new IResource[] {source, sourceFolder, sourceFile});
+		createInWorkspace(new IResource[] {source, sourceFolder, sourceFile});
 
 		/*
 		 * persistent properties
@@ -327,7 +327,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		/* create common objects */
 		IPropertyManager manager = new PropertyManager2((Workspace) ResourcesPlugin.getWorkspace());
 		IFile target = projects[0].getFile("target");
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 
 		/* server properties */
 		QualifiedName propName = new QualifiedName("eclipse", "prop");
@@ -344,7 +344,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IResource sourceFile = sourceFolder.getFile("myfile.txt");
 		propName = new QualifiedName("test", "prop");
 		propValue = "this is the property value";
-		ensureExistsInWorkspace(new IResource[] {source, sourceFolder, sourceFile});
+		createInWorkspace(new IResource[] {source, sourceFolder, sourceFile});
 
 		/*
 		 * persistent properties
@@ -375,12 +375,12 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IProject project = root.getProject("proj");
 		IFolder folder = project.getFolder("folder");
 		IFile file1a = folder.getFile("file1");
-		ensureExistsInWorkspace(file1a);
+		createInWorkspace(file1a);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		file1a.setPersistentProperty(key, "value");
 		file1a.move(IPath.fromOSString("file2"), true, createTestMonitor());
 		IFile file1b = folder.getFile("file1");
-		ensureExistsInWorkspace(file1b);
+		createInWorkspace(file1b);
 		String value = null;
 		value = file1b.getPersistentProperty(key);
 		assertNull("1.0", value);
@@ -396,12 +396,12 @@ public class PropertyManagerTest extends LocalStoreTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("proj");
 		IFolder folder1a = project.getFolder("folder1");
-		ensureExistsInWorkspace(folder1a);
+		createInWorkspace(folder1a);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		folder1a.setPersistentProperty(key, "value");
 		folder1a.move(IPath.fromOSString("folder2"), true, createTestMonitor());
 		IFolder folder1b = project.getFolder("folder1");
-		ensureExistsInWorkspace(folder1b);
+		createInWorkspace(folder1b);
 		String value = null;
 		value = folder1b.getPersistentProperty(key);
 		assertNull("1.0", value);
@@ -434,12 +434,12 @@ public class PropertyManagerTest extends LocalStoreTest {
 	public void testProjectRename() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project1a = root.getProject("proj1");
-		ensureExistsInWorkspace(project1a);
+		createInWorkspace(project1a);
 		QualifiedName key = new QualifiedName(PI_RESOURCES_TESTS, "key");
 		project1a.setPersistentProperty(key, "value");
 		project1a.move(IPath.fromOSString("proj2"), true, createTestMonitor());
 		IProject project1b = root.getProject("proj1");
-		ensureExistsInWorkspace(project1b);
+		createInWorkspace(project1b);
 		String value = project1b.getPersistentProperty(key);
 		assertNull("1.0", value);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
@@ -41,7 +41,7 @@ public class Bug544975Test extends ResourceTest {
 		boolean originalRefreshSetting = prefs.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
 		try {
 			prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			createFile(project, "someFile.txt", "some text");
 			IFile file1 = project.getFile("someFile.txt");
 			assertTrue(file1.exists());
@@ -75,7 +75,7 @@ public class Bug544975Test extends ResourceTest {
 	public void testBug544975ProjectOpenWithoutBackgroundRefresh() throws Exception {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject project = root.getProject("Bug544975");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createFile(project, "someFile.txt", "some text");
 		IFile file1 = project.getFile("someFile.txt");
 		assertTrue(file1.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -44,7 +44,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		project = getWorkspace().getRoot().getProject("ProjectBuildConfigsTest_Project");
-		ensureExistsInWorkspace(new IProject[] {project});
+		createInWorkspace(new IProject[] {project});
 		variant0 = new BuildConfiguration(project, variantId0);
 		variant1 = new BuildConfiguration(project, variantId1);
 		variant2 = new BuildConfiguration(project, variantId2);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -54,7 +54,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		project0 = getWorkspace().getRoot().getProject(PROJECT_0_NAME);
 		project1 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p2");
-		ensureExistsInWorkspace(new IProject[] { project0, project1, project2 });
+		createInWorkspace(new IProject[] { project0, project1, project2 });
 		addBuilder(project0);
 		addBuilder(project1);
 		addBuilder(project2);
@@ -227,7 +227,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		IFile projectFile = project0.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		String projectDescription = readStringInFileSystem(projectFile);
 		projectDescription = projectDescription.replace(PROJECT_0_NAME, "anotherName");
-		ensureExistsInWorkspace(projectFile, projectDescription);
+		createInWorkspace(projectFile, projectDescription);
 		project0.delete(false, true, null);
 		project0.create(null);
 		project0.open(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -124,7 +124,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String projectValue = "project" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		IScopeContext instanceContext = InstanceScope.INSTANCE;
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		ArrayList<IScopeContext[]> list = new ArrayList<>();
 		list.add(null);
@@ -216,7 +216,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		// create project
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		// set preferences
 		Preferences node = projectContext.getNode(qualifier);
 		node.put(key, value);
@@ -269,7 +269,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void testProjectDelete() throws Exception {
 		// create the project
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		// set some settings
 		String qualifier = createUniqueString();
 		String key = createUniqueString();
@@ -287,7 +287,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertTrue("3.0", !parent.nodeExists(project.getName()));
 
 		// create a project with the same name
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		// ensure that the preference value is not set
 		assertNull("4.0", context.getNode(qualifier).get(key, null));
@@ -298,7 +298,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		IProject project1 = getProject(createUniqueString());
 		IProject project2 = getProject(createUniqueString());
 
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		String qualifier = createUniqueString();
 		String key = createUniqueString();
 		String value = createUniqueString();
@@ -335,7 +335,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void test_60925() throws Exception {
 		// setup
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		String qualifier = createUniqueString();
 		IFile file = getFileInWorkspace(project, qualifier);
 
@@ -365,7 +365,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_55410() throws Exception {
 		IProject project1 = getProject(createUniqueString());
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES).node("subnode");
 		String key1 = ".";
 		String key2 = "x";
@@ -396,7 +396,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void test_61277a() throws Exception {
 		IProject project = getProject(createUniqueString());
 		IProject destProject = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		ensureDoesNotExistInWorkspace(destProject);
 		IScopeContext context = new ProjectScope(project);
 		String qualifier = createUniqueString();
@@ -426,7 +426,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	public void test_61277b() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		IProject project2 = getProject(createUniqueString());
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertTrue("1.0", getFileInWorkspace(project1, ResourcesPlugin.PI_RESOURCES).exists());
 		node.put("key", "value");
@@ -449,7 +449,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_61277c() throws Exception {
 		IProject project1 = getProject(createUniqueString());
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		assertTrue("1.0", getFileInWorkspace(project1, ResourcesPlugin.PI_RESOURCES).exists());
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES);
 		String key1 = "key";
@@ -481,7 +481,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		// create the project and manually give it a settings file
 		final String qualifier = createUniqueString();
 		final IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IFile settingsFile = getFileInWorkspace(project, qualifier);
 
 		// write some property values in the settings file
@@ -524,7 +524,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_65068() throws Exception {
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		String key = "key";
 		String value = createUniqueString();
@@ -543,7 +543,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_95052() throws Exception {
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		node.put("key1", "value1");
 		node.put("key2", "value2");
@@ -586,7 +586,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_579372() throws Exception {
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		node.put("key1", "value1");
 		node.node("child").put("key", "childValue1");
@@ -653,12 +653,12 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_256900() throws Exception {
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		// create the destination project and the .settings folder inside
 		IProject project2 = getProject(createUniqueString());
-		ensureExistsInWorkspace(project2);
-		ensureExistsInWorkspace(project2.getFolder(DIR_NAME));
+		createInWorkspace(project2);
+		createInWorkspace(project2.getFolder(DIR_NAME));
 
 		// get the pref node for the project and add a sample key/value to it
 		Preferences node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
@@ -687,7 +687,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 */
 	public void test_325000() throws Exception {
 		IProject project1 = getProject(createUniqueString());
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		Preferences node = new ProjectScope(project1).getNode(ResourcesPlugin.PI_RESOURCES).node("subnode");
 
 		List<String> keys = new ArrayList<>();
@@ -814,7 +814,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		Preferences rootNode = Platform.getPreferencesService().getRootNode();
 		Preferences instanceNode = rootNode.node(InstanceScope.SCOPE).node(Platform.PI_RUNTIME);
@@ -910,7 +910,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 	public void testProjectOpenClose() throws Exception {
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		String qualifier = createUniqueString();
 		String key = createUniqueString();
 		String value = createUniqueString();
@@ -940,7 +940,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		String value = "value" + createUniqueString();
 		IScopeContext projectContext = new ProjectScope(project);
 		// create project
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		// set preferences
 		Preferences node = projectContext.getNode(qualifier);
 		node.put(key, value);
@@ -1006,7 +1006,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 
 		// setup
 		IProject project = getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IScopeContext context = new ProjectScope(project);
 		String qualifier = "test.load.is.import";
 		IEclipsePreferences node = context.getNode(qualifier);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -55,7 +55,7 @@ public class ProjectReferencesTest extends ResourceTest {
 		project1 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p2");
 		project3 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p3");
-		ensureExistsInWorkspace(new IProject[] {project0, project1, project2, project3});
+		createInWorkspace(new IProject[] {project0, project1, project2, project3});
 		setUpVariants(project0);
 		setUpVariants(project1);
 		setUpVariants(project2);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
@@ -66,7 +66,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 	 */
 	public void testCancelOnBlocked() throws Throwable {
 		//create a dummy project
-		ensureExistsInWorkspace(getWorkspace().getRoot().getProject("P1"));
+		createInWorkspace(getWorkspace().getRoot().getProject("P1"));
 		//add a resource change listener that blocks forever, thus
 		//simulating a scenario where workspace lock is held indefinitely
 		final AtomicIntegerArray barrier = new AtomicIntegerArray(new int[1]);
@@ -164,9 +164,9 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 		final IProject touch = workspace.getRoot().getProject("ToTouch");
 		final IProject rule = workspace.getRoot().getProject("jobThree");
 		final IFile ruleFile = rule.getFile("somefile.txt");
-		ensureExistsInWorkspace(rule);
-		ensureExistsInWorkspace(touch);
-		ensureExistsInWorkspace(ruleFile);
+		createInWorkspace(rule);
+		createInWorkspace(touch);
+		createInWorkspace(ruleFile);
 		AtomicReference<Throwable> failure = new AtomicReference<>();
 		IResourceChangeListener listener = event -> {
 			try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -185,7 +185,7 @@ public class CharsetTest extends ResourceTest {
 		final IProject project = workspace.getRoot().getProject("MyProject");
 		try {
 			final IFile file = project.getFile("file.txt");
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			workspace.run((IWorkspaceRunnable) monitor -> {
 				assertEquals("0.9", "FOO", file.getCharset());
@@ -207,7 +207,7 @@ public class CharsetTest extends ResourceTest {
 		final IProject project = workspace.getRoot().getProject("MyProject");
 		try {
 			final IFile file = project.getFile("file.txt");
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			assertEquals("Setting up Projects default charset was successful", "FOO", file.getCharset());
 			file.setCharset("BAR", createTestMonitor());
@@ -230,7 +230,7 @@ public class CharsetTest extends ResourceTest {
 			project.create(createTestMonitor());
 			project.open(createTestMonitor());
 			final IFile file = project.getFile("file.txt");
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			file.setCharset("FOO", createTestMonitor());
 			assertEquals("File charset correctly set", file.getCharset(true), "FOO");
 			file.copy(project.getFullPath().append("file2.txt"), IResource.NONE, createTestMonitor());
@@ -344,7 +344,7 @@ public class CharsetTest extends ResourceTest {
 		try {
 			IFile file = project.getFile("file.txt");
 			IFolder folder = project.getFolder("folder");
-			ensureExistsInWorkspace(new IResource[] {file, folder});
+			createInWorkspace(new IResource[] {file, folder});
 			file.setCharset("FOO", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
 			project.setDefaultCharset("PROJECT_CHARSET", createTestMonitor());
@@ -360,9 +360,9 @@ public class CharsetTest extends ResourceTest {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType anotherXML = contentTypeManager.getContentType("org.eclipse.core.tests.resources.anotherXML");
 		assertNotNull("0.5", anotherXML);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IFile file = project.getFile("file.xml");
-		ensureExistsInWorkspace(file, SAMPLE_SPECIFIC_XML);
+		createInWorkspace(file, SAMPLE_SPECIFIC_XML);
 		IContentDescription description = file.getContentDescription();
 		assertNotNull("1.0", description);
 		assertEquals("1.1", anotherXML, description.getContentType());
@@ -377,7 +377,7 @@ public class CharsetTest extends ResourceTest {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
 		IFile file = project.getFile("file.txt");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		IContentDescription description = file.getContentDescription();
 		assertNotNull("1.0", description);
 		assertEquals("1.1", text, description.getContentType());
@@ -408,14 +408,14 @@ public class CharsetTest extends ResourceTest {
 		try {
 			IWorkspace workspace = getWorkspace();
 			project = workspace.getRoot().getProject("MyProject");
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			project.setDefaultCharset("BAR", createTestMonitor());
 
 			IFolder folder = project.getFolder(createUniqueString());
 			IFile file = folder.getFile(createUniqueString());
 			assertEquals("1.0", "BAR", file.getCharset(true));
 
-			ensureExistsInWorkspace(folder);
+			createInWorkspace(folder);
 			assertEquals("2.0", "BAR", file.getCharset(true));
 
 			folder.setDerived(true, createTestMonitor());
@@ -447,7 +447,7 @@ public class CharsetTest extends ResourceTest {
 		file.getCharset(true);
 
 		// test that we can get the charset, when the file is out-of-sync
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		assertTrue(file.getLocation().toFile().delete());
 		file.getCharset(true);
 
@@ -524,7 +524,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder a1 = project1.getFolder("a1");
 			IFolder b1 = project1.getFolder("b1");
 			IFile a = a1.getFile("a.txt");
-			ensureExistsInWorkspace(new IResource[] {project1, a1, b1, a});
+			createInWorkspace(new IResource[] {project1, a1, b1, a});
 			verifier.reset();
 			verifier.addExpectedChange(b1, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
 			b1.setDerived(true, createTestMonitor());
@@ -764,13 +764,13 @@ public class CharsetTest extends ResourceTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project1 = workspace.getRoot().getProject("Project1");
 		IFile file = project1.getFile("file1.xml");
-		ensureExistsInWorkspace(file, SAMPLE_XML_ISO_8859_1_ENCODING);
+		createInWorkspace(file, SAMPLE_XML_ISO_8859_1_ENCODING);
 		ContentDescriptionManagerTest.waitForCacheFlush();
 		assertEquals("1.0", "ISO-8859-1", file.getCharset());
 
 		//delete and recreate the file with different contents
 		ensureDoesNotExistInWorkspace(file);
-		ensureExistsInWorkspace(file, SAMPLE_XML_DEFAULT_ENCODING);
+		createInWorkspace(file, SAMPLE_XML_DEFAULT_ENCODING);
 		assertEquals("2.0", "UTF-8", file.getCharset());
 	}
 
@@ -782,7 +782,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder = project1.getFolder("folder1");
 			IFile file1 = project1.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2, project2});
+			createInWorkspace(new IResource[] {file1, file2, project2});
 			project1.setDefaultCharset("FOO", createTestMonitor());
 			project2.setDefaultCharset("ZOO", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
@@ -811,7 +811,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder = project.getFolder("folder1");
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2});
+			createInWorkspace(new IResource[] {file1, file2});
 			project.setDefaultCharset("FOO", createTestMonitor());
 			file1.setCharset("FRED", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
@@ -830,7 +830,7 @@ public class CharsetTest extends ResourceTest {
 			// delete a file and recreate it and ensure the encoding is not
 			// remembered
 			file1.delete(false, false, null);
-			ensureExistsInWorkspace(new IResource[] {file1});
+			createInWorkspace(new IResource[] {file1});
 			assertEquals("3.0", project.getDefaultCharset(), file1.getCharset());
 		} finally {
 			clearAllEncodings(project);
@@ -845,7 +845,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder = project.getFolder("folder");
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2});
+			createInWorkspace(new IResource[] {file1, file2});
 			project.setDefaultCharset("FOO", createTestMonitor());
 			file1.setCharset("FRED", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
@@ -870,12 +870,12 @@ public class CharsetTest extends ResourceTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("MyProject");
 		try {
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
 			assertEquals("0.9", "FOO", project.getDefaultCharset());
 			// content-based encoding is BAR
-			ensureExistsInWorkspace(file, SAMPLE_XML_US_ASCII_ENCODING);
+			createInWorkspace(file, SAMPLE_XML_US_ASCII_ENCODING);
 			assertEquals("1.0", "US-ASCII", file.getCharset());
 			// content-based encoding is FRED
 			file.setContents(new ByteArrayInputStream(SAMPLE_XML_ISO_8859_1_ENCODING.getBytes(StandardCharsets.ISO_8859_1)), false, false, null);
@@ -913,7 +913,7 @@ public class CharsetTest extends ResourceTest {
 			IFile file2 = folder1.getFile("file2.txt");
 			IFile file3 = folder2.getFile("file3.txt");
 
-			ensureExistsInWorkspace(new IResource[] { project });
+			createInWorkspace(new IResource[] { project });
 			assertEquals(ResourcesPlugin.getEncoding(), project.getDefaultCharset(false));
 
 			IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
@@ -927,7 +927,7 @@ public class CharsetTest extends ResourceTest {
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertEquals("Missing encoding marker should be set", 1, markers.length);
 
-			ensureExistsInWorkspace(new IResource[] {file1, file2, file3});
+			createInWorkspace(new IResource[] {file1, file2, file3});
 			// project and children should be using the workspace's default now
 			assertCharsetIs("1.0", ResourcesPlugin.getEncoding(), new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
 			assertCharsetIs("1.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
@@ -1005,7 +1005,7 @@ public class CharsetTest extends ResourceTest {
 			IFile file2 = folder1.getFile("file2.resources-mc");
 			IFile file3 = project.getFile("file3.resources-mc");
 			IFile file4 = project.getFile("file4.resources-mc");
-			ensureExistsInWorkspace(new IResource[] {file1, file2, file3, file4});
+			createInWorkspace(new IResource[] {file1, file2, file3, file4});
 			project.setDefaultCharset("FOO", createTestMonitor());
 			// even files with a user-set charset will appear in the delta
 			file4.setCharset("BAR", createTestMonitor());
@@ -1051,7 +1051,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder1 = project.getFolder("folder1");
 			IFile file1 = folder1.getFile("file1.txt");
 			IFile file2 = project.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2});
+			createInWorkspace(new IResource[] {file1, file2});
 
 			IFile resourcesPrefs = getResourcesPreferenceFile(project, false);
 			assertTrue("0.9", resourcesPrefs.exists());
@@ -1109,7 +1109,7 @@ public class CharsetTest extends ResourceTest {
 			IFile prefs = getResourcesPreferenceFile(project, false);
 			// leaf folder
 			IFolder folder1 = project.getFolder("folder1");
-			ensureExistsInWorkspace(new IResource[] {project, folder1});
+			createInWorkspace(new IResource[] {project, folder1});
 			verifier.reset();
 			verifier.addExpectedChange(folder1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(new IResource[] { prefs.getParent() }, IResourceDelta.CHANGED, 0);
@@ -1121,7 +1121,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder2 = folder1.getFolder("folder2");
 			IFile file1 = folder1.getFile("file1.txt");
 			IFile file2 = folder2.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {folder2, file1, file2});
+			createInWorkspace(new IResource[] {folder2, file1, file2});
 			verifier.reset();
 			verifier.addExpectedChange(new IResource[] {folder1, folder2, file1, file2}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
@@ -1200,7 +1200,7 @@ public class CharsetTest extends ResourceTest {
 			// File:
 			// single file
 			final IFile file1 = project.getFile("file1.txt");
-			ensureExistsInWorkspace(file1, getRandomString());
+			createInWorkspace(file1, getRandomString());
 			// change from default
 			verifier.reset();
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
@@ -1239,7 +1239,7 @@ public class CharsetTest extends ResourceTest {
 			// multiple files (same operation)
 			verifier.reset();
 			final IFile file2 = project.getFile("file2.txt");
-			ensureExistsInWorkspace(file2, getRandomString());
+			createInWorkspace(file2, getRandomString());
 			verifier.addExpectedChange(new IResource[] {file1, file2}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
@@ -1261,7 +1261,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder = project.getFolder("folder");
 			IFile file1 = project.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2});
+			createInWorkspace(new IResource[] {file1, file2});
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
 			project.setDefaultCharset("FOO", createTestMonitor());
 			assertExistsInWorkspace(getResourcesPreferenceFile(project, false));
@@ -1296,7 +1296,7 @@ public class CharsetTest extends ResourceTest {
 			IFile newXMLFile = project.getFile("newfile.xml");
 			IFile newTXTFile = project.getFile("newfile.txt");
 			IFile newRandomFile = project.getFile("newFile." + (long) (Math.random() * (Long.MAX_VALUE)));
-			ensureExistsInWorkspace(oldFile, SAMPLE_XML_DEFAULT_ENCODING);
+			createInWorkspace(oldFile, SAMPLE_XML_DEFAULT_ENCODING);
 			// sets project default charset
 			project.setDefaultCharset("BAR", createTestMonitor());
 			oldFile.setCharset("FOO", createTestMonitor());
@@ -1338,7 +1338,7 @@ public class CharsetTest extends ResourceTest {
 			IFolder folder = project1.getFolder("folder1");
 			IFile file1 = project1.getFile("file1.txt");
 			IFile file2 = folder.getFile("file2.txt");
-			ensureExistsInWorkspace(new IResource[] {file1, file2});
+			createInWorkspace(new IResource[] {file1, file2});
 			project1.setDefaultCharset("FOO", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
 
@@ -1374,14 +1374,14 @@ public class CharsetTest extends ResourceTest {
 		try {
 			CoreException e = assertThrows(CoreException.class, () -> project.setDefaultCharset("FOO", createTestMonitor()));
 			assertEquals("project should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
 			assertDoesNotExistInWorkspace(file);
 			assertEquals("2.2", "FOO", file.getCharset());
 			e = assertThrows(CoreException.class, () -> file.setCharset("BAR", createTestMonitor()));
 			assertEquals("file should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			file.setCharset("BAR", createTestMonitor());
 			assertEquals("2.8", "BAR", file.getCharset());
 			file.delete(IResource.NONE, null);
@@ -1397,7 +1397,7 @@ public class CharsetTest extends ResourceTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
 		IFile file = project.getFile("file.txt");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		file.getLocation().toFile().delete();
 		CoreException e = assertThrows(CoreException.class, file::getContentDescription);
 		assertEquals("the resource should not exist", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
@@ -1406,7 +1406,7 @@ public class CharsetTest extends ResourceTest {
 	public void testBug528827() throws CoreException, OperationCanceledException, InterruptedException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		JobChangeAdapterExtension listener = new JobChangeAdapterExtension();
 		Job.getJobManager().addJobChangeListener(listener);
 		try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -76,8 +76,8 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		String newExtension = "xml_bug_79151";
 		IFile file1 = project.getFile("file.xml");
 		IFile file2 = project.getFile("file." + newExtension);
-		ensureExistsInWorkspace(file1, CharsetTest.SAMPLE_XML_ISO_8859_1_ENCODING);
-		ensureExistsInWorkspace(file2, CharsetTest.SAMPLE_XML_US_ASCII_ENCODING);
+		createInWorkspace(file1, CharsetTest.SAMPLE_XML_ISO_8859_1_ENCODING);
+		createInWorkspace(file2, CharsetTest.SAMPLE_XML_US_ASCII_ENCODING);
 		// ensure we start in a known state
 		((Workspace) workspace).getContentDescriptionManager().invalidateCache(true, null);
 		// wait for cache flush to finish
@@ -127,7 +127,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertNotNull("0.1", text);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFile unrelatedFile = project.getFile("file." + getName());
-		ensureExistsInWorkspace(unrelatedFile, "");
+		createInWorkspace(unrelatedFile, "");
 
 		IContentDescription description = null;
 		description = unrelatedFile.getContentDescription();
@@ -177,7 +177,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFile file = project.getFile("file.nature-associated");
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		ensureExistsInWorkspace(file, "it really does not matter");
+		createInWorkspace(file, "it really does not matter");
 		IContentDescription description = null;
 
 		// originally, project description has no natures
@@ -239,8 +239,8 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		IFile txtFile = project.getFile(getName() + ".txt");
 		IFile xmlFile = project.getFile(getName() + ".xml");
 
-		ensureExistsInWorkspace(txtFile, "");
-		ensureExistsInWorkspace(xmlFile, "");
+		createInWorkspace(txtFile, "");
+		createInWorkspace(xmlFile, "");
 
 		project.setDefaultCharset("FOO", createTestMonitor());
 		assertEquals("1.0", "FOO", txtFile.getCharset());
@@ -277,9 +277,9 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		IFile xmlFile = project.getFile(getName() + ".xml");
 		IFile unrelatedFile = project.getFile("file." + getName());
 
-		ensureExistsInWorkspace(txtFile, "");
-		ensureExistsInWorkspace(xmlFile, "");
-		ensureExistsInWorkspace(unrelatedFile, "");
+		createInWorkspace(txtFile, "");
+		createInWorkspace(xmlFile, "");
+		createInWorkspace(unrelatedFile, "");
 		IContentDescription description = null;
 
 		description = txtFile.getContentDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -73,7 +73,7 @@ public class FilteredResourceTest extends ResourceTest {
 	protected IProject otherExistingProject;
 
 	protected void doCleanup() throws Exception {
-		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
+		createInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
 		closedProject.close(createTestMonitor());
 		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
 		resolve(localFolder).toFile().mkdirs();
@@ -133,7 +133,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo");
 		IFile bar = existingFolderInExistingProject.getFile("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -170,7 +170,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFolder foo = existingProject.getFolder("foo");
 		IFolder bar = existingProject.getFolder("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -216,7 +216,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -402,7 +402,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 		// Create 'foo.cpp' in existingFolder...
 		IFile newFile = existingFolderInExistingFolder.getFile("foo.cpp");
-		ensureExistsInWorkspace(newFile);
+		createInWorkspace(newFile);
 		IResource[] members = existingFolderInExistingFolder.members();
 		assertEquals("1.9", 1, members.length);
 		assertEquals("2.0", IResource.FILE, members[0].getType());
@@ -410,7 +410,7 @@ public class FilteredResourceTest extends ResourceTest {
 
 		// Create a 'foo.h' under folder
 		newFile = folder.getFile("foo.h");
-		ensureExistsInWorkspace(newFile);
+		createInWorkspace(newFile);
 		// Check that foo.h has appeared in 'folder'
 		// // Refreshing restores sanity (hides the .cpp files)...
 		// folder.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
@@ -617,7 +617,7 @@ public class FilteredResourceTest extends ResourceTest {
 		}
 
 		// Create a file under existingFolderInExistingFolder
-		ensureExistsInWorkspace(folder2.getFile("foo"));
+		createInWorkspace(folder2.getFile("foo"));
 
 		assertTrue("22.0", folder1.exists());
 		assertTrue("22.2", folder2.exists());
@@ -666,7 +666,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = folder.getFile("foo");
 		IFile bar = folder.getFile("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -700,7 +700,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -738,7 +738,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingFolder.getFile("foo");
 		IFile bar = existingFolderInExistingFolder.getFile("bar");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar});
+		createInWorkspace(new IResource[] {foo, bar});
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		filterDescription.delete(0, createTestMonitor());
@@ -768,7 +768,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile file = existingFolderInExistingProject.getFile("file.c");
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar, file});
+		createInWorkspace(new IResource[] {foo, bar, file});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingProject.members();
@@ -807,7 +807,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile fooh = existingFolderInExistingFolder.getFile("foo.h");
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh});
+		createInWorkspace(new IResource[] {foo, bar, file, fooh});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
@@ -848,7 +848,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile fooh = existingFolderInExistingProject.getFile("foo.h");
 		IFile bar = existingFolderInExistingProject.getFile("bar.h");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh});
+		createInWorkspace(new IResource[] {foo, bar, file, fooh});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingProject.members();
@@ -875,7 +875,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile fooh = existingFolderInExistingFolder.getFile("foo.h");
 		IFile bar = existingFolderInExistingFolder.getFile("bar.h");
 
-		ensureExistsInWorkspace(new IResource[] {foo, bar, file, fooh});
+		createInWorkspace(new IResource[] {foo, bar, file, fooh});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
@@ -896,7 +896,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
@@ -917,7 +917,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingFolder.getFile("foo.c");
 		IFolder food = existingFolderInExistingFolder.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IResource members[] = existingFolderInExistingFolder.members();
@@ -938,7 +938,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
@@ -967,7 +967,7 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		IFolder destination = otherExistingProject.getFolder("destination");
@@ -1000,10 +1000,10 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
+		createInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
 		existingFolderInExistingProject.copy(destination.getFullPath(), 0, createTestMonitor());
 
@@ -1034,10 +1034,10 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
+		createInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
 		IFolder destination = nonExistingFolderInExistingProject.getFolder("destination");
 		existingFolderInExistingProject.move(destination.getFullPath(), 0, createTestMonitor());
 
@@ -1069,10 +1069,10 @@ public class FilteredResourceTest extends ResourceTest {
 		IFile foo = existingFolderInExistingProject.getFile("foo.c");
 		IFolder food = existingFolderInExistingProject.getFolder("foo.d");
 
-		ensureExistsInWorkspace(new IResource[] {foo, food});
+		createInWorkspace(new IResource[] {foo, food});
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		ensureExistsInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
+		createInWorkspace(new IResource[] {nonExistingFolderInExistingProject});
 		existingFolderInExistingProject.delete(0, createTestMonitor());
 
 		IResourceFilterDescription[] filters = existingFolderInExistingProject.getFilters();
@@ -1122,10 +1122,10 @@ public class FilteredResourceTest extends ResourceTest {
 	 */
 	public void test317783() throws CoreException {
 		IFolder folder = existingProject.getFolder("foo");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFile file = folder.getFile("bar.txt");
-		ensureExistsInWorkspace(file, "content");
+		createInWorkspace(file, "content");
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
@@ -1154,10 +1154,10 @@ public class FilteredResourceTest extends ResourceTest {
 	 */
 	public void test317824() throws CoreException {
 		IFolder folder = existingProject.getFolder("foo");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFile file = folder.getFile("bar.txt");
-		ensureExistsInWorkspace(file, "content");
+		createInWorkspace(file, "content");
 
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER, ".*");
@@ -1187,10 +1187,10 @@ public class FilteredResourceTest extends ResourceTest {
 	 */
 	public void test328464() throws CoreException {
 		IFolder folder = existingProject.getFolder(createUniqueString());
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFile file_a_txt = folder.getFile("a.txt");
-		ensureExistsInWorkspace(file_a_txt);
+		createInWorkspace(file_a_txt);
 
 		FileInfoMatcherDescription matcherDescription = new FileInfoMatcherDescription(REGEX_FILTER_PROVIDER,
 				"a\\.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -42,7 +42,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		waitForEncodingRelatedJobs(getName());
 
 		ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
@@ -68,7 +68,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// no hidden resources
 		assertEquals("1.0", project, root.findMember(project.getFullPath()));
@@ -102,7 +102,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
 		IResource[] members = null;
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// Initial values should be false.
 		assertHidden(project, false, IResource.DEPTH_INFINITE);
@@ -189,7 +189,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFolder settings = project.getFolder(".settings");
 		IFile prefs = settings.getFile("org.eclipse.core.resources.prefs");
 		IResource[] resources = new IResource[] { project, folder, file, subFile, settings, prefs };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		IResource description = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 
 		// default case, no hidden resources
@@ -261,7 +261,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// handles to the destination resources
 		IProject destProject = root.getProject("MyOtherProject");
@@ -281,8 +281,8 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// do it again and but just copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
@@ -291,7 +291,7 @@ public class HiddenResourceTest extends ResourceTest {
 		// set all the resources to be hidden
 		// copy the project
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
@@ -299,8 +299,8 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// do it again but only copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
@@ -314,7 +314,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// handles to the destination resources
 		IProject destProject = root.getProject("MyOtherProject");
@@ -334,8 +334,8 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// do it again and but just move the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -344,7 +344,7 @@ public class HiddenResourceTest extends ResourceTest {
 		// set all the resources to be hidden
 		// move the project
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
@@ -352,8 +352,8 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// do it again but only move the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -367,7 +367,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// default behavior with no hidden
 		int flags = IResource.ALWAYS_DELETE_PROJECT_CONTENT | IResource.FORCE;
@@ -375,43 +375,43 @@ public class HiddenResourceTest extends ResourceTest {
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set one child to be hidden
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set all resources to be hidden
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -430,7 +430,7 @@ public class HiddenResourceTest extends ResourceTest {
 		final IResource[] resources = new IResource[] { project, folder, file, subFile, settings, prefs };
 		final ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
 		try {
-			IWorkspaceRunnable body = monitor -> ensureExistsInWorkspace(resources);
+			IWorkspaceRunnable body = monitor -> createInWorkspace(resources);
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
@@ -448,7 +448,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		try {
 			IWorkspaceRunnable body = monitor -> {
-				ensureExistsInWorkspace(resources);
+				createInWorkspace(resources);
 				setHidden(folder, true, IResource.DEPTH_ZERO);
 			};
 			listener.reset();
@@ -467,7 +467,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		try {
 			IWorkspaceRunnable body = monitor -> {
-				ensureExistsInWorkspace(resources);
+				createInWorkspace(resources);
 				setHidden(project, true, IResource.DEPTH_INFINITE);
 			};
 			listener.reset();
@@ -514,7 +514,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// check to see if all the resources exist in the workspace tree.
 		assertExistsInWorkspace(resources);
@@ -546,7 +546,7 @@ public class HiddenResourceTest extends ResourceTest {
 		}
 
 		// create the resources
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// initial values should be false
 		for (IResource resource2 : resources) {
@@ -597,7 +597,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		folder.create(IResource.HIDDEN, true, createTestMonitor());
 		file.create(getRandomContents(), IResource.HIDDEN, createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -223,7 +223,7 @@ public class IFileTest extends ResourceTest {
 			return;
 		}
 		if (file.getName().equals(WORKSPACE_ONLY)) {
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			ensureDoesNotExistInFileSystem(file);
 			return;
 		}
@@ -236,11 +236,11 @@ public class IFileTest extends ResourceTest {
 			return;
 		}
 		if (file.getName().equals(EXISTING)) {
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			return;
 		}
 		if (file.getName().equals(OUT_OF_SYNC)) {
-			ensureExistsInWorkspace(file);
+			createInWorkspace(file);
 			ensureOutOfSync(file);
 			return;
 		}
@@ -425,7 +425,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testCreateDerived() throws CoreException {
 		IFile derived = projects[0].getFile("derived.txt");
-		ensureExistsInWorkspace(projects[0]);
+		createInWorkspace(projects[0]);
 		ensureDoesNotExistInWorkspace(derived);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -447,7 +447,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testDeltaOnCreateDerived() throws CoreException {
 		IFile derived = projects[0].getFile("derived.txt");
-		ensureExistsInWorkspace(projects[0]);
+		createInWorkspace(projects[0]);
 
 		ResourceDeltaVerifier verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
@@ -464,7 +464,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivateDerived.txt");
-		ensureExistsInWorkspace(projects[0]);
+		createInWorkspace(projects[0]);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -487,7 +487,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testCreateTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivate.txt");
-		ensureExistsInWorkspace(projects[0]);
+		createInWorkspace(projects[0]);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -942,7 +942,7 @@ public class IFileTest extends ResourceTest {
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
 		assertTrue("2.0", target.getPersistentProperty(name).equals(value));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -46,7 +46,7 @@ public class IFolderTest extends ResourceTest {
 		IFile afterFile = after.getFile("file");
 
 		// create the resources and set some content in a file that will be moved.
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		beforeFile.create(getRandomContents(), false, createTestMonitor());
 
 		// Be sure the resources exist and then move them.
@@ -67,8 +67,8 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder before = project.getFolder("OldFolder");
 		IFolder after = project.getFolder("NewFolder");
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(before);
+		createInWorkspace(project);
+		createInWorkspace(before);
 		ensureDoesNotExistInFileSystem(before);
 
 		// should fail because 'before' does not exist in the filesystem
@@ -82,7 +82,7 @@ public class IFolderTest extends ResourceTest {
 	public void testCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		ensureDoesNotExistInWorkspace(derived);
 
 		derived.create(IResource.DERIVED, true, createTestMonitor());
@@ -97,7 +97,7 @@ public class IFolderTest extends ResourceTest {
 	public void testDeltaOnCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		ResourceDeltaVerifier verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
@@ -112,7 +112,7 @@ public class IFolderTest extends ResourceTest {
 	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, createTestMonitor());
@@ -128,7 +128,7 @@ public class IFolderTest extends ResourceTest {
 	public void testCreateTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		ensureDoesNotExistInWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE, true, createTestMonitor());
@@ -144,7 +144,7 @@ public class IFolderTest extends ResourceTest {
 	public void testFolderCreation() throws Exception {
 		// basic folder creation
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFolder target = project.getFolder("Folder1");
 		assertTrue("1.0", !target.exists());
@@ -202,7 +202,7 @@ public class IFolderTest extends ResourceTest {
 	public void testFolderDeletion() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/x", "c/b/y", "c/b/z"});
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		//
 		assertExistsInWorkspace(before);
 		project.getFolder("c").delete(true, createTestMonitor());
@@ -215,7 +215,7 @@ public class IFolderTest extends ResourceTest {
 		IResource[] after = buildResources(project, new String[] {"a/", "a/b/", "a/x", "a/b/y", "a/b/z"});
 
 		// create the resources and set some content in a file that will be moved.
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		String content = getRandomString();
 		IFile file = project.getFile(IPath.fromOSString("b/b/z"));
 		file.setContents(getContents(content), true, false, createTestMonitor());
@@ -234,7 +234,7 @@ public class IFolderTest extends ResourceTest {
 	public void testFolderOverFile() throws Throwable {
 		IPath path = IPath.fromOSString("/Project/File");
 		IFile existing = getWorkspace().getRoot().getFile(path);
-		ensureExistsInWorkspace(existing);
+		createInWorkspace(existing);
 		IFolder target = getWorkspace().getRoot().getFolder(path);
 		assertThrows("Should not be able to create folder over a file", CoreException.class,
 				() -> target.create(true, true, createTestMonitor()));
@@ -246,7 +246,7 @@ public class IFolderTest extends ResourceTest {
 	 */
 	public void testInvalidFolderNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		//do some tests with invalid names
 		String[] names = new String[0];
@@ -284,7 +284,7 @@ public class IFolderTest extends ResourceTest {
 	public void testLeafFolderMove() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder source = project.getFolder("Folder1");
-		ensureExistsInWorkspace(source);
+		createInWorkspace(source);
 		IFolder dest = project.getFolder("Folder2");
 		source.move(dest.getFullPath(), true, createTestMonitor());
 		assertExistsInWorkspace(dest);
@@ -299,7 +299,7 @@ public class IFolderTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder source = project.getFolder("Folder1");
-		ensureExistsInWorkspace(source);
+		createInWorkspace(source);
 		source.setReadOnly(true);
 		IFolder dest = project.getFolder("Folder2");
 		source.copy(dest.getFullPath(), true, createTestMonitor());
@@ -321,7 +321,7 @@ public class IFolderTest extends ResourceTest {
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
 		assertTrue("2.0", target.getPersistentProperty(name).equals(value));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -586,7 +586,7 @@ public class IPathVariableTest extends ResourceTest {
 
 		IProject existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 
-		ensureExistsInWorkspace(new IResource[] {existingProject});
+		createInWorkspace(new IResource[] {existingProject});
 
 		existingProject.close(createTestMonitor());
 		ProjectInfo info = (ProjectInfo) ((Project) existingProject).getResourceInfo(false, false);
@@ -617,7 +617,7 @@ public class IPathVariableTest extends ResourceTest {
 
 		// Create filep
 		IFile f = project.getFile(filep);
-		ensureExistsInWorkspace(f);
+		createInWorkspace(f);
 
 		// Get a reference to a child
 		IFile invalidFile = project.getFile(invalidChild);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -46,7 +46,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	 */
 	public void testBuildSpecBuilder() throws Exception {
 		Project project = (Project) getWorkspace().getRoot().getProject("ProjectTBSB");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		assertTrue("1.0", descriptionFile.exists());
@@ -80,7 +80,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IProject target1 = getWorkspace().getRoot().getProject("target1");
 		IProject target2 = getWorkspace().getRoot().getProject("target2");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		assertTrue("1.0", descriptionFile.exists());
 
@@ -118,7 +118,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	public void testDirtyBuildSpec() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile projectDescription = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		String key = "key";
 		String value1 = "value1";
 		String value2 = "value2";
@@ -147,11 +147,11 @@ public class IProjectDescriptionTest extends ResourceTest {
 	public void testDynamicProjectReferences() throws CoreException {
 		IProject target1 = getWorkspace().getRoot().getProject("target1");
 		IProject target2 = getWorkspace().getRoot().getProject("target2");
-		ensureExistsInWorkspace(target1);
-		ensureExistsInWorkspace(target2);
+		createInWorkspace(target1);
+		createInWorkspace(target2);
 
 		IProject project = getWorkspace().getRoot().getProject("project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IProjectDescription description = project.getDescription();
 		description.setReferencedProjects(new IProject[] {target1});
@@ -174,10 +174,10 @@ public class IProjectDescriptionTest extends ResourceTest {
 	 */
 	public void testProjectReferences() throws CoreException {
 		IProject target = getWorkspace().getRoot().getProject("Project1");
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 
 		IProject project = getWorkspace().getRoot().getProject("Project2");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		project.open(createTestMonitor());
 		IProjectDescription description = project.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -309,9 +309,9 @@ public class IProjectTest extends ResourceTest {
 
 	public void testProjectCloseOpen() throws CoreException {
 		IProject target = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 		IFolder folder = target.getFolder("Folder");
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		target.close(monitor);
 		monitor.assertUsedUp();
@@ -340,8 +340,8 @@ public class IProjectTest extends ResourceTest {
 		source = project;
 		children = new String[] {"/1/", "/1/2"};
 		resources = buildResources(project, children);
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		assertDoesNotExistInWorkspace(destination);
 		// set a property to copy
@@ -369,8 +369,8 @@ public class IProjectTest extends ResourceTest {
 		source = project;
 		children = new String[] {"/1/", "/1/2"};
 		resources = buildResources(project, children);
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		IProjectDescription description = getWorkspace().newProjectDescription(destination.getName());
 		assertDoesNotExistInWorkspace(destination);
@@ -403,8 +403,8 @@ public class IProjectTest extends ResourceTest {
 		resources = buildResources(project, children);
 		destProject = getWorkspace().getRoot().getProject("DestProject");
 		destination = destProject.getFolder("MyFolder");
-		ensureExistsInWorkspace(new IResource[] {project, destProject});
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(new IResource[] {project, destProject});
+		createInWorkspace(resources);
 		assertDoesNotExistInWorkspace(destination);
 
 		monitor.prepare();
@@ -422,8 +422,8 @@ public class IProjectTest extends ResourceTest {
 		source = project.getFolder("1");
 		resources = buildResources(project, children);
 		destination = getWorkspace().getRoot().getProject("DestProject");
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		assertDoesNotExistInWorkspace(destination);
 
 		monitor.prepare();
@@ -499,7 +499,7 @@ public class IProjectTest extends ResourceTest {
 		IFile file = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		IProjectDescription description;
 		try {
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			// new .project should have OS default line separator
 			assertEquals("1.0", systemValue, getLineSeparatorFromFile(file));
 
@@ -517,7 +517,7 @@ public class IProjectTest extends ResourceTest {
 			project.delete(true, monitor);
 			monitor.assertUsedUp();
 
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			// new .project should have instance-specific line separator
 			assertEquals("3.0", newInstanceValue, getLineSeparatorFromFile(file));
 
@@ -539,7 +539,7 @@ public class IProjectTest extends ResourceTest {
 			project.delete(true, monitor);
 			monitor.assertUsedUp();
 
-			ensureExistsInWorkspace(project);
+			createInWorkspace(project);
 			// new .project should have OS default line separator
 			assertEquals("5.0", systemValue, getLineSeparatorFromFile(file));
 
@@ -654,7 +654,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -684,7 +684,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -714,7 +714,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -747,7 +747,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -779,7 +779,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -811,7 +811,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file, otherFile});
+		createInWorkspace(new IResource[] {project, file, otherFile});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -856,7 +856,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -889,7 +889,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -920,7 +920,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -953,7 +953,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -986,7 +986,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1019,7 +1019,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1068,7 +1068,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", file.exists());
@@ -1094,7 +1094,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.2", project.exists());
 		assertTrue("2.3", file.exists());
@@ -1118,7 +1118,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.2", project.exists());
 		assertTrue("3.3", file.exists());
@@ -1142,7 +1142,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.2", project.exists());
 		assertTrue("4.3", file.exists());
@@ -1166,7 +1166,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.2", project.exists());
 		assertTrue("5.3", file.exists());
@@ -1190,7 +1190,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.2", project.exists());
 		assertTrue("6.3", file.exists());
@@ -1228,7 +1228,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1259,7 +1259,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1288,7 +1288,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1316,7 +1316,7 @@ public class IProjectTest extends ResourceTest {
 
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1344,7 +1344,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1372,7 +1372,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		waitForRefresh();
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -1413,7 +1413,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.0", project.exists());
@@ -1431,7 +1431,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.0", project.exists());
@@ -1448,7 +1448,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.0", project.exists());
@@ -1465,7 +1465,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.0", project.exists());
@@ -1482,7 +1482,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.0", project.exists());
@@ -1499,7 +1499,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.0", project.exists());
@@ -1528,7 +1528,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1548,7 +1548,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = ALWAYS (always_delete_content over-rides FORCE flag)
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1566,7 +1566,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1586,7 +1586,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1606,7 +1606,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
@@ -1624,7 +1624,7 @@ public class IProjectTest extends ResourceTest {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		waitForRefresh();
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
@@ -1660,7 +1660,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", file.exists());
@@ -1682,7 +1682,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("2.2", project.exists());
 		assertTrue("2.3", file.exists());
@@ -1702,7 +1702,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("3.2", project.exists());
 		assertTrue("3.3", file.exists());
@@ -1721,7 +1721,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("4.2", project.exists());
 		assertTrue("4.3", file.exists());
@@ -1742,7 +1742,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		fileStore = ((Resource) file).getStore();
 		assertTrue("5.2", project.exists());
 		assertTrue("5.3", file.exists());
@@ -1762,7 +1762,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
 		assertTrue("6.2", project.exists());
 		assertTrue("6.3", file.exists());
@@ -1796,7 +1796,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1824,7 +1824,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1850,7 +1850,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1876,7 +1876,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1900,7 +1900,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
@@ -1925,7 +1925,7 @@ public class IProjectTest extends ResourceTest {
 		projectStore = getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		waitForRefresh();
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
@@ -2107,8 +2107,8 @@ public class IProjectTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		String[] children = new String[] {"/1/", "/1/2"};
 		IResource[] resources = buildResources(project, children);
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 
 		// move the project content
 		IProjectDescription destination = project.getDescription();
@@ -2148,8 +2148,8 @@ public class IProjectTest extends ResourceTest {
 		source = project;
 		children = new String[] {"/1/", "/1/2"};
 		resources = buildResources(project, children);
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		destination = getWorkspace().getRoot().getProject("DestProject");
 		assertDoesNotExistInWorkspace(destination);
 		// set a property to move
@@ -2183,8 +2183,8 @@ public class IProjectTest extends ResourceTest {
 		source = project;
 		children = new String[] {"/1/", "/1/2"};
 		resources = buildResources(project, children);
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		// set a property to move
 		sourceChild = resources[1];
 		sourceChild.setPersistentProperty(qname, value);
@@ -2310,8 +2310,8 @@ public class IProjectTest extends ResourceTest {
 		monitor.prepare();
 		project.open(monitor);
 		monitor.assertUsedUp();
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(project);
+		createInWorkspace(resources);
 		// set a property to move
 		IResource sourceChild = resources[1];
 		QualifiedName qname = new QualifiedName("com.example", "myProperty");
@@ -2351,7 +2351,7 @@ public class IProjectTest extends ResourceTest {
 	 */
 	public void testReplaceLocation() throws Exception {
 		IProject target = getWorkspace().getRoot().getProject("testReplaceLocation");
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 
 		IFileStore projectStore = getTempStore();
 		IFileStore childFile = projectStore.getChild("File.txt");
@@ -2359,7 +2359,7 @@ public class IProjectTest extends ResourceTest {
 		// add some content to the current location
 		IFolder folder = target.getFolder("Folder");
 		IFile file = folder.getFile("File.txt");
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 
 		// add content to new location
 		IFile newFile = target.getFile(childFile.getName());
@@ -2392,7 +2392,7 @@ public class IProjectTest extends ResourceTest {
 
 	public void testSetGetProjectPersistentProperty() throws CoreException {
 		IProject target = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(target);
+		createInWorkspace(target);
 		setGetPersistentProperty(target);
 	}
 
@@ -2502,7 +2502,7 @@ public class IProjectTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject(projectName);
 		IFolder folder = project.getFolder(createUniqueString());
 		IFile file = folder.getFile(createUniqueString());
-		ensureExistsInWorkspace(new IResource[] {project, folder, file});
+		createInWorkspace(new IResource[] {project, folder, file});
 		project.open(monitor);
 		monitor.assertUsedUp();
 
@@ -2519,7 +2519,7 @@ public class IProjectTest extends ResourceTest {
 		assertFalse("1.0", p.toFile().exists());
 
 		IProject otherProject = getWorkspace().getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(otherProject);
+		createInWorkspace(otherProject);
 		monitor.prepare();
 		otherProject.open(monitor);
 		monitor.assertUsedUp();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -67,7 +67,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 
 		// Create and open the resources
 		IWorkspaceRunnable body = monitor -> {
-			ensureExistsInWorkspace(allResources);
+			createInWorkspace(allResources);
 			marker2 = file2.createMarker(IMarker.BOOKMARK);
 			marker3 = file3.createMarker(IMarker.BOOKMARK);
 		};

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -1102,7 +1102,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 	public void testMoveFileDeleteSourceParent() throws CoreException {
 		file1.delete(IResource.NONE, null);
-		ensureExistsInWorkspace(file3);
+		createInWorkspace(file3);
 		verifier.reset();
 		verifier.addExpectedChange(folder2, IResourceDelta.REMOVED, 0, null, null);
 		verifier.addExpectedChange(file1, IResourceDelta.ADDED, IResourceDelta.MOVED_FROM, file3.getFullPath(), null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -63,7 +63,7 @@ public class IResourceDeltaTest extends ResourceTest {
 		allResources = new IResource[] {project1, project2, folder1, folder2, folder3, file1, file2, file3};
 
 		// Create and open the resources
-		IWorkspaceRunnable body = monitor -> ensureExistsInWorkspace(allResources);
+		IWorkspaceRunnable body = monitor -> createInWorkspace(allResources);
 		getWorkspace().run(body, createTestMonitor());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -220,7 +220,7 @@ public class IResourceTest extends ResourceTest {
 		result[1] = emptyProject;
 		result[2] = fullProject;
 		System.arraycopy(resources, 0, result, 3, resources.length);
-		ensureExistsInWorkspace(result);
+		createInWorkspace(result);
 		return result;
 	}
 
@@ -228,7 +228,7 @@ public class IResourceTest extends ResourceTest {
 		// do not change the example resources unless you change references to
 		// specific indices in setUp()
 		IResource[] result = buildResources(root, new String[] {"1/", "1/1/", "1/1/1/", "1/1/1/1", "1/1/2/", "1/1/2/1/", "1/1/2/2/", "1/1/2/3/", "1/2/", "1/2/1", "1/2/2", "1/2/3/", "1/2/3/1", "1/2/3/2", "1/2/3/3", "1/2/3/4", "2", "2"});
-		ensureExistsInWorkspace(result);
+		createInWorkspace(result);
 		result[result.length - 1] = root.getFolder(IPath.fromOSString("2/"));
 		nonExistingResources.add(result[result.length - 1]);
 
@@ -322,7 +322,7 @@ public class IResourceTest extends ResourceTest {
 		if (changedTarget != null && changedTarget.getType() != target.getType()) {
 			ensureDoesNotExistInWorkspace(changedTarget);
 		}
-		ensureExistsInWorkspace(interestingResources);
+		createInWorkspace(interestingResources);
 	}
 
 	/**
@@ -510,10 +510,10 @@ public class IResourceTest extends ResourceTest {
 		}
 
 		/* the target's parents must exist */
-		ensureExistsInWorkspace(target.getParent());
+		createInWorkspace(target.getParent());
 		switch (state) {
 			case S_WORKSPACE_ONLY :
-				ensureExistsInWorkspace(target);
+				createInWorkspace(target);
 				ensureDoesNotExistInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -539,13 +539,13 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_UNCHANGED :
-				ensureExistsInWorkspace(target);
+				createInWorkspace(target);
 				if (addVerifier) {
 					verifier.reset();
 				}
 				break;
 			case S_CHANGED :
-				ensureExistsInWorkspace(target);
+				createInWorkspace(target);
 				touchInFilesystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -565,7 +565,7 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_FOLDER_TO_FILE :
-				ensureExistsInWorkspace(target);
+				createInWorkspace(target);
 				ensureDoesNotExistInFileSystem(target);
 				createInFileSystem(target);
 				if (addVerifier) {
@@ -579,7 +579,7 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_FILE_TO_FOLDER :
-				ensureExistsInWorkspace(target);
+				createInWorkspace(target);
 				ensureDoesNotExistInFileSystem(target);
 				target.getLocation().toFile().mkdirs();
 				if (addVerifier) {
@@ -701,7 +701,7 @@ public class IResourceTest extends ResourceTest {
 	public void testAcceptDoNotCheckExistence() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder a = project.getFolder("a");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		// pass DEPTH_ONE to avoid using proxy visitor
 		assertThrows(CoreException.class, () -> a.accept((IResourceVisitor) resource -> {
@@ -752,7 +752,7 @@ public class IResourceTest extends ResourceTest {
 			return true;
 		};
 
-		ensureExistsInWorkspace(new IResource[] {project, a, a1, a2, b, b1, b2, c, c1, c2});
+		createInWorkspace(new IResource[] {project, a, a1, a2, b, b1, b2, c, c1, c2});
 
 		toVisit.addAll(Arrays.asList(new IResource[] {a}));
 		toVisitCount[0] = 1;
@@ -1414,7 +1414,7 @@ public class IResourceTest extends ResourceTest {
 		IResource[] resources = { project, folder, file1, file2 };
 
 		// create the resources
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// initial values should be false
 		for (IResource resource2 : resources) {
@@ -1612,7 +1612,7 @@ public class IResourceTest extends ResourceTest {
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.PROJECT) {
 				assertEquals("3.4." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
-				ensureExistsInWorkspace(resource);
+				createInWorkspace(resource);
 				assertNotEquals("3.5." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
 				// cache the value for later use
 				table.put(resource.getFullPath(), Long.valueOf(resource.getModificationStamp()));
@@ -1719,7 +1719,7 @@ public class IResourceTest extends ResourceTest {
 		}
 
 		// create all the resources (non-local) and ensure all stamps are null
-		ensureExistsInWorkspace(getProjects(resources));
+		createInWorkspace(getProjects(resources));
 		for (IResource resource : resources) {
 			if (resource instanceof IFolder folder) {
 				folder.create(true, false, createTestMonitor());
@@ -1759,7 +1759,7 @@ public class IResourceTest extends ResourceTest {
 	 */
 	public void testGetModificationStampAfterReplace() throws Exception {
 		final IFile file = getWorkspace().getRoot().getFile(IPath.fromOSString("/project/f"));
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		long modificationStamp = file.getModificationStamp();
 		assertNotEquals("1.1", modificationStamp, IResource.NULL_STAMP);
 
@@ -1791,7 +1791,7 @@ public class IResourceTest extends ResourceTest {
 		assertNull("2.2", topFile.getRawLocation());
 		assertNull("2.3", deepFile.getRawLocation());
 
-		ensureExistsInWorkspace(allResources);
+		createInWorkspace(allResources);
 		//open project
 		assertNull("2.0", project.getRawLocation());
 		//resources in open project
@@ -1848,7 +1848,7 @@ public class IResourceTest extends ResourceTest {
 			folderLocation.toFile().mkdirs();
 			topFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
 			topFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
-			ensureExistsInWorkspace(deepFile);
+			createInWorkspace(deepFile);
 
 			//linked file
 			assertEquals("6.0", fileLocation, topFile.getRawLocation());
@@ -1876,7 +1876,7 @@ public class IResourceTest extends ResourceTest {
 			varMan.resolvePath(variableFolderLocation).toFile().mkdirs();
 			topFolder.createLink(variableFolderLocation, IResource.NONE, createTestMonitor());
 			topFile.createLink(variableFileLocation, IResource.NONE, createTestMonitor());
-			ensureExistsInWorkspace(deepFile);
+			createInWorkspace(deepFile);
 
 			//linked file with variable
 			assertEquals("8.0", variableFileLocation, topFile.getRawLocation());
@@ -1903,7 +1903,7 @@ public class IResourceTest extends ResourceTest {
 		IFolder a = project.getFolder("a");
 		IFolder b = project.getFolder("b");
 
-		ensureExistsInWorkspace(new IResource[] { project, a, b });
+		createInWorkspace(new IResource[] { project, a, b });
 
 		ISchedulingRule multi = MultiRule.combine(a, b);
 
@@ -1921,7 +1921,7 @@ public class IResourceTest extends ResourceTest {
 
 	public void testIsConflicting2() throws CoreException {
 		final IProject project = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		ISchedulingRule wrapper = new ISchedulingRule() {
 			@Override
@@ -2512,7 +2512,7 @@ public class IResourceTest extends ResourceTest {
 		IFile b1 = b.getFile("b1.txt");
 		IFile b2 = b.getFile("B2.txt");
 
-		ensureExistsInWorkspace(new IResource[] {project, settings, prefs, a, a1, a2, b, b1, b2});
+		createInWorkspace(new IResource[] {project, settings, prefs, a, a1, a2, b, b1, b2});
 
 		final List<IResource> actualOrder = new ArrayList<>();
 		IResourceProxyVisitor visitor = proxy -> {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -91,7 +91,7 @@ public class ISynchronizerTest extends ResourceTest {
 		super.setUp();
 		resources = buildResources(getWorkspace().getRoot(),
 				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 	}
 
 	@Override
@@ -279,7 +279,7 @@ public class ISynchronizerTest extends ResourceTest {
 		IProject project = (IProject) testResources[0];
 		IFile source = (IFile) testResources[1];
 		// create in workspace
-		ensureExistsInWorkspace(testResources);
+		createInWorkspace(testResources);
 
 		// register partner and add sync info
 		synchronizer.add(qname);
@@ -309,7 +309,7 @@ public class ISynchronizerTest extends ResourceTest {
 		IProject sourceProject = (IProject) toTest[0];
 		IFile sourceFile = (IFile) toTest[1];
 		// create in workspace
-		ensureExistsInWorkspace(toTest);
+		createInWorkspace(toTest);
 
 		// register partner and add sync info
 		synchronizer.add(qname);
@@ -713,7 +713,7 @@ public class ISynchronizerTest extends ResourceTest {
 		IFolder folder = project.getFolder("foo");
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = folder.getFile("file2.txt");
-		ensureExistsInWorkspace(new IResource[] {file1, file2});
+		createInWorkspace(new IResource[] {file1, file2});
 
 		// sets sync info for the folder and its children
 		synchronizer.setSyncInfo(partner, folder, getRandomString().getBytes());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -54,7 +54,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		Assume.assumeTrue(OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFile link = project.getFile("file.txt");
 		IFileStore fileStore = getTempStore();
@@ -94,7 +94,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject("p1");
 		IProject p2 = root.getProject("p2");
-		ensureExistsInWorkspace(new IResource[] {p1, p2});
+		createInWorkspace(new IResource[] {p1, p2});
 		replaceProject(p1, WrapperFileSystem.getWrappedURI(p1.getLocationURI()));
 		replaceProject(p2, WrapperFileSystem.getWrappedURI(p2.getLocationURI()));
 		testFindContainersForLocation(p1, p2);
@@ -113,13 +113,13 @@ public class IWorkspaceRootTest extends ResourceTest {
 		//deep linked resource
 		IFolder parent = p2.getFolder("parent");
 		IFolder link = parent.getFolder("link");
-		ensureExistsInWorkspace(new IResource[] {p1, p2, parent});
+		createInWorkspace(new IResource[] {p1, p2, parent});
 		link.createLink(p1.getLocationURI(), IResource.NONE, createTestMonitor());
 		assertResources("2.0", p1, link, root.findContainersForLocation(p1.getLocation()));
 
 		//existing folder
 		IFolder existing = p2.getFolder("existing");
-		ensureExistsInWorkspace(existing);
+		createInWorkspace(existing);
 		assertResources("3.0", existing, root.findContainersForLocation(existing.getLocation()));
 		assertResources("3.1", existing, root.findContainersForLocationURI(existing.getLocationURI()));
 
@@ -160,7 +160,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("p1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		replaceProject(project, WrapperFileSystem.getWrappedURI(project.getLocationURI()));
 		testFindFilesForLocation(project);
 	}
@@ -185,7 +185,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		assertEquals("1.0", 0, result.length);
 
 		IFile existing = project.getFile("file1");
-		ensureExistsInWorkspace(existing);
+		createInWorkspace(existing);
 
 		//existing file
 		final IPath existingFileLocation = existing.getLocation();
@@ -321,7 +321,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testRefreshLocal() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.close(createTestMonitor());
 		//refreshing the root shouldn't fail
 		root.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
@@ -376,7 +376,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testBug476585() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("a");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		String subProjectName = "subProject";
 		IPath subProjectLocation = project.getLocation().append(subProjectName);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -70,7 +70,7 @@ public class IWorkspaceTest extends ResourceTest {
 	}
 
 	private void ensureResourceHierarchyExist() throws CoreException {
-		ensureExistsInWorkspace(buildResourceHierarchy());
+		createInWorkspace(buildResourceHierarchy());
 	}
 
 	/**
@@ -496,7 +496,7 @@ public class IWorkspaceTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile anotherFile = project.getFile("anotherFile.txt");
 		IFile oneMoreFile = project.getFile("oneMoreFile.txt");
-		ensureExistsInWorkspace(new IResource[] {project, folder, file, anotherFile, oneMoreFile});
+		createInWorkspace(new IResource[] {project, folder, file, anotherFile, oneMoreFile});
 
 		/* normal case */
 		IResource[] resources = {file, anotherFile, oneMoreFile};
@@ -557,16 +557,16 @@ public class IWorkspaceTest extends ResourceTest {
 		IFolder folder = (IFolder) resources[2];
 
 		/* create folder and file */
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 		createInFileSystem(folder);
 		IFile file1 = project.getFile("file.txt");
-		ensureExistsInWorkspace(file1);
+		createInWorkspace(file1);
 		createInFileSystem(file1);
 		IFile anotherFile = project.getFile("anotherFile.txt");
-		ensureExistsInWorkspace(anotherFile);
+		createInWorkspace(anotherFile);
 		createInFileSystem(anotherFile);
 		IFile oneMoreFile = project.getFile("oneMoreFile.txt");
-		ensureExistsInWorkspace(oneMoreFile);
+		createInWorkspace(oneMoreFile);
 		createInFileSystem(oneMoreFile);
 
 		/* normal case */
@@ -672,7 +672,7 @@ public class IWorkspaceTest extends ResourceTest {
 	public void testMultiDeletion() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("testProject");
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/x", "c/b/y", "c/b/z"});
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		//
 		assertExistsInWorkspace(before);
 		getWorkspace().delete(before, true, createTestMonitor());
@@ -726,7 +726,7 @@ public class IWorkspaceTest extends ResourceTest {
 	public void testSave() throws CoreException {
 		// ensure save returns a warning if a project's .project file is deleted.
 		IProject project = getWorkspace().getRoot().getProject("Broken");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		// wait for snapshot before modifying file
 		TestingSupport.waitForSnapshot();
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -780,7 +780,7 @@ public class IWorkspaceTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("myfile.txt");
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		IStatus result = getWorkspace().validateEdit(new IFile[] {file}, null);
 		assertTrue("1.0", result.isOK());
 		file.setReadOnly(true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -58,7 +58,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		super.setUp();
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		otherExistingProject = getWorkspace().getRoot().getProject("OtherExistingProject");
-		ensureExistsInWorkspace(new IResource[] { existingProject, otherExistingProject });
+		createInWorkspace(new IResource[] { existingProject, otherExistingProject });
 	}
 
 	public void internalMovedAndCopyTest(IResource resource, int copyMoveFlag, boolean copyMoveSucceeds) {
@@ -232,7 +232,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 
 	public void testFolderWithFileLinkedToNonExistent_Deep() throws Exception {
 		IFolder folder = existingProject.getFolder(createUniqueString());
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFile fileLinkInFolder = folder.getFile(createUniqueString());
 
@@ -256,7 +256,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 
 	public void testFolderWithFileLinkedToNonExistent_Shallow() throws Exception {
 		IFolder folder = existingProject.getFolder(createUniqueString());
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFile fileLinkInFolder = folder.getFile(createUniqueString());
 
@@ -280,7 +280,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 
 	public void testFolderWithFolderLinkedToNonExistent_Deep() throws CoreException {
 		IFolder folder = existingProject.getFolder(createUniqueString());
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFolder folderLinkInFolder = folder.getFolder(createUniqueString());
 
@@ -304,7 +304,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 
 	public void testFolderWithFolderLinkedToNonExistent_Shallow() throws CoreException {
 		IFolder folder = existingProject.getFolder(createUniqueString());
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(folder);
 
 		IFolder folderLinkInFolder = folder.getFolder(createUniqueString());
 
@@ -331,8 +331,8 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		IFile fileLink = existingProject.getFile(linkName);
 		IFile file = existingProject.getFolder("dir").getFile("foo.txt");
 
-		ensureExistsInWorkspace(file.getParent());
-		ensureExistsInWorkspace(file, "content");
+		createInWorkspace(file.getParent());
+		createInWorkspace(file, "content");
 		IPath fileLocation = file.getLocation();
 
 		URI relativeLocation = existingProject.getPathVariableManager().convertToRelative(URIUtil.toURI(fileLocation),

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -98,7 +98,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 	protected void doCleanup() throws Exception {
 		waitForRefresh();
-		ensureExistsInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
+		createInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
 		closedProject.close(createTestMonitor());
 		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
 		ensureDoesNotExistInFileSystem(resolve(nonExistingLocation).toFile());
@@ -630,7 +630,7 @@ public class LinkedResourceTest extends ResourceTest {
 	public void testCreateLinkCaseVariant() throws Throwable {
 		IFolder link = nonExistingFolderInExistingProject;
 		IFolder variant = link.getParent().getFolder(IPath.fromOSString(link.getName().toUpperCase()));
-		ensureExistsInWorkspace(variant);
+		createInWorkspace(variant);
 
 		ThrowingRunnable linkCreation = () -> link.createLink(localFolder, IResource.NONE, createTestMonitor());
 		// should fail on case insensitive platforms
@@ -742,7 +742,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IFile linkChild = link.getFile("child.txt");
 		IFileStore childStore = null;
 		link.createLink(localFolder, IResource.NONE, createTestMonitor());
-		ensureExistsInWorkspace(linkChild);
+		createInWorkspace(linkChild);
 		childStore = EFS.getStore(linkChild.getLocationURI());
 
 		//everything should exist at this point
@@ -929,7 +929,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 		nonExistingFolderInExistingProject.createLink(parentLoc, IResource.NONE, createTestMonitor());
 		nonExistingFolderInOtherExistingProject.createLink(childLoc, IResource.NONE, createTestMonitor());
-		ensureExistsInWorkspace(nonExistingFolderInOtherExistingProject.getFile("foo"));
+		createInWorkspace(nonExistingFolderInOtherExistingProject.getFile("foo"));
 
 		assertTrue("2.0", existingFolderInExistingFolder.members().length == 1);
 		assertTrue("3.0", existingFolderInExistingFolder.members()[0].getName().equals("foo"));
@@ -1003,7 +1003,7 @@ public class LinkedResourceTest extends ResourceTest {
 		fileStore.openOutputStream(EFS.NONE, createTestMonitor()).close();
 
 		// create the structure in the workspace
-		ensureExistsInWorkspace(top);
+		createInWorkspace(top);
 		linkedFolder.createLink(folderStore.toURI(), IResource.NONE, createTestMonitor());
 		linkedFile.createLink(fileStore.toURI(), IResource.NONE, createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -155,7 +155,7 @@ public class MarkerTest extends ResourceTest {
 		new MarkerTest().addChildren(result, IPath.ROOT, 3, 4);
 		String[] names = result.toArray(new String[result.size()]);
 		IResource[] created = buildResources(getWorkspace().getRoot(), names);
-		ensureExistsInWorkspace(created);
+		createInWorkspace(created);
 		return created;
 	}
 
@@ -179,7 +179,7 @@ public class MarkerTest extends ResourceTest {
 		super.setUp();
 		resources = buildResources(getWorkspace().getRoot(),
 				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// disable autorefresh an wait till that is finished
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
@@ -432,7 +432,7 @@ public class MarkerTest extends ResourceTest {
 	 */
 	public void test_35300() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		String MARKER_ID = "foomarker.example.com";
 		int expected = 4;
 
@@ -447,7 +447,7 @@ public class MarkerTest extends ResourceTest {
 
 	public void test_10989() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IFile file = project.getFile("foo.txt");
 		file.create(getRandomContents(), true, null);
 		file.createMarker(IMarker.PROBLEM);
@@ -486,7 +486,7 @@ public class MarkerTest extends ResourceTest {
 		IFile topFile = folder.getFile("a.txt");
 		IFile subFile = sub.getFile("b.txt");
 		IResource[] allResources = new IResource[] {project, folder, sub, topFile, subFile};
-		ensureExistsInWorkspace(allResources);
+		createInWorkspace(allResources);
 
 		assertThat(root.findMaxProblemSeverity(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE), is(-1));
 		assertThat(root.findMaxProblemSeverity(IMarker.TASK, true, IResource.DEPTH_INFINITE), is(-1));
@@ -539,7 +539,7 @@ public class MarkerTest extends ResourceTest {
 
 		final String INVALID_MARKER = "does.not.exist.at.AllMarker";
 
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		marker = project.createMarker(IMarker.MARKER);
 		task = project.createMarker(IMarker.TASK);
 		problem = project.createMarker(IMarker.PROBLEM);
@@ -870,7 +870,7 @@ public class MarkerTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subFile.txt");
-		ensureExistsInWorkspace(new IResource[] { project, folder, file, subFile });
+		createInWorkspace(new IResource[] { project, folder, file, subFile });
 		waitForEncodingRelatedJobs(getName());
 		IFolder destFolder = project.getFolder("myOtherFolder");
 		IFile destSubFile = destFolder.getFile(subFile.getName());
@@ -909,7 +909,7 @@ public class MarkerTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subFile.txt");
-		ensureExistsInWorkspace(new IResource[] { project, folder, file, subFile });
+		createInWorkspace(new IResource[] { project, folder, file, subFile });
 		waitForEncodingRelatedJobs(getName());
 		IFile destFile = folder.getFile(file.getName());
 		IFile destSubFile = project.getFile(subFile.getName());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -137,7 +137,7 @@ public class NatureTest extends ResourceTest {
 	 * Tests invalid additions to the set of natures for a project.
 	 */
 	public void testInvalidAdditions() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		setNatures(project, new String[] { NATURE_SIMPLE }, false);
 
 		//Adding a nature that is not available.
@@ -161,7 +161,7 @@ public class NatureTest extends ResourceTest {
 	 * Tests invalid removals from the set of natures for a project.
 	 */
 	public void testInvalidRemovals() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		//Removing a nature that still has dependents.
 		setNatures(project, new String[] { NATURE_WATER, NATURE_SNOW }, false);
@@ -171,7 +171,7 @@ public class NatureTest extends ResourceTest {
 	}
 
 	public void testNatureLifecyle() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		//add simple nature
 		setNatures(project, new String[] { NATURE_SIMPLE }, false);
@@ -207,7 +207,7 @@ public class NatureTest extends ResourceTest {
 	 * Test simple addition and removal of natures.
 	 */
 	public void testSimpleNature() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		String[][] valid = getValidNatureSets();
 		for (String[] element : valid) {
@@ -232,7 +232,7 @@ public class NatureTest extends ResourceTest {
 	 * See bugs 127562 and  128709.
 	 */
 	public void testBug127562Nature() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IWorkspace ws = project.getWorkspace();
 
 		String[][] valid = getValidNatureSets();
@@ -263,7 +263,7 @@ public class NatureTest extends ResourceTest {
 	}
 
 	public void testBug297871() throws Throwable {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFileStore descStore = ((File) project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME)).getStore();
 		java.io.File desc = descStore.toLocalFile(EFS.NONE, createTestMonitor());
@@ -308,7 +308,7 @@ public class NatureTest extends ResourceTest {
 	 */
 	public void testBug338055() throws Exception {
 		final boolean finished[] = new boolean[1];
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		AtomicReference<CoreException> failureInJob = new AtomicReference<>();
 		Job simulateNatureAccessJob = new Job("CheckNatureJob") {
@@ -357,7 +357,7 @@ public class NatureTest extends ResourceTest {
 	}
 
 	public void testMissingNatureAddsMarker() throws Exception {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
 		IProjectDescription desc = project.getDescription();
@@ -381,7 +381,7 @@ public class NatureTest extends ResourceTest {
 	}
 
 	public void testMissingNatureWithWhitespacesSetChars() throws Exception {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
 		IFile dotProjectFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -405,7 +405,7 @@ public class NatureTest extends ResourceTest {
 	}
 
 	public void testKnownNatureDoesntAddMarker() throws Exception {
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
 		IProjectDescription desc = project.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -66,7 +66,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFile localFile = project.getFile(sourceFile.getName());
 
 		//setup initial resources
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
 		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
@@ -92,7 +92,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFolder destination = project.getFolder("destination");
 
 		//setup initial resources
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		parentFolder.create(IResource.NONE, true, createTestMonitor());
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 
@@ -123,7 +123,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFile localFile = project.getFile(sourceFile.getName());
 
 		//setup initial resources
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
 		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
@@ -153,7 +153,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		IFolder destination = project.getFolder("destination");
 		IFile sourceFile = source.getFile("file.txt");
 		//setup initial resources
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
 		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -162,7 +162,7 @@ public class ProjectEncodingTest extends ResourceTest {
 
 	private void whenProjectIsCreated() throws CoreException {
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 	}
 
 	private void whenProjectSpecificEncodingWasRemoved() throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
@@ -116,7 +116,7 @@ public class ProjectSnapshotPerfManualTest extends ResourceTest {
 		}.run(new ProjectSnapshotPerfManualTest("Original open"), 1, 1);
 
 		// dump the snapshot refresh info
-		ensureExistsInWorkspace(project.getFolder(DIR_NAME));
+		createInWorkspace(project.getFolder(DIR_NAME));
 		IPath projPath = project.getLocation();
 		projPath = projPath.append(REFRESH_SNAPSHOT_FILE_LOCATION);
 		final URI snapshotLocation = org.eclipse.core.filesystem.URIUtil.toURI(projPath);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -57,7 +57,7 @@ public class ProjectSnapshotTest extends ResourceTest {
 		super.setUp();
 		projects[0] = getWorkspace().getRoot().getProject("p1");
 		projects[1] = getWorkspace().getRoot().getProject("p2");
-		ensureExistsInWorkspace(projects);
+		createInWorkspace(projects);
 	}
 
 	private void populateProject(IProject project) throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -68,7 +68,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		// file bit is set already for a new file
 		assertTrue("1.0", file.getResourceAttributes().isArchive());
@@ -92,7 +92,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isExecutable());
@@ -117,7 +117,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isHidden());
@@ -141,7 +141,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isReadOnly());
@@ -163,7 +163,7 @@ public class ResourceAttributeTest extends ResourceTest {
 	 */
 	public void testClosedProject() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.close(createTestMonitor());
 		assertNull("1.0", project.getResourceAttributes());
 	}
@@ -179,9 +179,9 @@ public class ResourceAttributeTest extends ResourceTest {
 		assertNull("1.2", file.getResourceAttributes());
 
 		//now create the resources and ensure non-null result
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(folder);
-		ensureExistsInWorkspace(file);
+		createInWorkspace(project);
+		createInWorkspace(folder);
+		createInWorkspace(file);
 		assertNotNull("2.0", project.getResourceAttributes());
 		assertNotNull("2.1", folder.getResourceAttributes());
 		assertNotNull("2.2", file.getResourceAttributes());
@@ -205,7 +205,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("testRefreshExecutableOnFolder");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		// folder is executable initially and the file should exist
 		assertTrue("1.0", project.getResourceAttributes().isExecutable());
@@ -232,7 +232,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile link = project.getFile("link");
-		ensureExistsInWorkspace(link, getRandomString());
+		createInWorkspace(link, getRandomString());
 
 		// attempts to set the symbolic link attribute wont't affect
 		// the resource and the underlying file
@@ -251,7 +251,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		// create a link to the target file and add it to the workspace,
 		// the resource in the workspace should have symbolic link attribute set
 		createSymLink(project.getLocation().toFile(), "link", "target", false);
-		ensureExistsInWorkspace(link);
+		createInWorkspace(link);
 		assertTrue("5.0", link.getResourceAttributes().isSymbolicLink());
 
 		// attempts to clear the symbolic link attribute shouldn't affect
@@ -274,7 +274,7 @@ public class ResourceAttributeTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFile file = project.getFile(createUniqueString());
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 
 		for (int attribute : attributes) {
 			// only activate this test on platforms that support it

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -78,7 +78,7 @@ public class ResourceURLTest extends ResourceTest {
 
 	public void testBasicURLs() throws Throwable {
 		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		for (IResource resource : resources) {
 			checkURL(resource);
 		}
@@ -91,7 +91,7 @@ public class ResourceURLTest extends ResourceTest {
 		project.create(desc, null);
 		project.open(null);
 		IResource[] resources = buildResources(project, resourcePaths);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		for (IResource resource : resources) {
 			checkURL(resource);
 		}
@@ -111,7 +111,7 @@ public class ResourceURLTest extends ResourceTest {
 	public void testSpaces() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("My Project");
 		IFile file = project.getFile("a.txt");
-		ensureExistsInWorkspace(file, CONTENT);
+		createInWorkspace(file, CONTENT);
 		URL url = new URL(PlatformURLResourceConnection.RESOURCE_URL_STRING + "My%20Project/a.txt");
 		InputStream stream = url.openStream();
 		assertTrue("1.0", compareContent(stream, getContents(CONTENT)));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -43,7 +43,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = { project, folder, file, subFile };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
 		listener.addExpectedChange(subFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
@@ -68,7 +68,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = { project, folder, file, subFile };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// no team private members
 		assertThat(root.findMember(project.getFullPath()), is(project));
@@ -103,7 +103,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFolder settings = project.getFolder(".settings");
 		IFile prefs = settings.getFile("org.eclipse.core.resources.prefs");
 		IResource[] resources = new IResource[] { project, folder, file, subFile, settings, prefs };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// Initial values should be false.
 		assertTeamPrivateMember(project, false, IResource.DEPTH_INFINITE);
@@ -168,7 +168,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFolder settings = project.getFolder(".settings");
 		IFile prefs = settings.getFile("org.eclipse.core.resources.prefs");
 		IResource[] resources = { project, folder, file, subFile, settings, prefs };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		IResource description = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 
 		// default case, no team private members
@@ -259,7 +259,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = { project, folder, file, subFile };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// handles to the destination resources
 		IProject destProject = root.getProject("MyOtherProject");
@@ -279,8 +279,8 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// Do it again and but just copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
@@ -289,7 +289,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		// set all the resources to be team private
 		// copy the project
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(resources);
@@ -297,8 +297,8 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// do it again but only copy the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		folder.copy(destFolder.getFullPath(), flags, createTestMonitor());
 		assertExistsInWorkspace(new IResource[] { folder, subFile });
@@ -312,7 +312,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = { project, folder, file, subFile };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// handles to the destination resources
 		IProject destProject = root.getProject("MyOtherProject");
@@ -332,8 +332,8 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// Do it again and but just move the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -342,7 +342,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		// set all the resources to be team private
 		// move the project
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
@@ -350,8 +350,8 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// do it again but only move the folder
 		ensureDoesNotExistInWorkspace(destResources);
-		ensureExistsInWorkspace(resources);
-		ensureExistsInWorkspace(destProject);
+		createInWorkspace(resources);
+		createInWorkspace(destProject);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		folder.move(destFolder.getFullPath(), flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -365,7 +365,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// default behaviour with no team private members
 		int flags = IResource.ALWAYS_DELETE_PROJECT_CONTENT | IResource.FORCE;
@@ -373,43 +373,43 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set one child to be team private
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		// delete the project
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
 		assertExistsInWorkspace(new IResource[] { project, file });
 
 		// set all resources to be team private
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		// delete the project
 		project.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(resources);
 		// delete a file
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		file.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(file);
 		assertExistsInWorkspace(new IResource[] { project, folder, subFile });
 		// delete a folder
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		folder.delete(flags, createTestMonitor());
 		assertDoesNotExistInWorkspace(new IResource[] { folder, subFile });
@@ -430,7 +430,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		final ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(listener);
 		try {
-			IWorkspaceRunnable body = monitor -> ensureExistsInWorkspace(resources);
+			IWorkspaceRunnable body = monitor -> createInWorkspace(resources);
 			listener.addExpectedChange(resources, IResourceDelta.ADDED, IResource.NONE);
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
@@ -446,7 +446,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		getWorkspace().addResourceChangeListener(listener);
 		try {
 			IWorkspaceRunnable body = monitor -> {
-				ensureExistsInWorkspace(resources);
+				createInWorkspace(resources);
 				setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 			};
 			listener.reset();
@@ -464,7 +464,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		getWorkspace().addResourceChangeListener(listener);
 		try {
 			IWorkspaceRunnable body = monitor -> {
-				ensureExistsInWorkspace(resources);
+				createInWorkspace(resources);
 				setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 			};
 			listener.reset();
@@ -489,7 +489,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = { project, folder, file, subFile };
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// Check to see if all the resources exist in the workspace tree.
 		assertExistsInWorkspace(resources);
@@ -521,7 +521,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		}
 
 		// create the resources
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// Initial values should be false.
 		for (IResource resource : resources) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -46,7 +46,7 @@ public class VirtualFolderTest extends ResourceTest {
 		super.setUp();
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingVirtualFolderInExistingProject = existingProject.getFolder("existingVirtualFolderInExistingProject");
-		ensureExistsInWorkspace(new IResource[] { existingProject });
+		createInWorkspace(new IResource[] { existingProject });
 		existingVirtualFolderInExistingProject.create(IResource.VIRTUAL, true, createTestMonitor());
 	}
 
@@ -311,7 +311,7 @@ public class VirtualFolderTest extends ResourceTest {
 		subFolderLocation.toFile().mkdir();
 
 		// create the structure in the workspace
-		ensureExistsInWorkspace(topFolder);
+		createInWorkspace(topFolder);
 		linkedFolder.createLink(linkedFolderLocation, IResource.NONE, createTestMonitor());
 		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -122,7 +122,7 @@ public class WorkspaceTest extends ResourceTest {
 	public void testFolderDeletion() throws Throwable {
 		IProject project = getTestProject();
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/x", "c/b/y", "c/b/z"});
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		//
 		assertExistsInWorkspace(before);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -137,7 +137,7 @@ public class WorkspaceTest extends ResourceTest {
 		IResource[] after = buildResources(project, new String[] {"a/", "a/b/", "a/x", "a/b/y", "a/b/z"});
 
 		// create the resources and set some content in a file that will be moved.
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		String content = getRandomString();
 		IFile file = project.getFile(IPath.fromOSString("b/b/z"));
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -216,7 +216,7 @@ public class WorkspaceTest extends ResourceTest {
 	public void testMultiDeletion() throws Throwable {
 		IProject project = getTestProject();
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/x", "c/b/y", "c/b/z"});
-		ensureExistsInWorkspace(before);
+		createInWorkspace(before);
 		//
 		assertExistsInWorkspace(before);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -126,7 +126,7 @@ public class BenchWorkspace extends ResourceTest {
 			project.create(null);
 			project.open(null);
 			IResource[] resources = buildResources(project, defineHierarchy());
-			ensureExistsInWorkspace(resources);
+			createInWorkspace(resources);
 		};
 		getWorkspace().run(runnable, null);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -56,11 +56,11 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		final IWorkspace workspace = getWorkspace();
 		try {
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				ensureExistsInWorkspace(folders);
+				createInWorkspace(folders);
 				for (IFolder folder : folders) {
 					for (int j = 0; j < filesPerFolder; j++) {
 						IFile file = folder.getFile("file" + j);
-						ensureExistsInWorkspace(file, getRandomString());
+						createInWorkspace(file, getRandomString());
 						try {
 							for (int k = 0; k < statesPerFile; k++) {
 								file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
@@ -97,7 +97,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				ensureExistsInWorkspace(file, getRandomString());
+				createInWorkspace(file, getRandomString());
 			}
 
 			@Override
@@ -132,7 +132,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				ensureExistsInWorkspace(new IResource[] {project, folder1, folder2});
+				createInWorkspace(new IResource[] {project, folder1, folder2});
 				try {
 					file1.create(getRandomContents(), IResource.FORCE, createTestMonitor());
 					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
@@ -284,7 +284,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	public void testGetHistory() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFile file = project.getFile("file.txt");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 		for (int i = 0; i < 100; i++) {
 			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -52,11 +52,11 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		folders[4] = folders[3].getFolder("folder5");
 		List<IResource> resources = new ArrayList<>(filesPerFolder * folders.length);
 		resources.addAll(Arrays.asList(folders));
-		ensureExistsInWorkspace(folders);
+		createInWorkspace(folders);
 		for (IFolder folder : folders) {
 			for (int j = 0; j < filesPerFolder; j++) {
 				IFile file = folder.getFile("file" + j);
-				ensureExistsInWorkspace(file, getRandomString());
+				createInWorkspace(file, getRandomString());
 				resources.add(file);
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
@@ -290,7 +290,7 @@ public class WorkspacePerformanceTest extends ResourceTest {
 	public void testLoadSnapshot() throws CoreException {
 		// 2 minutes total test time, 528 msec test execution time
 		IProject snapProject = getWorkspace().getRoot().getProject("SnapProject");
-		ensureExistsInWorkspace(snapProject);
+		createInWorkspace(snapProject);
 		final URI snapshotLocation = snapProject.getFile("snapshot.zip").getLocationURI();
 		createAndPopulateProject(50000);
 		waitForBackgroundActivity();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -70,7 +70,7 @@ public class RefreshProviderTest extends ResourceTest {
 		deleteOnTearDown(location);
 		String name = "testUnmonitorLinkedResource";
 		IProject project = getWorkspace().getRoot().getProject(name);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		joinAutoRefreshJobs();
 		IFile link = project.getFile("Link");
 		// ensure we currently have just the project being monitored
@@ -97,7 +97,7 @@ public class RefreshProviderTest extends ResourceTest {
 	public void testProjectCloseOpen() throws Exception {
 		String name = "testProjectCloseOpen";
 		IProject project = getWorkspace().getRoot().getProject(name);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		joinAutoRefreshJobs();
 		// ensure we currently have just the project being monitored
 		TestRefreshProvider provider = TestRefreshProvider.getInstance();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -47,9 +47,9 @@ public class Bug_025457 extends ResourceTest {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("file.txt");
 		IFile destFile = source.getFile("File.txt");
-		ensureExistsInWorkspace(source);
+		createInWorkspace(source);
 		final String content = getRandomString();
-		ensureExistsInWorkspace(sourceFile, content);
+		createInWorkspace(sourceFile, content);
 
 		//open a stream in the source to cause the rename to fail
 		try (InputStream stream = sourceFile.getContents()) {
@@ -78,9 +78,9 @@ public class Bug_025457 extends ResourceTest {
 		IFile sourceFile = sourceFolder.getFile("Important.txt");
 		IFolder destFolder = source.getFolder("Folder");
 		IFile destFile = destFolder.getFile("Important.txt");
-		ensureExistsInWorkspace(source);
-		ensureExistsInWorkspace(sourceFolder);
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(source);
+		createInWorkspace(sourceFolder);
+		createInWorkspace(sourceFile);
 
 		//open a stream in the source to cause the rename to fail
 		try (InputStream stream = sourceFile.getContents()) {
@@ -107,8 +107,8 @@ public class Bug_025457 extends ResourceTest {
 		IProject destination = getWorkspace().getRoot().getProject("Project");
 		IFile sourceFile = source.getFile("Important.txt");
 		IFile destFile = destination.getFile("Important.txt");
-		ensureExistsInWorkspace(source);
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(source);
+		createInWorkspace(sourceFile);
 
 		//open a stream in the source to cause the rename to fail
 		try (InputStream stream = sourceFile.getContents()) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -59,7 +59,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file3 = folder.getFile("file3.txt");
 		IFile projectFile = project.getFile(IPath.fromOSString(".project"));
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2, file3 });
+		createInWorkspace(new IResource[] { file1, file2, file3 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
@@ -129,7 +129,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file2 = project.getFile("file2.txt");
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2 });
+		createInWorkspace(new IResource[] { file1, file2 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
@@ -180,7 +180,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file3 = folder.getFile("file3.txt");
 		IFile projectFile = project.getFile(IPath.fromOSString(".project"));
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2, file3 });
+		createInWorkspace(new IResource[] { file1, file2, file3 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
@@ -220,7 +220,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file2 = project.getFile("file2.txt");
 		IFile projectFile = project.getFile(IPath.fromOSString(".project"));
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2 });
+		createInWorkspace(new IResource[] { file1, file2 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
@@ -265,7 +265,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file1 = folder.getFile("file1.txt");
 		IFile file3 = folder.getFile("file3.txt");
 
-		ensureExistsInWorkspace(new IResource[] { file1, file3 });
+		createInWorkspace(new IResource[] { file1, file3 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 
@@ -302,7 +302,7 @@ public class Bug_026294 extends ResourceTest {
 		IFile file1 = subFolder.getFile("file1.txt");
 		IFile file3 = folder.getFile("file3.txt");
 
-		ensureExistsInWorkspace(new IResource[] { file1, file3 });
+		createInWorkspace(new IResource[] { file1, file3 });
 		IPath projectRoot = project.getLocation();
 		deleteOnTearDown(projectRoot);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
@@ -48,7 +48,7 @@ public class Bug_028981 extends ResourceTest {
 		IFolder settings = project.getFolder(".settings");
 		IFile prefs = settings.getFile("org.eclipse.core.resources.prefs");
 
-		ensureExistsInWorkspace(new IResource[] {teamPrivateFile, regularFile});
+		createInWorkspace(new IResource[] {teamPrivateFile, regularFile});
 		synchronizer.setSyncInfo(partner, phantomFile, getRandomString().getBytes());
 		teamPrivateFile.setTeamPrivateMember(true);
 		assertTrue("0.7", !regularFile.isPhantom() && !regularFile.isTeamPrivateMember());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -41,7 +41,7 @@ public class Bug_029671 extends ResourceTest {
 		IFolder folder = project.getFolder("source");
 		IFile file = folder.getFile("file.txt");
 
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 
 		try {
 			// sets sync info for the folder and its children

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
@@ -51,7 +51,7 @@ public class Bug_029851 extends ResourceTest {
 		Collection<String> result = createChildren(breadth, depth, prefix);
 		result.add(prefix.toString());
 		IResource[] resources = buildResources(getWorkspace().getRoot(), result.toArray(new String[0]));
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 	}
 
 	public void test() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -53,7 +53,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile sourceFile = sourceParent.getFile("file1.txt");
 		IFile destinationFile = destinationParent.getFile(sourceFile.getName());
 
-		ensureExistsInWorkspace(new IResource[] { sourceFile, destinationParent });
+		createInWorkspace(new IResource[] { sourceFile, destinationParent });
 		deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
@@ -110,7 +110,7 @@ public class Bug_032076 extends ResourceTest {
 		// but not this one
 		IFile file2 = folder.getFile("file2.txt");
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2, destinationParent });
+		createInWorkspace(new IResource[] { file1, file2, destinationParent });
 		deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
@@ -170,7 +170,7 @@ public class Bug_032076 extends ResourceTest {
 		// but not this one
 		IFile file2 = sourceProject.getFile("file2.txt");
 
-		ensureExistsInWorkspace(new IResource[] {file1, file2});
+		createInWorkspace(new IResource[] {file1, file2});
 		deleteOnTearDown(sourceProject.getLocation()); // Ensure project location is moved after test
 
 		// add a marker to a file to ensure the move operation is not losing anything
@@ -223,7 +223,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile sourceFile = roFolder.getFile("file.txt");
 		IFile destinationFile = destinationParent.getFile("file.txt");
 
-		ensureExistsInWorkspace(new IResource[] { sourceFile, destinationParent });
+		createInWorkspace(new IResource[] { sourceFile, destinationParent });
 		deleteOnTearDown(project.getLocation());
 
 		IFileStore roFolderStore = ((Resource) roFolder).getStore();
@@ -286,7 +286,7 @@ public class Bug_032076 extends ResourceTest {
 		IFolder destinationParent = project.getFolder("destination_parent");
 		IFolder destinationROFolder = destinationParent.getFolder(roFolder.getName());
 
-		ensureExistsInWorkspace(new IResource[] { file1, file2, destinationParent });
+		createInWorkspace(new IResource[] { file1, file2, destinationParent });
 		deleteOnTearDown(project.getLocation());
 
 		IFileStore roFolderLocation = ((Resource) roFolder).getStore();
@@ -371,7 +371,7 @@ public class Bug_032076 extends ResourceTest {
 
 		IFile file1 = sourceProject.getFile("file1.txt");
 
-		ensureExistsInWorkspace(new IResource[] { file1 });
+		createInWorkspace(new IResource[] { file1 });
 
 		// add a marker to a file to ensure the move operation is not losing anything
 		String attributeKey = getRandomString();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -56,7 +56,7 @@ public class Bug_044106 extends ResourceTest {
 
 		// create some resources in the workspace
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		// link in the folder
 		String target = new java.io.File(linkDestFile.toURI()).getAbsolutePath();
@@ -94,7 +94,7 @@ public class Bug_044106 extends ResourceTest {
 		assertTrue("0.2", linkDestFile.fetchInfo().exists());
 
 		// create some resources in the workspace
-		ensureExistsInWorkspace(linkedFolder.getParent());
+		createInWorkspace(linkedFolder.getParent());
 
 		// link in the folder
 		String target = new java.io.File(linkDestLocation.toURI()).getAbsolutePath();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -47,7 +47,7 @@ public class Bug_079398 extends ResourceTest {
 		// max size of file = 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
 		getWorkspace().setDescription(description);
-		ensureExistsInWorkspace(file1, getRandomString());
+		createInWorkspace(file1, getRandomString());
 		for (int i = 0; i < 10; i++) {
 			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
@@ -32,7 +32,7 @@ public class Bug_098740 extends ResourceTest {
 
 	public void testBug() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Bug98740");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.close(createTestMonitor());
 		assertThrows(CoreException.class, () -> project.members());
 		IResourceVisitor visitor = resource -> true;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -33,7 +33,7 @@ public class Bug_126104 extends ResourceTest {
 	public void testBug() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("p1");
 		IFile source = project.getFile("source");
-		ensureExistsInWorkspace(source);
+		createInWorkspace(source);
 		IFolder link = project.getFolder("link");
 		IFileStore location = getTempStore();
 		link.createLink(location.toURI(), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
@@ -31,7 +31,7 @@ public class Bug_127562 extends ResourceTest {
 
 	public void testBug() throws CoreException {
 		final IProject project = getWorkspace().getRoot().getProject("Bug127562");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IProjectDescription description = project.getDescription();
 		description.setComment("Foo");
 		getWorkspace().run((IWorkspaceRunnable) monitor -> project.setDescription(description, createTestMonitor()),

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -80,7 +80,7 @@ public class Bug_147232 extends AbstractBuilderTest implements IResourceChangeLi
 		addBuilder(project, ClearMarkersBuilder.BUILDER_NAME);
 		setAutoBuilding(true);
 		//create a file in the project to trigger a build
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		waitForBuild();
 		assertEquals("2.0", 1, deltaSeenCount);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -41,8 +41,8 @@ public class Bug_160251 extends ResourceTest {
 		IFile sourceFile = source.getFile("Important.txt");
 		IFileStore destination = getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
-		ensureExistsInWorkspace(source);
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(source);
+		createInWorkspace(sourceFile);
 
 		//move the project (should succeed)
 		IProjectDescription description = source.getDescription();
@@ -65,8 +65,8 @@ public class Bug_160251 extends ResourceTest {
 		IFile sourceFile = source.getFile("Important.txt");
 		IFileStore destination = getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
-		ensureExistsInWorkspace(source);
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(source);
+		createInWorkspace(sourceFile);
 		destination.mkdir(EFS.NONE, createTestMonitor());
 
 		//move the project (should succeed)
@@ -90,8 +90,8 @@ public class Bug_160251 extends ResourceTest {
 		IFile sourceFile = source.getFile("Important.txt");
 		IFileStore destination = getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
-		ensureExistsInWorkspace(source);
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(source);
+		createInWorkspace(sourceFile);
 		destination.mkdir(EFS.NONE, createTestMonitor());
 		createFileInFileSystem(destinationFile);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -39,7 +39,7 @@ public class Bug_165892 extends ResourceTest {
 		IFolder sourceFolder = source.getFolder("folder");
 		IFile sourceFile = sourceFolder.getFile("source");
 		IFile destinationFile = sourceFolder.getFile("destination");
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(sourceFile);
 
 		final String sourceValue = "SourceValue";
 		QualifiedName name = new QualifiedName("Bug_165892", "Property");
@@ -70,7 +70,7 @@ public class Bug_165892 extends ResourceTest {
 		IFolder sourceFolder = source.getFolder("folder");
 		IFile sourceFile = sourceFolder.getFile("source");
 		IFile destinationFile = sourceFolder.getFile("destination");
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(sourceFile);
 
 		// modify the source file so it has some history
 		sourceFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
@@ -101,7 +101,7 @@ public class Bug_165892 extends ResourceTest {
 		IFile sourceFile = sourceFolder.getFile("Important.txt");
 		IFolder destinationFolder = source.getFolder("destination");
 		IFile destinationFile = destinationFolder.getFile(sourceFile.getName());
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(sourceFile);
 
 		//add a persistent property to each source resource
 		final String sourceValue = "SourceValue";
@@ -143,7 +143,7 @@ public class Bug_165892 extends ResourceTest {
 		IProject destination = getWorkspace().getRoot().getProject("destination");
 		IFolder destinationFolder = destination.getFolder(sourceFolder.getName());
 		IFile destinationFile = destinationFolder.getFile(sourceFile.getName());
-		ensureExistsInWorkspace(sourceFile);
+		createInWorkspace(sourceFile);
 
 		//add a persistent property to each source resource
 		final String sourceValue = "SourceValue";

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
@@ -79,12 +79,12 @@ public class Bug_192631 extends ResourceTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		IProject projectA = workspace.getRoot().getProject("projectA");
-		ensureExistsInWorkspace(projectA);
+		createInWorkspace(projectA);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
 		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
-		ensureExistsInWorkspace(projectB);
+		createInWorkspace(projectB);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
 		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 
@@ -124,12 +124,12 @@ public class Bug_192631 extends ResourceTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		IProject projectA = workspace.getRoot().getProject("projectA");
-		ensureExistsInWorkspace(projectA);
+		createInWorkspace(projectA);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
 		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
-		ensureExistsInWorkspace(projectB);
+		createInWorkspace(projectB);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
 		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 
@@ -169,12 +169,12 @@ public class Bug_192631 extends ResourceTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		IProject projectA = workspace.getRoot().getProject("projectA");
-		ensureExistsInWorkspace(projectA);
+		createInWorkspace(projectA);
 		IFolder linkA = projectA.getFolder("link_to_commonA");
 		linkA.createLink(commonA, IResource.NONE, createTestMonitor());
 
 		IProject projectB = workspace.getRoot().getProject("projectB");
-		ensureExistsInWorkspace(projectB);
+		createInWorkspace(projectB);
 		IFolder linkB = projectB.getFolder("link_to_commonB");
 		linkB.createLink(commonB, IResource.NONE, createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -101,8 +101,8 @@ public class Bug_233939 extends ResourceTest {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject projectA = root.getProject(createUniqueString());
 		IProject projectB = root.getProject(createUniqueString());
-		ensureExistsInWorkspace(projectA);
-		ensureExistsInWorkspace(projectB);
+		createInWorkspace(projectA);
+		createInWorkspace(projectB);
 		symLinkAndRefresh(projectA, "folderA", tempFolderPath);
 		symLinkAndRefresh(projectB, "folderB", tempFolderPath);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -49,7 +49,7 @@ public class Bug_303517 extends ResourceTest {
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
 		prefs.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
 		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 	}
 
 	@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -32,7 +32,7 @@ public class Bug_331445 extends ResourceTest {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
 
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		String variableName = "a" + createUniqueString();
 		String variablePath = "mem:/MyProject";

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -85,14 +85,14 @@ public class Bug_378156 extends ResourceTest {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		final IProject project1 = root.getProject("Bug_378156");
 		final IFile file = project1.getFile("content.txt");
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		//add a builder that can tell us if it was called
 		IProjectDescription desc = project1.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 		//build may not be triggered immediately
 		Thread.sleep(2000);
 		waitForBuild();
@@ -127,14 +127,14 @@ public class Bug_378156 extends ResourceTest {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		final IProject project1 = root.getProject("Bug_378156");
 		final IFile file = project1.getFile("content.txt");
-		ensureExistsInWorkspace(project1);
+		createInWorkspace(project1);
 		//add a builder that can tell us if it was called
 		IProjectDescription desc = project1.getDescription();
 		ICommand command = desc.newCommand();
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 		waitForBuild();
 
 		//initialize the builder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -58,7 +58,7 @@ public class IFileTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
-		ensureExistsInWorkspace(new IResource[] {project, folder});
+		createInWorkspace(new IResource[] {project, folder});
 		IFile file = folder.getFile("file.txt");
 
 		try {
@@ -90,7 +90,7 @@ public class IFileTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
-		ensureExistsInWorkspace(new IResource[] {project, folder});
+		createInWorkspace(new IResource[] {project, folder});
 		IFile file = folder.getFile("file.txt");
 
 		try {
@@ -111,7 +111,7 @@ public class IFileTest extends ResourceTest {
 	public void testBug43936() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		assertTrue("1.0", descFile.exists());
 
 		IProjectDescription desc = project.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -54,7 +54,7 @@ public class IFolderTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder parentFolder = project.getFolder("parentFolder");
-		ensureExistsInWorkspace(new IResource[] {project, parentFolder});
+		createInWorkspace(new IResource[] {project, parentFolder});
 		IFolder folder = parentFolder.getFolder("folder");
 
 		try {
@@ -77,7 +77,7 @@ public class IFolderTest extends ResourceTest {
 		IFolder folder = project.getFolder("fold1");
 		IFile subFile = folder.getFile("f1");
 		IFile file = project.getFile("f2");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		folder.create(true, false, createTestMonitor());
 		file.create(null, true, createTestMonitor());
 		subFile.create(null, true, createTestMonitor());
@@ -116,8 +116,8 @@ public class IFolderTest extends ResourceTest {
 		IProject project = root.getProject("TestProject");
 		IFolder folder = project.getFolder("folder");
 
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(new IResource[] {folder});
+		createInWorkspace(project);
+		createInWorkspace(new IResource[] {folder});
 
 		IFileStore dir = EFS.getLocalFileSystem().fromLocalFile(folder.getLocation().toFile());
 		assertTrue(dir.fetchInfo().exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -175,7 +175,7 @@ public class IProjectTest extends AbstractBuilderTest {
 
 		String[] paths = new String[] {"/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1"};
 		IResource[] resources = buildResources(project, paths);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		IFolder folder = project.getFolder("folder");
 		createInFileSystem(folder);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -79,7 +79,7 @@ public class IResourceTest extends ResourceTest {
 		IFolder outputFolder = project.getFolder("bin");
 		IFile description = project.getFile(".project");
 		IFile destination = outputFolder.getFile(".project");
-		ensureExistsInWorkspace(new IResource[] {project, outputFolder});
+		createInWorkspace(new IResource[] {project, outputFolder});
 
 		assertTrue("0.0", description.exists());
 		description.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
@@ -93,7 +93,7 @@ public class IResourceTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("a.txt");
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 		// ensure archive bit is not set
 		ResourceAttributes attributes = file.getResourceAttributes();
 		attributes.setArchive(false);
@@ -125,7 +125,7 @@ public class IResourceTest extends ResourceTest {
 	public void testBug35991() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		final IFile file = project.getFile("file1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		//create phantom file by adding sync info
 		final QualifiedName name = new QualifiedName("test", "testBug35991");
 		getWorkspace().getSynchronizer().add(name);
@@ -188,8 +188,8 @@ public class IResourceTest extends ResourceTest {
 	public void testBug83777() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("testBug83777");
 		IFolder folder = project.getFolder("f");
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(folder);
+		createInWorkspace(project);
+		createInWorkspace(folder);
 		folder.setLocal(false, IResource.DEPTH_ZERO, createTestMonitor());
 		// non-local resource is never synchronized because it doesn't exist on disk
 		assertTrue("1.0", !project.isSynchronized(IResource.DEPTH_INFINITE));
@@ -202,7 +202,7 @@ public class IResourceTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("testBug111821");
 		IFolder folder = project.getFolder(new Path(null, "c:"));
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		QualifiedName partner = new QualifiedName("HowdyThere", "Partner");
 		ISynchronizer sync = getWorkspace().getSynchronizer();
 		sync.add(partner);
@@ -345,7 +345,7 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("MyFile");
 
 		// setup
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		ResourceAttributes attributes = file.getResourceAttributes();
 		attributes.setReadOnly(true);
 		file.setResourceAttributes(attributes);
@@ -370,7 +370,7 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("MyFile");
 
 		// setup
-		ensureExistsInWorkspace(new IResource[] {project, file});
+		createInWorkspace(new IResource[] {project, file});
 		ensureOutOfSync(file);
 
 		// doit

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -83,7 +83,7 @@ public class NLTest extends ResourceTest {
 
 		String[] files = getFileNames(Locale.ENGLISH.getLanguage());
 		IResource[] resources = buildResources(project, files);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
@@ -91,7 +91,7 @@ public class NLTest extends ResourceTest {
 
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -60,7 +60,7 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 	 */
 	public void test1() throws CoreException {
 		IResource[] resources = {project1, unsorted1, sorted1, unsortedFile1};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// give unsorted files some initial content
 		unsortedFile1.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -57,7 +57,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	public void testDeleteFileBeforeLoad1() throws Exception {
 		IProject project = getProject("testDeleteFileBeforeLoad");
 		String qualifier = "test.delete.file.before.load";
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode(qualifier);
 		node.put("key", "value");
@@ -100,7 +100,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	 */
 	public void testSaveLoad1() throws Exception {
 		IProject project = getProject("testSaveLoad");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode("test.save.load");
 		node.put("key", "value");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
@@ -47,7 +47,7 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 		IProject project = workspace.getRoot().getProject("Project1");
 		IFolder link = project.getFolder("link");
 		IFile linkChild = link.getFile("child.txt");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		IFileStore parent = EFS.getStore(location.toFile().toURI());
 		IFileStore child = parent.getChild(linkChild.getName());
 		parent.mkdir(EFS.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug12575.java
@@ -51,7 +51,7 @@ public class TestBug12575 extends WorkspaceSerializationTest {
 		desc.setReferencedProjects(new IProject[] { other });
 		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		//creating a project will cause a snapshot
-		ensureExistsInWorkspace(other);
+		createInWorkspace(other);
 
 		//crash
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -41,7 +41,7 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 	 */
 	public void test1() throws CoreException {
 		IProject project = workspace.getRoot().getProject("Project1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		setAutoBuilding(false);
 
 		//create a project and configure builder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -33,7 +33,7 @@ public class TestBug202384 extends WorkspaceSessionTest {
 	public void testInitializeWorkspace() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		project.setDefaultCharset("UTF-8", createTestMonitor());
 		assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
 		project.close(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -40,8 +40,8 @@ public class TestBug208833 extends WorkspaceSessionTest {
 		IFile file = project.getFile("file1.txt");
 
 		// create a project with a file
-		ensureExistsInWorkspace(project);
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(project);
+		createInWorkspace(file, getRandomString());
 
 		// save the workspace
 		workspace.save(true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
@@ -73,7 +73,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 	private IProject createProject() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_OLD_NAME);
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		assertTrue("1.0", project.exists());
 
 		// make sure we do not have .snap file

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
@@ -35,7 +35,7 @@ public class TestBug316182 extends WorkspaceSessionTest {
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project_TestBug316182");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		workspace.save(true, createTestMonitor());
 		// reset last caught exception
 		CAUGHT_EXCEPTION = null;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
@@ -35,7 +35,7 @@ public class TestBug369177 extends WorkspaceSessionTest {
 	public void test01_prepareWorkspace() throws CoreException, URISyntaxException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 
 		IFile link = project.getFile("link_to_file");
 		link.createLink(new URI("bug369177:/dummy_path.txt"), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -57,7 +57,7 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		IFile file = project.getFile("foo.txt");
 		assertDoesNotExistInWorkspace(file);
-		ensureExistsInWorkspace(file, getRandomString());
+		createInWorkspace(file, getRandomString());
 		// this will also cause the cache flush job to be scheduled
 		file.getContentDescription();
 		// after waiting cache flushing, cache should be new

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -64,7 +64,7 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 	 */
 	public void test1() throws CoreException {
 		IResource[] resources = {project1, project2, unsorted1, unsorted2, sorted1, sorted2, unsortedFile1, unsortedFile2};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 
 		// give unsorted files some initial content
 		unsortedFile1.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -43,7 +43,7 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 		desc.setLocation(location);
 		project.create(desc, createTestMonitor());
 		project.open(createTestMonitor());
-		ensureExistsInWorkspace(file);
+		createInWorkspace(file);
 		project.close(createTestMonitor());
 		assertEquals("1.1", location, project.getLocation());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -69,7 +69,7 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 	 */
 	public void test1() throws CoreException {
 		IResource[] resources = {project1, project2, project3, project4, file1, file2, file3, file4};
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		setAutoBuilding(false);
 
 		// create a project and configure builder

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -65,7 +65,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	 */
 	public void test1() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
-		ensureExistsInWorkspace(project);
+		createInWorkspace(project);
 		setAutoBuilding(true);
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_WATER, NATURE_SNOW });

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -47,7 +47,7 @@ public class Snapshot1Test extends SnapshotTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 
@@ -68,7 +68,7 @@ public class Snapshot1Test extends SnapshotTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -56,7 +56,7 @@ public class Snapshot2Test extends SnapshotTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 	}
@@ -72,7 +72,7 @@ public class Snapshot2Test extends SnapshotTest {
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
 	}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -112,7 +112,7 @@ public class WorkspaceTest extends ResourceTest {
 			resources.add(container);
 		resources.addAll(Arrays.asList(buildResources(container, hierarchy)));
 		IResource[] result = resources.toArray(new IResource[resources.size()]);
-		ensureExistsInWorkspace(result);
+		createInWorkspace(result);
 		for (IResource r : result) {
 			if (r.getType() == IResource.FILE) {
 				((IFile) r).setContents(getRandomContents(100), true, false, null);

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderTests.java
@@ -228,7 +228,7 @@ public class RepositoryProviderTests extends TeamTest {
 		bicProvider.setMoveDeleteHook(hook);
 
 		IResource[] resources = buildResources(project, new String[] {"deleteFile.txt", "moveFile.txt", "deletedFolder/", "moveFolder/"});
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		resources[0].delete(false, null);
 		resources[1].move(resources[1].getFullPath().removeLastSegments(1).append("movedFile_NEW"), false, null);
 		resources[2].delete(false, null);
@@ -325,7 +325,7 @@ public class RepositoryProviderTests extends TeamTest {
 
 		// test that moving files/folders between two projects with providers calls the destination
 		IResource[] resources = buildResources(projectA, new String[] {"moveFile.txt", "moveFolder/"});
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		resources[0].move(projectB.getFullPath().append("moveFile_new.txt"), false, null);
 		resources[1].move(projectB.getFullPath().append("movedFolder"), false, null);
 		for (int i = 0; i < calledProjectA.length; i++) {
@@ -337,7 +337,7 @@ public class RepositoryProviderTests extends TeamTest {
 		calledProjectA[0] = false; calledProjectA[1] = false;
 		calledProjectB[0] = false; calledProjectB[1] = false;
 		resources = buildResources(projectA, new String[] {"anotherMovedFiled.txt", "anotherMovedFolder/"});
-		ensureExistsInWorkspace(resources);
+		createInWorkspace(resources);
 		resources[0].move(projectC.getFullPath().append("moveFileOther_new.txt"), false, null);
 		resources[1].move(projectC.getFullPath().append("movedFolderOther"), false, null);
 		for (int i = 0; i < calledProjectA.length; i++) {


### PR DESCRIPTION
There are two kinds of methods in ResourceTest for creating resources in the workspace. One of them is called ensureExistsInWorkspace() and the other is called createInWorkspace(). Both use each other and are inconsistent with the method names for creating file system resources, which are called create...InFileSystem(). This change unifies the methods to be called create...InWorkspace().

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903