### PR TITLE
Unify method names for resource removal in ResourceTest #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -635,7 +635,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create some resources
 		proj1.create(createTestMonitor());
 		proj1.open(createTestMonitor());
-		ensureDoesNotExistInWorkspace(proj2);
+		removeFromWorkspace(proj2);
 
 		// Create and set a build spec for project one
 		IProjectDescription desc = proj1.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -346,7 +346,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		IFile herringRouge = project.getFile(name);
 
 		// create a file in the local file system with the same name but different casing
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		createInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem
@@ -369,7 +369,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		IFile herringRouge = project.getFile(name);
 
 		// create a file in the local file system with the same name but different casing
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		createInFileSystem(herringRouge);
 
 		// do a refresh, which should cause a problem

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -57,7 +57,7 @@ public class CopyTest extends LocalStoreTest {
 
 		/* copy to absolute path */
 		IResource destination = testProjects[0].getFile("copy of file.txt");
-		ensureDoesNotExistInFileSystem(destination);
+		removeFromFileSystem(destination);
 		file.copy(destination.getFullPath(), true, null);
 		assertTrue(destination.exists());
 		/* assert properties were properly copied */
@@ -67,13 +67,13 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not((sessionValue))));
 		}
-		ensureDoesNotExistInWorkspace(destination);
-		ensureDoesNotExistInFileSystem(destination);
+		removeFromWorkspace(destination);
+		removeFromFileSystem(destination);
 
 		/* copy to relative path */
 		IPath path = IPath.fromOSString("copy of file.txt");
 		IFile destinationInFolder = folder.getFile(path);
-		ensureDoesNotExistInFileSystem(destinationInFolder);
+		removeFromFileSystem(destinationInFolder);
 		file.copy(path, true, null);
 		assertTrue(destinationInFolder.exists());
 		/* assert properties were properly copied */
@@ -83,8 +83,8 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not(sessionValue)));
 		}
-		ensureDoesNotExistInWorkspace(destinationInFolder);
-		ensureDoesNotExistInFileSystem(destinationInFolder);
+		removeFromWorkspace(destinationInFolder);
+		removeFromFileSystem(destinationInFolder);
 
 		/* copy folder to destination under its hierarchy */
 		IFolder destinationInSubfolder = folder.getFolder("subfolder");
@@ -112,13 +112,13 @@ public class CopyTest extends LocalStoreTest {
 			assertThat(propValues[i], is(persistentValue));
 			assertThat(propValues[i], is(not(sessionValue)));
 		}
-		ensureDoesNotExistInWorkspace(destinationFolder);
-		ensureDoesNotExistInFileSystem(destinationFolder);
+		removeFromWorkspace(destinationFolder);
+		removeFromFileSystem(destinationFolder);
 
 		/* copy a file that is not local but exists in the workspace */
 		IFile ghostFile = testProjects[0].getFile("ghost");
 		ghostFile.create(null, true, null);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		IFile destinationFile = testProjects[0].getFile("destination");
 		assertThrows(CoreException.class, () -> ghostFile.copy(destinationFile.getFullPath(), true, null));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -303,7 +303,7 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);
-		ensureDoesNotExistInFileSystem(deletedfolderSync);
+		removeFromFileSystem(deletedfolderSync);
 		ensureOutOfSync(subsubfileUnsync);
 
 		/* delete */
@@ -349,7 +349,7 @@ public class DeleteTest extends LocalStoreTest {
 
 		/* make some resources "unsync" with the workspace */
 		ensureOutOfSync(fileUnsync);
-		ensureDoesNotExistInFileSystem(deletedfolderSync);
+		removeFromFileSystem(deletedfolderSync);
 		ensureOutOfSync(subsubfileUnsync);
 
 		/* delete */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -171,7 +171,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 				"/Folder1/Folder2/", "/Folder1/Folder2/File2", "/Folder1/Folder2/Folder3/" });
 		createInWorkspace(resources);
 		for (IResource resource : resources) {
-			ensureDoesNotExistInFileSystem(resource);
+			removeFromFileSystem(resource);
 		}
 
 		// exists
@@ -191,7 +191,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertFalse(folder.isLocal(IResource.DEPTH_INFINITE));
 
 		// remove the trash
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	/**
@@ -294,14 +294,14 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		file.setContents(another, true, false, null);
 
 		/* test the overwrite parameter (false) */
-		ensureDoesNotExistInFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
+		removeFromFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
 		InputStream another3 = getContents(anotherContent);
 		waitForRefresh(); // wait for refresh to ensure that file is not present in workspace
 		assertThrows("Should fail writing non existing file", CoreException.class,
 				() -> write(file, another3, false, null));
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	// See https://github.com/eclipse-platform/eclipse.platform/issues/103
@@ -335,7 +335,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertThrows(CoreException.class, () -> write(file, another, false, null));
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 
 	@Test
@@ -346,14 +346,14 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		createInWorkspace(folder);
 
 		/* existing file on destination */
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		IFile file = project.getFile("testWriteFolder");
 		createInFileSystem(file);
 		/* force = true */
 		assertThrows(CoreException.class, () -> write(folder, true, null));
 		/* force = false */
 		assertThrows(CoreException.class, () -> write(folder, false, null));
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		/* existing folder on destination */
 		createInFileSystem(folder);
