### PR TITLE
Move resource test methods for random contents to utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager1Test.java
@@ -31,6 +31,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWo
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 /**
  * This class needs to be used with SaveManager2Test. Basically this
@@ -177,7 +178,7 @@ public class SaveManager1Test extends SaveManagerTest {
 		DeltaVerifierBuilder verifier = DeltaVerifierBuilder.getInstance();
 		verifier.reset();
 		verifier.addExpectedChange(added, project, IResourceDelta.ADDED, 0);
-		added.create(getRandomContents(), true, null);
+		added.create(createRandomContentsStream(), true, null);
 		waitForBuild();
 		assertTrue("3.2", verifier.wasAutoBuild());
 		assertTrue("3.3", verifier.isDeltaValid());

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager2Test.java
@@ -35,6 +35,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 /**
  * @see SaveManager1Test
@@ -73,7 +74,7 @@ public class SaveManager2Test extends SaveManagerTest {
 		DeltaVerifierBuilder verifier = DeltaVerifierBuilder.getInstance();
 		verifier.reset();
 		verifier.addExpectedChange(added, project, IResourceDelta.ADDED, 0);
-		added.create(getRandomContents(), true, null);
+		added.create(createRandomContentsStream(), true, null);
 		waitForBuild();
 		assertTrue("3.2", verifier.wasAutoBuild());
 		assertTrue("3.3", verifier.isDeltaValid());
@@ -131,7 +132,7 @@ public class SaveManager2Test extends SaveManagerTest {
 
 		// add a file to test save participant delta
 		IFile file = project.getFile("addedFile");
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 	}
 
 	public void testVerifyRestoredWorkspace() throws CoreException {
@@ -146,6 +147,6 @@ public class SaveManager2Test extends SaveManagerTest {
 
 		// add a file to test save participant delta
 		IFile file = project.getFile("addedFile");
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/src/org/eclipse/core/tests/resources/saveparticipant/SaveManager3Test.java
@@ -26,6 +26,7 @@ import org.eclipse.core.tests.resources.saveparticipant2.SaveParticipant2Plugin;
 import org.eclipse.core.tests.resources.saveparticipant3.SaveParticipant3Plugin;
 import org.osgi.framework.Bundle;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
 
 /**
  * @see SaveManager1Test
@@ -67,7 +68,7 @@ public class SaveManager3Test extends SaveManagerTest {
 
 		IFile added = project.getFile("added file");
 		verifier.addExpectedChange(added, project, IResourceDelta.ADDED, 0);
-		added.create(getRandomContents(), true, null);
+		added.create(createRandomContentsStream(), true, null);
 		waitForBuild();
 		assertTrue("3.2", verifier.wasAutoBuild());
 		assertTrue("3.3", verifier.isDeltaValid());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.filesystem;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
@@ -201,7 +203,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
 		IFileStore existing = getTempStore();
-		createFile(existing, getRandomString());
+		createFile(existing, createRandomString());
 		// try to copy when parent of destination does not exist
 		assertThrows(CoreException.class, () -> existing.copy(child, EFS.NONE, createTestMonitor()));
 		// destination should not exist
@@ -221,15 +223,15 @@ public class FileStoreTest extends LocalStoreTest {
 		createFile(fileWithSmallName, content);
 		System.out.println(fileWithSmallName.fetchInfo().getName());
 		assertTrue("1.3", fileWithSmallName.fetchInfo().exists());
-		assertTrue("1.4", compareContent(getContents(content), fileWithSmallName.openInputStream(EFS.NONE, null)));
+		assertTrue("1.4", compareContent(createInputStream(content), fileWithSmallName.openInputStream(EFS.NONE, null)));
 
 		IFileStore fileWithOtherName = temp.getChild("FILENAME");
 		System.out.println(fileWithOtherName.fetchInfo().getName());
 		// file content is already the same for both Cases:
-		assertTrue("2.0", compareContent(getContents(content), fileWithOtherName.openInputStream(EFS.NONE, null)));
+		assertTrue("2.0", compareContent(createInputStream(content), fileWithOtherName.openInputStream(EFS.NONE, null)));
 		fileWithSmallName.copy(fileWithOtherName, IResource.DEPTH_INFINITE, null); // a NOP Operation
 		// file content is still the same for both Cases:
-		assertTrue("2.1", compareContent(getContents(content), fileWithOtherName.openInputStream(EFS.NONE, null)));
+		assertTrue("2.1", compareContent(createInputStream(content), fileWithOtherName.openInputStream(EFS.NONE, null)));
 		assertTrue("3.0", fileWithOtherName.fetchInfo().exists());
 		assertTrue("3.1", fileWithSmallName.fetchInfo().exists());
 		fileWithOtherName.delete(EFS.NONE, null);
@@ -251,12 +253,12 @@ public class FileStoreTest extends LocalStoreTest {
 		target.delete(EFS.NONE, null);
 		createFile(target, content);
 		assertTrue("1.3", target.fetchInfo().exists());
-		assertTrue("1.4", compareContent(getContents(content), target.openInputStream(EFS.NONE, null)));
+		assertTrue("1.4", compareContent(createInputStream(content), target.openInputStream(EFS.NONE, null)));
 
 		/* temp\target -> temp\copy of target */
 		IFileStore copyOfTarget = temp.getChild("copy of target");
 		target.copy(copyOfTarget, IResource.DEPTH_INFINITE, null);
-		assertTrue("2.1", compareContent(getContents(content), copyOfTarget.openInputStream(EFS.NONE, null)));
+		assertTrue("2.1", compareContent(createInputStream(content), copyOfTarget.openInputStream(EFS.NONE, null)));
 		copyOfTarget.delete(EFS.NONE, null);
 
 		// We need to know whether or not we can unset the read-only flag
