### PR TITLE
Remove or replace LocalStoreTest utility methods #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -705,4 +705,20 @@ public class FileStoreTest extends LocalStoreTest {
 				.map(URI::getPath).toList();
 		assertEquals("2.0 ", pathsTrimmed, sortedLocalFileStores);
 	}
+
+	private boolean verifyNode(IFileStore node) {
+		char type = node.getName().charAt(0);
+		// if the name starts with d it must be a directory
+		return (type == 'd') == node.fetchInfo().isDirectory();
+	}
+
+	private boolean verifyTree(IFileStore[] tree) {
+		for (IFileStore t : tree) {
+			if (!verifyNode(t)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -482,4 +482,9 @@ public class FileSystemResourceManagerTest extends LocalStoreTest implements ICo
 			localManager.write(file, contents, info, flags, false, jobMonitor);
 		}
 	}
+
+	private FileSystemResourceManager getLocalManager() {
+		return ((Workspace) getWorkspace()).getFileSystemManager();
+	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTest.java
@@ -15,22 +15,16 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.internal.localstore.FileSystemResourceManager;
-import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.ResourceTest;
@@ -39,7 +33,6 @@ public abstract class LocalStoreTest extends ResourceTest {
 	// test configuration attributes
 	protected static int numberOfProjects = 3;
 	protected static int numberOfProperties = 5;
-	protected static final int sleepTime = 5000;
 
 	// projects names and projects
 	protected String[] projectNames;
@@ -53,38 +46,9 @@ public abstract class LocalStoreTest extends ResourceTest {
 		super(name);
 	}
 
-	protected int countChildren(File root) {
-		String[] children = root.list();
-		if (children == null) {
-			return 0;
-		}
-		int result = 0;
-		for (String element : children) {
-			File child = new File(root, element);
-			if (child.isDirectory()) {
-				result += countChildren(child);
-			}
-			result++;
-		}
-		return result;
-	}
-
-	public int countChildren(IFolder root) throws CoreException {
-		int total = 0;
-		IResource[] children = root.members();
-		for (IResource element : children) {
-			if (element.getType() == IResource.FILE) {
-				total++;
-			} else {
-				total += countChildren((IFolder) element);
-			}
-		}
-		return total;
-	}
-
 	/**
-	 * Create a file with random content. If a resource exists in the same path,
-	 * the resource is deleted.
+	 * Create a file with random content. If a resource exists in the same path, the
+	 * resource is deleted.
 	 */
 	protected void createFile(IFileStore target, String content) throws CoreException, IOException {
 		target.delete(EFS.NONE, null);
@@ -94,19 +58,6 @@ public abstract class LocalStoreTest extends ResourceTest {
 		}
 		IFileInfo info = target.fetchInfo();
 		assertTrue(info.exists() && !info.isDirectory());
-	}
-
-	/**
-	 * Create a file with random content. If a resource exists in the same path,
-	 * the resource is deleted.
-	 */
-	protected void createIOFile(java.io.File target, String content) throws IOException {
-		target.delete();
-		InputStream input = new ByteArrayInputStream(content.getBytes());
-		try (OutputStream output = new FileOutputStream(target)) {
-			input.transferTo(output);
-		}
-		assertTrue(target.exists() && !target.isDirectory());
 	}
 
 	protected void createNode(IFileStore node) throws CoreException, IOException {
@@ -125,28 +76,6 @@ public abstract class LocalStoreTest extends ResourceTest {
 		for (IFileStore element : tree) {
 			createNode(element);
 		}
-	}
-
-	/**
-	 * The returned array will have at least the specified size.
-	 */
-	protected byte[] getBigContents(int size) {
-		return getBigString(size).getBytes();
-	}
-
-	/**
-	 * The returned array will have at least the specified size.
-	 */
-	protected String getBigString(int size) {
-		StringBuilder sb = new StringBuilder();
-		while (sb.length() < size) {
-			sb.append(createRandomString());
-		}
-		return sb.toString();
-	}
-
-	public FileSystemResourceManager getLocalManager() {
-		return ((Workspace) getWorkspace()).getFileSystemManager();
 	}
 
 	protected IFileStore[] getTree(IFileStore root) {
@@ -193,18 +122,4 @@ public abstract class LocalStoreTest extends ResourceTest {
 		}, null);
 	}
 
-	protected boolean verifyNode(IFileStore node) {
-		char type = node.getName().charAt(0);
-		//if the name starts with d it must be a directory
-		return (type == 'd') == node.fetchInfo().isDirectory();
-	}
-
-	protected boolean verifyTree(IFileStore[] tree) {
-		for (IFileStore t : tree) {
-			if (!verifyNode(t)) {
-				return false;
-			}
-		}
-		return true;
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -96,6 +96,17 @@ public class SafeChunkyInputOutputStreamTest extends LocalStoreTest {
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
+	/**
+	 * The returned array will have at least the specified size.
+	 */
+	private byte[] getBigContents(int size) {
+		StringBuilder sb = new StringBuilder();
+		while (sb.length() < size) {
+			sb.append(createRandomString());
+		}
+		return sb.toString().getBytes();
+	}
+
 	public void testFailure() throws Exception {
 		Workspace.clear(target); // make sure there was nothing here before
 		assertFalse(target.exists());


### PR DESCRIPTION
* Removes unused methods
* Pushes down methods to single consumers in inheritance hierarchy.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903