@@ -362,13 +362,13 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		assertTrue(folder.getLocation().toFile().isDirectory());
 		/* force = false */
 		assertThrows(CoreException.class, () -> write(folder, false, null));
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 
 		/* inexisting resource on destination */
 		/* force = true */
 		write(folder, true, null);
 		assertTrue(folder.getLocation().toFile().isDirectory());
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		/* force = false */
 		write(folder, false, null);
 		assertTrue(folder.getLocation().toFile().isDirectory());
@@ -387,7 +387,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		// create project and then delete from file system
 		// wrap in runnable to prevent snapshot from occurring in the middle.
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
-			ensureDoesNotExistInFileSystem(project);
+			removeFromFileSystem(project);
 			assertFalse("2.1", fileStore.fetchInfo().isDirectory());
 			//write project in a runnable, otherwise tree will be locked
 			((Project) project).writeDescription(IResource.FORCE);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -119,10 +119,10 @@ public class LocalSyncTest extends LocalStoreTest implements ICoreConstants {
 
 		// make some modifications in the local resources
 		// index stays the same
-		ensureDoesNotExistInFileSystem(toc);
+		removeFromFileSystem(toc);
 		//
-		ensureDoesNotExistInFileSystem(file);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(file);
+		removeFromFileSystem(folder);
 
 		Thread.sleep(5000);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -122,9 +122,9 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		IFile file = folder.getFile("File");
 
 		createInFileSystem(folder);
-		ensureDoesNotExistInWorkspace(folder);
+		removeFromWorkspace(folder);
 		createInFileSystem(file);
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
@@ -138,9 +138,9 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		project.delete(IResource.FORCE, createTestMonitor());
 
 		createInFileSystem(folder);
-		ensureDoesNotExistInWorkspace(folder);
+		removeFromWorkspace(folder);
 		createInFileSystem(file);
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		assertFalse(file.exists());
 		assertFalse(folder.exists());
@@ -156,7 +156,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* */
 		IFile file = project.getFile("file");
 		file.create(null, true, null);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		//
 		File target = file.getLocation().toFile();
 		target.mkdirs();
@@ -176,7 +176,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* test folder to file */
 		IFolder folder = project.getFolder("folder");
 		folder.create(true, true, null);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromFileSystem(folder);
 		//
 		IFile file = project.getFile("folder");
 		createInFileSystem(file);
@@ -214,8 +214,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertFalse(file.exists());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 
 		/* test creation of a child */
 		file = project.getFile("file");
@@ -223,8 +223,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertFalse(file.exists());
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue(file.exists());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 
 		/* test changes of a child (child is folder) */
 		IFolder folder = project.getFolder("folder");
@@ -242,8 +242,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		assertTrue(folder.exists());
 		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
 		assertTrue(file.exists());
-		ensureDoesNotExistInWorkspace(folder);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromWorkspace(folder);
+		removeFromFileSystem(folder);
 
 		/* test changes of a child (child is file) */
 		file = project.getFile("file");
@@ -260,8 +260,8 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertEquals(fileStore.fetchInfo().getLastModified(),
 				((Resource) file).getResourceInfo(false, false).getLocalSyncInfo());
-		ensureDoesNotExistInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromWorkspace(file);
+		removeFromFileSystem(file);
 	}
 
 	public void testSimpleRefresh() throws Throwable {
@@ -271,7 +271,7 @@ public class RefreshLocalTest extends LocalStoreTest implements ICoreConstants {
 		/* test root deletion */
 		IFile file = project.getFile("file");
 		createInWorkspace(file);
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 		assertTrue(file.exists());
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertFalse(file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -69,7 +69,7 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 				// ignore
 			}
 		}
-		ensureDoesNotExistInFileSystem(temp.getParentFile());
+		removeFromFileSystem(temp.getParentFile());
 		super.tearDown();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -328,7 +328,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(workspace);
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
 			getContents(invalidProjectDescription).transferTo(output);
 		}
