### PR TITLE
Move AbstractBuilderTest#setBuildOrder() into utility class #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AbstractBuilderTest.java
@@ -14,18 +14,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.util.Map;
-import java.util.stream.Stream;
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
 
@@ -73,16 +69,6 @@ public abstract class AbstractBuilderTest extends ResourceTest {
 	 */
 	protected void dirty(IFile file) throws CoreException {
 		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
-	}
-
-	/**
-	 * Sets the workspace build order to just contain the given projects.
-	 */
-	protected void setBuildOrder(IProject... projects) throws CoreException {
-		IWorkspace workspace = getWorkspace();
-		IWorkspaceDescription desc = workspace.getDescription();
-		desc.setBuildOrder(Stream.of(projects).map(IProject::getName).toArray(String[]::new));
-		workspace.setDescription(desc);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
 import static org.junit.Assert.assertArrayEquals;
@@ -229,9 +230,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		IFile file1 = project1.getFile("FILE1");
 		IFile file2 = project2.getFile("FILE2");
 		//set the build order
-		IWorkspaceDescription workspaceDesc = workspace.getDescription();
-		workspaceDesc.setBuildOrder(new String[] { project1.getName(), project2.getName() });
-		workspace.setDescription(workspaceDesc);
+		setBuildOrder(project1, project2);
 		TestBuilder verifier = null;
 
 		// Turn auto-building off
@@ -457,9 +456,7 @@ public class BuilderTest extends AbstractBuilderTest {
 
 		// Turn auto-building on and make sure there is no explicit build order
 		setAutoBuilding(true);
-		IWorkspaceDescription wsDescription = getWorkspace().getDescription();
-		wsDescription.setBuildOrder(null);
-		getWorkspace().setDescription(wsDescription);
+		setBuildOrder((IProject[]) null);
 		// Create and set a build spec for project two
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			proj2.create(createTestMonitor());
@@ -688,9 +685,7 @@ public class BuilderTest extends AbstractBuilderTest {
 		IProjectDescription description = proj2.getDescription();
 		description.setDynamicReferences(new IProject[] { proj1 });
 		proj2.setDescription(description, IResource.NONE, null);
-		IWorkspaceDescription wsDescription = getWorkspace().getDescription();
-		wsDescription.setBuildOrder(null);
-		getWorkspace().setDescription(wsDescription);
+		setBuildOrder((IProject[]) null);
 
 		// Create and set a build specs for project one
 		IProjectDescription desc = proj1.getDescription();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -576,6 +577,22 @@ public final class ResourceTestUtil {
 	}
 
 	/**
+	 * Sets the workspace build order to just contain the given projects. With
+	 * {@code projects} is null, the default build order of the workspace will be
+	 * used.
+	 */
+	public static void setBuildOrder(IProject... projects) throws CoreException {
+		IWorkspace workspace = getWorkspace();
+		IWorkspaceDescription desc = workspace.getDescription();
+		if (projects == null) {
+			desc.setBuildOrder(null);
+		} else {
+			desc.setBuildOrder(Stream.of(projects).map(IProject::getName).toArray(String[]::new));
+		}
+		workspace.setDescription(desc);
+	}
+
+	/**
 	 * Returns the character sequence used as a line separator within the given
 	 * file.
 	 */
@@ -643,5 +660,6 @@ public final class ResourceTestUtil {
 		}
 		return devices;
 	}
+
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 
 import java.io.ByteArrayInputStream;
 import java.util.Map;
@@ -29,7 +30,6 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
@@ -72,10 +72,7 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 		unsortedFile1.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);
 		unsortedFile2.setContents(new ByteArrayInputStream(new byte[] { 1, 4, 3 }), true, true, null);
 
-		// set build order
-		IWorkspaceDescription workspaceDescription = workspace.getDescription();
-		workspaceDescription.setBuildOrder(new String[] { project1.getName(), project2.getName() });
-		workspace.setDescription(workspaceDescription);
+		setBuildOrder(project1, project2);
 		setAutoBuilding(false);
 
 		// configure builder for project1


### PR DESCRIPTION
This change extracts the setBuildOrder() method from AbstractBuildTest into the ResourceTestUtil utility class. It replaces inline implementations of the method within resource test class with a call to the utility method. This prepares for removing the ResourceTest inheritance hierarchy to migrate to JUnit 4.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903