### PR TITLE
Remove unnecessary exception handling in ResourceTest utilities #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -247,7 +247,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	}
 
 	@Test
-	public void testWriteFile() throws CoreException {
+	public void testWriteFile() throws Exception {
 		/* initialize common objects */
 		IProject project = projects[0];
 		IFile file = project.getFile("testWriteFile");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -35,7 +35,7 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 
 public class HiddenResourceTest extends ResourceTest {
-	public void testRefreshLocal() throws CoreException {
+	public void testRefreshLocal() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -105,7 +105,7 @@ public class IWorkspaceTest extends ResourceTest {
 	 * 		IStatus copy([IResource, IPath, boolean, IProgressMonitor)
 	 * See also testMultiCopy()
 	 */
-	public void testCopy() throws CoreException {
+	public void testCopy() throws Exception {
 		IResource[] resources = buildResourceHierarchy();
 		IProject project = (IProject) resources[1];
 		IFolder folder = (IFolder) resources[2];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -36,7 +36,7 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 
 public class TeamPrivateMemberTest extends ResourceTest {
-	public void testRefreshLocal() throws CoreException {
+	public void testRefreshLocal() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -362,7 +362,7 @@ public class IResourceTest extends ResourceTest {
 		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
 	}
 
-	public void testDelete_Bug8754() throws CoreException {
+	public void testDelete_Bug8754() throws Exception {
 		//In this test, we delete with force false on a file that does not exist in the file system,
 		//and ensure that the returned exception is of type OUT_OF_SYNC_LOCAL
 


### PR DESCRIPTION
Some utility methods in ResourceTest unnecessarily wrap IOExceptions into CoreExceptions. This change makes the according methods throw the IOException and lets them be thrown by the calling test methods.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903