@@ -407,12 +407,12 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
 			getContents(longProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
 			assertThat("Unexpected location URI for link with relative path: " + link.getProjectRelativePath(),
 					link.getLocationURI(), is(LONG_LOCATION_URI));
@@ -429,12 +429,12 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(ResourcesPlugin.getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
 			getContents(longProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		for (LinkDescription link : projDesc.getLinks().values()) {
 			assertThat("Unexpected location URI for link with relative path: " + link.getProjectRelativePath(),
 					link.getLocationURI(), is(LONG_LOCATION_URI));
@@ -457,8 +457,8 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(workspace);
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(multiLocation.toFile());
-		ensureDoesNotExistInFileSystem(singleLocation.toFile());
+		removeFromFileSystem(multiLocation.toFile());
+		removeFromFileSystem(singleLocation.toFile());
 		try (FileOutputStream output = new FileOutputStream(multiLocation.toFile())) {
 			getContents(multiLineProjectDescription).transferTo(output);
 		}
@@ -681,7 +681,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 
 		ProjectDescriptionReader reader = new ProjectDescriptionReader(getWorkspace());
 		// Write out the project description file
-		ensureDoesNotExistInFileSystem(location.toFile());
+		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
 			getContents(projectDescription).transferTo(output);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -397,7 +397,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		IProject project = getProject(createUniqueString());
 		IProject destProject = getProject(createUniqueString());
 		createInWorkspace(project);
-		ensureDoesNotExistInWorkspace(destProject);
+		removeFromWorkspace(destProject);
 		IScopeContext context = new ProjectScope(project);
 		String qualifier = createUniqueString();
 		Preferences node = context.getNode(qualifier);
@@ -533,7 +533,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertTrue("1.2", getFileInWorkspace(project, ResourcesPlugin.PI_RESOURCES).exists());
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertEquals("1.3", value, node.get(key, null));
-		ensureDoesNotExistInWorkspace(project.getFolder(DIR_NAME));
+		removeFromWorkspace(project.getFolder(DIR_NAME));
 		node = new ProjectScope(project).getNode(ResourcesPlugin.PI_RESOURCES);
 		assertNull("2.0", node.get(key, null));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -208,8 +208,8 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 			// ensures preferences exported match the imported ones
 			assertEquals("5.1", modified, workspace.getDescription());
 		} finally {
-			ensureDoesNotExistInFileSystem(originalPreferencesFile.removeLastSegments(1).toFile());
-			ensureDoesNotExistInFileSystem(modifiedPreferencesFile.removeLastSegments(1).toFile());
+			removeFromFileSystem(originalPreferencesFile.removeLastSegments(1).toFile());
+			removeFromFileSystem(modifiedPreferencesFile.removeLastSegments(1).toFile());
 		}
 
 		setDefaultWorkspaceDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -197,7 +197,7 @@ public class CharsetTest extends ResourceTest {
 				assertEquals("2.0", "BAR", file.getCharset());
 			}, null);
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -217,7 +217,7 @@ public class CharsetTest extends ResourceTest {
 			assertExistsInWorkspace(file2);
 			assertEquals("The file's charset was correctly copied while coying the file", "BAR", file2.getCharset());
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -237,7 +237,7 @@ public class CharsetTest extends ResourceTest {
 			final IFile copiedFile = project.getFile("file2.txt");
 			assertEquals("File with explicitly set charset keeps charset", copiedFile.getCharset(true), "FOO");
 		} finally {
-			ensureDoesNotExistInWorkspace(project);
+			removeFromWorkspace(project);
 		}
 	}
 
@@ -381,7 +381,7 @@ public class CharsetTest extends ResourceTest {
 		IContentDescription description = file.getContentDescription();
 		assertNotNull("1.0", description);
 		assertEquals("1.1", text, description.getContentType());
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 		CoreException e = assertThrows(CoreException.class, file::getContentDescription);
 		// Ok, the resource does not exist.
 		assertEquals("1.3", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
@@ -769,7 +769,7 @@ public class CharsetTest extends ResourceTest {
 		assertEquals("1.0", "ISO-8859-1", file.getCharset());
 
 		//delete and recreate the file with different contents
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 		createInWorkspace(file, SAMPLE_XML_DEFAULT_ENCODING);
 		assertEquals("2.0", "UTF-8", file.getCharset());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -75,7 +75,7 @@ public class FilteredResourceTest extends ResourceTest {
 	protected void doCleanup() throws Exception {
 		createInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
 		closedProject.close(createTestMonitor());
-		ensureDoesNotExistInWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
+		removeFromWorkspace(new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolder2InOtherExistingProject, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder});
 		resolve(localFolder).toFile().mkdirs();
 		createFileInFileSystem(resolve(localFile));
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -269,7 +269,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = new IResource[] {destProject, destFolder, destFile, destSubFile};
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -280,7 +280,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again and but just copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -290,7 +290,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// set all the resources to be hidden
 		// copy the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, createTestMonitor());
@@ -298,7 +298,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
@@ -322,7 +322,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = new IResource[] {destProject, destFolder, destFile, destSubFile};
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -333,7 +333,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again and but just move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setHidden(folder, true, IResource.DEPTH_ZERO);
@@ -343,7 +343,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		// set all the resources to be hidden
 		// move the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, createTestMonitor());
@@ -351,7 +351,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setHidden(project, true, IResource.DEPTH_INFINITE);
@@ -441,7 +441,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}
@@ -460,7 +460,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}
@@ -479,7 +479,7 @@ public class HiddenResourceTest extends ResourceTest {
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue("3.1." + listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -215,7 +215,7 @@ public class IFileTest extends ResourceTest {
 	 */
 	public void refreshFile(IFile file) throws CoreException, IOException {
 		if (file.getName().equals(LOCAL_ONLY)) {
-			ensureDoesNotExistInWorkspace(file);
+			removeFromWorkspace(file);
 			//project must exist to access file system store.
 			if (file.getProject().exists()) {
 				createInFileSystem(file);
@@ -224,14 +224,14 @@ public class IFileTest extends ResourceTest {
 		}
 		if (file.getName().equals(WORKSPACE_ONLY)) {
 			createInWorkspace(file);
-			ensureDoesNotExistInFileSystem(file);
+			removeFromFileSystem(file);
 			return;
 		}
 		if (file.getName().equals(DOES_NOT_EXIST)) {
-			ensureDoesNotExistInWorkspace(file);
+			removeFromWorkspace(file);
 			//project must exist to access file system store.
 			if (file.getProject().exists()) {
-				ensureDoesNotExistInFileSystem(file);
+				removeFromFileSystem(file);
 			}
 			return;
 		}
@@ -281,7 +281,7 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testAppendContents2() throws Exception {
 		IFile file = projects[0].getFile("file1");
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=true, IFile is non-local, file exists in local file system:
 		// make IFile local, append contents (the thinking being that this file,
@@ -303,7 +303,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.5", file.isLocal(IResource.DEPTH_ZERO));
 		assertTrue("1.6", file.getLocation().toFile().exists());
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=true, IFile is non-local, file does not exist in local file system:
 		// fail - file not local (this file is not local for real - cannot append
@@ -320,7 +320,7 @@ public class IFileTest extends ResourceTest {
 		monitor.sanityCheck();
 		assertTrue("2.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=false, IFile is non-local, file exists in local file system:
 		// fail - file not local
@@ -338,7 +338,7 @@ public class IFileTest extends ResourceTest {
 		monitor.assertUsedUp();
 		assertTrue("3.5", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 
 		// If force=false, IFile is non-local, file does not exist in local file system:
 		// fail - file not local
@@ -354,7 +354,7 @@ public class IFileTest extends ResourceTest {
 		monitor.sanityCheck();
 		assertTrue("4.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
-		ensureDoesNotExistInWorkspace(file);
+		removeFromWorkspace(file);
 	}
 
 	/**
@@ -426,7 +426,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateDerived() throws CoreException {
 		IFile derived = projects[0].getFile("derived.txt");
 		createInWorkspace(projects[0]);
-		ensureDoesNotExistInWorkspace(derived);
+		removeFromWorkspace(derived);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		derived.create(getRandomContents(), IResource.DERIVED, monitor);
@@ -465,7 +465,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivateDerived.txt");
 		createInWorkspace(projects[0]);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE | IResource.DERIVED, monitor);
@@ -488,7 +488,7 @@ public class IFileTest extends ResourceTest {
 	public void testCreateTeamPrivate() throws CoreException {
 		IFile teamPrivate = projects[0].getFile("teamPrivate.txt");
 		createInWorkspace(projects[0]);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE, monitor);
@@ -565,8 +565,8 @@ public class IFileTest extends ResourceTest {
 
 		//create from stream that throws exceptions
 		IFile fileFromStream = projects[0].getFile("file2");
-		ensureDoesNotExistInWorkspace(fileFromStream);
-		ensureDoesNotExistInFileSystem(fileFromStream);
+		removeFromWorkspace(fileFromStream);
+		removeFromFileSystem(fileFromStream);
 
 		InputStream content = new InputStream() {
 			@Override
@@ -606,8 +606,8 @@ public class IFileTest extends ResourceTest {
 	public void testFileCreation_Bug107188() throws CoreException {
 		//create from stream that is canceled
 		IFile target = projects[0].getFile("file1");
-		ensureDoesNotExistInWorkspace(target);
-		ensureDoesNotExistInFileSystem(target);
+		removeFromWorkspace(target);
+		removeFromFileSystem(target);
 
 		InputStream content = new InputStream() {
 			@Override
@@ -938,7 +938,7 @@ public class IFileTest extends ResourceTest {
 		String value = "this is a test property value";
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		// getting/setting persistent properties on non-existent resources should throw an exception
-		ensureDoesNotExistInWorkspace(target);
+		removeFromWorkspace(target);
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -70,7 +70,7 @@ public class IFolderTest extends ResourceTest {
 		IFolder after = project.getFolder("NewFolder");
 		createInWorkspace(project);
 		createInWorkspace(before);
-		ensureDoesNotExistInFileSystem(before);
+		removeFromFileSystem(before);
 
 		// should fail because 'before' does not exist in the filesystem
 		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, createTestMonitor()));
@@ -84,7 +84,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
 		createInWorkspace(project);
-		ensureDoesNotExistInWorkspace(derived);
+		removeFromWorkspace(derived);
 
 		derived.create(IResource.DERIVED, true, createTestMonitor());
 		assertTrue("1.0", derived.isDerived());
@@ -114,7 +114,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		createInWorkspace(project);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, createTestMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
@@ -130,7 +130,7 @@ public class IFolderTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
 		createInWorkspace(project);
-		ensureDoesNotExistInWorkspace(teamPrivate);
+		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE, true, createTestMonitor());
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
@@ -318,7 +318,7 @@ public class IFolderTest extends ResourceTest {
 		String value = "this is a test property value";
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		// getting/setting persistent properties on non-existent resources should throw an exception
-		ensureDoesNotExistInWorkspace(target);
+		removeFromWorkspace(target);
 		assertThrows(CoreException.class, () -> target.getPersistentProperty(name));
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(name, value));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -2477,7 +2477,7 @@ public class IProjectTest extends ResourceTest {
 
 	public void testCreateHiddenProject() throws CoreException {
 		IProject hiddenProject = getWorkspace().getRoot().getProject(createUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 
 		monitor.prepare();
 		hiddenProject.create(null, IResource.HIDDEN, monitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -942,7 +942,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		};
 		workspace.addResourceChangeListener(listener);
 		workspace.getSynchronizer().add(partner);
-		ensureDoesNotExistInWorkspace(phantomResources);
+		removeFromWorkspace(phantomResources);
 		try {
 			//create a phantom folder
 			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFolder, new byte[] {1}), createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -234,7 +234,7 @@ public class IResourceTest extends ResourceTest {
 		nonExistingResources.add(result[result.length - 1]);
 
 		IResource[] deleted = buildResources(root, new String[] {"1/1/2/1/", "1/2/3/1"});
-		ensureDoesNotExistInWorkspace(deleted);
+		removeFromWorkspace(deleted);
 		nonExistingResources.addAll(Arrays.asList(deleted));
 		//out of sync
 		IResource[] unsynchronized = buildResources(root, new String[] {"1/2/3/3"});
@@ -243,7 +243,7 @@ public class IResourceTest extends ResourceTest {
 
 		//file system only
 		unsynchronized = buildResources(root, new String[] {"1/1/2/2/1"});
-		ensureDoesNotExistInWorkspace(unsynchronized);
+		removeFromWorkspace(unsynchronized);
 		for (IResource resource : unsynchronized) {
 			createInFileSystem(resource);
 		}
@@ -321,7 +321,7 @@ public class IResourceTest extends ResourceTest {
 		//target may have changed gender
 		IResource changedTarget = getWorkspace().getRoot().findMember(target.getFullPath());
 		if (changedTarget != null && changedTarget.getType() != target.getType()) {
-			ensureDoesNotExistInWorkspace(changedTarget);
+			removeFromWorkspace(changedTarget);
 		}
 		createInWorkspace(interestingResources);
 	}
@@ -515,7 +515,7 @@ public class IResourceTest extends ResourceTest {
 		switch (state) {
 			case S_WORKSPACE_ONLY :
 				createInWorkspace(target);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 					// we only get a delta if the receiver of refreshLocal
@@ -527,7 +527,7 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_FILESYSTEM_ONLY :
-				ensureDoesNotExistInWorkspace(target);
+				removeFromWorkspace(target);
 				createInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -559,15 +559,15 @@ public class IResourceTest extends ResourceTest {
 				}
 				break;
 			case S_DOES_NOT_EXIST :
-				ensureDoesNotExistInWorkspace(target);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromWorkspace(target);
+				removeFromFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
 				}
 				break;
 			case S_FOLDER_TO_FILE :
 				createInWorkspace(target);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				createInFileSystem(target);
 				if (addVerifier) {
 					verifier.reset();
@@ -581,7 +581,7 @@ public class IResourceTest extends ResourceTest {
 				break;
 			case S_FILE_TO_FOLDER :
 				createInWorkspace(target);
-				ensureDoesNotExistInFileSystem(target);
+				removeFromFileSystem(target);
 				target.getLocation().toFile().mkdirs();
 				if (addVerifier) {
 					verifier.reset();
@@ -1059,7 +1059,7 @@ public class IResourceTest extends ResourceTest {
 
 	private IProjectDescription prepareDestProjDesc(IProject sourceProj, IProject destProj, IPath destLocation)
 			throws CoreException {
-		ensureDoesNotExistInWorkspace(destProj);
+		removeFromWorkspace(destProj);
 		IProjectDescription desc = sourceProj.getDescription();
 		desc.setName(destProj.getName());
 		desc.setLocation(destLocation);
@@ -1843,8 +1843,8 @@ public class IResourceTest extends ResourceTest {
 			assertEquals("5.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
 			project.open(createTestMonitor());
-			ensureDoesNotExistInWorkspace(topFolder);
-			ensureDoesNotExistInWorkspace(topFile);
+			removeFromWorkspace(topFolder);
+			removeFromWorkspace(topFile);
 			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(fileLocation));
 			folderLocation.toFile().mkdirs();
 			topFolder.createLink(folderLocation, IResource.NONE, createTestMonitor());
@@ -1871,8 +1871,8 @@ public class IResourceTest extends ResourceTest {
 			project.open(createTestMonitor());
 			IPath variableFolderLocation = IPath.fromOSString(variableName).append("/VarFolderName");
 			IPath variableFileLocation = IPath.fromOSString(variableName).append("/VarFileName");
-			ensureDoesNotExistInWorkspace(topFolder);
-			ensureDoesNotExistInWorkspace(topFile);
+			removeFromWorkspace(topFolder);
+			removeFromWorkspace(topFile);
 			createFileInFileSystem(EFS.getFileSystem(EFS.SCHEME_FILE).getStore(varMan.resolvePath(variableFileLocation)));
 			varMan.resolvePath(variableFolderLocation).toFile().mkdirs();
 			topFolder.createLink(variableFolderLocation, IResource.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -757,6 +757,6 @@ public class ISynchronizerTest extends ResourceTest {
 
 		// clean-up
 		synchronizer.remove(partner);
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -331,7 +331,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testBug234343_folderInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(createUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
 		hiddenProject.open(createTestMonitor());
 
@@ -349,7 +349,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void testBug234343_fileInHiddenProject() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject hiddenProject = root.getProject(createUniqueString());
-		ensureDoesNotExistInWorkspace(hiddenProject);
+		removeFromWorkspace(hiddenProject);
 		hiddenProject.create(null, IResource.HIDDEN, createTestMonitor());
 		hiddenProject.open(createTestMonitor());
 
@@ -421,7 +421,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 	public void checkFindMethods(int updateFlags, int[][] results) throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 
 		project.create(null, IResource.NONE, createTestMonitor());
 		project.open(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -175,8 +175,8 @@ public class IWorkspaceTest extends ResourceTest {
 			file2Copy.create(getRandomContents(), false, createTestMonitor());
 			getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
 		});
-		ensureDoesNotExistInWorkspace(file2Copy);
-		ensureDoesNotExistInFileSystem(file2Copy);
+		removeFromWorkspace(file2Copy);
+		removeFromFileSystem(file2Copy);
 
 		//make sure the first copy worked
 		fileCopy = folder2.getFile("File");
@@ -198,24 +198,24 @@ public class IWorkspaceTest extends ResourceTest {
 		//copy single file
 		getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.2", fileCopy.exists());
-		ensureDoesNotExistInWorkspace(fileCopy);
-		ensureDoesNotExistInFileSystem(fileCopy);
+		removeFromWorkspace(fileCopy);
+		removeFromFileSystem(fileCopy);
 
 		//copy two files
 		getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.4", fileCopy.exists());
 		assertTrue("3.5", file2Copy.exists());
-		ensureDoesNotExistInWorkspace(fileCopy);
-		ensureDoesNotExistInWorkspace(file2Copy);
-		ensureDoesNotExistInFileSystem(fileCopy);
-		ensureDoesNotExistInFileSystem(file2Copy);
+		removeFromWorkspace(fileCopy);
+		removeFromWorkspace(file2Copy);
+		removeFromFileSystem(fileCopy);
+		removeFromFileSystem(file2Copy);
 
 		//copy a folder
 		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.7", folderCopy.exists());
 		assertTrue("3.8", folderCopy.members().length > 0);
-		ensureDoesNotExistInWorkspace(folderCopy);
-		ensureDoesNotExistInFileSystem(folderCopy);
+		removeFromWorkspace(folderCopy);
+		removeFromFileSystem(folderCopy);
 	}
 
 	/**
@@ -579,12 +579,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("1.4", folder.getFile(file1.getName()).exists());
 		assertTrue("1.5", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("1.6", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* test duplicates */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile, file1};
@@ -595,12 +595,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("2.5", folder.getFile(file1.getName()).exists());
 		assertTrue("2.6", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("2.7", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* test no siblings */
 		IResource[] resources2 = new IResource[] { file1, anotherFile, oneMoreFile, project };
@@ -615,12 +615,12 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue("3.6", folder.getFile(file1.getName()).exists());
 		assertTrue("3.7", folder.getFile(anotherFile.getName()).exists());
 		assertTrue("3.8", folder.getFile(oneMoreFile.getName()).exists());
-		ensureDoesNotExistInWorkspace(folder.getFile(file1.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInWorkspace(folder.getFile(oneMoreFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(file1.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(anotherFile.getName()));
-		ensureDoesNotExistInFileSystem(folder.getFile(oneMoreFile.getName()));
+		removeFromWorkspace(folder.getFile(file1.getName()));
+		removeFromWorkspace(folder.getFile(anotherFile.getName()));
+		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
+		removeFromFileSystem(folder.getFile(file1.getName()));
+		removeFromFileSystem(folder.getFile(anotherFile.getName()));
+		removeFromFileSystem(folder.getFile(oneMoreFile.getName()));
 
 		/* inexisting resource */
 		IResource[] resources3 = new IResource[] { file1, anotherFile, project.getFile("inexisting"), oneMoreFile };
@@ -1067,8 +1067,8 @@ public class IWorkspaceTest extends ResourceTest {
 				open.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 			} catch (CoreException e) {
 			}
-			ensureDoesNotExistInFileSystem(openProjectLocation.toFile());
-			ensureDoesNotExistInFileSystem(closedProjectLocation.toFile());
+			removeFromFileSystem(openProjectLocation.toFile());
+			removeFromFileSystem(closedProjectLocation.toFile());
 		}
 
 		// cannot overlap .metadata folder from the current workspace

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -100,8 +100,8 @@ public class LinkedResourceTest extends ResourceTest {
 		waitForRefresh();
 		createInWorkspace(new IResource[] {existingProject, otherExistingProject, closedProject, existingFolderInExistingProject, existingFolderInExistingFolder, existingFileInExistingProject});
 		closedProject.close(createTestMonitor());
-		ensureDoesNotExistInWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
-		ensureDoesNotExistInFileSystem(resolve(nonExistingLocation).toFile());
+		removeFromWorkspace(new IResource[] { nonExistingProject, nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInOtherExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder });
+		removeFromFileSystem(resolve(nonExistingLocation).toFile());
 		resolve(localFolder).toFile().mkdirs();
 		createFileInFileSystem(resolve(localFile));
 	}
@@ -273,7 +273,7 @@ public class LinkedResourceTest extends ResourceTest {
 		IPath resolvedLocation = resolve(localFolder);
 		folder.createLink(localFolder, IResource.NONE, createTestMonitor());
 
-		ensureDoesNotExistInFileSystem(resolvedLocation.toFile());
+		removeFromFileSystem(resolvedLocation.toFile());
 		createFileInFileSystem(resolvedLocation);
 		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
@@ -283,7 +283,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertEquals("3.3", resolvedLocation, file.getLocation());
 
 		//change back to folder
-		ensureDoesNotExistInFileSystem(resolvedLocation.toFile());
+		removeFromFileSystem(resolvedLocation.toFile());
 		resolvedLocation.toFile().mkdirs();
 
 		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
@@ -1264,7 +1264,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.0", linkedFile.getModificationStamp() >= 0);
 
 		// delete local file
-		ensureDoesNotExistInFileSystem(resolve(location).toFile());
+		removeFromFileSystem(resolve(location).toFile());
 		linkedFile.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertEquals("4.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -837,7 +837,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
 
 		// clean-up
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		// restore the previous value
 		manager.setValue(VARIABLE_NAME, existingValue);
@@ -902,7 +902,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
 
 		// clean-up
-		ensureDoesNotExistInFileSystem(file);
+		removeFromFileSystem(file);
 
 		// restore the previous value
 		manager.setValue(PROJECT_VARIABLE_NAME, existingValue);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -76,7 +76,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		//copy to local destination should succeed
 		sourceFile.copy(localFile.getFullPath(), IResource.NONE, createTestMonitor());
 		//copy from local to non local
-		ensureDoesNotExistInWorkspace(destinationFile);
+		removeFromWorkspace(destinationFile);
 		//copy from local to non local
 		localFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -173,7 +173,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("testNonExistingResource");
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file");
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 		assertNull("1.0", project.getResourceAttributes());
 		assertNull("1.1", folder.getResourceAttributes());
 		assertNull("1.2", file.getResourceAttributes());
@@ -242,7 +242,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		setSymlink(link, false);
 		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
 
-		ensureDoesNotExistInWorkspace(link);
+		removeFromWorkspace(link);
 
 		// create the target file in the filesystem
 		IFile target = project.getFile("target");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -233,33 +233,42 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Delete the given resource from the local store. Use the resource manager to
-	 * ensure that we have a correct Path -&gt; File mapping.
+	 * Delete the given file in the file system.
 	 */
-	public void ensureDoesNotExistInFileSystem(IResource resource) {
+	public void removeFromFileSystem(java.io.File file) {
+		FileSystemHelper.clear(file);
+	}
+
+	/**
+	 * Delete the given resource in the file system.
+	 */
+	public void removeFromFileSystem(IResource resource) {
 		IPath path = resource.getLocation();
 		if (path != null) {
-			ensureDoesNotExistInFileSystem(path.toFile());
+			removeFromFileSystem(path.toFile());
 		}
 	}
 
 	/**
-	 * Delete the given resource from the workspace resource tree.
+	 * Delete the given resource in the workspace resource tree. Also removes
+	 * project contents in case the resource is a project and the project is
+	 * currently closed.
 	 */
-	public void ensureDoesNotExistInWorkspace(IResource resource) throws CoreException {
+	public void removeFromWorkspace(IResource resource) throws CoreException {
 		if (resource.exists()) {
 			resource.delete(IResource.FORCE | IResource.ALWAYS_DELETE_PROJECT_CONTENT, createTestMonitor());
 		}
 	}
 
 	/**
-	 * Delete each element of the resource array from the workspace
-	 * resource info tree.
+	 * Delete each element of the resource array in the workspace resource info
+	 * tree. Also removes project contents in case a resource is a project and the
+	 * project is currently closed.
 	 */
-	public void ensureDoesNotExistInWorkspace(final IResource[] resources) throws CoreException {
+	public void removeFromWorkspace(final IResource[] resources) throws CoreException {
 		IWorkspaceRunnable body = monitor -> {
 			for (IResource resource : resources) {
-				ensureDoesNotExistInWorkspace(resource);
+				removeFromWorkspace(resource);
 			}
 		};
 		getWorkspace().run(body, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -267,7 +267,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = { destProject, destFolder, destFile, destSubFile };
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be team private
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -278,7 +278,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// Do it again and but just copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -288,7 +288,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// set all the resources to be team private
 		// copy the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.copy(destProject.getFullPath(), flags, createTestMonitor());
@@ -296,7 +296,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only copy the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
@@ -320,7 +320,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		IFile destFile = destProject.getFile(file.getName());
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 		IResource[] destResources = { destProject, destFolder, destFile, destSubFile };
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 
 		// set a folder to be team private
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -331,7 +331,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// Do it again and but just move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
@@ -341,7 +341,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 
 		// set all the resources to be team private
 		// move the project
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
 		project.move(destProject.getFullPath(), flags, createTestMonitor());
@@ -349,7 +349,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(destResources);
 
 		// do it again but only move the folder
-		ensureDoesNotExistInWorkspace(destResources);
+		removeFromWorkspace(destResources);
 		createInWorkspace(resources);
 		createInWorkspace(destProject);
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
@@ -437,7 +437,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -455,7 +455,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -473,7 +473,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, createTestMonitor());
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
-			ensureDoesNotExistInWorkspace(resources);
+			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -146,7 +146,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void tearDown() {
 				try {
-					ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+					removeFromWorkspace(getWorkspace().getRoot());
 					IHistoryStore store = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 					// Remove all the entries from the history store index.  Note that
 					// this does not cause the history store states to be removed.
@@ -173,7 +173,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	private void testClearHistory(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		new PerformanceTestRunner() {
 			private IWorkspaceDescription original;
 
@@ -184,7 +184,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				cleanHistory();
 				// create our own garbage
 				createTree(base, filesPerFolder, statesPerFile);
-				ensureDoesNotExistInWorkspace(base);
+				removeFromWorkspace(base);
 			}
 
 			@Override
@@ -254,7 +254,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFolder base = project.getFolder("base");
 		createTree(base, filesPerFolder, statesPerFile);
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		// need a final reference so the inner class can see it
 		final IProject tmpProject = project;
 		new PerformanceTestRunner() {
@@ -303,7 +303,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	private void testHistoryCleanUp(final int filesPerFolder, final int statesPerFile) throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFolder base = project.getFolder("base");
-		ensureDoesNotExistInWorkspace(base);
+		removeFromWorkspace(base);
 		new PerformanceTestRunner() {
 			private IWorkspaceDescription original;
 
@@ -314,7 +314,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				cleanHistory();
 				// create our own garbage
 				createTree(base, filesPerFolder, statesPerFile);
-				ensureDoesNotExistInWorkspace(base);
+				removeFromWorkspace(base);
 			}
 
 			@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -82,7 +82,7 @@ public class RefreshProviderTest extends ResourceTest {
 		link.delete(IResource.FORCE, createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.2", 1, provider.getMonitoredResources().length);
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 		joinAutoRefreshJobs();
 		assertEquals("1.3", 0, provider.getMonitoredResources().length);
 		// check provider for other errors
@@ -108,7 +108,7 @@ public class RefreshProviderTest extends ResourceTest {
 		project.open(createTestMonitor());
 		joinAutoRefreshJobs();
 		assertEquals("1.2", 1, provider.getMonitoredResources().length);
-		ensureDoesNotExistInWorkspace(project);
+		removeFromWorkspace(project);
 		joinAutoRefreshJobs();
 		assertEquals("1.3", 0, provider.getMonitoredResources().length);
 		// check provider for other errors

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -42,7 +42,7 @@ public class Bug_126104 extends ResourceTest {
 		assertTrue("1.0", destination.exists());
 
 		//try the same thing with move
-		ensureDoesNotExistInWorkspace(destination);
+		removeFromWorkspace(destination);
 		location.delete(EFS.NONE, createTestMonitor());
 		source.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertTrue("3.0", !source.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -359,7 +359,7 @@ public class IResourceTest extends ResourceTest {
 		attributes.setReadOnly(false);
 		file.setResourceAttributes(attributes);
 		assertTrue("4.0", !file.isReadOnly());
-		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
+		removeFromWorkspace(new IResource[] {project, file});
 	}
 
 	public void testDelete_Bug8754() throws Exception {
@@ -383,7 +383,7 @@ public class IResourceTest extends ResourceTest {
 		}
 		assertEquals("1.2", IResourceStatus.OUT_OF_SYNC_LOCAL, status.getCode());
 		//cleanup
-		ensureDoesNotExistInWorkspace(new IResource[] {project, file});
+		removeFromWorkspace(new IResource[] {project, file});
 	}
 
 	public void testEquals_1FUOU25() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -58,8 +58,8 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue("1.1", folder.exists());
 		assertTrue("1.2", file.exists());
-		ensureDoesNotExistInWorkspace(folder);
-		ensureDoesNotExistInFileSystem(folder);
+		removeFromWorkspace(folder);
+		removeFromFileSystem(folder);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -88,7 +88,7 @@ public class NLTest extends ResourceTest {
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		assertExistsInFileSystem(resources);
 		assertExistsInWorkspace(resources);
-		ensureDoesNotExistInWorkspace(resources);
+		removeFromWorkspace(resources);
 
 		files = getFileNames(Locale.getDefault().getLanguage());
 		resources = buildResources(project, files);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.tests.harness.FileSystemHelper.clear;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
@@ -62,7 +63,7 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 			assertTrue("1.2", !file.exists());
 			assertEquals("1.3", location, project.getLocation());
 		} finally {
-			ensureDoesNotExistInFileSystem(location.toFile());
+			clear(location.toFile());
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
@@ -66,6 +66,6 @@ public class ConcurrencyTest extends ResourceTest {
 		assertTrue("2.2", op2.getStatus().isOK());
 
 		/* remove trash */
-		ensureDoesNotExistInWorkspace(getWorkspace().getRoot());
+		removeFromWorkspace(getWorkspace().getRoot());
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
@@ -14,17 +14,27 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.perf;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.eclipse.core.internal.content.*;
+import org.eclipse.core.internal.content.ContentTypeBuilder;
+import org.eclipse.core.internal.content.ContentTypeHandler;
+import org.eclipse.core.internal.content.Util;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.content.*;
+import org.eclipse.core.runtime.content.BinarySignatureDescriber;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.harness.*;
+import org.eclipse.core.tests.harness.BundleTestingHelper;
+import org.eclipse.core.tests.harness.PerformanceTestRunner;
+import org.eclipse.core.tests.harness.TestRegistryChangeListener;
 import org.eclipse.core.tests.runtime.RuntimeTest;
 import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
 import org.eclipse.core.tests.session.PerformanceSessionTestSuite;


### PR DESCRIPTION
The ResourceTest class contains methods for removing resources from the workspace and from the file system. The names of these methods are ensureDoesNotExist...() and are misleading because, first, it is not obvious that the method actually performs a removal and, second, it is grammatically incorrect when taking an array of resources. This change simplifies the method names to removeFromWorkspace/removeFromFileSytem.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903