@@ -267,7 +269,7 @@ public class FileStoreTest extends LocalStoreTest {
 			setReadOnly(target, true);
 
 			target.copy(copyOfTarget, IResource.DEPTH_INFINITE, null);
-			assertTrue("3.1", compareContent(getContents(content), copyOfTarget.openInputStream(EFS.NONE, null)));
+			assertTrue("3.1", compareContent(createInputStream(content), copyOfTarget.openInputStream(EFS.NONE, null)));
 			// reset read only flag for cleanup
 			setReadOnly(copyOfTarget, false);
 			copyOfTarget.delete(EFS.NONE, null);
@@ -284,12 +286,12 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore bigFile = temp.getChild("bigFile");
 		createFile(bigFile, sb.toString());
 		assertTrue("7.1", bigFile.fetchInfo().exists());
-		assertTrue("7.2", compareContent(getContents(sb.toString()), bigFile.openInputStream(EFS.NONE, null)));
+		assertTrue("7.2", compareContent(createInputStream(sb.toString()), bigFile.openInputStream(EFS.NONE, null)));
 		IFileStore destination = temp.getChild("copy of bigFile");
 		// IProgressMonitor monitor = new LoggingProgressMonitor(System.out);
 		IProgressMonitor monitor = createTestMonitor();
 		bigFile.copy(destination, EFS.NONE, monitor);
-		assertTrue("7.3", compareContent(getContents(sb.toString()), destination.openInputStream(EFS.NONE, null)));
+		assertTrue("7.3", compareContent(createInputStream(sb.toString()), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
 	}
 
@@ -318,13 +320,13 @@ public class FileStoreTest extends LocalStoreTest {
 		createFile(target, content);
 		deleteOnTearDown(target);
 		assertTrue("1.3", target.fetchInfo().exists());
-		assertTrue("1.4", compareContent(getContents(content), target.openInputStream(EFS.NONE, null)));
+		assertTrue("1.4", compareContent(createInputStream(content), target.openInputStream(EFS.NONE, null)));
 
 		/* c:\temp\target -> d:\temp\target */
 		IFileStore destination = tempDest.getChild(subfolderName);
 		deleteOnTearDown(destination);
 		target.copy(destination, IResource.DEPTH_INFINITE, null);
-		assertTrue("3.1", compareContent(getContents(content), destination.openInputStream(EFS.NONE, null)));
+		assertTrue("3.1", compareContent(createInputStream(content), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
 
 		/* c:\temp\target -> d:\temp\copy of target */
@@ -332,7 +334,7 @@ public class FileStoreTest extends LocalStoreTest {
 		destination = tempDest.getChild(copyOfSubfoldername);
 		deleteOnTearDown(destination);
 		target.copy(destination, IResource.DEPTH_INFINITE, null);
-		assertTrue("4.1", compareContent(getContents(content), destination.openInputStream(EFS.NONE, null)));
+		assertTrue("4.1", compareContent(createInputStream(content), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
 
 		/* c:\temp\target -> d:\temp\target (but the destination is already a file */
@@ -342,7 +344,7 @@ public class FileStoreTest extends LocalStoreTest {
 		createFile(destination, anotherContent);
 		assertTrue("5.1", !destination.fetchInfo().isDirectory());
 		target.copy(destination, IResource.DEPTH_INFINITE, null);
-		assertTrue("5.2", compareContent(getContents(content), destination.openInputStream(EFS.NONE, null)));
+		assertTrue("5.2", compareContent(createInputStream(content), destination.openInputStream(EFS.NONE, null)));
 		destination.delete(EFS.NONE, null);
 
 		/* c:\temp\target -> d:\temp\target (but the destination is already a folder */
@@ -502,7 +504,7 @@ public class FileStoreTest extends LocalStoreTest {
 		IFileStore parent = getTempStore();
 		IFileStore child = parent.getChild("child");
 		IFileStore existing = getTempStore();
-		createFile(existing, getRandomString());
+		createFile(existing, createRandomString());
 		// try to move when parent of destination does not exist
 		assertThrows(CoreException.class, () -> existing.move(child, EFS.NONE, createTestMonitor()));
 		// destination should not exist

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -19,6 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.findAvailableDevices;
@@ -209,7 +211,7 @@ public class BasicAliasTest extends ResourceTest {
 		location.toFile().mkdirs();
 		deleteOnTearDown(location);
 		link.createLink(location, IResource.NONE, createTestMonitor());
-		createInWorkspace(child, getRandomString());
+		createInWorkspace(child, createRandomString());
 		// move the link (rename)
 		IFolder movedLink = project.getFolder("MovedLink");
 		link.move(movedLink.getFullPath(), IResource.SHALLOW, createTestMonitor());
@@ -251,7 +253,7 @@ public class BasicAliasTest extends ResourceTest {
 		sub2.open(createTestMonitor());
 		IFile sub2File = sub2.getFile("file.txt");
 		IFile topFile = top.getFolder(sub2.getName()).getFile(sub2File.getName());
-		createInWorkspace(sub2File, getRandomString());
+		createInWorkspace(sub2File, createRandomString());
 		assertTrue("1.0", topFile.exists());
 	}
 
@@ -471,7 +473,7 @@ public class BasicAliasTest extends ResourceTest {
 		// close the project and make sure aliases in that project are no longer updated
 		pOverlap.close(createTestMonitor());
 		IFile linkFile = fLinked.getFile("ChildFile.txt");
-		linkFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		linkFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		IFile closedFile = fOverlap.getFile(linkFile.getName());
 		assertFalse("1.0", closedFile.exists());
 		pOverlap.open(IResource.NONE, createTestMonitor());
@@ -584,7 +586,7 @@ public class BasicAliasTest extends ResourceTest {
 		// file in linked folder
 		lChildLinked.delete(IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lChildLinked, lChildOverlap);
-		lChildLinked.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildLinked.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.2", lChildLinked, lChildOverlap);
 		//duplicate file
 		lOverlap.delete(IResource.NONE, createTestMonitor());
@@ -598,15 +600,15 @@ public class BasicAliasTest extends ResourceTest {
 		assertTrue("2.4", lLinked.exists());
 		assertFalse("2.5", lLinked.getLocation().toFile().exists());
 		assertTrue("2.6", lLinked.isSynchronized(IResource.DEPTH_INFINITE));
-		assertThrows(CoreException.class, () -> lLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> lLinked.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
 
-		lOverlap.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		lOverlap.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.8", lLinked, lOverlap);
 
 		//file in duplicate folder
 		lChildOverlap.delete(IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lChildLinked, lChildOverlap);
-		lChildOverlap.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildOverlap.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.2", lChildLinked, lChildOverlap);
 	}
 
@@ -804,34 +806,34 @@ public class BasicAliasTest extends ResourceTest {
 	@Test
 	public void testFileAppendContents() throws CoreException {
 		//linked file
-		lLinked.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lLinked.appendContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lLinked, lOverlap);
 
 		//file in linked folder
-		lChildLinked.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildLinked.appendContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.1", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lOverlap.appendContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lLinked, lOverlap);
 		//file in duplicate folder
-		lChildOverlap.appendContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildOverlap.appendContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lChildLinked, lChildOverlap);
 	}
 
 	@Test
 	public void testFileSetContents() throws CoreException {
 		//linked file
-		lLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lLinked.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("1.1", lLinked, lOverlap);
 
 		//file in linked folder
-		lChildLinked.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildLinked.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("2.1", lChildLinked, lChildOverlap);
 		//duplicate file
-		lOverlap.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lOverlap.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lLinked, lOverlap);
 		//file in duplicate folder
-		lChildOverlap.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		lChildOverlap.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertOverlap("3.1", lChildLinked, lChildOverlap);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
@@ -71,7 +72,7 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	 * Dirties the given file, forcing a build.
 	 */
 	protected void dirty(IFile file) throws CoreException {
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -95,12 +96,12 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		ConfigurationBuilder.clearStats();
 		// Run some incremental builds while varying the active variant and whether the project was modified
 		// and check that the builder is run/not run with the correct trigger
-		file0.setContents(getRandomContents(), true, true, createTestMonitor());
+		file0.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(1, project0, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, project0, variant1, false, 1, 0);
 		incrementalBuild(3, project0, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(4, project0, variant1, false, 1, 0);
-		file0.setContents(getRandomContents(), true, true, createTestMonitor());
+		file0.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(5, project0, variant1, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		incrementalBuild(6, project0, variant2, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		incrementalBuild(7, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
@@ -111,7 +112,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 	 */
 	public void testCloseAndOpenProject() throws CoreException {
 		ConfigurationBuilder.clearStats();
-		file0.setContents(getRandomContents(), true, true, createTestMonitor());
+		file0.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(1, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, project0, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(3, project0, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
@@ -139,16 +140,16 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 
 		ConfigurationBuilder.clearStats();
 
-		tempFile0.setContents(getRandomContents(), true, true, createTestMonitor());
-		tempFile1.setContents(getRandomContents(), true, true, createTestMonitor());
+		tempFile0.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		tempFile1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(1, tempProject, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(2, tempProject, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		incrementalBuild(3, tempProject, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
-		tempFile0.setContents(getRandomContents(), true, true, createTestMonitor());
+		tempFile0.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(4, tempProject, variant1, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 
-		tempFile1.setContents(getRandomContents(), true, true, createTestMonitor());
+		tempFile1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		incrementalBuild(5, tempProject, variant2, true, 2, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 
 		tempProject.close(createTestMonitor());
@@ -219,7 +220,7 @@ public class BuildConfigurationsTest extends AbstractBuilderTest {
 		checkBuild(7, project1, variant2, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
 		// Modify project1, all project1 builders should do an incremental build
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 
 		ConfigurationBuilder.clearBuildOrder();
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -114,7 +115,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		project1.create(createTestMonitor());
 		project1.open(createTestMonitor());
 		folder1.create(true, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project1.getDescription();
@@ -262,7 +263,7 @@ public class BuildDeltaVerificationTest extends AbstractBuilderTest {
 		verifier.addExpectedChange(file1, project1, IResourceDelta.CHANGED,
 				IResourceDelta.REPLACED | IResourceDelta.CONTENT);
 		file1.delete(true, null);
-		file1.create(getRandomContents(), true, null);
+		file1.create(createRandomContentsStream(), true, null);
 		rebuild();
 		// new builder gets instantiated so grab a reference to the latest builder
 		verifier = DeltaVerifierBuilder.getInstance();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -62,7 +63,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		builder.setAfterProjects(new IProject[] {after1, after2});
 
 		// create a file to ensure incremental build is called
-		project.getFile("Foo.txt").create(getRandomContents(), IResource.NONE, createTestMonitor());
+		project.getFile("Foo.txt").create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		builder.resetBuildCount();
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
@@ -98,7 +99,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 		//force an incremental build
 		IFile file = project.getFile("foo.txt");
 		builder.resetBuildCount();
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertEquals(1, builder.getBuildCount());
 
 		//request 1 rebuild and ensure we're called twice
@@ -109,7 +110,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertEquals(2, builder.getBuildCount());
 
 		//request 5 rebuilds and ensure we're called six times
@@ -120,7 +121,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertEquals(6, builder.getBuildCount());
 
 		//request many rebuilds and ensure we're called according to the build policy
@@ -132,7 +133,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 		//change the rebuild policy and ensure we're called the correct number of times
@@ -147,7 +148,7 @@ public class BuilderCycleTest extends AbstractBuilderTest {
 
 		//force an incremental build
 		builder.resetBuildCount();
-		file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertEquals(maxBuilds, builder.getBuildCount());
 
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
@@ -125,9 +127,9 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		// Create folders and files
 		folder.create(true, true, createTestMonitor());
-		fileA.create(getRandomContents(), true, createTestMonitor());
+		fileA.create(createRandomContentsStream(), true, createTestMonitor());
 		sub.create(true, true, createTestMonitor());
-		fileB.create(getRandomContents(), true, createTestMonitor());
+		fileB.create(createRandomContentsStream(), true, createTestMonitor());
 	}
 
 	/**
@@ -237,8 +239,8 @@ public class BuilderTest extends AbstractBuilderTest {
 		project1.open(createTestMonitor());
 		project2.create(createTestMonitor());
 		project2.open(createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		// Do an initial build to get the builder instance
 		IProjectDescription desc = project1.getDescription();
 		desc.setBuildSpec(new ICommand[] { createCommand(desc, "Project1Build1") });
@@ -858,7 +860,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
 		project.setDescription(desc, createTestMonitor());
-		createInWorkspace(input, getRandomString());
+		createInWorkspace(input, createRandomString());
 
 		waitForBuild();
 		assertTrue("1.0", output.exists());
@@ -901,7 +903,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		command.setBuilderName(SortBuilder.BUILDER_NAME);
 		desc.setBuildSpec(new ICommand[] { command });
 		project.setDescription(desc, createTestMonitor());
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		waitForBuild();
 
 		// Set up a plug-in lifecycle verifier for testing purposes
@@ -930,7 +932,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		try {
 			getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.PRE_BUILD);
 			// Now change a file. The build should not complete until the job triggered by the listener completes
-			file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			//wait for job to be scheduled
 			barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 			//wait for test job to complete
@@ -1054,7 +1056,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Create and open a project
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		// Create and set a build spec for the project
 		IProjectDescription desc = project.getDescription();
@@ -1077,7 +1079,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		// Now make a change and then turn autobuild on. Turning it on should
 		// cause a build.
 		IWorkspaceRunnable r = monitor -> {
-			file.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			file.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			IWorkspaceDescription description = getWorkspace().getDescription();
 			description.setAutoBuilding(true);
 			getWorkspace().setDescription(description);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
@@ -149,7 +150,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		assertTrue("3.0", builder.wasFullBuild());
 
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		// But subsequent INCREMENTAL_BUILD builds should cause INCREMENTAL_BUILD
 		builder.reset();
@@ -206,7 +207,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		IFile file = project.getFile("b.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertTrue("6.0", !builder.wasCleanBuild());
@@ -385,7 +386,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		//add a file in the project, to trigger an autobuild
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		//autobuild should not call our builder
 		waitForBuild();
@@ -451,7 +452,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 
 		// add a file in the project before an incremental build is triggered again
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		// do an incremental build - build should NOT be triggered
 		builder.clearBuildTrigger();
@@ -505,7 +506,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		IFile file = project.getFile("a.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertEquals("4.0", 0, builder.triggerForLastBuild);
@@ -520,7 +521,7 @@ public class CustomBuildTriggerTest extends AbstractBuilderTest {
 		builder.reset();
 
 		file = project.getFile("b.txt");
-		file.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
 		assertTrue("6.0", !builder.wasCleanBuild());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.builders;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -72,7 +73,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 			for (IProject project : projects) {
 				for (IResource member : project.members()) {
 					if (member.getType() == IResource.FILE && !member.getName().equals(IProjectDescription.DESCRIPTION_FILE_NAME)) {
-						((IFile) member).setContents(getRandomContents(), true, true, null);
+						((IFile) member).setContents(createRandomContentsStream(), true, true, null);
 					}
 				}
 			}
@@ -220,7 +221,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 		builder.checkDeltas(allProjects);
 
 		//modify a file in project1 to force an autobuild
-		file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 	}
 
 	/**
@@ -244,7 +245,7 @@ public class MultiProjectBuildTest extends AbstractBuilderTest {
 
 		//do an incremental build by creating a file
 		IFile file = project.getFile("Foo");
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
@@ -95,7 +96,7 @@ public class BlobStoreTest extends LocalStoreTest {
 		createFile(target, content);
 		uuid = store.addBlob(target, true);
 		InputStream input = store.getBlob(uuid);
-		assertTrue(compareContent(getContents(content), input));
+		assertTrue(compareContent(createInputStream(content), input));
 	}
 
 	public void testSetBlob() throws CoreException, IOException {
@@ -110,6 +111,6 @@ public class BlobStoreTest extends LocalStoreTest {
 		createFile(target, content);
 		uuid = store.addBlob(target, true);
 		InputStream input = store.getBlob(uuid);
-		assertTrue(compareContent(getContents(content), input));
+		assertTrue(compareContent(createInputStream(content), input));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
@@ -69,7 +70,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a file; should fail because has same name with different casing
 		IFile file = aProject.getFile(folderName.toUpperCase());
-		assertThrows(CoreException.class, () -> file.create(getRandomContents(), true, null));
+		assertThrows(CoreException.class, () -> file.create(createRandomContentsStream(), true, null));
 	}
 
 	public void testCreateFiles() throws Throwable {
@@ -78,11 +79,11 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a file, should be fine
 		IFile file1 = aProject.getFile(fileName);
-		file1.create(getRandomContents(), true, null);
+		file1.create(createRandomContentsStream(), true, null);
 
 		// create a second file; should fail because has same name with different casing
 		IFile file2 = aProject.getFile(fileName.toUpperCase());
-		ThrowingRunnable fileCreation = () -> file2.create(getRandomContents(), true, null);
+		ThrowingRunnable fileCreation = () -> file2.create(createRandomContentsStream(), true, null);
 		if (isCaseSensitive) {
 			fileCreation.run();
 		} else {
@@ -146,10 +147,10 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create 2 files with different names
 		IFile file1 = aProject.getFile(file1name);
-		file1.create(getRandomContents(), true, null);
+		file1.create(createRandomContentsStream(), true, null);
 
 		IFile file2 = aProject.getFile(file2name);
-		file2.create(getRandomContents(), true, null);
+		file2.create(createRandomContentsStream(), true, null);
 
 		// try to rename folder 1 to the uppercase name of folder 2, should fail
 		IFile file3 = aProject.getFile(file2name.toUpperCase());
@@ -196,10 +197,10 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create 2 files, one in each project, with case-different names
 		IFile file1 = sourceProject.getFile(fileName);
-		file1.create(getRandomContents(), true, null);
+		file1.create(createRandomContentsStream(), true, null);
 
 		IFile file2 = destinationProject.getFile(fileName.toUpperCase());
-		file2.create(getRandomContents(), true, null);
+		file2.create(createRandomContentsStream(), true, null);
 
 		// try to copy the file from source project to destination project.
 		// should fail due to conflict
@@ -227,7 +228,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 		folder.create(true, true, null);
 
 		IFile file = destinationProject.getFile(name.toUpperCase());
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// try to copy the folder from source project to destination project.
 		// should fail due to conflict with existing file with case-different name
@@ -252,7 +253,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create 2 resources, one in each project, with case-different names
 		IFile file = sourceProject.getFile(name);
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		IFolder folder = destinationProject.getFolder(name.toUpperCase());
 		folder.create(true, true, null);
@@ -296,7 +297,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a file in the destination project with a case-different name of the source project
 		IFile file = destinationProject.getFile(sourceProject.getName().toUpperCase());
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// try to move the source project to the destination project, which makes it a folder.
 		// should fail because we aren't allowed to move a project to be a folder
@@ -339,7 +340,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a File, which should be fine
 		IFile file = project.getFile(name.toUpperCase());
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// get a File handle with the same name but different casing
 		// in order to determine file system location
@@ -385,7 +386,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a File, which should be fine
 		IFile file = project.getFile(name.toUpperCase());
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// get a Folder handle with the same name but different casing
 		// in order to determine file system location
@@ -420,7 +421,7 @@ public class CaseSensitivityTest extends LocalStoreTest {
 
 		// create a File, which should be fine
 		IFile file = folder.getFile(name);
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// replace the File's filesystem rep. with a case-different name
 		java.io.File localFile = file.getLocation().toFile();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.localstore;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
@@ -123,11 +124,11 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		String originalContent = "this string should not be equal the other";
 
 		/* create file with flag false */
-		file.create(getContents(originalContent), false, null);
+		file.create(createInputStream(originalContent), false, null);
 		assertTrue(file.exists());
 		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
 		assertEquals(file.getStore().fetchInfo().getLastModified(), file.getResourceInfo(false, false).getLocalSyncInfo());
-		assertTrue(compareContent(getContents(originalContent), getLocalManager().read(file, true, null)));
+		assertTrue(compareContent(createInputStream(originalContent), getLocalManager().read(file, true, null)));
 	}
 
 	@Test
@@ -262,32 +263,32 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		InputStream another;
 
 		/* write file for the first time */
-		original = getContents(originalContent);
+		original = createInputStream(originalContent);
 		write(file, original, true, null);
 
-		original = getContents(originalContent);
+		original = createInputStream(originalContent);
 		assertTrue("Unexpected content in " + original,
 				compareContent(original, getLocalManager().read(file, true, null)));
 
 		/* test the overwrite parameter (false) */
-		another = getContents(anotherContent);
+		another = createInputStream(anotherContent);
 		write(file, another, false, null);
 
-		another = getContents(anotherContent);
+		another = createInputStream(anotherContent);
 		assertTrue("Unexpected content in " + another,
 				compareContent(another, getLocalManager().read(file, true, null)));
 
 		/* test the overwrite parameter (true) */
-		original = getContents(originalContent);
+		original = createInputStream(originalContent);
 		write(file, original, true, null);
 
-		original = getContents(originalContent);
+		original = createInputStream(originalContent);
 		assertTrue("Unexpected content in " + original,
 				compareContent(original, getLocalManager().read(file, true, null)));
 
 		/* test the overwrite parameter (false) */
 		ensureOutOfSync(file);
-		InputStream another2 = getContents(anotherContent);
+		InputStream another2 = createInputStream(anotherContent);
 		assertThrows("Should fail writing out of sync file #1", CoreException.class,
 				() -> write(file, another2, false, null));
 		ensureOutOfSync(file);
@@ -297,7 +298,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 
 		/* test the overwrite parameter (false) */
 		removeFromFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
-		InputStream another3 = getContents(anotherContent);
+		InputStream another3 = createInputStream(anotherContent);
 		waitForRefresh(); // wait for refresh to ensure that file is not present in workspace
 		assertThrows("Should fail writing non existing file", CoreException.class,
 				() -> write(file, another3, false, null));
@@ -316,11 +317,11 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 		String content = "original";
 
 		/* write file for the first time */
-		write(file, getContents(content), true, null);
+		write(file, createInputStream(content), true, null);
 
 		file.delete(true, null);
 		assertThrows("Should fail writing file that is already deleted", CoreException.class,
-				() -> write(file, getContents(content), false, null));
+				() -> write(file, createInputStream(content), false, null));
 	}
 
 	@Test
@@ -333,7 +334,7 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 
 		/* common contents */
 		String anotherContent = "and this string should not... well, you know...";
-		InputStream another = getContents(anotherContent);
+		InputStream another = createInputStream(anotherContent);
 		assertThrows(CoreException.class, () -> write(file, another, false, null));
 
 		/* remove trash */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.junit.Assert.assertThrows;
@@ -211,7 +213,7 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		/* set local history policies */
 		IWorkspaceDescription description = getWorkspace().getDescription();
@@ -227,7 +229,7 @@ public class HistoryStoreTest extends ResourceTest {
 		for (int i = 0; i < 8; i++) {
 			ensureOutOfSync(file);
 			file.refreshLocal(IResource.DEPTH_ZERO, createTestMonitor());
-			file.setContents(getRandomContents(), true, true, createTestMonitor());
+			file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 		IFileState[] states = file.getHistory(createTestMonitor());
 		// Make sure we have 8 states as we haven't trimmed yet.
@@ -261,7 +263,7 @@ public class HistoryStoreTest extends ResourceTest {
 		file.create(new ByteArrayInputStream(new byte[0]), true, createTestMonitor());
 		// Add 10 bytes to exceed the max file state size.
 		for (int i = 0; i < 10; i++) {
-			file.appendContents(getContents("a"), true, true, createTestMonitor());
+			file.appendContents(createInputStream("a"), true, true, createTestMonitor());
 		}
 		getWorkspace().save(true, null);
 		states = file.getHistory(createTestMonitor());
@@ -340,10 +342,10 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// directly deletes history files if project did already existed:
 		createInWorkspace(new IResource[] {project, folder1, folder2});
-		file1.create(getRandomContents(), IResource.FORCE, createTestMonitor());
-		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
-		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
-		file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+		file1.create(createRandomContentsStream(), IResource.FORCE, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		setMaxFileStates(50);
 
 		int maxStates = ResourcesPlugin.getWorkspace().getDescription().getMaxFileStates();
@@ -381,7 +383,7 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		IHistoryStore store = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 		// get another copy for changes
 		IWorkspaceDescription description = getWorkspace().getDescription();
@@ -404,7 +406,7 @@ public class HistoryStoreTest extends ResourceTest {
 			// file systems
 			// } catch (InterruptedException e) {
 			// }
-			file.setContents(getRandomContents(), true, true, createTestMonitor());
+			file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 		// All 8 states should exist.
 		long oldLastModTimes[] = new long[8];
@@ -503,13 +505,13 @@ public class HistoryStoreTest extends ResourceTest {
 		file = folder.getFile("file1.txt");
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		// Now do the move
 		folder.copy(folder2.getFullPath(), true, createTestMonitor());
@@ -519,20 +521,20 @@ public class HistoryStoreTest extends ResourceTest {
 		assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
 
 		// Give the new (copied file) some new contents
-		file2.setContents(getContents(contents[3]), true, true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[3]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
 		assertEquals("2.0", 2, states.length);
-		assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("2.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("2.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -569,20 +571,20 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
 
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
-		file2.create(getContents(contents[3]), true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		file2.create(createInputStream(contents[3]), true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Run some tests with illegal arguments
 		LogListenerVerifier verifier = new LogListenerVerifier();
@@ -620,9 +622,9 @@ public class HistoryStoreTest extends ResourceTest {
 		store.copyHistory(file, file2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
 	}
 
 	public void testCopyHistoryFolder() throws Exception {
@@ -638,30 +640,30 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
 
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 		folder2.create(true, true, createTestMonitor());
-		file2.create(getContents(contents[3]), true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		file2.create(createInputStream(contents[3]), true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Test a valid copy of a folder
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(folder, folder2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
 	}
 
 	public void testCopyHistoryProject() throws Exception {
@@ -677,30 +679,30 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file2 = folder2.getFile("file1.txt");
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
 
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		Thread.sleep(1000);
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 		folder2.create(true, true, createTestMonitor());
-		file2.create(getContents(contents[3]), true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		file2.create(createInputStream(contents[3]), true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Test a valid copy of a folder
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(project, project2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[2].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
 	}
 
 	public void testDelete() throws CoreException {
@@ -711,9 +713,9 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// test file
 		IFile file = project.getFile("file.txt");
-		file.create(getRandomContents(), true, createTestMonitor());
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 
 		// Check to see that there are only 2 states before the deletion
 		IFileState[] states = file.getHistory(createTestMonitor());
@@ -725,7 +727,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("1.1", 3, states.length);
 
 		// Re-create the file. This should not affect the history store.
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
 		assertEquals("1.2", 3, states.length);
 
@@ -735,9 +737,9 @@ public class HistoryStoreTest extends ResourceTest {
 		// for the first 'file.txt' is likely still around.
 		file = folder.getFile("file2.txt");
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 
 		// There should only be 2 history store entries.
 		states = file.getHistory(createTestMonitor());
@@ -750,7 +752,7 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// Re-create the folder. There should be no new history store entries.
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
 		assertEquals("2.2", 3, states.length);
 
@@ -767,14 +769,14 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file = project.getFile("removeAllStatesFile.txt");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// Constant for the number of states we will create
 		final int ITERATIONS = 20;
 
 		/* Add multiple states for one file location. */
 		for (int i = 0; i < ITERATIONS; i++) {
-			file.setContents(getRandomContents(), true, true, createTestMonitor());
+			file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 
 		/* Valid Case: Test retrieved values. */
@@ -800,7 +802,7 @@ public class HistoryStoreTest extends ResourceTest {
 		// test that a deleted file can be found
 		IFile pfile = project.getFile("findDeletedFile.txt");
 		// create and delete a file
-		pfile.create(getRandomContents(), true, createTestMonitor());
+		pfile.create(createRandomContentsStream(), true, createTestMonitor());
 		pfile.delete(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of project
@@ -827,7 +829,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("0.5.4", 0, df.length);
 
 		// recreate the file
-		pfile.create(getRandomContents(), true, createTestMonitor());
+		pfile.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the deleted file should no longer show up as a deleted member of project
 		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
@@ -864,7 +866,7 @@ public class HistoryStoreTest extends ResourceTest {
 
 		// create and delete a file in a folder
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		file.delete(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member
@@ -879,7 +881,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("1.4", 0, df.length);
 
 		// recreate the file
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the deleted file should no longer show up as a deleted member
 		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
@@ -906,7 +908,7 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("1.11", 0, df.length);
 
 		// create and delete a file where the folder was
-		folderAsFile.create(getRandomContents(), true, createTestMonitor());
+		folderAsFile.create(createRandomContentsStream(), true, createTestMonitor());
 		folderAsFile.delete(true, true, createTestMonitor());
 		folder.create(true, true, createTestMonitor());
 
@@ -945,9 +947,9 @@ public class HistoryStoreTest extends ResourceTest {
 		// create and delete a file in a folder
 		folder.create(true, true, createTestMonitor());
 		folder2.create(true, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
-		file3.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
+		file3.create(createRandomContentsStream(), true, createTestMonitor());
 		folder.delete(true, true, createTestMonitor());
 
 		// under root
@@ -1074,7 +1076,7 @@ public class HistoryStoreTest extends ResourceTest {
 			historyStore.addState(file.getFullPath(), ((Resource) file).getStore(), fileInfo, true);
 			contents = "This file has some contents in testGetContents.";
 			try (FileOutputStream output = new FileOutputStream(file.getLocation().toFile())) {
-				getContents(contents).transferTo(output);
+				createInputStream(contents).transferTo(output);
 			}
 			file.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
@@ -1086,7 +1088,7 @@ public class HistoryStoreTest extends ResourceTest {
 			historyStore.addState(secondValidFile.getFullPath(), ((Resource) secondValidFile).getStore(), fileInfo, true);
 			contents = "A file with some other contents in testGetContents.";
 			try (FileOutputStream output = new FileOutputStream(secondValidFile.getLocation().toFile())) {
-				getContents(contents).transferTo(output);
+				createInputStream(contents).transferTo(output);
 			}
 			secondValidFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
@@ -1132,14 +1134,14 @@ public class HistoryStoreTest extends ResourceTest {
 		project.open(createTestMonitor());
 
 		IFile file = project.getFile("file");
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		IFileState[] history = file.getHistory(createTestMonitor());
 		// no history yet
 		assertEquals("1.2", 0, history.length);
 		// save the file's current time stamp - it will be remembered in the file state
 		long fileTimeStamp = file.getLocalTimeStamp();
-		file.setContents(getRandomContents(), true, true, createTestMonitor());
+		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		history = file.getHistory(createTestMonitor());
 		// one state in the history
 		assertEquals("2.2", 1, history.length);
@@ -1178,13 +1180,13 @@ public class HistoryStoreTest extends ResourceTest {
 		file = folder.getFile("file1.txt");
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		// Now do the move
 		folder.move(folder2.getFullPath(), true, createTestMonitor());
@@ -1194,20 +1196,20 @@ public class HistoryStoreTest extends ResourceTest {
 		assertTrue("1.3", file2.getFullPath().toString().endsWith("folder2/file1.txt"));
 
 		// Give the new (moved file) some new contents
-		file2.setContents(getContents(contents[3]), true, true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[3]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
 		assertEquals("2.0", 2, states.length);
-		assertTrue("2.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("2.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("2.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("2.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1243,13 +1245,13 @@ public class HistoryStoreTest extends ResourceTest {
 		file = folder.getFile("file1.txt");
 		// Setup folder1 and file1.txt with some local history
 		folder.create(true, true, createTestMonitor());
-		file.create(getContents(contents[0]), true, createTestMonitor());
-		file.setContents(getContents(contents[1]), true, true, createTestMonitor());
-		file.setContents(getContents(contents[2]), true, true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
+		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
+		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		// Now do the move
 		project.move(IPath.fromOSString("SecondMoveProjectProject"), true, createTestMonitor());
@@ -1259,8 +1261,8 @@ public class HistoryStoreTest extends ResourceTest {
 		assertTrue("1.3", file2.getFullPath().toString().endsWith("SecondMoveProjectProject/folder1/file1.txt"));
 
 		// Give the new (copied file) some new contents
-		file2.setContents(getContents(contents[3]), true, true, createTestMonitor());
-		file2.setContents(getContents(contents[4]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[3]), true, true, createTestMonitor());
+		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
@@ -1269,10 +1271,10 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("2.0", 0, states.length);
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1283,13 +1285,13 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file = project.getFile("removeAllStatesFile.txt");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		final int ITERATIONS = 20;
 
 		/* test remove in a file */
 		for (int i = 0; i < ITERATIONS; i++) {
-			file.setContents(getRandomContents(), true, true, createTestMonitor());
+			file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 
 		/* Valid Case: Ensure correct number of states available. */
@@ -1305,10 +1307,10 @@ public class HistoryStoreTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IFile anotherOne = folder.getFile("anotherOne");
 		folder.create(true, true, createTestMonitor());
-		anotherOne.create(getRandomContents(), true, createTestMonitor());
+		anotherOne.create(createRandomContentsStream(), true, createTestMonitor());
 		for (int i = 0; i < ITERATIONS; i++) {
-			file.setContents(getRandomContents(), true, true, createTestMonitor());
-			anotherOne.setContents(getRandomContents(), true, true, createTestMonitor());
+			file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+			anotherOne.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 
 		states = file.getHistory(createTestMonitor());
@@ -1329,14 +1331,14 @@ public class HistoryStoreTest extends ResourceTest {
 		anotherOne = bbb.getFile("anotherOne");
 		IFile ccc = project.getFile("ccc");
 		bbb.create(true, true, createTestMonitor());
-		anotherOne.create(getRandomContents(), true, createTestMonitor());
-		aaa.create(getRandomContents(), true, createTestMonitor());
-		ccc.create(getRandomContents(), true, createTestMonitor());
+		anotherOne.create(createRandomContentsStream(), true, createTestMonitor());
+		aaa.create(createRandomContentsStream(), true, createTestMonitor());
+		ccc.create(createRandomContentsStream(), true, createTestMonitor());
 
 		for (int i = 0; i < ITERATIONS; i++) {
-			anotherOne.setContents(getRandomContents(), true, true, createTestMonitor());
-			aaa.setContents(getRandomContents(), true, true, createTestMonitor());
-			ccc.setContents(getRandomContents(), true, true, createTestMonitor());
+			anotherOne.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+			aaa.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+			ccc.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		}
 
 		states = anotherOne.getHistory(createTestMonitor());
@@ -1383,11 +1385,11 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile copyFile = project.getFile("copyOfSimpleCopyFileWithHistoryCopy");
 
 		/* Create first file. */
-		file.create(getContents(contents[0]), true, null);
+		file.create(createInputStream(contents[0]), true, null);
 
 		/* Set new contents on first file. Should add two entries to the history store. */
-		file.setContents(getContents(contents[1]), true, true, null);
-		file.setContents(getContents(contents[2]), true, true, null);
+		file.setContents(createInputStream(contents[1]), true, true, null);
+		file.setContents(createInputStream(contents[2]), true, true, null);
 
 		/* Copy first file to the second. Second file should have no history. */
 		file.copy(copyFile.getFullPath(), true, null);
@@ -1399,23 +1401,23 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("4.1", 2, states.length);
 
 		/* Set new contents on second file. Should add two entries to the history store. */
-		copyFile.setContents(getContents(contents[3]), true, true, null);
-		copyFile.setContents(getContents(contents[4]), true, true, null);
+		copyFile.setContents(createInputStream(contents[3]), true, true, null);
+		copyFile.setContents(createInputStream(contents[4]), true, true, null);
 
 		/* Check history for both files. */
 		// Check log for original file.
 		states = file.getHistory(null);
 		assertEquals("6.0", 2, states.length);
-		assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("6.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("6.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		// Check log for copy.
 		states = copyFile.getHistory(null);
 		assertEquals("6.3", 4, states.length);
-		assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("6.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("6.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("6.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("6.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
 	}
 
 	/**
@@ -1445,11 +1447,11 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile moveFile = project.getFile("copyOfSimpleMoveFileWithCopy");
 
 		/* Create first file. */
-		file.create(getContents(contents[0]), true, null);
+		file.create(createInputStream(contents[0]), true, null);
 
 		/* Set new contents on source file. Should add two entries to the history store. */
-		file.setContents(getContents(contents[1]), true, true, null);
-		file.setContents(getContents(contents[2]), true, true, null);
+		file.setContents(createInputStream(contents[1]), true, true, null);
+		file.setContents(createInputStream(contents[2]), true, true, null);
 
 		/* Move source file to second location.
 		 * Moved files should have the history of the original file.
@@ -1463,23 +1465,23 @@ public class HistoryStoreTest extends ResourceTest {
 		assertEquals("4.1", 2, states.length);
 
 		/* Set new contents on moved file. Should add two entries to the history store. */
-		moveFile.setContents(getContents(contents[3]), true, true, null);
-		moveFile.setContents(getContents(contents[4]), true, true, null);
+		moveFile.setContents(createInputStream(contents[3]), true, true, null);
+		moveFile.setContents(createInputStream(contents[4]), true, true, null);
 
 		/* Check history for both files. */
 		// Check log for original file.
 		states = file.getHistory(null);
 		assertEquals("6.0", 2, states.length);
-		assertTrue("6.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("6.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("6.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("6.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		// Check log for moved file.
 		states = moveFile.getHistory(null);
 		assertEquals("6.3", 4, states.length);
-		assertTrue("6.4", compareContent(getContents(contents[3]), states[0].getContents()));
-		assertTrue("6.5", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("6.6", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("6.7", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("6.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
+		assertTrue("6.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("6.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("6.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
 	}
 
 	/**
@@ -1504,18 +1506,18 @@ public class HistoryStoreTest extends ResourceTest {
 		IFile file = project.getFile("file");
 
 		/* Create the file. */
-		file.create(getContents(contents[0]), true, createTestMonitor());
+		file.create(createInputStream(contents[0]), true, createTestMonitor());
 
 		/* Set new contents on the file. Should add two entries to the store. */
 		for (int i = 0; i < 2; i++) {
-			file.setContents(getContents(contents[i + 1]), true, true, createTestMonitor());
+			file.setContents(createInputStream(contents[i + 1]), true, true, createTestMonitor());
 		}
 
 		/* Ensure two entries are available for the file, and that content matches. */
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertEquals("3.0", 2, states.length);
-		assertTrue("3.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("3.1.2", compareContent(getContents(contents[0]), states[1].getContents()));
+		assertTrue("3.1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("3.1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
 
 		/* Delete the file. Should add an entry to the store. */
 		file.delete(true, true, createTestMonitor());
@@ -1523,9 +1525,9 @@ public class HistoryStoreTest extends ResourceTest {
 		/* Ensure three entries are available for the file, and that content matches. */
 		states = file.getHistory(createTestMonitor());
 		assertEquals("5.0", 3, states.length);
-		assertTrue("5.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-		assertTrue("5.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
-		assertTrue("5.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
+		assertTrue("5.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
+		assertTrue("5.1.2", compareContent(createInputStream(contents[1]), states[1].getContents()));
+		assertTrue("5.1.3", compareContent(createInputStream(contents[0]), states[2].getContents()));
 
 		/* Roll file back to first version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
@@ -1536,23 +1538,23 @@ public class HistoryStoreTest extends ResourceTest {
 		// Check history store.
 		states = file.getHistory(createTestMonitor());
 		assertEquals("6.0", 3, states.length);
-		assertTrue("6.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-		assertTrue("6.1.2", compareContent(getContents(contents[1]), states[1].getContents()));
-		assertTrue("6.1.3", compareContent(getContents(contents[0]), states[2].getContents()));
+		assertTrue("6.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
+		assertTrue("6.1.2", compareContent(createInputStream(contents[1]), states[1].getContents()));
+		assertTrue("6.1.3", compareContent(createInputStream(contents[0]), states[2].getContents()));
 
 		// Check file contents.
-		assertTrue("6.2", compareContent(getContents(contents[2]), file.getContents(false)));
+		assertTrue("6.2", compareContent(createInputStream(contents[2]), file.getContents(false)));
 
 		/* Set new contents on the file. Should add an entry to the history store. */
-		file.setContents(getContents(contents[1]), true, true, null);
+		file.setContents(createInputStream(contents[1]), true, true, null);
 
 		/* Ensure four entries are available for the file, and that entries match. */
 		states = file.getHistory(createTestMonitor());
 		assertEquals("8.0", 4, states.length);
-		assertTrue("8.1.1", compareContent(getContents(contents[2]), states[0].getContents()));
-		assertTrue("8.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("8.1.3", compareContent(getContents(contents[1]), states[2].getContents()));
-		assertTrue("8.1.4", compareContent(getContents(contents[0]), states[3].getContents()));
+		assertTrue("8.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
+		assertTrue("8.1.2", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("8.1.3", compareContent(createInputStream(contents[1]), states[2].getContents()));
+		assertTrue("8.1.4", compareContent(createInputStream(contents[0]), states[3].getContents()));
 
 		/* Roll file back to third version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
@@ -1562,13 +1564,13 @@ public class HistoryStoreTest extends ResourceTest {
 		// Check history log.
 		states = file.getHistory(createTestMonitor());
 		assertEquals("9.0", 5, states.length);
-		assertTrue("9.1.1", compareContent(getContents(contents[1]), states[0].getContents()));
-		assertTrue("9.1.2", compareContent(getContents(contents[2]), states[1].getContents()));
-		assertTrue("9.1.3", compareContent(getContents(contents[2]), states[2].getContents()));
-		assertTrue("9.1.4", compareContent(getContents(contents[1]), states[3].getContents()));
-		assertTrue("9.1.5", compareContent(getContents(contents[0]), states[4].getContents()));
+		assertTrue("9.1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
+		assertTrue("9.1.2", compareContent(createInputStream(contents[2]), states[1].getContents()));
+		assertTrue("9.1.3", compareContent(createInputStream(contents[2]), states[2].getContents()));
+		assertTrue("9.1.4", compareContent(createInputStream(contents[1]), states[3].getContents()));
+		assertTrue("9.1.5", compareContent(createInputStream(contents[0]), states[4].getContents()));
 
 		// Check file contents.
-		assertTrue("9.2", compareContent(getContents(contents[1]), file.getContents(false)));
+		assertTrue("9.2", compareContent(createInputStream(contents[1]), file.getContents(false)));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -112,7 +114,7 @@ public abstract class LocalStoreTest extends ResourceTest {
 		if (type == 'd') {
 			node.mkdir(EFS.NONE, null);
 		} else {
-			InputStream input = getRandomContents();
+			InputStream input = createRandomContentsStream();
 			try (OutputStream output = node.openOutputStream(EFS.NONE, null)) {
 				input.transferTo(output);
 			}
@@ -138,7 +140,7 @@ public abstract class LocalStoreTest extends ResourceTest {
 	protected String getBigString(int size) {
 		StringBuilder sb = new StringBuilder();
 		while (sb.length() < size) {
-			sb.append(getRandomString());
+			sb.append(createRandomString());
 		}
 		return sb.toString();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.findAvailableDevices;
@@ -76,7 +77,7 @@ public class MoveTest extends LocalStoreTest {
 
 		String fileName = "fileToBeMoved.txt";
 		IFile file = source.getFile(fileName);
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// add some properties to file (persistent and session)
 		QualifiedName[] propNames = new QualifiedName[numberOfProperties];

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertThrows;
 
 import java.io.DataInputStream;
@@ -104,12 +105,12 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 		fakeEnd[fakeEnd.length - 1] = 86;
 
 		// write chunks
-		byte[] chunk1 = getRandomString().getBytes();
-		byte[] chunk2 = getRandomString().getBytes();
-		byte[] chunk3 = getRandomString().getBytes();
-		byte[] chunk4 = getRandomString().getBytes();
-		byte[] chunk5 = getRandomString().getBytes();
-		byte[] chunk6 = getRandomString().getBytes();
+		byte[] chunk1 = createRandomString().getBytes();
+		byte[] chunk2 = createRandomString().getBytes();
+		byte[] chunk3 = createRandomString().getBytes();
+		byte[] chunk4 = createRandomString().getBytes();
+		byte[] chunk5 = createRandomString().getBytes();
+		byte[] chunk6 = createRandomString().getBytes();
 		SafeChunkyOutputStream output = new SafeChunkyOutputStream(target);
 		try {
 			output.write(chunk1);
@@ -196,11 +197,11 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 		assertFalse(target.exists());
 
 		// write chunks
-		byte[] chunk1 = getRandomString().getBytes();
-		byte[] chunk2 = getRandomString().getBytes();
-		byte[] chunk3 = getRandomString().getBytes();
-		byte[] chunk4 = getRandomString().getBytes();
-		byte[] chunk5 = getRandomString().getBytes();
+		byte[] chunk1 = createRandomString().getBytes();
+		byte[] chunk2 = createRandomString().getBytes();
+		byte[] chunk3 = createRandomString().getBytes();
+		byte[] chunk4 = createRandomString().getBytes();
+		byte[] chunk5 = createRandomString().getBytes();
 		try (SafeChunkyOutputStream output = new SafeChunkyOutputStream(target)) {
 			output.write(chunk1);
 			output.succeed();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,21 +60,21 @@ public class SafeFileInputOutputStreamTest extends ResourceTest {
 		// define temp path
 		IPath parentLocation = IPath.fromOSString(target.getParentFile().getAbsolutePath());
 		IPath tempLocation = parentLocation.append(target.getName() + ".backup");
-		String contents = getRandomString();
+		String contents = createRandomString();
 		File tempFile = tempLocation.toFile();
 
 		// we did not have a file on the destination, so we should not have a temp file
 		try (SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString())) {
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		// now we should have a temp file
 		try(SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString())) {
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		assertTrue(target.exists());
 		assertFalse(tempFile.exists());
 		InputStream diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath());
-		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertTrue(compareContent(diskContents, createInputStream(contents)));
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
@@ -80,26 +82,26 @@ public class SafeFileInputOutputStreamTest extends ResourceTest {
 		File target = new File(temp.toFile(), "target");
 		Workspace.clear(target); // make sure there was nothing here before
 		assertTrue(!target.exists());
-		String contents = getRandomString();
+		String contents = createRandomString();
 
 		// basic use (like a FileOutputStream)
 		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		InputStream diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertTrue(compareContent(diskContents, createInputStream(contents)));
 
-		contents = getRandomString();
+		contents = createRandomString();
 		// update target contents
 		File tempFile;
 		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
 			tempFile = new File(safeStream.getTempFilePath());
 			assertTrue(tempFile.exists());
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
 		diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertTrue(compareContent(diskContents, createInputStream(contents)));
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
@@ -112,28 +114,28 @@ public class SafeFileInputOutputStreamTest extends ResourceTest {
 		IPath parentLocation = IPath.fromOSString(target.getParentFile().getAbsolutePath());
 		IPath tempLocation = parentLocation.append(target.getName() + ".backup");
 
-		String contents = getRandomString();
+		String contents = createRandomString();
 		File tempFile = tempLocation.toFile();
 		// we did not have a file on the destination, so we should not have a temp file
 		try (SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString())) {
 			assertFalse(tempFile.exists());
 			// update target contents
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
 		InputStream diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertTrue(compareContent(diskContents, createInputStream(contents)));
 
-		contents = getRandomString();
+		contents = createRandomString();
 		// now we should have a temp file
 		try (SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString())) {
 			assertTrue(tempFile.exists());
 			// update target contents
-			getContents(contents).transferTo(safeStream);
+			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
 		diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, getContents(contents)));
+		assertTrue(compareContent(diskContents, createInputStream(contents)));
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.internal.properties;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -118,7 +119,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		// create common objects
 		final IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, createTestMonitor());
+		target.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// prepare keys and values
 		final int N = 50;
@@ -416,7 +417,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 	public void testLargeProperty() throws CoreException {
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, createTestMonitor());
+		target.create(createRandomContentsStream(), true, createTestMonitor());
 
 		QualifiedName name = new QualifiedName("stressTest", "prop");
 		final int SIZE = 10000;
@@ -486,7 +487,7 @@ public class PropertyManagerTest extends LocalStoreTest {
 
 		// create common objects
 		IFile target = projects[0].getFile("target");
-		target.create(getRandomContents(), true, createTestMonitor());
+		target.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// prepare keys and values
 		int N = 3;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/FilePropertyTesterTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.propertytester;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
@@ -67,7 +68,7 @@ public class FilePropertyTesterTest extends ResourceTest {
 	public void testExistingTextFile() throws Throwable {
 		String expected = "org.eclipse.core.runtime.text";
 		IFile target = project.getFile("tmp.txt");
-		target.create(getRandomContents(), true, createTestMonitor());
+		target.create(createRandomContentsStream(), true, createTestMonitor());
 
 		boolean ret;
 		ret = tester.test(target, CONTENT_TYPE_ID, new String[] {}, expected);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ModelObjectReaderWriterTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -330,7 +331,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		// Write out the project description file
 		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
-			getContents(invalidProjectDescription).transferTo(output);
+			createInputStream(invalidProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
 		assertThat(projDesc, nullValue());
@@ -342,7 +343,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
-			getContents(invalidProjectDescription).transferTo(output);
+			createInputStream(invalidProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = readDescription(store);
 		assertThat(projDesc, not(nullValue()));
@@ -361,7 +362,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
-			getContents(invalidProjectDescription).transferTo(output);
+			createInputStream(invalidProjectDescription).transferTo(output);
 		}
 
 		ProjectDescription projDesc = readDescription(store);
@@ -381,7 +382,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		IFileStore store = getTempStore();
 		// Write out the project description file
 		try (OutputStream output = store.openOutputStream(EFS.NONE, null)) {
-			getContents(invalidProjectDescription).transferTo(output);
+			createInputStream(invalidProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = readDescription(store);
 		assertThat(projDesc, not(nullValue()));
@@ -409,7 +410,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		// Write out the project description file
 		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
-			getContents(longProjectDescription).transferTo(output);
+			createInputStream(longProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
 		removeFromFileSystem(location.toFile());
@@ -431,7 +432,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		// Write out the project description file
 		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
-			getContents(longProjectDescription).transferTo(output);
+			createInputStream(longProjectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
 		removeFromFileSystem(location.toFile());
@@ -460,10 +461,10 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		removeFromFileSystem(multiLocation.toFile());
 		removeFromFileSystem(singleLocation.toFile());
 		try (FileOutputStream output = new FileOutputStream(multiLocation.toFile())) {
-			getContents(multiLineProjectDescription).transferTo(output);
+			createInputStream(multiLineProjectDescription).transferTo(output);
 		}
 		try (FileOutputStream output = new FileOutputStream(singleLocation.toFile())) {
-			getContents(singleLineProjectDescription).transferTo(output);
+			createInputStream(singleLineProjectDescription).transferTo(output);
 		}
 		ProjectDescription multiDesc = reader.read(multiLocation);
 		ProjectDescription singleDesc = reader.read(singleLocation);
@@ -683,7 +684,7 @@ public class ModelObjectReaderWriterTest extends ResourceTest {
 		// Write out the project description file
 		removeFromFileSystem(location.toFile());
 		try (FileOutputStream output = new FileOutputStream(location.toFile())) {
-			getContents(projectDescription).transferTo(output);
+			createInputStream(projectDescription).transferTo(output);
 		}
 		ProjectDescription projDesc = reader.read(location);
 		assertThat(projDesc, not(nullValue()));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -173,7 +174,7 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 
 			// sets a non-used preference to a non-default value so a
 			// preferences file can be generated
-			preferences.setValue("foo.bar", getRandomString());
+			preferences.setValue("foo.bar", createRandomString());
 
 			// exports original preferences (only default values - except for bogus preference above)
 			Preferences.exportPreferences(originalPreferencesFile);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
@@ -14,7 +14,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.utils;
 
-import java.util.*;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.eclipse.core.internal.utils.ObjectMap;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -87,7 +92,7 @@ public class ObjectMapTest extends ResourceTest {
 		assertFalse("3.0", map.containsKey(Integer.valueOf(MAXIMUM + 1)));
 		assertFalse("3.1", map.containsKey(Integer.valueOf(-1)));
 		assertFalse("3.2", map.containsValue(null));
-		assertFalse("3.3", map.containsValue(getRandomString()));
+		assertFalse("3.3", map.containsValue(createRandomString()));
 	}
 
 	public void testValues() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -18,6 +18,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
@@ -1202,7 +1203,7 @@ public class CharsetTest extends ResourceTest {
 			// File:
 			// single file
 			final IFile file1 = project.getFile("file1.txt");
-			createInWorkspace(file1, getRandomString());
+			createInWorkspace(file1, createRandomString());
 			// change from default
 			verifier.reset();
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
@@ -1241,7 +1242,7 @@ public class CharsetTest extends ResourceTest {
 			// multiple files (same operation)
 			verifier.reset();
 			final IFile file2 = project.getFile("file2.txt");
-			createInWorkspace(file2, getRandomString());
+			createInWorkspace(file2, createRandomString());
 			verifier.addExpectedChange(new IResource[] {file1, file2}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
@@ -600,7 +601,7 @@ public class HiddenResourceTest extends ResourceTest {
 
 		createInWorkspace(project);
 		folder.create(IResource.HIDDEN, true, createTestMonitor());
-		file.create(getRandomContents(), IResource.HIDDEN, createTestMonitor());
+		file.create(createRandomContentsStream(), IResource.HIDDEN, createTestMonitor());
 
 		assertHidden(project, false, IResource.DEPTH_ZERO);
 		assertHidden(folder, true, IResource.DEPTH_ZERO);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -21,6 +21,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.junit.Assert.assertThrows;
@@ -193,7 +196,7 @@ public class IFileTest extends ResourceTest {
 		streams.add(bis);
 
 		// random content
-		streams.add(getRandomContents());
+		streams.add(createRandomContentsStream());
 
 		//large stream
 		bis = new ByteArrayInputStream(new byte[10000]);
@@ -272,11 +275,11 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testAppendContents() throws Exception {
 		IFile target = projects[0].getFile("file1");
-		target.create(getContents("abc"), false, null);
-		target.appendContents(getContents("def"), false, false, null);
+		target.create(createInputStream("abc"), false, null);
+		target.appendContents(createInputStream("def"), false, false, null);
 
 		try (InputStream content = target.getContents(false)) {
-			assertTrue("3.0", compareContent(content, getContents("abcdef")));
+			assertTrue("3.0", compareContent(content, createInputStream("abcdef")));
 		}
 	}
 
@@ -299,7 +302,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("1.2", !file.isLocal(IResource.DEPTH_ZERO));
 
 		monitor.prepare();
-		file.appendContents(getRandomContents(), IResource.FORCE, monitor);
+		file.appendContents(createRandomContentsStream(), IResource.FORCE, monitor);
 		monitor.assertUsedUp();
 
 		assertTrue("1.5", file.isLocal(IResource.DEPTH_ZERO));
@@ -318,7 +321,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.1", !file.getLocation().toFile().exists());
 
 		monitor.prepare();
-		assertThrows(CoreException.class, () -> file.appendContents(getRandomContents(), IResource.FORCE, monitor));
+		assertThrows(CoreException.class, () -> file.appendContents(createRandomContentsStream(), IResource.FORCE, monitor));
 		monitor.sanityCheck();
 		assertTrue("2.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
@@ -336,7 +339,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("3.2", !file.isLocal(IResource.DEPTH_ZERO));
 
 		monitor.prepare();
-		assertThrows(CoreException.class, () -> file.appendContents(getRandomContents(), IResource.NONE, monitor));
+		assertThrows(CoreException.class, () -> file.appendContents(createRandomContentsStream(), IResource.NONE, monitor));
 		monitor.assertUsedUp();
 		assertTrue("3.5", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
@@ -352,7 +355,7 @@ public class IFileTest extends ResourceTest {
 		assertTrue("4.1", !file.getLocation().toFile().exists());
 
 		monitor.prepare();
-		assertThrows(CoreException.class, () -> file.appendContents(getRandomContents(), IResource.NONE, monitor));
+		assertThrows(CoreException.class, () -> file.appendContents(createRandomContentsStream(), IResource.NONE, monitor));
 		monitor.sanityCheck();
 		assertTrue("4.4", !file.isLocal(IResource.DEPTH_ZERO));
 		// cleanup
@@ -431,7 +434,7 @@ public class IFileTest extends ResourceTest {
 		removeFromWorkspace(derived);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		derived.create(getRandomContents(), IResource.DERIVED, monitor);
+		derived.create(createRandomContentsStream(), IResource.DERIVED, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.0", derived.isDerived());
 		assertTrue("1.1", !derived.isTeamPrivateMember());
@@ -440,7 +443,7 @@ public class IFileTest extends ResourceTest {
 		derived.delete(false, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		derived.create(getRandomContents(), IResource.NONE, monitor);
+		derived.create(createRandomContentsStream(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
 		assertTrue("2.0", !derived.isDerived());
 		assertTrue("2.1", !derived.isTeamPrivateMember());
@@ -457,7 +460,7 @@ public class IFileTest extends ResourceTest {
 		verifier.addExpectedChange(derived, IResourceDelta.ADDED, IResource.NONE);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		derived.create(getRandomContents(), IResource.FORCE | IResource.DERIVED, monitor);
+		derived.create(createRandomContentsStream(), IResource.FORCE | IResource.DERIVED, monitor);
 		monitor.assertUsedUp();
 
 		assertTrue("2.0", verifier.isDeltaValid());
@@ -470,7 +473,7 @@ public class IFileTest extends ResourceTest {
 		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE | IResource.DERIVED, monitor);
+		teamPrivate.create(createRandomContentsStream(), IResource.TEAM_PRIVATE | IResource.DERIVED, monitor);
 		monitor.assertUsedUp();
 
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
@@ -480,7 +483,7 @@ public class IFileTest extends ResourceTest {
 		teamPrivate.delete(false, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		teamPrivate.create(getRandomContents(), IResource.NONE, monitor);
+		teamPrivate.create(createRandomContentsStream(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
@@ -493,7 +496,7 @@ public class IFileTest extends ResourceTest {
 		removeFromWorkspace(teamPrivate);
 
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		teamPrivate.create(getRandomContents(), IResource.TEAM_PRIVATE, monitor);
+		teamPrivate.create(createRandomContentsStream(), IResource.TEAM_PRIVATE, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
 		assertTrue("1.1", !teamPrivate.isDerived());
@@ -502,7 +505,7 @@ public class IFileTest extends ResourceTest {
 		teamPrivate.delete(false, monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
-		teamPrivate.create(getRandomContents(), IResource.NONE, monitor);
+		teamPrivate.create(createRandomContentsStream(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
 		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
 		assertTrue("2.1", !teamPrivate.isDerived());
@@ -523,23 +526,23 @@ public class IFileTest extends ResourceTest {
 		assertTrue("2.0", !emptyFile.exists());
 		String contents = "";
 		monitor.prepare();
-		emptyFile.create(getContents(contents), true, monitor);
+		emptyFile.create(createInputStream(contents), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("2.2", emptyFile.exists());
 		try (InputStream stream = emptyFile.getContents(false)) {
 			assertTrue("2.4", stream.available() == 0);
 		}
-		assertTrue("2.6", compareContent(emptyFile.getContents(false), getContents(contents)));
+		assertTrue("2.6", compareContent(emptyFile.getContents(false), createInputStream(contents)));
 
 		// creation with random content
 		IFile fileWithRandomContent = projects[0].getFile("file3");
 		assertTrue("3.0", !fileWithRandomContent.exists());
-		contents = getRandomString();
+		contents = createRandomString();
 		monitor.prepare();
-		fileWithRandomContent.create(getContents(contents), true, monitor);
+		fileWithRandomContent.create(createInputStream(contents), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("3.2", fileWithRandomContent.exists());
-		assertTrue("3.2", compareContent(fileWithRandomContent.getContents(false), getContents(contents)));
+		assertTrue("3.2", compareContent(fileWithRandomContent.getContents(false), createInputStream(contents)));
 
 		// try to create a file over a folder that exists
 		IFolder folder = projects[0].getFolder("folder1");
@@ -641,7 +644,7 @@ public class IFileTest extends ResourceTest {
 	public void testFileEmptyDeletion() throws Throwable {
 		IFile target = projects[0].getFile("file1");
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getContents(""), true, monitor);
+		target.create(createInputStream(""), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.0", target.exists());
 		monitor.prepare();
@@ -659,7 +662,7 @@ public class IFileTest extends ResourceTest {
 
 		IFile target = folder.getFile("file1");
 		monitor.prepare();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.1", target.exists());
 	}
@@ -671,7 +674,7 @@ public class IFileTest extends ResourceTest {
 
 		IFile target = folder.getFile("file1");
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.0", target.exists());
 	}
@@ -685,7 +688,7 @@ public class IFileTest extends ResourceTest {
 
 		IFile target = folder.getFile("file1");
 		monitor.prepare();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.1", target.exists());
 	}
@@ -694,7 +697,7 @@ public class IFileTest extends ResourceTest {
 	public void testFileMove() throws Throwable {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		IFile target = projects[0].getFile("file1");
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 
 		IFile destination = projects[0].getFile("file2");
@@ -773,10 +776,10 @@ public class IFileTest extends ResourceTest {
 	@Test
 	public void testGetContents2() throws IOException, CoreException {
 		IFile target = projects[0].getFile("file1");
-		String testString = getRandomString();
+		String testString = createRandomString();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		target.create(null, false, null);
-		target.setContents(getContents(testString), true, false, monitor);
+		target.setContents(createInputStream(testString), true, false, monitor);
 		monitor.assertUsedUp();
 		ensureOutOfSync(target);
 
@@ -836,7 +839,7 @@ public class IFileTest extends ResourceTest {
 			monitor.prepare();
 			IFile file = project.getFile(IPath.fromPortableString(name));
 			assertTrue("1.0 " + name, !file.exists());
-			assertThrows(CoreException.class, () -> file.create(getRandomContents(), true, monitor));
+			assertThrows(CoreException.class, () -> file.create(createRandomContentsStream(), true, monitor));
 			monitor.sanityCheck();
 			assertTrue("1.2 " + name, !file.exists());
 		}
@@ -853,7 +856,7 @@ public class IFileTest extends ResourceTest {
 			IFile file = project.getFile(name);
 			assertTrue("2.0 " + name, !file.exists());
 			monitor.prepare();
-			file.create(getRandomContents(), true, monitor);
+			file.create(createRandomContentsStream(), true, monitor);
 			monitor.assertUsedUp();
 			assertTrue("2.2 " + name, file.exists());
 		}
@@ -924,13 +927,13 @@ public class IFileTest extends ResourceTest {
 		IFile target = projects[0].getFile("file1");
 		target.create(null, false, null);
 
-		String testString = getRandomString();
+		String testString = createRandomString();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.setContents(getContents(testString), true, false, monitor);
+		target.setContents(createInputStream(testString), true, false, monitor);
 		monitor.assertUsedUp();
 
 		try (InputStream content = target.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, getContents(testString)));
+			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -18,6 +18,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;
@@ -49,7 +52,7 @@ public class IFolderTest extends ResourceTest {
 
 		// create the resources and set some content in a file that will be moved.
 		createInWorkspace(before);
-		beforeFile.create(getRandomContents(), false, createTestMonitor());
+		beforeFile.create(createRandomContentsStream(), false, createTestMonitor());
 
 		// Be sure the resources exist and then move them.
 		assertExistsInWorkspace(before);
@@ -168,7 +171,7 @@ public class IFolderTest extends ResourceTest {
 		// try to create a folder over a file that exists
 		IFile file = target.getFile("File1");
 		target = target.getFolder("File1");
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		assertTrue("4.0", file.exists());
 
 		IFolder subfolderTarget = target;
@@ -218,9 +221,9 @@ public class IFolderTest extends ResourceTest {
 
 		// create the resources and set some content in a file that will be moved.
 		createInWorkspace(before);
-		String content = getRandomString();
+		String content = createRandomString();
 		IFile file = project.getFile(IPath.fromOSString("b/b/z"));
-		file.setContents(getContents(content), true, false, createTestMonitor());
+		file.setContents(createInputStream(content), true, false, createTestMonitor());
 
 		// Be sure the resources exist and then move them.
 		assertExistsInWorkspace(before);
@@ -230,7 +233,7 @@ public class IFolderTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(before);
 		assertExistsInWorkspace(after);
 		file = project.getFile(IPath.fromOSString("a/b/z"));
-		assertTrue("2.1", compareContent(getContents(content), file.getContents(false)));
+		assertTrue("2.1", compareContent(createInputStream(content), file.getContents(false)));
 	}
 
 	public void testFolderOverFile() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATUR
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.getLineSeparatorFromFile;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
@@ -2510,7 +2511,7 @@ public class IProjectTest extends ResourceTest {
 
 		// modify the file to create an entry in the history
 		monitor.prepare();
-		file.setContents(new ByteArrayInputStream(getRandomString().getBytes()), true, true, monitor);
+		file.setContents(new ByteArrayInputStream(createRandomString().getBytes()), true, true, monitor);
 		monitor.assertUsedUp();
 
 		// delete the project and check that its metadata is also deleted

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
@@ -175,7 +176,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 
 		//do the work
 		try {
-			file1.setContents(getRandomContents(), true, true, createTestMonitor());
+			file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
@@ -227,7 +228,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			project1.create(createTestMonitor());
 			project1.open(createTestMonitor());
 			folder1.create(true, true, createTestMonitor());
-			file1.create(getRandomContents(), true, createTestMonitor());
+			file1.create(createRandomContentsStream(), true, createTestMonitor());
 		};
 		verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
@@ -314,7 +315,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		getWorkspace().run((IWorkspaceRunnable) m -> {
 			m.beginTask("Creating and deleting", 100);
 			try {
-				file2.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file2.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 				file2.delete(true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
@@ -341,7 +342,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 
 	public void testAddFile() throws CoreException {
 		verifier.addExpectedChange(file2, IResourceDelta.ADDED, 0);
-		file2.create(getRandomContents(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		assertDelta();
 	}
 
@@ -352,7 +353,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Creating folder and file", 100);
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
-				file3.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file3.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
@@ -485,7 +486,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	public void testChangeFile() throws CoreException {
 		/* change file1's contents */
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		file1.setContents(getRandomContents(), true, false, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, false, createTestMonitor());
 		assertDelta();
 	}
 
@@ -550,7 +551,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Deleting and Creating", 100);
 			try {
 				folder3.delete(true, SubMonitor.convert(m, 50));
-				file1.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file1.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
@@ -580,7 +581,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
 				file1.copy(file3.getFullPath(), true, SubMonitor.convert(m, 50));
-				file3.setContents(getRandomContents(), IResource.NONE, SubMonitor.convert(m, 50));
+				file3.setContents(createRandomContentsStream(), IResource.NONE, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
@@ -616,7 +617,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Deleting and Creating", 100);
 			try {
 				file1.delete(true, SubMonitor.convert(m, 50));
-				file1.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file1.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
@@ -666,7 +667,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	 */
 	public void testDeleteMoveFile() throws CoreException {
 		verifier.reset();
-		file2.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		file2.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		verifier.reset();
 		int flags = IResourceDelta.REPLACED | IResourceDelta.MOVED_FROM | IResourceDelta.CONTENT;
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, flags, file2.getFullPath(), null);
@@ -957,7 +958,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			//delete phantom folder and change some other file
 			workspace.run((IWorkspaceRunnable) monitor -> {
 				phantomFolder.delete(IResource.NONE, createTestMonitor());
-				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+				file1.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			}, createTestMonitor());
 			//create phantom file
 			workspace.run((IWorkspaceRunnable) monitor -> workspace.getSynchronizer().setSyncInfo(partner, phantomFile, new byte[] {2}), createTestMonitor());
@@ -1000,23 +1001,23 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			}, createTestMonitor());
 			//create children in team private folder
 			IFile fileInFolder = teamPrivateFolder.getFile("FileInPrivateFolder");
-			fileInFolder.create(getRandomContents(), true, createTestMonitor());
+			fileInFolder.create(createRandomContentsStream(), true, createTestMonitor());
 			//modify children in team private folder
-			fileInFolder.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			fileInFolder.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			//delete children in team private folder
 			fileInFolder.delete(IResource.NONE, createTestMonitor());
 			//delete team private folder and change some other file
 			workspace.run((IWorkspaceRunnable) monitor -> {
 				teamPrivateFolder.delete(IResource.NONE, createTestMonitor());
-				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+				file1.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			}, createTestMonitor());
 			//create team private file
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				teamPrivateFile.create(getRandomContents(), true, createTestMonitor());
+				teamPrivateFile.create(createRandomContentsStream(), true, createTestMonitor());
 				teamPrivateFile.setTeamPrivateMember(true);
 			}, createTestMonitor());
 			//modify team private file
-			teamPrivateFile.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			teamPrivateFile.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			//delete team private file
 			teamPrivateFile.delete(IResource.NONE, createTestMonitor());
 		} finally {
@@ -1034,7 +1035,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Creating and moving", 100);
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
-				file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+				file1.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 				file1.move(file3.getFullPath(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
@@ -1083,7 +1084,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 	public void testMoveFileDeleteFolder() throws CoreException {
 		// file2 moved to file1, and colliding folder3 is deleted
 		file1.delete(IResource.NONE, null);
-		file2.create(getRandomContents(), IResource.NONE, null);
+		file2.create(createRandomContentsStream(), IResource.NONE, null);
 		folder3.create(IResource.NONE, true, null);
 		verifier.reset();
 		verifier.addExpectedChange(file2, IResourceDelta.REMOVED, IResourceDelta.MOVED_TO, null, file1.getFullPath());
@@ -1130,7 +1131,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			try {
 				folder2.create(true, true, SubMonitor.convert(m, 50));
 				file1.move(file3.getFullPath(), true, SubMonitor.convert(m, 50));
-				file3.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+				file3.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 			} finally {
 				m.done();
 			}
@@ -1423,7 +1424,7 @@ public class IResourceChangeListenerTest extends ResourceTest {
 			m.beginTask("Deleting and Creating", 100);
 			try {
 				file1.delete(true, SubMonitor.convert(m, 50));
-				file1.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file1.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}
@@ -1542,12 +1543,12 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		// create children in team private folder
 		IFile fileInFolder = teamPrivateFolder.getFile("FileInPrivateFolder");
 		verifier.addExpectedChange(fileInFolder, IResourceDelta.ADDED, 0);
-		fileInFolder.create(getRandomContents(), true, createTestMonitor());
+		fileInFolder.create(createRandomContentsStream(), true, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// modify children in team private folder
 		verifier.addExpectedChange(fileInFolder, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		fileInFolder.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		fileInFolder.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// delete children in team private folder
@@ -1560,21 +1561,21 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		workspace.run((IWorkspaceRunnable) monitor -> {
 			teamPrivateFolder.delete(IResource.NONE, createTestMonitor());
-			file1.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+			file1.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		}, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// create team private file
 		verifier.addExpectedChange(teamPrivateFile, IResourceDelta.ADDED, 0);
 		workspace.run((IWorkspaceRunnable) monitor -> {
-			teamPrivateFile.create(getRandomContents(), true, createTestMonitor());
+			teamPrivateFile.create(createRandomContentsStream(), true, createTestMonitor());
 			teamPrivateFile.setTeamPrivateMember(true);
 		}, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// modify team private file
 		verifier.addExpectedChange(teamPrivateFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-		teamPrivateFile.setContents(getRandomContents(), IResource.NONE, createTestMonitor());
+		teamPrivateFile.setContents(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 		assertDelta();
 		verifier.reset();
 		// delete team private file
@@ -1590,8 +1591,8 @@ public class IResourceChangeListenerTest extends ResourceTest {
 		getWorkspace().run((IWorkspaceRunnable) m -> {
 			m.beginTask("setting contents and creating", 100);
 			try {
-				file1.setContents(getRandomContents(), true, false, SubMonitor.convert(m, 50));
-				file2.create(getRandomContents(), true, SubMonitor.convert(m, 50));
+				file1.setContents(createRandomContentsStream(), true, false, SubMonitor.convert(m, 50));
+				file2.create(createRandomContentsStream(), true, SubMonitor.convert(m, 50));
 			} finally {
 				m.done();
 			}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
@@ -110,9 +111,9 @@ public class IResourceDeltaTest extends ResourceTest {
 
 		//do the work
 		IWorkspaceRunnable body = monitor -> {
-			file1.setContents(getRandomContents(), true, true, createTestMonitor());
+			file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 			folder2.delete(true, createTestMonitor());
-			file4.create(getRandomContents(), true, createTestMonitor());
+			file4.create(createRandomContentsStream(), true, createTestMonitor());
 		};
 		try {
 			getWorkspace().run(body, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
@@ -1224,7 +1225,7 @@ public class IResourceTest extends ResourceTest {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		verifier = new ResourceDeltaVerifier();
 		getWorkspace().addResourceChangeListener(verifier, IResourceChangeEvent.POST_CHANGE);
@@ -1335,7 +1336,7 @@ public class IResourceTest extends ResourceTest {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// all resources have independent derived flag; all non-derived by
 		// default; check each type
@@ -2220,7 +2221,7 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("target");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// file
 		assertFalse("1.0", file.isReadOnly());
@@ -2433,7 +2434,7 @@ public class IResourceTest extends ResourceTest {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// all resources have independent team private member flag
 		// all non-TPM by default; check each type

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
@@ -121,7 +122,7 @@ public class ISynchronizerTest extends ResourceTest {
 			if (resource.getType() == IResource.ROOT) {
 				return true;
 			}
-			byte[] b = getRandomString().getBytes();
+			byte[] b = createRandomString().getBytes();
 			table.put(resource.getFullPath(), b);
 			synchronizer.setSyncInfo(qname, resource, b);
 			return true;
@@ -194,7 +195,7 @@ public class ISynchronizerTest extends ResourceTest {
 			if (resource.getType() == IResource.ROOT) {
 				return true;
 			}
-			byte[] b = getRandomString().getBytes();
+			byte[] b = createRandomString().getBytes();
 			table.put(resource.getFullPath(), b);
 			synchronizer.setSyncInfo(qname, resource, b);
 			return true;
@@ -388,7 +389,7 @@ public class ISynchronizerTest extends ResourceTest {
 			if (resource.getType() == IResource.ROOT) {
 				return true;
 			}
-			byte[] b = getRandomString().getBytes();
+			byte[] b = createRandomString().getBytes();
 			synchronizer.setSyncInfo(qname, resource, b);
 			table.put(resource.getFullPath(), b);
 			return true;
@@ -607,7 +608,7 @@ public class ISynchronizerTest extends ResourceTest {
 			if (resource.getType() == IResource.ROOT) {
 				return true;
 			}
-			byte[] b = getRandomString().getBytes();
+			byte[] b = createRandomString().getBytes();
 			table.put(resource.getFullPath(), b);
 			return true;
 		};
@@ -667,7 +668,7 @@ public class ISynchronizerTest extends ResourceTest {
 			if (resource.getType() == IResource.ROOT) {
 				return true;
 			}
-			byte[] b = getRandomString().getBytes();
+			byte[] b = createRandomString().getBytes();
 			synchronizer.setSyncInfo(qname, resource, b);
 			table.put(resource.getFullPath(), b);
 			return true;
@@ -717,9 +718,9 @@ public class ISynchronizerTest extends ResourceTest {
 		createInWorkspace(new IResource[] {file1, file2});
 
 		// sets sync info for the folder and its children
-		synchronizer.setSyncInfo(partner, folder, getRandomString().getBytes());
-		synchronizer.setSyncInfo(partner, file1, getRandomString().getBytes());
-		synchronizer.setSyncInfo(partner, file2, getRandomString().getBytes());
+		synchronizer.setSyncInfo(partner, folder, createRandomString().getBytes());
+		synchronizer.setSyncInfo(partner, file1, createRandomString().getBytes());
+		synchronizer.setSyncInfo(partner, file2, createRandomString().getBytes());
 
 		// 1) tests with one child first
 		assertTrue("1.1", file1.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
@@ -152,9 +153,9 @@ public class IWorkspaceTest extends ResourceTest {
 
 		// create the files
 		IFile projectFile = project.getFile("ProjectPhile");
-		file2.create(getRandomContents(), false, createTestMonitor());
-		file3.create(getRandomContents(), false, createTestMonitor());
-		projectFile.create(getRandomContents(), false, createTestMonitor());
+		file2.create(createRandomContentsStream(), false, createTestMonitor());
+		file3.create(createRandomContentsStream(), false, createTestMonitor());
+		projectFile.create(createRandomContentsStream(), false, createTestMonitor());
 
 		//source files aren't siblings
 		assertThrows(CoreException.class, () -> getWorkspace().copy(new IResource[] { file, projectFile },
@@ -173,7 +174,7 @@ public class IWorkspaceTest extends ResourceTest {
 
 		//target exists
 		assertThrows(CoreException.class, () -> {
-			file2Copy.create(getRandomContents(), false, createTestMonitor());
+			file2Copy.create(createRandomContentsStream(), false, createTestMonitor());
 			getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
 		});
 		removeFromWorkspace(file2Copy);
@@ -245,7 +246,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		file.create(getRandomContents(), false, createTestMonitor());
+		file.create(createRandomContentsStream(), false, createTestMonitor());
 		resources = new IResource[] {};
 		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
@@ -264,7 +265,7 @@ public class IWorkspaceTest extends ResourceTest {
 		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		assertDoesNotExistInFileSystem(resources);
 		assertDoesNotExistInWorkspace(resources);
-		file.create(getRandomContents(), false, createTestMonitor());
+		file.create(createRandomContentsStream(), false, createTestMonitor());
 		resources = new IResource[] {fakeProject};
 		assertTrue(getWorkspace().delete(resources, false, createTestMonitor()).isOK());
 		//	assertDoesNotExistInFileSystem(resources);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
@@ -93,7 +94,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		CoreException exception = assertThrows(CoreException.class, () -> fileLink
-				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, createTestMonitor()));
+				.setContents(new ByteArrayInputStream(createRandomString().getBytes()), IResource.NONE, createTestMonitor()));
 		assertEquals("1.2", IResourceStatus.NOT_FOUND_LOCAL, exception.getStatus().getCode());
 
 		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
@@ -103,7 +104,7 @@ public class LinkedResourceSyncMoveAndCopyTest extends ResourceTest {
 		deleteOnTearDown(fileLocation);
 
 		exception = assertThrows(CoreException.class, () -> fileLink
-				.setContents(new ByteArrayInputStream(getRandomString().getBytes()), IResource.NONE, createTestMonitor()));
+				.setContents(new ByteArrayInputStream(createRandomString().getBytes()), IResource.NONE, createTestMonitor()));
 		assertEquals("2.2", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.readStringInFileSystem;
@@ -216,7 +217,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 		// creating child should fail
 		assertThrows(CoreException.class,
-				() -> folder.getFile("abc.txt").create(getRandomContents(), IResource.NONE, createTestMonitor()));
+				() -> folder.getFile("abc.txt").create(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -22,6 +22,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
@@ -235,7 +237,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -253,7 +255,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
-		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
+		assertThrows(CoreException.class, () -> file.setContents(createInputStream("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace(file);
 		// the location is null
@@ -270,7 +272,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
+		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
 	}
 
 	/**
@@ -290,7 +292,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -308,7 +310,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
-		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
+		assertThrows(CoreException.class, () -> file.setContents(createInputStream("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace(file);
 		// the location is null
@@ -326,7 +328,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
+		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
 	}
 
 	/**
@@ -436,7 +438,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -469,7 +471,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -501,7 +503,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -519,7 +521,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
-		assertThrows(CoreException.class, () -> file.setContents(getContents("new contents"), IResource.NONE, null));
+		assertThrows(CoreException.class, () -> file.setContents(createInputStream("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace(file);
 		// the location is null
@@ -537,7 +539,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
+		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
 	}
 
 	/**
@@ -558,8 +560,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		childFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
-		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		childFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
+		childFile.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(folder);
@@ -584,7 +586,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertTrue("3.6", !destination.exists());
 
 		//try to create a sub-file
-		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> destination.create(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
 
 		//try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
@@ -593,7 +595,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
 		assertThrows(CoreException.class,
-				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
+				() -> childFile.setContents(createInputStream("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace(folder);
 		// the location is null
@@ -674,8 +676,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(folder);
 
 		folder.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		childFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
-		childFile.setContents(getContents("contents for a file"), IResource.FORCE, null);
+		childFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
+		childFile.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(folder);
@@ -701,7 +703,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertTrue("3.6", !destination.exists());
 
 		// try to create a sub-file
-		assertThrows(CoreException.class, () -> destination.create(getRandomContents(), IResource.NONE, createTestMonitor()));
+		assertThrows(CoreException.class, () -> destination.create(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
 
 		// try to create a sub-folder
 		IFolder subFolder = folder.getFolder("SubFolder");
@@ -710,7 +712,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource has no-defined location - should fail
 		assertThrows(CoreException.class,
-				() -> childFile.setContents(getContents("new contents"), IResource.NONE, null));
+				() -> childFile.setContents(createInputStream("new contents"), IResource.NONE, null));
 
 		assertExistsInWorkspace(folder);
 		// the location is null
@@ -802,7 +804,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		file.setContents(getContents("contents for a file"), IResource.FORCE, createTestMonitor());
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -816,7 +818,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
-				() -> file.setContents(getContents("new contents"), IResource.NONE, createTestMonitor()));
+				() -> file.setContents(createInputStream("new contents"), IResource.NONE, createTestMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
@@ -824,7 +826,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		file.setContents(getContents("contents in different location"), IResource.FORCE, createTestMonitor());
+		file.setContents(createInputStream("contents in different location"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem(file);
@@ -835,7 +837,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
+		assertTrue("4.3", compareContent(file.getContents(), createInputStream("contents in different location")));
 
 		// clean-up
 		removeFromFileSystem(file);
@@ -846,7 +848,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
+		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
 	}
 
 	/**
@@ -867,7 +869,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		file.setContents(getContents("contents for a file"), IResource.FORCE, createTestMonitor());
+		file.setContents(createInputStream("contents for a file"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -881,7 +883,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// try to change resource's contents
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
-				() -> file.setContents(getContents("new contents"), IResource.NONE, createTestMonitor()));
+				() -> file.setContents(createInputStream("new contents"), IResource.NONE, createTestMonitor()));
 		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
@@ -889,7 +891,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInFileSystem(file);
 
 		// successfully changes resource's contents (using IResource.FORCE)
-		file.setContents(getContents("contents in different location"), IResource.FORCE, createTestMonitor());
+		file.setContents(createInputStream("contents in different location"), IResource.FORCE, createTestMonitor());
 
 		// now the file exists in a different location
 		assertExistsInFileSystem(file);
@@ -900,7 +902,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		assertTrue("4.3", compareContent(file.getContents(), getContents("contents in different location")));
+		assertTrue("4.3", compareContent(file.getContents(), createInputStream("contents in different location")));
 
 		// clean-up
 		removeFromFileSystem(file);
@@ -911,7 +913,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), getContents("contents for a file")));
+		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
@@ -14,9 +14,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
+
 import java.util.Arrays;
 import java.util.Map;
-import org.eclipse.core.internal.resources.*;
+import org.eclipse.core.internal.resources.IMarkerSetElement;
+import org.eclipse.core.internal.resources.MarkerAttributeMap;
+import org.eclipse.core.internal.resources.MarkerInfo;
+import org.eclipse.core.internal.resources.MarkerSet;
 import org.eclipse.core.resources.IMarker;
 
 public class MarkerSetTest extends ResourceTest {
@@ -53,7 +58,7 @@ public class MarkerSetTest extends ResourceTest {
 		MarkerInfo[] infos = new MarkerInfo[max];
 		for (int i = 0; i < max; i++) {
 			info = new MarkerInfo(IMarker.PROBLEM, i);
-			info.setAttribute(IMarker.MESSAGE, getRandomString(), true);
+			info.setAttribute(IMarker.MESSAGE, createRandomString(), true);
 			infos[i] = info;
 		}
 
@@ -83,7 +88,7 @@ public class MarkerSetTest extends ResourceTest {
 		MarkerInfo[] infos = new MarkerInfo[max];
 		for (int i = 0; i < max; i++) {
 			info = new MarkerInfo(IMarker.PROBLEM, i);
-			info.setAttribute(IMarker.MESSAGE, getRandomString(), true);
+			info.setAttribute(IMarker.MESSAGE, createRandomString(), true);
 			infos[i] = info;
 		}
 		set.addAll(infos);
@@ -102,7 +107,7 @@ public class MarkerSetTest extends ResourceTest {
 		MarkerInfo[] infos = new MarkerInfo[max];
 		for (int i = 0; i < max; i++) {
 			info = new MarkerInfo(IMarker.PROBLEM, i);
-			info.setAttribute(IMarker.MESSAGE, getRandomString(), true);
+			info.setAttribute(IMarker.MESSAGE, createRandomString(), true);
 			infos[i] = info;
 		}
 		set.addAll(infos);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
@@ -321,7 +323,7 @@ public class MarkerTest extends ResourceTest {
 			listener.reset();
 			// each setAttributes triggers one additional resource change event
 			IMarker marker = resource.createMarker(TEST_PROBLEM_MARKER);
-			marker.setAttribute(IMarker.MESSAGE, getRandomString());
+			marker.setAttribute(IMarker.MESSAGE, createRandomString());
 			marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
 			assertThat(listener.numberOfChanges(), is(3));
 		}
@@ -338,7 +340,7 @@ public class MarkerTest extends ResourceTest {
 			listener.reset();
 			// each setAttributes triggers one resource change event
 			resource.createMarker(TEST_PROBLEM_MARKER,
-					Map.of(IMarker.MESSAGE, getRandomString(), IMarker.PRIORITY, IMarker.PRIORITY_HIGH));
+					Map.of(IMarker.MESSAGE, createRandomString(), IMarker.PRIORITY, IMarker.PRIORITY_HIGH));
 			assertThat(listener.numberOfChanges(), is(1));
 		}
 	}
@@ -443,14 +445,14 @@ public class MarkerTest extends ResourceTest {
 
 		int actual = marker.getAttribute(IMarker.TRANSIENT, -1);
 		assertThat(actual, is(expected));
-		marker.setAttribute(IMarker.MESSAGE, getRandomString());
+		marker.setAttribute(IMarker.MESSAGE, createRandomString());
 	}
 
 	public void test_10989() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		createInWorkspace(project);
 		IFile file = project.getFile("foo.txt");
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 		file.createMarker(IMarker.PROBLEM);
 		IMarker[] found = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
 		assertThat(found, arrayWithSize(1));
@@ -463,12 +465,12 @@ public class MarkerTest extends ResourceTest {
 	 * Bug 289811 - ArrayIndexOutOfBoundsException in MarkerAttributeMap
 	 */
 	public void test_289811() throws CoreException {
-		String testValue = getRandomString();
+		String testValue = createRandomString();
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		project.create(null);
 		project.open(null);
 		IFile file = project.getFile("foo.txt");
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 		IMarker marker = file.createMarker(IMarker.PROBLEM);
 		marker.setAttributes(new HashMap<>());
 		marker.setAttribute(IMarker.SEVERITY, testValue);
@@ -640,7 +642,7 @@ public class MarkerTest extends ResourceTest {
 			listener.reset();
 			markers[0].delete();
 			assertMarkerDoesNotExist(markers[0]);
-			markers[1].setAttribute(IMarker.MESSAGE, getRandomString());
+			markers[1].setAttribute(IMarker.MESSAGE, createRandomString());
 			markers[2] = resource.createMarker(IMarker.TASK);
 			listener.assertNumberOfAffectedResources(1);
 			listener.assertChanges(resource, new IMarker[] { markers[2] }, new IMarker[] { markers[0] },
@@ -1186,7 +1188,7 @@ public class MarkerTest extends ResourceTest {
 			assertMarkerHasAttributeValue(marker, IMarker.MESSAGE, null);
 
 			// set an attribute, get its value, then remove it
-			String testMessage = getRandomString();
+			String testMessage = createRandomString();
 			marker.setAttribute(IMarker.MESSAGE, testMessage);
 			assertMarkerHasAttributeValue(marker, IMarker.MESSAGE, testMessage);
 			marker.setAttribute(IMarker.MESSAGE, null);
@@ -1195,7 +1197,7 @@ public class MarkerTest extends ResourceTest {
 			// set more attributes, get their values, then remove one
 			String[] keys = new String[] { IMarker.LOCATION, IMarker.SEVERITY, IMarker.DONE };
 			Object[] values = new Object[3];
-			values[0] = getRandomString();
+			values[0] = createRandomString();
 			values[1] = Integer.valueOf(5);
 			values[2] = Boolean.FALSE;
 			Map<String, Object> originalMap = Map.of(keys[0], values[0], keys[1], values[1], keys[2], values[2]);
@@ -1213,9 +1215,9 @@ public class MarkerTest extends ResourceTest {
 			// try sending null as args
 			assertThrows(resourcePath, RuntimeException.class, () -> marker.getAttribute(null));
 			assertThrows(resourcePath, RuntimeException.class, () -> marker.getAttributes(null));
-			assertThrows(resourcePath, RuntimeException.class, () -> marker.setAttribute(null, getRandomString()));
+			assertThrows(resourcePath, RuntimeException.class, () -> marker.setAttribute(null, createRandomString()));
 			assertThrows(resourcePath, RuntimeException.class,
-					() -> marker.setAttributes(null, new String[] { getRandomString() }));
+					() -> marker.setAttributes(null, new String[] { createRandomString() }));
 			assertThrows(resourcePath, RuntimeException.class,
 					() -> marker.setAttributes(new String[] { IMarker.MESSAGE }, null));
 			//set attributes on deleted marker
@@ -1265,7 +1267,7 @@ public class MarkerTest extends ResourceTest {
 			assertThat(resourcePath, marker.getAttributes(new String[] { IMarker.MESSAGE })[0], is(nullValue()));
 
 			// set an attribute, get its value, then remove it
-			String testMessage = getRandomString();
+			String testMessage = createRandomString();
 			marker.setAttribute(IMarker.MESSAGE, testMessage);
 			assertMarkerHasAttributeValue(marker, IMarker.MESSAGE, testMessage);
 			marker.setAttribute(IMarker.MESSAGE, null);
@@ -1274,7 +1276,7 @@ public class MarkerTest extends ResourceTest {
 			// set more attributes, get their values, then remove one
 			String[] keys = new String[] { IMarker.LOCATION, IMarker.SEVERITY, IMarker.DONE };
 			Object[] values = new Object[3];
-			values[0] = getRandomString();
+			values[0] = createRandomString();
 			values[1] = Integer.valueOf(5);
 			values[2] = Boolean.FALSE;
 			Map<String, Object> originalMap = Map.of(keys[0], values[0], keys[1], values[1], keys[2], values[2]);
@@ -1295,9 +1297,9 @@ public class MarkerTest extends ResourceTest {
 			assertThrows(resourcePath, RuntimeException.class, () -> marker.getAttribute(null, true));
 			assertThrows(resourcePath, RuntimeException.class, () -> marker.getAttribute(null, 5));
 			assertThrows(resourcePath, RuntimeException.class, () -> marker.getAttributes(null));
-			assertThrows(resourcePath, RuntimeException.class, () -> marker.setAttribute(null, getRandomString()));
+			assertThrows(resourcePath, RuntimeException.class, () -> marker.setAttribute(null, createRandomString()));
 			assertThrows(resourcePath, RuntimeException.class,
-					() -> marker.setAttributes(null, new String[] { getRandomString() }));
+					() -> marker.setAttributes(null, new String[] { createRandomString() }));
 			assertThrows(resourcePath, RuntimeException.class,
 					() -> marker.setAttributes(new String[] { IMarker.MESSAGE }, null));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
 
@@ -69,7 +70,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		sourceFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		//copy to linked destination should succeed
 		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
@@ -126,7 +127,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		sourceFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		//move to linked destination should succeed
 		sourceFile.move(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
@@ -156,7 +157,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		createInWorkspace(project);
 		source.createLink(sourceStore.toURI(), IResource.NONE, createTestMonitor());
 		destination.createLink(destinationStore.toURI(), IResource.NONE, createTestMonitor());
-		sourceFile.create(getRandomContents(), IResource.NONE, createTestMonitor());
+		sourceFile.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		//move to linked destination should succeed
 		project.move(IPath.fromPortableString("movedProject"), IResource.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
@@ -68,7 +69,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// file bit is set already for a new file
 		assertTrue("1.0", file.getResourceAttributes().isArchive());
@@ -92,7 +93,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isExecutable());
@@ -117,7 +118,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isHidden());
@@ -141,7 +142,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// file
 		assertTrue("1.0", !file.getResourceAttributes().isReadOnly());
@@ -205,7 +206,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		IProject project = getWorkspace().getRoot().getProject("testRefreshExecutableOnFolder");
 		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// folder is executable initially and the file should exist
 		assertTrue("1.0", project.getResourceAttributes().isExecutable());
@@ -232,7 +233,7 @@ public class ResourceAttributeTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile link = project.getFile("link");
-		createInWorkspace(link, getRandomString());
+		createInWorkspace(link, createRandomString());
 
 		// attempts to set the symbolic link attribute wont't affect
 		// the resource and the underlying file
@@ -274,7 +275,7 @@ public class ResourceAttributeTest extends ResourceTest {
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFile file = project.getFile(createUniqueString());
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		for (int attribute : attributes) {
 			// only activate this test on platforms that support it

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTest.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources;
 
 import static java.io.InputStream.nullInputStream;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
@@ -167,7 +169,7 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public void createFileInFileSystem(IFileStore file) throws CoreException, IOException {
 		file.getParent().mkdir(EFS.NONE, null);
-		try (InputStream input = getRandomContents(); OutputStream output = file.openOutputStream(EFS.NONE, null)) {
+		try (InputStream input = createRandomContentsStream(); OutputStream output = file.openOutputStream(EFS.NONE, null)) {
 			input.transferTo(output);
 		}
 	}
@@ -178,7 +180,7 @@ public abstract class ResourceTest extends CoreTest {
 	 */
 	public void createFileInFileSystem(IPath path) throws CoreException, IOException {
 		path.toFile().getParentFile().mkdirs();
-		try (InputStream input = getRandomContents(); OutputStream output = new FileOutputStream(path.toFile())) {
+		try (InputStream input = createRandomContentsStream(); OutputStream output = new FileOutputStream(path.toFile())) {
 			input.transferTo(output);
 		}
 	}
@@ -241,7 +243,7 @@ public abstract class ResourceTest extends CoreTest {
 	 * Create the given file in the workspace resource info tree.
 	 */
 	public void createInWorkspace(IFile resource, String contents) throws CoreException {
-		InputStream contentStream = getContents(contents);
+		InputStream contentStream = createInputStream(contents);
 		if (resource == null) {
 			return;
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,6 +30,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -60,6 +62,8 @@ import org.eclipse.core.tests.harness.FussyProgressMonitor;
  * Utilities for resource tests.
  */
 public final class ResourceTestUtil {
+	private static final Random RANDOM = new Random();
+
 	private ResourceTestUtil() {
 	}
 
@@ -69,6 +73,29 @@ public final class ResourceTestUtil {
 
 	public static String createUniqueString() {
 		return new UniversalUniqueIdentifier().toString();
+	}
+
+	/**
+	 * Return an input stream with some the specified text to use as contents for a
+	 * file resource.
+	 */
+	public static InputStream createInputStream(String text) {
+		return new ByteArrayInputStream(text.getBytes());
+	}
+
+	/**
+	 * Return String with some random text to use as contents for a file resource.
+	 */
+	public static String createRandomString() {
+		return RANDOM.nextLong() + " " + RANDOM.nextLong();
+	}
+
+	/**
+	 * Return an input stream with some random text to use as contents for a file
+	 * resource.
+	 */
+	public static InputStream createRandomContentsStream() {
+		return createInputStream(createRandomString());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
@@ -116,6 +117,6 @@ public class ResourceURLTest extends ResourceTest {
 		createInWorkspace(file, CONTENT);
 		URL url = new URL(PlatformURLResourceConnection.RESOURCE_URL_STRING + "My%20Project/a.txt");
 		InputStream stream = url.openStream();
-		assertTrue("1.0", compareContent(stream, getContents(CONTENT)));
+		assertTrue("1.0", compareContent(stream, createInputStream(CONTENT)));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -19,6 +19,7 @@ import static java.io.InputStream.nullInputStream;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertThrows;
@@ -198,7 +199,7 @@ public class VirtualFolderTest extends ResourceTest {
 		folder.createLink(folderLocation, IResource.NONE, createTestMonitor());
 		file.createLink(fileLocation, IResource.NONE, createTestMonitor());
 
-		childFile.create(getRandomContents(), true, createTestMonitor());
+		childFile.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// move the project
 		IProject destinationProject = getWorkspace().getRoot().getProject("MoveTargetProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -20,6 +20,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -78,7 +81,7 @@ public class WorkspaceTest extends ResourceTest {
 		IPath path = IPath.fromOSString("/testProject/testFileForDelete2");
 		IFile target = getWorkspace().getRoot().getFile(path);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getContents(""), true, monitor);
+		target.create(createInputStream(""), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue(target.exists());
 		monitor.prepare();
@@ -91,7 +94,7 @@ public class WorkspaceTest extends ResourceTest {
 		IPath path = IPath.fromOSString("/testProject/testFolder/testFile2");
 		IFile target = getWorkspace().getRoot().getFile(path);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue(target.exists());
 	}
@@ -100,7 +103,7 @@ public class WorkspaceTest extends ResourceTest {
 		IPath path = IPath.fromOSString("/testProject/targetFile");
 		IFile target = getWorkspace().getRoot().getFile(path);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		IFile destination = getWorkspace().getRoot().getFile(IPath.fromOSString("/testProject/movedFile"));
 		monitor.prepare();
@@ -140,10 +143,10 @@ public class WorkspaceTest extends ResourceTest {
 
 		// create the resources and set some content in a file that will be moved.
 		createInWorkspace(before);
-		String content = getRandomString();
+		String content = createRandomString();
 		IFile file = project.getFile(IPath.fromOSString("b/b/z"));
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		file.setContents(getContents(content), true, false, monitor);
+		file.setContents(createInputStream(content), true, false, monitor);
 		monitor.assertUsedUp();
 
 		// Be sure the resources exist and then move them.
@@ -156,7 +159,7 @@ public class WorkspaceTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(before);
 		assertExistsInWorkspace(after);
 		file = project.getFile(IPath.fromOSString("a/b/z"));
-		assertTrue("get not equal set", compareContent(getContents(content), file.getContents(false)));
+		assertTrue("get not equal set", compareContent(createInputStream(content), file.getContents(false)));
 	}
 
 	public void testFolderOverFile() throws Throwable {
@@ -287,12 +290,12 @@ public class WorkspaceTest extends ResourceTest {
 		fileTarget.create(null, true, monitor);
 		monitor.assertUsedUp();
 		assertTrue(fileTarget.exists());
-		String testString = getRandomString();
+		String testString = createRandomString();
 		monitor = new FussyProgressMonitor();
-		fileTarget.setContents(getContents(testString), true, false, monitor);
+		fileTarget.setContents(createInputStream(testString), true, false, monitor);
 		monitor.assertUsedUp();
 		try (InputStream content = fileTarget.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, getContents(testString)));
+			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
 		}
 	}
 
@@ -367,12 +370,12 @@ public class WorkspaceTest extends ResourceTest {
 	public void testSetContents() throws Throwable {
 		IPath path = IPath.fromOSString("/testProject/testFile");
 		IFile target = getWorkspace().getRoot().getFile(path);
-		String testString = getRandomString();
+		String testString = createRandomString();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.setContents(getContents(testString), true, false, monitor);
+		target.setContents(createInputStream(testString), true, false, monitor);
 		monitor.assertUsedUp();
 		try (InputStream content = target.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, getContents(testString)));
+			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
 		}
 	}
 
@@ -404,7 +407,7 @@ public class WorkspaceTest extends ResourceTest {
 		IPath path = IPath.fromOSString("/testProject/simpleFile");
 		IFile target = getWorkspace().getRoot().getFile(path);
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
-		target.create(getRandomContents(), true, monitor);
+		target.create(createRandomContentsStream(), true, monitor);
 		monitor.assertUsedUp();
 		IFile destination = getWorkspace().getRoot().getFile(IPath.fromOSString("/testProject/newSimpleFile"));
 		monitor.prepare();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Set;
@@ -74,7 +75,7 @@ public class ContentDescriptionPerformanceTest extends ResourceTest {
 			folder.create(false, true, createTestMonitor());
 			for (int j = 0; j < TOTAL_FILES / SUBDIRS; j++) {
 				IFile file = folder.getFile("file_" + j + getFileName(j));
-				file.create(getContents(getContents(j)), false, createTestMonitor());
+				file.create(createInputStream(getContents(j)), false, createTestMonitor());
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
@@ -60,10 +62,10 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 				for (IFolder folder : folders) {
 					for (int j = 0; j < filesPerFolder; j++) {
 						IFile file = folder.getFile("file" + j);
-						createInWorkspace(file, getRandomString());
+						createInWorkspace(file, createRandomString());
 						try {
 							for (int k = 0; k < statesPerFile; k++) {
-								file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+								file.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 							}
 						} catch (CoreException ce) {
 							fail("0.5", ce);
@@ -97,7 +99,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 
 			@Override
 			protected void setUp() throws CoreException {
-				createInWorkspace(file, getRandomString());
+				createInWorkspace(file, createRandomString());
 			}
 
 			@Override
@@ -113,7 +115,7 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			@Override
 			protected void test() {
 				try {
-					file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+					file.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 				} catch (CoreException e) {
 					fail("", e);
 				}
@@ -134,10 +136,10 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 			protected void setUp() throws CoreException {
 				createInWorkspace(new IResource[] {project, folder1, folder2});
 				try {
-					file1.create(getRandomContents(), IResource.FORCE, createTestMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
-					file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+					file1.create(createRandomContentsStream(), IResource.FORCE, createTestMonitor());
+					file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+					file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+					file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 				} catch (CoreException e) {
 					fail("0.0", e);
 				}
@@ -284,9 +286,9 @@ public class LocalHistoryPerformanceTest extends ResourceTest {
 	public void testGetHistory() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		final IFile file = project.getFile("file.txt");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 		for (int i = 0; i < 100; i++) {
-			file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+			file.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 		}
 		new PerformanceTestRunner() {
 			@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -91,7 +92,7 @@ public class MarkerPerformanceTest extends ResourceTest {
 			project.create(null);
 			project.open(null);
 			file = project.getFile(IPath.ROOT.append("file.txt"));
-			file.create(getRandomContents(), true, null);
+			file.create(createRandomContentsStream(), true, null);
 			//create markers
 			for (int i = 0; i < NUM_MARKERS; i++) {
 				createdMarkers[i] = file.createMarker(IMarker.BOOKMARK);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,7 +57,7 @@ public class PropertyManagerPerformanceTest extends ResourceTest {
 		for (IFolder folder : folders) {
 			for (int j = 0; j < filesPerFolder; j++) {
 				IFile file = folder.getFile("file" + j);
-				createInWorkspace(file, getRandomString());
+				createInWorkspace(file, createRandomString());
 				resources.add(file);
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;
@@ -49,7 +50,7 @@ public class Bug_025457 extends ResourceTest {
 		IFile sourceFile = source.getFile("file.txt");
 		IFile destFile = source.getFile("File.txt");
 		createInWorkspace(source);
-		final String content = getRandomString();
+		final String content = createRandomString();
 		createInWorkspace(sourceFile, content);
 
 		//open a stream in the source to cause the rename to fail

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.IContainer;
@@ -49,7 +50,7 @@ public class Bug_028981 extends ResourceTest {
 		IFile prefs = settings.getFile("org.eclipse.core.resources.prefs");
 
 		createInWorkspace(new IResource[] {teamPrivateFile, regularFile});
-		synchronizer.setSyncInfo(partner, phantomFile, getRandomString().getBytes());
+		synchronizer.setSyncInfo(partner, phantomFile, createRandomString().getBytes());
 		teamPrivateFile.setTeamPrivateMember(true);
 		assertTrue("0.7", !regularFile.isPhantom() && !regularFile.isTeamPrivateMember());
 		assertTrue("0.8", teamPrivateFile.isTeamPrivateMember());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
@@ -45,8 +46,8 @@ public class Bug_029671 extends ResourceTest {
 
 		try {
 			// sets sync info for the folder and its children
-			synchronizer.setSyncInfo(partner, folder, getRandomString().getBytes());
-			synchronizer.setSyncInfo(partner, file, getRandomString().getBytes());
+			synchronizer.setSyncInfo(partner, folder, createRandomString().getBytes());
+			synchronizer.setSyncInfo(partner, file, createRandomString().getBytes());
 
 			IFolder targetFolder = project.getFolder("target");
 			IFile targetFile = targetFolder.getFile(file.getName());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
@@ -57,8 +58,8 @@ public class Bug_032076 extends ResourceTest {
 		deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = sourceFile.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);
@@ -114,8 +115,8 @@ public class Bug_032076 extends ResourceTest {
 		deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = file1.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);
@@ -174,8 +175,8 @@ public class Bug_032076 extends ResourceTest {
 		deleteOnTearDown(sourceProject.getLocation()); // Ensure project location is moved after test
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = file1.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);
@@ -229,8 +230,8 @@ public class Bug_032076 extends ResourceTest {
 		IFileStore roFolderStore = ((Resource) roFolder).getStore();
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = sourceFile.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);
@@ -293,8 +294,8 @@ public class Bug_032076 extends ResourceTest {
 		IFileStore destinationROFolderLocation = ((Resource) destinationROFolder).getStore();
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = file1.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);
@@ -374,8 +375,8 @@ public class Bug_032076 extends ResourceTest {
 		createInWorkspace(new IResource[] { file1 });
 
 		// add a marker to a file to ensure the move operation is not losing anything
-		String attributeKey = getRandomString();
-		String attributeValue = getRandomString();
+		String attributeKey = createRandomString();
+		String attributeValue = createRandomString();
 		long markerId = -1;
 		IMarker bookmark = file1.createMarker(IMarker.BOOKMARK);
 		bookmark.setAttribute(attributeKey, attributeValue);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
@@ -47,9 +49,9 @@ public class Bug_079398 extends ResourceTest {
 		// max size of file = 1 Mb
 		description.setMaxFileStateSize(1024 * 1024);
 		getWorkspace().setDescription(description);
-		createInWorkspace(file1, getRandomString());
+		createInWorkspace(file1, createRandomString());
 		for (int i = 0; i < 10; i++) {
-			file1.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+			file1.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}
 
 		IFileState[] sourceStates = file1.getHistory(createTestMonitor());
@@ -70,7 +72,7 @@ public class Bug_079398 extends ResourceTest {
 
 		// now cause the destination to have many more states
 		for (int i = 0; i <= description.getMaxFileStates(); i++) {
-			file2.setContents(getRandomContents(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
+			file2.setContents(createRandomContentsStream(), IResource.FORCE | IResource.KEEP_HISTORY, createTestMonitor());
 		}
 		IHistoryStore history = ((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore();
 		// clean history

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
@@ -73,7 +74,7 @@ public class Bug_165892 extends ResourceTest {
 		createInWorkspace(sourceFile);
 
 		// modify the source file so it has some history
-		sourceFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+		sourceFile.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 		// check that the source file has the expected history
 		assertEquals("1.0", 1, sourceFile.getHistory(createTestMonitor()).length);
 
@@ -85,7 +86,7 @@ public class Bug_165892 extends ResourceTest {
 		assertEquals("2.1", 1, destinationFile.getHistory(createTestMonitor()).length);
 
 		//modify the destination to change its history
-		destinationFile.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+		destinationFile.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 
 		//make sure the history is correct
 		assertEquals("2.0", 1, sourceFile.getHistory(createTestMonitor()).length);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.ByteArrayInputStream;
@@ -57,7 +58,7 @@ public class Bug_265810 extends ResourceTest {
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
 		file.createLink(createFolderAtRandomLocation(), IResource.NONE, new NullProgressMonitor());
-		file.setContents(getContents("contents for a file"), IResource.NONE, new NullProgressMonitor());
+		file.setContents(createInputStream("contents for a file"), IResource.NONE, new NullProgressMonitor());
 
 		// save the .project [1] content
 		byte[] dotProject1 = storeDotProject(project);
@@ -110,7 +111,7 @@ public class Bug_265810 extends ResourceTest {
 		listenerInMainThreadCallback.get().run();
 
 		// create newFile as a non-linked resource
-		newFile.create(getContents("content"), IResource.NONE, new NullProgressMonitor());
+		newFile.create(createInputStream("content"), IResource.NONE, new NullProgressMonitor());
 
 		try {
 			resourceDeltas = new ArrayList<>();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 
@@ -61,7 +63,7 @@ public class Bug_378156 extends ResourceTest {
 			if (cancel) {
 				throw new OperationCanceledException();
 			}
-			jobFile.setContents(getRandomContents(), IResource.NONE, null);
+			jobFile.setContents(createRandomContentsStream(), IResource.NONE, null);
 			//wait for signal
 			try {
 				jobFlag.acquire();
@@ -92,7 +94,7 @@ public class Bug_378156 extends ResourceTest {
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 		//build may not be triggered immediately
 		Thread.sleep(2000);
 		waitForBuild();
@@ -134,7 +136,7 @@ public class Bug_378156 extends ResourceTest {
 		command.setBuilderName(SignaledBuilder.BUILDER_ID);
 		desc.setBuildSpec(new ICommand[] {command});
 		project1.setDescription(desc, createTestMonitor());
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 		waitForBuild();
 
 		//initialize the builder
@@ -143,7 +145,7 @@ public class Bug_378156 extends ResourceTest {
 
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			//modify the file so autobuild is needed
-			file.setContents(getRandomContents(), IResource.NONE, null);
+			file.setContents(createRandomContentsStream(), IResource.NONE, null);
 			//create a nested operation that immediately cancels
 			try {
 				getWorkspace().run((IWorkspaceRunnable) monitor1 -> {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;
@@ -65,7 +66,7 @@ public class IFileTest extends ResourceTest {
 			folder.setReadOnly(true);
 			assertTrue(folder.isReadOnly());
 			CoreException exception = assertThrows(CoreException.class,
-					() -> file.create(getRandomContents(), true, createTestMonitor()));
+					() -> file.create(createRandomContentsStream(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.FAILED_WRITE_LOCAL, exception.getStatus().getCode());
 		} finally {
 			folder.setReadOnly(false);
@@ -97,7 +98,7 @@ public class IFileTest extends ResourceTest {
 			folder.setReadOnly(true);
 			assertTrue(folder.isReadOnly());
 			CoreException exception = assertThrows(CoreException.class,
-					() -> file.create(getRandomContents(), true, createTestMonitor()));
+					() -> file.create(createRandomContentsStream(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.PARENT_READ_ONLY, exception.getStatus().getCode());
 		} finally {
 			folder.setReadOnly(false);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -16,6 +16,9 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
@@ -65,11 +68,11 @@ public class IResourceTest extends ResourceTest {
 		project.open(null);
 
 		IFile target = project.getFile("file1");
-		target.create(getContents("abc"), false, null);
-		target.appendContents(getContents("def"), false, true, null);
+		target.create(createInputStream("abc"), false, null);
+		target.appendContents(createInputStream("def"), false, true, null);
 
 		InputStream content = target.getContents(false);
-		assertTrue("3.0", compareContent(content, getContents("abcdef")));
+		assertTrue("3.0", compareContent(content, createInputStream("abcdef")));
 	}
 
 	/**
@@ -95,14 +98,14 @@ public class IResourceTest extends ResourceTest {
 		}
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("a.txt");
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 		// ensure archive bit is not set
 		ResourceAttributes attributes = file.getResourceAttributes();
 		attributes.setArchive(false);
 		file.setResourceAttributes(attributes);
 		assertTrue("1.0", !file.getResourceAttributes().isArchive());
 		// modify the file
-		file.setContents(getRandomContents(), IResource.KEEP_HISTORY, createTestMonitor());
+		file.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 
 		//now the archive bit should be set
 		assertTrue("2.0", file.getResourceAttributes().isArchive());
@@ -219,7 +222,7 @@ public class IResourceTest extends ResourceTest {
 		IFile source = project.getFile("file1");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		source.create(getContents("abc"), true, createTestMonitor());
+		source.create(createInputStream("abc"), true, createTestMonitor());
 
 		Thread.sleep(2000);
 
@@ -251,13 +254,13 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("file");
 		project.create(null);
 		project.open(null);
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 
 		// force = true
 		assertTrue("2.0", file.exists());
 		IFile anotherFile = project.getFile("File");
 
-		ThrowingRunnable forcedFileCreation = () -> anotherFile.create(getRandomContents(), true, null);
+		ThrowingRunnable forcedFileCreation = () -> anotherFile.create(createRandomContentsStream(), true, null);
 		if (caseSensitive) {
 			forcedFileCreation.run();
 		} else {
@@ -268,7 +271,7 @@ public class IResourceTest extends ResourceTest {
 		anotherFile.delete(true, false, null);
 
 		// force = false
-		ThrowingRunnable fileCreation = () -> anotherFile.create(getRandomContents(), false, null);
+		ThrowingRunnable fileCreation = () -> anotherFile.create(createRandomContentsStream(), false, null);
 		if (caseSensitive) {
 			fileCreation.run();
 		} else {
@@ -302,7 +305,7 @@ public class IResourceTest extends ResourceTest {
 		assertTrue("2.2", !folder.exists());
 
 		IFile file = project.getFile(sb.toString());
-		assertThrows(CoreException.class, () -> file.create(getRandomContents(), true, null));
+		assertThrows(CoreException.class, () -> file.create(createRandomContentsStream(), true, null));
 		assertTrue("3.1", !file.exists());
 
 		// clean up
@@ -327,7 +330,7 @@ public class IResourceTest extends ResourceTest {
 		IFile file = project.getFile("MyFile");
 		createInFileSystem(file);
 
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 	}
 
 	/*
@@ -438,16 +441,16 @@ public class IResourceTest extends ResourceTest {
 
 		final IFile target = project.getFile("file1");
 		String contents = "some random contents";
-		target.create(getContents(contents), false, null);
+		target.create(createInputStream(contents), false, null);
 
 		try (InputStream is = target.getContents(false)) {
-			assertTrue("2.0", compareContent(getContents(contents), is));
+			assertTrue("2.0", compareContent(createInputStream(contents), is));
 		}
 
 		final String newContents = "some other contents";
 		Thread.sleep(5000);
 		try (FileOutputStream output = new FileOutputStream(target.getLocation().toFile())) {
-			getContents(newContents).transferTo(output);
+			createInputStream(newContents).transferTo(output);
 		}
 
 		final AtomicReference<ThrowingRunnable> listenerInMainThreadCallback = new AtomicReference<>(() -> {
@@ -455,7 +458,7 @@ public class IResourceTest extends ResourceTest {
 		IResourceChangeListener listener = event -> {
 			listenerInMainThreadCallback.set(() -> {
 				try (InputStream is = target.getContents(true)) {
-					assertTrue("4.0", compareContent(getContents(newContents), is));
+					assertTrue("4.0", compareContent(createInputStream(newContents), is));
 				}
 			});
 		};
@@ -475,7 +478,7 @@ public class IResourceTest extends ResourceTest {
 		assertEquals("5.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		try (InputStream is = target.getContents(true)) {
-			assertTrue("6.0", compareContent(getContents(newContents), is));
+			assertTrue("6.0", compareContent(createInputStream(newContents), is));
 		}
 	}
 
@@ -489,7 +492,7 @@ public class IResourceTest extends ResourceTest {
 		project.create(null);
 		project.open(null);
 		folder.create(true, true, null);
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 		assertTrue("2.0", file.exists());
 		folder.refreshLocal(IResource.DEPTH_ZERO, null);
 		assertTrue("2.2", file.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.internal.resources.Workspace;
@@ -44,11 +45,11 @@ public class IWorkspaceTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IResource[] allResources = new IResource[] {file1, folder};
 		folder.create(true, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		IFileState[] states = file1.getHistory(createTestMonitor());
 		assertEquals("1.0", 3, states.length);
 		getWorkspace().delete(allResources, true, createTestMonitor());
@@ -56,11 +57,11 @@ public class IWorkspaceTest extends ResourceTest {
 
 		// test file (force = false)
 		folder.create(true, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), false, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file1.getHistory(createTestMonitor());
 		assertEquals("2.0", 3, states.length);
 		getWorkspace().delete(allResources, true, createTestMonitor());
@@ -78,22 +79,22 @@ public class IWorkspaceTest extends ResourceTest {
 
 		// test file (force = true)
 		IFile file1 = project.getFile("file.txt");
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().delete(new IFile[] { file1 }, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		IFileState[] states = file1.getHistory(createTestMonitor());
 		assertEquals("1.0", 3, states.length);
 		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 
 		// test file (force = false)
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().delete(new IFile[] { file1 }, false, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file1.getHistory(createTestMonitor());
 		assertEquals("2.0", 3, states.length);
 		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
@@ -103,12 +104,12 @@ public class IWorkspaceTest extends ResourceTest {
 		IFolder folder = project.getFolder("folder");
 		IFile file2 = folder.getFile("file2.txt");
 		folder.create(true, true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
-		file2.setContents(getRandomContents(), true, true, createTestMonitor());
-		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
+		file2.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file2.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().delete(new IResource[] { folder }, true, createTestMonitor());
 		folder.create(true, true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("3.0", 3, states.length);
 		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());
@@ -116,12 +117,12 @@ public class IWorkspaceTest extends ResourceTest {
 
 		// test folder (force = false)
 		folder.create(true, true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
-		file2.setContents(getRandomContents(), true, true, createTestMonitor());
-		file2.setContents(getRandomContents(), true, true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
+		file2.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file2.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		getWorkspace().delete(new IResource[] { folder }, false, createTestMonitor());
 		folder.create(true, true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file2.getHistory(createTestMonitor());
 		assertEquals("4.0", 3, states.length);
 		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.ICommand;
@@ -46,7 +47,7 @@ public class PR_1GHOM0N_Test extends ResourceTest {
 		IWorkspaceRunnable body = monitor -> {
 			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 			IFile file = project.getFile("test.txt");
-			file.create(getRandomContents(), true, createTestMonitor());
+			file.create(createRandomContentsStream(), true, createTestMonitor());
 		};
 		getWorkspace().run(body, createTestMonitor());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,7 +60,7 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		project.open(createTestMonitor());
 
 		IFile f = project.getFile(FILE_NAME);
-		f.create(getContents("content"), true, createTestMonitor());
+		f.create(createInputStream("content"), true, createTestMonitor());
 
 		IMarker marker = f.createMarker(IMarker.BOOKMARK);
 		marker.setAttribute(MARKER_ATTRIBUTE_NAME, MARKER_ATTRIBUTE);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Arrays;
@@ -75,7 +76,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 		// test that a deleted file can be found
 		// create and delete a file
-		pfile.create(getRandomContents(), true, createTestMonitor());
+		pfile.create(createRandomContentsStream(), true, createTestMonitor());
 		pfile.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
@@ -106,7 +107,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertEquals("0.5.4", 0, df.length);
 
 		// recreate the file
-		pfile.create(getRandomContents(), true, createTestMonitor());
+		pfile.create(createRandomContentsStream(), true, createTestMonitor());
 
 		saveWorkspace();
 	}
@@ -143,7 +144,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		// test folder
 		// create and delete a file in a folder
 		folder.create(true, true, createTestMonitor());
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		file.delete(true, true, createTestMonitor());
 
 		saveWorkspace();
@@ -162,7 +163,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertEquals("1.4", 0, df.length);
 
 		// recreate the file
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the recreated file should no longer show up as a deleted member
 		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
@@ -193,7 +194,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		assertEquals("1.11", 0, df.length);
 
 		// create and delete a file where the folder was
-		folderAsFile.create(getRandomContents(), true, createTestMonitor());
+		folderAsFile.create(createRandomContentsStream(), true, createTestMonitor());
 		folderAsFile.delete(true, true, createTestMonitor());
 		folder.create(true, true, createTestMonitor());
 
@@ -226,9 +227,9 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		// create and delete a file in a folder
 		folder.create(true, true, createTestMonitor());
 		folder2.create(true, true, createTestMonitor());
-		file1.create(getRandomContents(), true, createTestMonitor());
-		file2.create(getRandomContents(), true, createTestMonitor());
-		file3.create(getRandomContents(), true, createTestMonitor());
+		file1.create(createRandomContentsStream(), true, createTestMonitor());
+		file2.create(createRandomContentsStream(), true, createTestMonitor());
+		file3.create(createRandomContentsStream(), true, createTestMonitor());
 		folder.delete(true, true, createTestMonitor());
 
 		saveWorkspace();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
@@ -38,7 +39,7 @@ public class SampleSessionTest extends WorkspaceSessionTest {
 		p1.create(null);
 		p1.open(null);
 		IFile file = p1.getFile("foo.txt");
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 		workspace.save(true, null);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 
 import junit.framework.Test;
 import org.eclipse.core.resources.ICommand;
@@ -47,7 +48,7 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 		project.setDescription(description, getMonitor());
 
 		IFile file = project.getFile("foo.txt");
-		file.create(getRandomContents(), true, getMonitor());
+		file.create(createRandomContentsStream(), true, getMonitor());
 
 		getWorkspace().save(true, getMonitor());
 	}
@@ -58,7 +59,7 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 	public void test2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("foo.txt");
-		file.setContents(getRandomContents(), true, true, getMonitor());
+		file.setContents(createRandomContentsStream(), true, true, getMonitor());
 		// crash
 		System.exit(-1);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.io.File;
 import junit.framework.Test;
@@ -41,7 +42,7 @@ public class TestBug208833 extends WorkspaceSessionTest {
 
 		// create a project with a file
 		createInWorkspace(project);
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 
 		// save the workspace
 		workspace.save(true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -80,7 +81,7 @@ public class TestBug6995 extends WorkspaceSessionTest {
 		//build
 		//make a change so build doesn't get short-circuited
 		IFile file = project.getFile("File");
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
 		//make sure an incremental build occurred

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
@@ -57,7 +58,7 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		IFile file = project.getFile("foo.txt");
 		assertDoesNotExistInWorkspace(file);
-		createInWorkspace(file, getRandomString());
+		createInWorkspace(file, createRandomString());
 		// this will also cause the cache flush job to be scheduled
 		file.getContentDescription();
 		// after waiting cache flushing, cache should be new

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
@@ -36,7 +37,7 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 		IFolder folder = project.getFolder(FOLDER);
 		folder.create(true, true, createTestMonitor());
 		IFile file = folder.getFile(FILE);
-		file.create(getRandomContents(), true, createTestMonitor());
+		file.create(createRandomContentsStream(), true, createTestMonitor());
 	}
 
 	public void test2() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 
@@ -96,7 +97,7 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
 		builder.requestDeltas(new IProject[] {project1, project2, project4});
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		ArrayList<IProject> received = builder.getReceivedDeltas();
 
@@ -119,9 +120,9 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
 		builder.checkDeltas(new IProject[] {project1, project2, project3, project4});
 		// dirty projects 1, 2, 3
-		file1.setContents(getRandomContents(), true, true, createTestMonitor());
-		file2.setContents(getRandomContents(), true, true, createTestMonitor());
-		file3.setContents(getRandomContents(), true, true, createTestMonitor());
+		file1.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file2.setContents(createRandomContentsStream(), true, true, createTestMonitor());
+		file3.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 
 		// build
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
@@ -33,7 +34,7 @@ public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
 		IFile file = project.getFile(FILE);
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		file.create(getRandomContents(), true, null);
+		file.create(createRandomContentsStream(), true, null);
 		project.close(createTestMonitor());
 
 		workspace.save(true, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/HistoryStorePerformanceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import org.eclipse.core.resources.IFile;
@@ -54,7 +55,7 @@ public class HistoryStorePerformanceTest extends ResourceTest {
 		int nTimes = 1000;
 		long startTime = System.currentTimeMillis();
 		for (int i = 0; i < nTimes; i++) {
-			file.setContents(getContents(contents), true, true, null);
+			file.setContents(createInputStream(contents), true, true, null);
 		}
 		long endTime = System.currentTimeMillis();
 		System.out.println("Adding " + nTimes + " states: " + (endTime - startTime) + " milliseconds.");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -103,7 +104,7 @@ public class IFileTest extends IResourceTest {
 		nonexistentFileFailureTests(file, workspace);
 
 		// Create the file
-		file.create(getContents("0123456789"), false, monitor);
+		file.create(createInputStream("0123456789"), false, monitor);
 
 		// Now tests pass that require that the file exists.
 		assertThat("file does not exist: " + file, file.exists());


### PR DESCRIPTION
This moves utility methods for creating random strings and stream from the ResourceTest class hierarchy to the dedicated ResourceTestUtil utility class. This prepares for removing the ResourceTest inheritance hierarchy to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903