### PR TITLE
Move stream comparison method from ResourceTest to utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.filesystem;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
@@ -114,7 +115,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 	 * this test should move to FileTest
 	 */
 	@Test
-	public void testCreateFile() throws CoreException {
+	public void testCreateFile() throws Exception {
 		/* initialize common objects */
 		IProject project = projects[0];
 		File file = (File) project.getFile("testCreateFile");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.junit.Assert.assertThrows;
@@ -488,7 +489,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testCopyFolder() throws CoreException {
+	public void testCopyFolder() throws Exception {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("CopyFolderProject");
@@ -1163,7 +1164,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the moved file should have 4 states as it retains the states from
 	 * before the move took place as well.
 	 */
-	public void testMoveFolder() throws CoreException {
+	public void testMoveFolder() throws Exception {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -1228,7 +1229,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testMoveProject() throws CoreException {
+	public void testMoveProject() throws Exception {
 		String[] contents = {"content1", "content2", "content3", "content4", "content5"};
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MoveProjectProject");
@@ -1371,7 +1372,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the copied file should have 4 states as it retains the states from
 	 * before the copy took place as well.
 	 */
-	public void testSimpleCopy() throws CoreException {
+	public void testSimpleCopy() throws Exception {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("SimpleCopyProject");
 		project.create(createTestMonitor());
@@ -1433,7 +1434,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 * But the moved file should have 4 states as it retains the states from
 	 * before the move took place as well.
 	 */
-	public void testSimpleMove() throws CoreException {
+	public void testSimpleMove() throws Exception {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("SimpleMoveProject");
 		project.create(createTestMonitor());
@@ -1493,7 +1494,7 @@ public class HistoryStoreTest extends ResourceTest {
 	 *   6. Set new content				"content 2"			4
 	 *   7. Roll back to third version  "content 3"			5
 	 */
-	public void testSimpleUse() throws CoreException {
+	public void testSimpleUse() throws Exception {
 		/* Initialize common objects. */
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		project.create(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
@@ -221,7 +222,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileVariableRemoved() throws CoreException {
+	public void testFileVariableRemoved() throws Exception {
 		final IPathVariableManager manager = getWorkspace().getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -276,7 +277,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileProjectVariableRemoved() throws CoreException {
+	public void testFileProjectVariableRemoved() throws Exception {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -487,7 +488,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * removed.
 	 */
-	public void testFileProjectRelativeVariableRemoved() throws CoreException {
+	public void testFileProjectRelativeVariableRemoved() throws Exception {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IFile file = nonExistingFileInExistingProject;
@@ -787,7 +788,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * changed.
 	 */
-	public void testVariableChanged() throws CoreException {
+	public void testVariableChanged() throws Exception {
 		final IPathVariableManager manager = getWorkspace().getPathVariableManager();
 
 		IPath existingValue = manager.getValue(VARIABLE_NAME);
@@ -852,7 +853,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	 * Tests a scenario where a variable used in a linked file location is
 	 * changed.
 	 */
-	public void testProjectVariableChanged() throws CoreException {
+	public void testProjectVariableChanged() throws Exception {
 		final IPathVariableManager manager = existingProject.getPathVariableManager();
 
 		IPath existingValue = manager.getValue(PROJECT_VARIABLE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -164,31 +164,6 @@ public abstract class ResourceTest extends CoreTest {
 	}
 
 	/**
-	 * Returns a boolean value indicating whether or not the contents
-	 * of the given streams are considered to be equal. Closes both input streams.
-	 */
-	public boolean compareContent(InputStream a, InputStream b) {
-		int c, d;
-		if (a == null && b == null) {
-			return true;
-		}
-		try {
-			if (a == null || b == null) {
-				return false;
-			}
-			while ((c = a.read()) == (d = b.read()) && (c != -1 && d != -1)) {
-				//body not needed
-			}
-			return (c == -1 && d == -1);
-		} catch (IOException e) {
-			return false;
-		} finally {
-			assertClose(a);
-			assertClose(b);
-		}
-	}
-
-	/**
 	 * Create the given file and its parents in the local store with random
 	 * contents.
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
@@ -360,6 +361,26 @@ public final class ResourceTestUtil {
 	private static long getLastModifiedTime(IPath fileLocation) {
 		IFileInfo fileInfo = EFS.getLocalFileSystem().getStore(fileLocation).fetchInfo();
 		return fileInfo.getLastModified();
+	}
+
+	/**
+	 * Returns a boolean value indicating whether or not the contents
+	 * of the given streams are considered to be equal. Closes both input streams.
+	 */
+	public static boolean compareContent(InputStream a, InputStream b) throws IOException {
+		int c, d;
+		if (a == null && b == null) {
+			return true;
+		}
+		try (a; b) {
+			if (a == null || b == null) {
+				return false;
+			}
+			while ((c = a.read()) == (d = b.read()) && (c != -1 && d != -1)) {
+				// body not needed
+			}
+		}
+		return (c == -1 && d == -1);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
@@ -58,7 +59,7 @@ public class IResourceTest extends ResourceTest {
 	/**
 	 * 1G9RBH5: ITPCORE:WIN98 - IFile.appendContents might lose data
 	 */
-	public void testAppendContents_1G9RBH5() throws CoreException {
+	public void testAppendContents_1G9RBH5() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(null);
 		project.open(null);

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/WorkspaceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.compare.tests;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -206,7 +207,7 @@ public class WorkspaceTest extends ResourceTest {
 	}
 
 	// Assert that the two containers have equal contents
-	protected void assertEquals(IContainer container1, IContainer container2) throws CoreException {
+	protected void assertEquals(IContainer container1, IContainer container2) throws CoreException, IOException {
 		assertEquals(container1.getName(), container2.getName());
 		List<IResource> members1 = new ArrayList<>();
 		members1.addAll(Arrays.asList(container1.members()));
@@ -224,14 +225,14 @@ public class WorkspaceTest extends ResourceTest {
 	}
 
 	// Assert that the two files have equal contents
-	protected void assertEquals(IFile file1, IFile file2) throws CoreException {
+	protected void assertEquals(IFile file1, IFile file2) throws CoreException, IOException {
 		assertEquals(file1.getName(), file2.getName());
 		assertTrue(compareContent(file1.getContents(), file2.getContents()));
 	}
 
 	// Assert that the two projects have equal contents ignoreing the project name
 	// and the .vcm_meta file
-	protected void assertEquals(IProject container1, IProject container2) throws CoreException {
+	protected void assertEquals(IProject container1, IProject container2) throws CoreException, IOException {
 		List<IResource> members1 = new ArrayList<>();
 		members1.addAll(Arrays.asList(container1.members()));
 		members1.remove(container1.findMember(".project"));
@@ -248,7 +249,7 @@ public class WorkspaceTest extends ResourceTest {
 			assertEquals(member1, member2);
 		}
 	}
-	protected void assertEquals(IResource resource1, IResource resource2) throws CoreException {
+	protected void assertEquals(IResource resource1, IResource resource2) throws CoreException, IOException {
 		assertEquals(resource1.getType(), resource2.getType());
 		if (resource1.getType() == IResource.FILE)
 			assertEquals((IFile)resource1, (IFile)resource2);

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/SaveableCompareEditorInputTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/SaveableCompareEditorInputTest.java
@@ -50,6 +50,7 @@ import org.eclipse.team.internal.ui.synchronize.SaveablesCompareEditorInput;
 import org.eclipse.team.tests.core.TeamTest;
 import org.eclipse.team.ui.synchronize.SaveableCompareEditorInput;
 import org.eclipse.ui.PlatformUI;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 public class SaveableCompareEditorInputTest extends TeamTest {
 
@@ -355,7 +356,7 @@ public class SaveableCompareEditorInputTest extends TeamTest {
 	private void verifyModifyAndSaveBothSidesOfCompareEditor(String extention)
 			throws InterruptedException, InvocationTargetException,
 			IllegalArgumentException, SecurityException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+			IllegalAccessException, NoSuchFieldException, CoreException, IOException {
 
 		// create files to compare
 		IFile file1 = project.getFile("CompareFile1." + extention);
@@ -411,38 +412,23 @@ public class SaveableCompareEditorInputTest extends TeamTest {
 				file2.getContents()));
 	}
 
-	public void testModifyAndSaveBothSidesOfCompareEditorHtml()
-			throws IllegalArgumentException, SecurityException,
-			InterruptedException, InvocationTargetException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+	public void testModifyAndSaveBothSidesOfCompareEditorHtml() throws Exception {
 		verifyModifyAndSaveBothSidesOfCompareEditor("html");
 	}
 
-	public void testModifyAndSaveBothSidesOfCompareEditorTxt()
-			throws IllegalArgumentException, SecurityException,
-			InterruptedException, InvocationTargetException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+	public void testModifyAndSaveBothSidesOfCompareEditorTxt() throws Exception {
 		verifyModifyAndSaveBothSidesOfCompareEditor("txt");
 	}
 
-	public void testModifyAndSaveBothSidesOfCompareEditorJava()
-			throws IllegalArgumentException, SecurityException,
-			InterruptedException, InvocationTargetException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+	public void testModifyAndSaveBothSidesOfCompareEditorJava() throws Exception {
 		verifyModifyAndSaveBothSidesOfCompareEditor("java");
 	}
 
-	public void testModifyAndSaveBothSidesOfCompareEditorXml()
-			throws IllegalArgumentException, SecurityException,
-			InterruptedException, InvocationTargetException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+	public void testModifyAndSaveBothSidesOfCompareEditorXml() throws Exception {
 		verifyModifyAndSaveBothSidesOfCompareEditor("xml");
 	}
 
-	public void testModifyAndSaveBothSidesOfCompareEditorProperties()
-			throws IllegalArgumentException, SecurityException,
-			InterruptedException, InvocationTargetException,
-			IllegalAccessException, NoSuchFieldException, CoreException {
+	public void testModifyAndSaveBothSidesOfCompareEditorProperties() throws Exception {
 		verifyModifyAndSaveBothSidesOfCompareEditor("properties");
 	}
 }


### PR DESCRIPTION
This change moves the compareContents() method that compares two streams from the ResourceTest class to the dedicated ResourceTestUtil utility class. It also simplifies the method by throwing a potentially occurring IOException and making the consuming tests pass it through. It prepares for removing the ResourceTest inheritance hierarchy to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903