### PR TITLE
Migrate all tests in o.e.c.tests.resources.regression to JUnit 4 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
@@ -21,16 +21,55 @@ import org.junit.runners.Suite;
  * A suite that runs all regression tests.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ Bug_006708.class, Bug_025457.class, Bug_026294.class, Bug_027271.class, Bug_028981.class,
-		Bug_029116.class, Bug_029671.class, Bug_029851.class, Bug_032076.class, Bug_044106.class, Bug_092108.class,
-		Bug_097608.class, Bug_098740.class, Bug_126104.class, Bug_127562.class, Bug_132510.class, Bug_134364.class,
-		Bug_147232.class, Bug_160251.class, Bug_165892.class, Bug_192631.class, Bug_226264.class, Bug_231301.class,
-		Bug_233939.class, Bug_265810.class, Bug_264182.class, Bug_297635.class, Bug_288315.class, Bug_303517.class,
-		Bug_329836.class, Bug_331445.class, Bug_332543.class, Bug_378156.class,
-		IFileTest.class, IFolderTest.class, IProjectTest.class,
-		IResourceTest.class, IWorkspaceTest.class, LocalStoreRegressionTests.class, NLTest.class,
-		PR_1GEAB3C_Test.class,
-		PR_1GH2B0N_Test.class, PR_1GHOM0N_Test.class, Bug_530868.class, Bug_185247_recursiveLinks.class,
-		Bug_185247_LinuxTests.class })
+@Suite.SuiteClasses({ //
+		Bug_006708.class, //
+		Bug_025457.class, //
+		Bug_026294.class, //
+		Bug_027271.class, //
+		Bug_028981.class, //
+		Bug_029116.class, //
+		Bug_029671.class, //
+		Bug_029851.class, //
+		Bug_032076.class, //
+		Bug_044106.class, //
+		Bug_079398.class, //
+		Bug_092108.class, //
+		Bug_097608.class, //
+		Bug_098740.class, //
+		Bug_126104.class, //
+		Bug_127562.class, //
+		Bug_132510.class, //
+		Bug_134364.class, //
+		Bug_147232.class, //
+		Bug_160251.class, //
+		Bug_165892.class, //
+		Bug_185247_LinuxTests.class, //
+		Bug_185247_recursiveLinks.class, //
+		Bug_192631.class, //
+		Bug_226264.class, //
+		Bug_231301.class, //
+		Bug_233939.class, //
+		Bug_264182.class, //
+		Bug_265810.class, //
+		Bug_288315.class, //
+		Bug_297635.class, //
+		Bug_303517.class, //
+		Bug_329836.class, //
+		Bug_331445.class, //
+		Bug_332543.class, //
+		Bug_378156.class, //
+		Bug_380386.class, //
+		Bug_530868.class, //
+		IFileTest.class, //
+		IFolderTest.class, //
+		IProjectTest.class, //
+		IResourceTest.class, //
+		IWorkspaceTest.class, //
+		LocalStoreRegressionTests.class, //
+		NLTest.class, //
+		PR_1GEAB3C_Test.class, //
+		PR_1GH2B0N_Test.class, //
+		PR_1GHOM0N_Test.class, //
+})
 public class AllRegressionTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_006708.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_006708.java
@@ -13,16 +13,24 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.ByteArrayInputStream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_006708 extends ResourceTest {
+public class Bug_006708 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject sourceProj = root.getProject("bug_6708");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -20,6 +20,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,7 +32,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 25457.  In this case, attempting to move a project
@@ -40,13 +44,15 @@ import org.eclipse.core.tests.resources.ResourceTest;
  * Note: this is similar to Bug_32076, which deals with failure to move in
  * the non case-change scenario.
  */
-public class Bug_025457 extends ResourceTest {
+public class Bug_025457 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testFile() throws Exception {
-		//this test only works on windows
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
+
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("file.txt");
 		IFile destFile = source.getFile("File.txt");
@@ -70,12 +76,11 @@ public class Bug_025457 extends ResourceTest {
 		assertTrue("2.3", !destFile.exists());
 	}
 
+	@Test
 	public void testFolder() throws IOException, CoreException {
-		//this test only works on windows
 		//native code must also be present so move can detect the case change
-		if (!OS.isWindows() || !isReadOnlySupported()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows() && isReadOnlySupported());
+
 		IProject source = getWorkspace().getRoot().getProject("SourceProject");
 		IFolder sourceFolder = source.getFolder("folder");
 		IFile sourceFile = sourceFolder.getFile("Important.txt");
@@ -101,11 +106,10 @@ public class Bug_025457 extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testProject() throws IOException, CoreException {
-		//this test only works on windows
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
+
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IProject destination = getWorkspace().getRoot().getProject("Project");
 		IFile sourceFile = source.getFile("Important.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -24,6 +24,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
@@ -34,23 +36,27 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * A parent container (projects and folders) would become out-of-sync if any of
  * its children could not be deleted for some reason. These platform-
  * specific test cases ensure that it does not happen.
  */
-public class Bug_026294 extends ResourceTest {
+public class Bug_026294 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tries to delete an open project containing an unremovable file.
 	 * Works only for Windows.
 	 */
+	@Test
 	public void testDeleteOpenProjectWindows() throws Exception {
-		if (!(OS.isWindows())) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -62,7 +68,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file2, file3 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		assertExistsInFileSystem(file1);
 		assertExistsInFileSystem(file2);
@@ -116,13 +122,12 @@ public class Bug_026294 extends ResourceTest {
 	}
 
 	/**
-	 * Tries to delete an open project containing an irremovable file.
-	 * Works only for Linux with natives.
+	 * Tries to delete an open project containing an non-removable file. Works only
+	 * for Linux with natives.
 	 */
+	@Test
 	public void testDeleteOpenProjectLinux() throws CoreException {
-		if (!(OS.isLinux() && isReadOnlySupported())) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -132,7 +137,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file2 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		try {
 			// marks folder as read-only so its files cannot be deleted on Linux
@@ -165,13 +170,12 @@ public class Bug_026294 extends ResourceTest {
 	}
 
 	/**
-	 * Tries to delete a closed project containing an unremovable file.
+	 * Tries to delete a closed project containing a non-removable file.
 	 * Works only for Windows.
 	 */
+	@Test
 	public void testDeleteClosedProjectWindows() throws Exception {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -183,7 +187,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file2, file3 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		// opens a file so it cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
@@ -204,15 +208,12 @@ public class Bug_026294 extends ResourceTest {
 	}
 
 	/**
-	 * Tries to delete a closed project containing an unremovable file.
-	 * Works only for Linux with natives.
-	 *
-	 * TODO: enable this test once bug 48321 is fixed.
+	 * Tries to delete a closed project containing an non-removable file. Works only
+	 * for Linux with natives.
 	 */
+	@Test
 	public void testDeleteClosedProjectLinux() throws CoreException {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -223,7 +224,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file2 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		try {
 			// marks folder as read-only so its files cannot be removed on Linux
@@ -252,13 +253,12 @@ public class Bug_026294 extends ResourceTest {
 	}
 
 	/**
-	 * Tries to delete a folder containing an unremovable file.
-	 * Works only for Windows.
+	 * Tries to delete a folder containing a non-removable file. Works only for
+	 * Windows.
 	 */
+	@Test
 	public void testDeleteFolderWindows() throws Exception {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -268,7 +268,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file3 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		// opens a file so it cannot be removed on Windows
 		try (InputStream input = file1.getContents()) {
@@ -288,13 +288,12 @@ public class Bug_026294 extends ResourceTest {
 	}
 
 	/**
-	 * Tries to delete a folder containing an irremovable file.
-	 * Works only for Linux with natives.
+	 * Tries to delete a folder containing a non-removable file. Works only for
+	 * Linux with natives.
 	 */
+	@Test
 	public void testDeleteFolderLinux() throws CoreException {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -305,7 +304,7 @@ public class Bug_026294 extends ResourceTest {
 
 		createInWorkspace(new IResource[] { file1, file3 });
 		IPath projectRoot = project.getLocation();
-		deleteOnTearDown(projectRoot);
+		workspaceRule.deleteOnTearDown(projectRoot);
 
 		try {
 			// marks sub-folder as read-only so its files cannot be removed on Linux

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -14,39 +14,45 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.resources.IPathVariableManager;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.Preferences;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests how changes in the underlying preference store may affect the path
  * variable manager.
  */
 
-public class Bug_027271 extends ResourceTest {
+public class Bug_027271 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	static final String VARIABLE_PREFIX = "pathvariable."; //$NON-NLS-1$
 
-	private Preferences preferences;
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
+	@Before
+	public void setUp() {
 		clearPathVariablesProperties();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() {
 		clearPathVariablesProperties();
-		super.tearDown();
 	}
 
 	private void clearPathVariablesProperties() {
+		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
 		// ensure we have no preferences related to path variables
 		String[] propertyNames = preferences.propertyNames();
 		for (String propertyName : propertyNames) {
@@ -56,11 +62,10 @@ public class Bug_027271 extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testBug() {
-		//this bug is only relevant on Windows
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("tested bug is only relevant on Windows", OS.isWindows());
+
 		IPathVariableManager pvm = getWorkspace().getPathVariableManager();
 		Preferences prefs = ResourcesPlugin.getPlugin().getPluginPreferences();
 
@@ -82,4 +87,5 @@ public class Bug_027271 extends ResourceTest {
 		assertEquals("3.1", 1, pvm.getPathVariableNames().length);
 		assertEquals("3.2", "VALID_VAR", pvm.getPathVariableNames()[0]);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_028981.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -27,15 +28,21 @@ import org.eclipse.core.resources.ISynchronizer;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
 import org.eclipse.core.tests.resources.ResourceVisitorVerifier;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Resource#accept doesn't obey member flags for the traversal entry point.
  */
 
-public class Bug_028981 extends ResourceTest {
+public class Bug_028981 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		final QualifiedName partner = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final IWorkspace workspace = getWorkspace();
@@ -87,4 +94,5 @@ public class Bug_028981 extends ResourceTest {
 		teamPrivateFile.accept(verifier, IResource.DEPTH_INFINITE, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
 		assertTrue("5.1 - " + verifier.getMessage(), verifier.isValid());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029116.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029116.java
@@ -20,13 +20,20 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
- * Test regression of bug 29116.  In this bug, triggering a builder during
+ * Test regression of bug 29116. In this bug, triggering a builder during
  * installation of a nature caused an assertion failure.
  */
-public class Bug_029116 extends ResourceTest {
+public class Bug_029116 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		// Create some resource handles
 		IProject project = getWorkspace().getRoot().getProject("PROJECT");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWo
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -26,13 +27,19 @@ import org.eclipse.core.resources.ISynchronizer;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * When a container was moved, its children were not added to phantom space.
  */
-public class Bug_029671 extends ResourceTest {
+public class Bug_029671 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		final QualifiedName partner = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		IWorkspace workspace = getWorkspace();
@@ -66,4 +73,5 @@ public class Bug_029671 extends ResourceTest {
 			synchronizer.remove(partner);
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029851.java
@@ -25,14 +25,19 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
- * Tests regression of bug 25457.  In this case, attempting to move a project
+ * Tests regression of bug 25457. In this case, attempting to move a project
  * that is only a case change, where the move fails due to another handle being
  * open on a file in the hierarchy, would cause deletion of the source.
  */
-public class Bug_029851 extends ResourceTest {
+public class Bug_029851 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private Collection<String> createChildren(int breadth, int depth, IPath prefix) {
 		ArrayList<String> result = new ArrayList<>();
@@ -56,6 +61,7 @@ public class Bug_029851 extends ResourceTest {
 		createInWorkspace(resources);
 	}
 
+	@Test
 	public void test() throws CoreException {
 		createResourceHierarchy();
 		final QualifiedName key = new QualifiedName("local", createUniqueString());
@@ -66,4 +72,5 @@ public class Bug_029851 extends ResourceTest {
 		};
 		getWorkspace().getRoot().accept(visitor);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -20,7 +20,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.InputStream;
 import org.eclipse.core.filesystem.IFileStore;
@@ -34,18 +38,23 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * When moving a resource "x" from parent "a" to parent "b", if "x" or any of
  * its children can't be deleted, both "a" and "b" become out-of-sync and resource info is lost.
  */
-public class Bug_032076 extends ResourceTest {
+public class Bug_032076 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testFileBugOnWindows() throws Exception {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -56,7 +65,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile destinationFile = destinationParent.getFile(sourceFile.getName());
 
 		createInWorkspace(new IResource[] { sourceFile, destinationParent });
-		deleteOnTearDown(project.getLocation());
+		workspaceRule.deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
 		String attributeKey = createRandomString();
@@ -96,10 +105,9 @@ public class Bug_032076 extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testFolderBugOnWindows() throws Exception {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -113,7 +121,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile file2 = folder.getFile("file2.txt");
 
 		createInWorkspace(new IResource[] { file1, file2, destinationParent });
-		deleteOnTearDown(project.getLocation());
+		workspaceRule.deleteOnTearDown(project.getLocation());
 
 		// add a marker to a file to ensure the move operation is not losing anything
 		String attributeKey = createRandomString();
@@ -159,10 +167,9 @@ public class Bug_032076 extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testProjectBugOnWindows() throws Exception {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");
@@ -173,7 +180,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile file2 = sourceProject.getFile("file2.txt");
 
 		createInWorkspace(new IResource[] {file1, file2});
-		deleteOnTearDown(sourceProject.getLocation()); // Ensure project location is moved after test
+		workspaceRule.deleteOnTearDown(sourceProject.getLocation()); // Ensure project location is moved after test
 
 		// add a marker to a file to ensure the move operation is not losing anything
 		String attributeKey = createRandomString();
@@ -208,13 +215,10 @@ public class Bug_032076 extends ResourceTest {
 		}
 	}
 
-	/**
-	 * TODO: This test is currently failing and needs further investigation (bug 203078)
-	 */
-	public void _testFileBugOnLinux() throws CoreException {
-		if (!(OS.isLinux() && isReadOnlySupported())) {
-			return;
-		}
+	@Test
+	@Ignore("test is currently failing and needs further investigation (bug 203078)")
+	public void testFileBugOnLinux() throws CoreException {
+		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -226,7 +230,7 @@ public class Bug_032076 extends ResourceTest {
 		IFile destinationFile = destinationParent.getFile("file.txt");
 
 		createInWorkspace(new IResource[] { sourceFile, destinationParent });
-		deleteOnTearDown(project.getLocation());
+		workspaceRule.deleteOnTearDown(project.getLocation());
 
 		IFileStore roFolderStore = ((Resource) roFolder).getStore();
 
@@ -270,13 +274,10 @@ public class Bug_032076 extends ResourceTest {
 		}
 	}
 
-	/**
-	 * TODO: This test is currently failing and needs further investigation (bug 203078)
-	 */
-	public void _testFolderBugOnLinux() throws CoreException {
-		if (!(OS.isLinux() && isReadOnlySupported())) {
-			return;
-		}
+	@Test
+	@Ignore("test is currently failing and needs further investigation (bug 203078)")
+	public void testFolderBugOnLinux() throws CoreException {
+		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -289,7 +290,7 @@ public class Bug_032076 extends ResourceTest {
 		IFolder destinationROFolder = destinationParent.getFolder(roFolder.getName());
 
 		createInWorkspace(new IResource[] { file1, file2, destinationParent });
-		deleteOnTearDown(project.getLocation());
+		workspaceRule.deleteOnTearDown(project.getLocation());
 
 		IFileStore roFolderLocation = ((Resource) roFolder).getStore();
 		IFileStore destinationROFolderLocation = ((Resource) destinationROFolder).getStore();
@@ -348,17 +349,14 @@ public class Bug_032076 extends ResourceTest {
 		}
 	}
 
-	/**
-	 * TODO: This test is currently failing and needs further investigation (bug 203078)
-	 */
-	public void _testProjectBugOnLinux() throws CoreException {
-		if (!(OS.isLinux() && isReadOnlySupported())) {
-			return;
-		}
+	@Test
+	@Ignore("test is currently failing and needs further investigation (bug 203078)")
+	public void testProjectBugOnLinux() throws CoreException {
+		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");
-		IFileStore projectParentStore = getTempStore();
+		IFileStore projectParentStore = workspaceRule.getTempStore();
 		IFileStore projectStore = projectParentStore.getChild(sourceProject.getName());
 		IProjectDescription sourceDescription = workspace.newProjectDescription(sourceProject.getName());
 		sourceDescription.setLocationURI(projectStore.toURI());
@@ -369,7 +367,7 @@ public class Bug_032076 extends ResourceTest {
 		// create and open the source project at a non-default location
 		sourceProject.create(sourceDescription, createTestMonitor());
 		sourceProject.open(createTestMonitor());
-		deleteOnTearDown(sourceProject.getLocation());
+		workspaceRule.deleteOnTearDown(sourceProject.getLocation());
 
 		IFile file1 = sourceProject.getFile("file1.txt");
 
@@ -389,7 +387,7 @@ public class Bug_032076 extends ResourceTest {
 
 			assertThrows(CoreException.class,
 					() -> sourceProject.move(destinationDescription, IResource.FORCE, createTestMonitor()));
-			deleteOnTearDown(destinationProject.getLocation());
+			workspaceRule.deleteOnTearDown(destinationProject.getLocation());
 
 			// the source does not exist
 			assertTrue("3.0", !sourceProject.exists());
@@ -412,4 +410,5 @@ public class Bug_032076 extends ResourceTest {
 			setReadOnly(projectParentStore, false);
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -21,6 +21,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import org.eclipse.core.filesystem.IFileStore;
@@ -29,7 +31,9 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 44106. In this case deleting a file which was a
@@ -39,7 +43,10 @@ import org.eclipse.core.tests.resources.ResourceTest;
  * Also tests bug 174492, which is a similar bug except the KEEP_HISTORY
  * flag is used when the resource is deleted from the workspace.
  */
-public class Bug_044106 extends ResourceTest {
+public class Bug_044106 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void createSymLink(String target, String local) throws InterruptedException, IOException {
 		Process p = Runtime.getRuntime().exec(new String[] { "/bin/ln", "-s", target, local });
@@ -50,9 +57,9 @@ public class Bug_044106 extends ResourceTest {
 	 * Tests various permutations of the bug.
 	 * @param deleteFlags The option flags to use when deleting the resource.
 	 */
-	public void doTestDeleteLinkedFile(int deleteFlags) throws Exception {
+	private void doTestDeleteLinkedFile(int deleteFlags) throws Exception {
 		// create the file/folder that we are going to link to
-		IFileStore linkDestFile = getTempStore();
+		IFileStore linkDestFile = workspaceRule.getTempStore();
 		createInFileSystem(linkDestFile);
 		assertTrue("0.1", linkDestFile.fetchInfo().exists());
 
@@ -85,11 +92,11 @@ public class Bug_044106 extends ResourceTest {
 	 * is deleted
 	 * @param deleteFlags The flags to use on the resource deletion call
 	 */
-	public void doTestDeleteLinkedFolder(IFolder linkedFolder, boolean deleteParent, int deleteFlags) throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
-		IFileStore linkDestLocation = getTempStore();
+	private void doTestDeleteLinkedFolder(IFolder linkedFolder, boolean deleteParent, int deleteFlags)
+			throws Exception {
+		assumeTrue("test only works on Linux", OS.isLinux());
+
+		IFileStore linkDestLocation = workspaceRule.getTempStore();
 		IFileStore linkDestFile = linkDestLocation.getChild(createUniqueString());
 		createInFileSystem(linkDestFile);
 		assertTrue("0.1", linkDestLocation.fetchInfo().exists());
@@ -125,61 +132,61 @@ public class Bug_044106 extends ResourceTest {
 		assertTrue("4.3", linkDestFile.fetchInfo().exists());
 	}
 
+	@Test
 	public void testDeleteLinkedFile() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		doTestDeleteLinkedFile(IResource.NONE);
 	}
 
+	@Test
 	public void testDeleteLinkedFolder() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, false, IResource.NONE);
 	}
 
+	@Test
 	public void testDeleteLinkedResourceInProject() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.NONE);
 	}
 
+	@Test
 	public void testDeleteLinkedFileKeepHistory() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		doTestDeleteLinkedFile(IResource.KEEP_HISTORY);
 	}
 
+	@Test
 	public void testDeleteLinkedFolderParentKeepHistory() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder parent = project.getFolder("parent");
 		IFolder linkedFolder = parent.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.KEEP_HISTORY);
 	}
 
+	@Test
 	public void testDeleteLinkedFolderKeepHistory() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, false, IResource.KEEP_HISTORY);
 	}
 
+	@Test
 	public void testDeleteLinkedResourceInProjectKeepHistory() throws Exception {
-		if (!OS.isLinux()) {
-			return;
-		}
+		assumeTrue("test only works on Linux", OS.isLinux());
+
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
 		doTestDeleteLinkedFolder(linkedFolder, true, IResource.KEEP_HISTORY);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -19,6 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
@@ -27,15 +29,18 @@ import org.eclipse.core.resources.IFileState;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceDescription;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
-//NOTE: Should not hook this test up until the corresponding bug is fixed.
-public class Bug_079398 extends ResourceTest {
+public class Bug_079398 {
 
-	public Bug_079398(String name) {
-		super(name);
-	}
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
+	@Test
+	@Ignore("Bug 78398 needs to be fixed")
 	public void testBug79398() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("myproject");
 		IFile file1 = project.getFile("myFile.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
@@ -13,21 +13,30 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests that obtaining file info works on the root directory on windows.
  */
-public class Bug_092108 extends ResourceTest {
+public class Bug_092108 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("test only works on Windows", OS.isWindows());
+
 		IFileStore root = EFS.getStore(new java.io.File("c:\\").toURI());
 		IFileInfo info = root.fetchInfo();
 		assertTrue("1.0", info.exists());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_097608.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_097608.java
@@ -22,16 +22,23 @@ import java.util.Map;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 97608 - error restoring workspace
  * after writing marker with value that is too long.
  */
-public class Bug_097608 extends ResourceTest {
+public class Bug_097608 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Tests that creating a marker with very long value causes failure.
 	 */
+	@Test
 	public void testBug() throws CoreException {
 		char[] chars = new char[40000];
 		Arrays.fill(chars, 'a');
@@ -51,6 +58,7 @@ public class Bug_097608 extends ResourceTest {
 	/**
 	 * Tests that creating a marker with very long value causes failure.
 	 */
+	@Test
 	public void testBug2() throws CoreException {
 		char[] chars = new char[40000];
 		Arrays.fill(chars, 'a');
@@ -72,4 +80,5 @@ public class Bug_097608 extends ResourceTest {
 		markerAttributes.put(IMarker.MESSAGE, value);
 		assertThrows(RuntimeException.class, () -> marker.setAttributes(markerAttributes));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_098740.java
@@ -22,15 +22,21 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * A parent container (projects and folders) would become out-of-sync if any of
  * its children could not be deleted for some reason. These platform-
  * specific test cases ensure that it does not happen.
  */
-public class Bug_098740 extends ResourceTest {
+public class Bug_098740 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Bug98740");
 		createInWorkspace(project);
@@ -39,4 +45,5 @@ public class Bug_098740 extends ResourceTest {
 		IResourceVisitor visitor = resource -> true;
 		assertThrows(CoreException.class, () -> project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -25,19 +26,25 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests copying a file to a linked folder that does not exist on disk
  */
-public class Bug_126104 extends ResourceTest {
+public class Bug_126104 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("p1");
 		IFile source = project.getFile("source");
 		createInWorkspace(source);
 		IFolder link = project.getFolder("link");
-		IFileStore location = getTempStore();
+		IFileStore location = workspaceRule.getTempStore();
 		link.createLink(location.toURI(), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		IFile destination = link.getFile(source.getName());
 		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_127562.java
@@ -22,14 +22,20 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Changing a project description requires the workspace root
  * scheduling rule.
  */
-public class Bug_127562 extends ResourceTest {
+public class Bug_127562 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException {
 		final IProject project = getWorkspace().getRoot().getProject("Bug127562");
 		createInWorkspace(project);
@@ -38,4 +44,5 @@ public class Bug_127562 extends ResourceTest {
 		getWorkspace().run((IWorkspaceRunnable) monitor -> project.setDescription(description, createTestMonitor()),
 				getWorkspace().getRoot(), IResource.NONE, createTestMonitor());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_132510.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_132510.java
@@ -19,12 +19,19 @@ import java.util.Iterator;
 import org.eclipse.core.internal.resources.LinkDescription;
 import org.eclipse.core.internal.resources.ProjectDescription;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests concurrent modification of the project description link table.
  */
-public class Bug_132510 extends ResourceTest {
+public class Bug_132510 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() {
 		ProjectDescription desc = new ProjectDescription();
 		IPath path1 = IPath.fromOSString("/a/b/");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_134364.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_134364.java
@@ -27,7 +27,8 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -38,7 +39,11 @@ import org.junit.Test;
  * malformed state.  The fix was to synchronize the routine that collapses
  * unused trees in ElementTree.
  */
-public class Bug_134364 extends ResourceTest {
+public class Bug_134364 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Creates a project with a builder attached
 	 */
@@ -112,4 +117,5 @@ public class Bug_134364 extends ResourceTest {
 			throw new AssertionError("1.0", failure[0]);
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -27,13 +28,21 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.ClearMarkersBuilder;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests duplicate resource change events caused by a builder that makes
  * no changes.
  */
-public class Bug_147232 extends ResourceTest implements IResourceChangeListener {
+public class Bug_147232 implements IResourceChangeListener {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Records the number of times we have seen the file creation delta
 	 */
@@ -41,10 +50,6 @@ public class Bug_147232 extends ResourceTest implements IResourceChangeListener 
 
 	IFile file;
 	IProject project;
-
-	public Bug_147232(String name) {
-		super(name);
-	}
 
 	@Override
 	public void resourceChanged(IResourceChangeEvent event) {
@@ -59,20 +64,19 @@ public class Bug_147232 extends ResourceTest implements IResourceChangeListener 
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		// make the builder wait after running to all a POST_CHANGE event to occur before POST_BUILD
 		ClearMarkersBuilder.pauseAfterBuild = true;
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		getWorkspace().removeResourceChangeListener(this);
 		ClearMarkersBuilder.pauseAfterBuild = false;
 	}
 
+	@Test
 	public void testBug() throws CoreException {
 		project = getWorkspace().getRoot().getProject("Bug_147232");
 		file = project.getFile("file.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -27,21 +28,28 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 160251.  In this case, attempting to move a project
  * to an existing directory on disk failed, but should succeed as long as
  * the destination directory is empty.
  */
-public class Bug_160251 extends ResourceTest {
+public class Bug_160251 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * The destination directory does not exist.
 	 */
+	@Test
 	public void testNonExistentDestination() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("Important.txt");
-		IFileStore destination = getTempStore();
+		IFileStore destination = workspaceRule.getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
 		createInWorkspace(source);
 		createInWorkspace(sourceFile);
@@ -62,10 +70,11 @@ public class Bug_160251 extends ResourceTest {
 	/**
 	 * The destination directory exists, but is empty
 	 */
+	@Test
 	public void testEmptyDestination() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("Important.txt");
-		IFileStore destination = getTempStore();
+		IFileStore destination = workspaceRule.getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
 		createInWorkspace(source);
 		createInWorkspace(sourceFile);
@@ -87,10 +96,11 @@ public class Bug_160251 extends ResourceTest {
 	/**
 	 * The destination directory exists, and contains an overlapping file. This should fail.
 	 */
+	@Test
 	public void testOccupiedDestination() throws Exception {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("Important.txt");
-		IFileStore destination = getTempStore();
+		IFileStore destination = workspaceRule.getTempStore();
 		IFileStore destinationFile = destination.getChild(sourceFile.getName());
 		createInWorkspace(source);
 		createInWorkspace(sourceFile);
@@ -109,4 +119,5 @@ public class Bug_160251 extends ResourceTest {
 		assertTrue("2.3", !URIUtil.equals(source.getLocationURI(), destination.toURI()));
 		assertTrue("2.4", !URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -24,7 +25,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 165892. Copying a resource should perform a deep
@@ -32,10 +35,15 @@ import org.eclipse.core.tests.resources.ResourceTest;
  * properties on the destination resource should not affect the properties on the
  * source resource.
  */
-public class Bug_165892 extends ResourceTest {
+public class Bug_165892 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Tests copying a file
 	 */
+	@Test
 	public void testCopyFile() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFolder sourceFolder = source.getFolder("folder");
@@ -67,6 +75,7 @@ public class Bug_165892 extends ResourceTest {
 	/**
 	 * Tests that history of source file isn't affected by a copy
 	 */
+	@Test
 	public void testCopyFileHistory() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFolder sourceFolder = source.getFolder("folder");
@@ -97,6 +106,7 @@ public class Bug_165892 extends ResourceTest {
 	/**
 	 * Tests copying a folder
 	 */
+	@Test
 	public void testCopyFolder() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFolder sourceFolder = source.getFolder("source");
@@ -138,6 +148,7 @@ public class Bug_165892 extends ResourceTest {
 	/**
 	 * Tests copying a project
 	 */
+	@Test
 	public void testCopyProject() throws CoreException {
 		IProject source = getWorkspace().getRoot().getProject("source");
 		IFolder sourceFolder = source.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,12 +33,20 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
 import org.eclipse.core.tests.internal.filesystem.remote.RemoteFileSystem;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test for bug 192631
  */
-public class Bug_192631 extends ResourceTest {
+public class Bug_192631 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	private static final String USER_A = "userA";
 	private static final String USER_B = "userB";
 	private static final String HOST_A = "hostA.example.com";
@@ -48,18 +58,17 @@ public class Bug_192631 extends ResourceTest {
 	private static final String FOLDER_A = "/common/folderA";
 	private static final String FOLDER_B = "/common/folderB";
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() {
 		MemoryTree.TREE.deleteAll();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() {
 		MemoryTree.TREE.deleteAll();
-		super.tearDown();
 	}
 
+	@Test
 	public void testCompareHost() throws CoreException, URISyntaxException {
 		URI commonA = new URI(RemoteFileSystem.SCHEME_REMOTE, null, HOST_A, -1, COMMON, null, null);
 		URI commonB = new URI(RemoteFileSystem.SCHEME_REMOTE, null, HOST_B, -1, COMMON, null, null);
@@ -105,6 +114,7 @@ public class Bug_192631 extends ResourceTest {
 		projectB.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testCompareUserInfo() throws CoreException, URISyntaxException {
 		URI commonA = new URI(RemoteFileSystem.SCHEME_REMOTE, USER_A, HOST_A, -1, COMMON, null, null);
 		URI commonB = new URI(RemoteFileSystem.SCHEME_REMOTE, USER_B, HOST_A, -1, COMMON, null, null);
@@ -150,6 +160,7 @@ public class Bug_192631 extends ResourceTest {
 		projectB.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testComparePort() throws CoreException, URISyntaxException {
 		URI commonA = new URI(RemoteFileSystem.SCHEME_REMOTE, null, HOST_A, PORT_A, COMMON, null, null);
 		URI commonB = new URI(RemoteFileSystem.SCHEME_REMOTE, null, HOST_A, PORT_B, COMMON, null, null);
@@ -194,4 +205,5 @@ public class Bug_192631 extends ResourceTest {
 		projectA.delete(true, createTestMonitor());
 		projectB.delete(true, createTestMonitor());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -25,9 +26,16 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_226264 extends ResourceTest {
+public class Bug_226264 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException, InterruptedException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IProject project1 = workspace.getRoot().getProject("Project1");
@@ -75,4 +83,5 @@ public class Bug_226264 extends ResourceTest {
 		assertDoesNotExistInWorkspace(project1);
 		assertDoesNotExistInWorkspace(project2);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -25,9 +26,16 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_231301 extends ResourceTest {
+public class Bug_231301 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException, InterruptedException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IProject project1 = workspace.getRoot().getProject("Project1");
@@ -74,4 +82,5 @@ public class Bug_231301 extends ResourceTest {
 		assertTrue("3.0", !project1.isOpen());
 		assertTrue("4.0", !project2.isOpen());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_264182.java
@@ -27,17 +27,22 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_264182 extends ResourceTest {
+public class Bug_264182 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	IProject project;
 	IFile dotProject;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		// create a project
 		project = getWorkspace().getRoot().getProject(createUniqueString());
 		project.create(new NullProgressMonitor());
@@ -48,17 +53,17 @@ public class Bug_264182 extends ResourceTest {
 		setReadOnly(dotProject, true);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		// make the description writable
 		setReadOnly(dotProject, false);
-		super.tearDown();
 	}
 
+	@Test
 	public void testBug() throws Exception {
 		// create a linked resource
 		final IFile file = project.getFile(createUniqueString());
-		IFileStore tempFileStore = getTempStore();
+		IFileStore tempFileStore = workspaceRule.getTempStore();
 		createInFileSystem(tempFileStore);
 		assertThrows(CoreException.class,
 				() -> file.createLink(tempFileStore.toURI(), IResource.NONE, new NullProgressMonitor()));
@@ -66,4 +71,5 @@ public class Bug_264182 extends ResourceTest {
 		// the file should not exist in the workspace
 		assertDoesNotExistInWorkspace(file);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -14,9 +14,11 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -32,21 +34,26 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
-public class Bug_265810 extends ResourceTest {
+public class Bug_265810 {
 
-	protected final static String VARIABLE_NAME = "ROOT";
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	List<IResourceDelta> resourceDeltas = new ArrayList<>();
 
 	public IPath createFolderAtRandomLocation() throws IOException {
 		IPath path = getRandomLocation();
 		path.toFile().createNewFile();
-		deleteOnTearDown(path);
+		workspaceRule.deleteOnTearDown(path);
 		return path;
 	}
 
+	@Test
 	public void testBug() throws Throwable {
 		// create a project
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
@@ -153,4 +160,5 @@ public class Bug_265810 extends ResourceTest {
 	boolean addToResourceDelta(IResourceDelta delta) {
 		return resourceDeltas.add(delta);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_288315.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_288315.java
@@ -19,17 +19,23 @@ import java.util.Arrays;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests regression of bug 288315 - MarkerInfo.setAttributes(Map map) calls
  * checkValidAttribute which throws IllegalArgumentException.
  */
-public class Bug_288315 extends ResourceTest {
+public class Bug_288315 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests that creating a marker with very long value causes failure.
 	 */
+	@Test
 	public void testBug() throws CoreException {
 		char[] chars = new char[65537];
 		Arrays.fill(chars, 'a');

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_297635.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_297635.java
@@ -29,8 +29,12 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.core.tests.resources.content.ContentTypeTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -38,24 +42,23 @@ import org.osgi.framework.BundleException;
 /**
  * Tests regression of bug 297635
  */
-public class Bug_297635 extends ResourceTest {
+public class Bug_297635 {
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Before
+	public void setUp() throws Exception {
 		BundleWithSaveParticipant.install();
 		saveFull();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		try {
-			BundleWithSaveParticipant.uninstall();
-		} finally {
-			super.tearDown();
-		}
+	@After
+	public void tearDown() throws BundleException {
+		BundleWithSaveParticipant.uninstall();
 	}
 
+	@Test
 	public void testCleanSaveStateBySaveParticipantOnSnapshotSave() throws Exception {
 		executeWithSaveManagerSpy(saveManagerSpy -> {
 			try {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -19,7 +19,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.touchInFilesystem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.InputStream;
@@ -32,21 +35,27 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests that, when the workspace discovery a resource is out-of-sync
  * it brings the resource back into sync in a timely manner.
  */
-public class Bug_303517 extends ResourceTest {
+public class Bug_303517 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private final String[] resourcePaths = new String[] { "/", "/Bug303517/", "/Bug303517/Folder/",
 			"/Bug303517/Folder/Resource", };
 	private boolean originalRefreshSetting;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
 		originalRefreshSetting = prefs.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
@@ -55,17 +64,17 @@ public class Bug_303517 extends ResourceTest {
 		createInWorkspace(resources);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
 		prefs.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
-		super.tearDown();
 	}
 
 	/**
 	 * Tests that file deleted is updated after #getContents
 	 */
+	@Test
 	public void testExists() throws Exception {
 		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
@@ -90,6 +99,7 @@ public class Bug_303517 extends ResourceTest {
 	/**
 	 * Tests that file discovered out-of-sync during #getContents is updated
 	 */
+	@Test
 	public void testGetContents() throws Exception {
 		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
@@ -116,6 +126,7 @@ public class Bug_303517 extends ResourceTest {
 	/**
 	 * Tests that file discovered out-of-sync during #getContents is updated
 	 */
+	@Test
 	public void testGetContentsTrue() throws Exception {
 		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
@@ -147,6 +158,7 @@ public class Bug_303517 extends ResourceTest {
 	/**
 	 * Tests that resource discovered out-of-sync during #isSynchronized is updated
 	 */
+	@Test
 	public void testIsSynchronized() throws Exception {
 		IFile f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
@@ -167,6 +179,7 @@ public class Bug_303517 extends ResourceTest {
 	/**
 	 * Tests that when changing resource gender is correctly picked up.
 	 */
+	@Test
 	public void testChangeResourceGender() throws Exception {
 		IResource f = getWorkspace().getRoot().getFile(IPath.fromOSString(resourcePaths[resourcePaths.length - 1]));
 		assertTrue("1.0", f.exists());
@@ -195,4 +208,5 @@ public class Bug_303517 extends ResourceTest {
 		assertTrue("1.5", f.exists());
 		assertTrue("1.6", f.isSynchronized(IResource.DEPTH_INFINITE));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -18,23 +18,31 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.runtime.Platform.OS;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test for bug 329836
  */
-public class Bug_329836 extends ResourceTest {
-	public void testBug() throws Exception {
-		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
-			return;
-		}
+public class Bug_329836 {
 
-		IFileStore fileStore = getTempStore().getChild(createUniqueString());
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
+	public void testBug() throws Exception {
+		assumeTrue("test only works on Mac", OS.isMac());
+
+		IFileStore fileStore = workspaceRule.getTempStore().getChild(createUniqueString());
 		createInFileSystem(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
@@ -65,4 +73,5 @@ public class Bug_329836 extends ResourceTest {
 			assertFalse("6.0", info.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.resources.regression;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -26,9 +28,16 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_331445 extends ResourceTest {
+public class Bug_331445 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug() throws CoreException, URISyntaxException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -49,4 +58,5 @@ public class Bug_331445 extends ResourceTest {
 		assertEquals("5.0", new URI(linkFolderLocation), folder.getLocationURI());
 		assertEquals("6.0", new URI(rawLinkFolderLocation), folder.getRawLocationURI());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_332543.java
@@ -37,13 +37,20 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileStore;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * This tests that I/O Exception on OuptuStream#close() after IFile#setContents
  * is correctly reported.
  */
-public class Bug_332543 extends ResourceTest {
+public class Bug_332543 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Wrapper FS which throws an IOException when someone closes an output
 	 * stream...
@@ -70,16 +77,17 @@ public class Bug_332543 extends ResourceTest {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() {
 		WrapperFileSystem.setCustomFileStore(null);
-		super.tearDown();
 	}
 
+	@Test
 	public void testBugForByteArrayInputStream() throws Exception {
 		testCancel(s -> s);
 	}
 
+	@Test
 	public void testBugForInputStream() throws Exception {
 		testCancel(delegate -> new InputStream() { // Not ArrayInputStream
 			@Override

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -20,6 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import org.eclipse.core.resources.IFile;
@@ -34,14 +35,19 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.core.tests.resources.usecase.SignaledBuilder;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests a timing problem where a canceled waiting thread could cause a change
  * in another thread to skip building.
  */
-public class Bug_378156 extends ResourceTest {
+public class Bug_378156 {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	class ModifyFileJob extends WorkspaceJob {
 		private boolean cancel;
@@ -81,6 +87,7 @@ public class Bug_378156 extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testBugTwoThreads() throws Exception {
 		//setup
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
@@ -119,6 +126,7 @@ public class Bug_378156 extends ResourceTest {
 		assertTrue("1.0", builder.wasExecuted());
 	}
 
+	@Test
 	public void testBugOneThread() throws Exception {
 		//setup
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_380386.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_380386.java
@@ -13,16 +13,27 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.resources.IPathVariableManager;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test for Bug 380386
  */
-public class Bug_380386 extends ResourceTest {
+public class Bug_380386 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
+	@Ignore("This regression test has to be rewritten in a proper way")
 	public void testBug() throws Exception {
 		String path = "C:\\temp";
 		java.net.URI value = new java.io.File(path).toURI();
@@ -55,4 +66,5 @@ public class Bug_380386 extends ResourceTest {
 
 		pathManager.setURIValue(name, value);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -18,7 +18,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -28,15 +32,15 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
-import org.junit.Assume;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class IFileTest extends ResourceTest {
-	private final boolean DISABLED = true;
+public class IFileTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Bug states that the error code in the CoreException which is thrown when
@@ -44,19 +48,14 @@ public class IFileTest extends ResourceTest {
 	 * ERROR_WRITE.
 	 */
 	@Test
+	@Ignore("This test is no longer valid since the error code is dependent on whether or not the parent folder is marked as read-only. We need to write a different test to make the file.create fail.")
 	public void testBug25658() throws CoreException {
-
-		// This test is no longer valid since the error code is dependent on whether
-		// or not the parent folder is marked as read-only. We need to write a different
-		// test to make the file.create fail.
-		Assume.assumeFalse(DISABLED);
-
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		Assume.assumeTrue(isReadOnlySupported());
+		assumeTrue(isReadOnlySupported());
 
 		// Don't test this on Windows
-		Assume.assumeFalse(OS.isWindows());
+		assumeFalse(OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -84,11 +83,11 @@ public class IFileTest extends ResourceTest {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		Assume.assumeTrue(isReadOnlySupported());
+		assumeTrue(isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		Assume.assumeTrue(OS.isLinux());
+		assumeTrue(OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -127,4 +126,5 @@ public class IFileTest extends ResourceTest {
 		// try setting the description -- shouldn't fail
 		project.setDescription(desc, createTestMonitor());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -18,7 +18,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -30,14 +33,15 @@ import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.ResourceTest;
-import org.junit.Assume;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class IFolderTest extends ResourceTest {
+public class IFolderTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Bug requests that if a failed folder creation occurs on Linux that we check
 	 * the immediate parent to see if it is read-only so we can return a better
@@ -45,14 +49,13 @@ public class IFolderTest extends ResourceTest {
 	 */
 	@Test
 	public void testBug25662() throws CoreException {
-
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		Assume.assumeTrue(isReadOnlySupported());
+		assumeTrue(isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		Assume.assumeTrue(OS.isLinux());
+		assumeTrue(OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder parentFolder = project.getFolder("parentFolder");
@@ -128,4 +131,5 @@ public class IFolderTest extends ResourceTest {
 		dir.mkdir(EFS.SHALLOW, null);
 		// should not throw an exception
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.touchInFilesystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -35,14 +36,17 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.core.tests.resources.usecase.SignaledBuilder;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IProjectTest extends ResourceTest {
-	public IProjectTest(String name) {
-		super(name);
-	}
+public class IProjectTest {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void test_1G0XIMA() throws CoreException {
 		/* common objects */
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -67,6 +71,7 @@ public class IProjectTest extends ResourceTest {
 		project.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void test_1G5I6PV() throws CoreException {
 		/* common objects */
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -83,6 +88,7 @@ public class IProjectTest extends ResourceTest {
 	/**
 	 * 1GC2FKV: ITPCORE:BuildManager triggers incremental build when doing full builds
 	 */
+	@Test
 	public void testAutoBuild_1GC2FKV() throws CoreException {
 		// set auto build OFF
 		IWorkspaceDescription description = getWorkspace().getDescription();
@@ -143,6 +149,7 @@ public class IProjectTest extends ResourceTest {
 	 * Create a project with resources already existing on disk and ensure
 	 * that the resources are automatically discovered and brought into the workspace.
 	 */
+	@Test
 	public void testBug78711() throws Exception {
 		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);
@@ -172,6 +179,7 @@ public class IProjectTest extends ResourceTest {
 	/**
 	 * 1GDW1RX: ITPCORE:ALL - IResource.delete() without force not working correctly
 	 */
+	@Test
 	public void testDelete_1GDW1RX() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(createTestMonitor());
@@ -188,11 +196,9 @@ public class IProjectTest extends ResourceTest {
 		createInFileSystem(file);
 
 		assertThrows(CoreException.class, () -> project.delete(false, createTestMonitor()));
-
-		// clean up
-		project.delete(true, true, createTestMonitor());
 	}
 
+	@Test
 	public void testRefreshDotProject() throws Exception {
 		String name = createUniqueString();
 		IProject project = getWorkspace().getRoot().getProject(name);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -14,8 +14,10 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -27,13 +29,19 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IWorkspaceTest extends ResourceTest {
+public class IWorkspaceTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * 1GDKIHD: ITPCORE:WINNT - API - IWorkspace.move needs to keep history
 	 */
+	@Test
 	public void testMultiMove_1GDKIHD() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -71,6 +79,7 @@ public class IWorkspaceTest extends ResourceTest {
 	/**
 	 * 1GDGRIZ: ITPCORE:WINNT - API - IWorkspace.delete needs to keep history
 	 */
+	@Test
 	public void testMultiDelete_1GDGRIZ() throws CoreException {
 		// create common objects
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -129,11 +138,12 @@ public class IWorkspaceTest extends ResourceTest {
 		project.clearHistory(createTestMonitor());
 	}
 
+	@Test
 	public void test_8974() throws CoreException {
 		IProject one = getWorkspace().getRoot().getProject("One");
 		IPath oneLocation = getRandomLocation().append(one.getName());
 		oneLocation.toFile().mkdirs();
-		deleteOnTearDown(oneLocation.removeLastSegments(1));
+		workspaceRule.deleteOnTearDown(oneLocation.removeLastSegments(1));
 		IProjectDescription oneDescription = getWorkspace().newProjectDescription(one.getName());
 		oneDescription.setLocation(oneLocation);
 
@@ -145,4 +155,5 @@ public class IWorkspaceTest extends ResourceTest {
 		IStatus result = getWorkspace().validateProjectLocation(two, twoLocation);
 		assertEquals(Workspace.caseSensitive, result.isOK());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -15,8 +15,11 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -31,16 +34,22 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.internal.localstore.LocalStoreTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class LocalStoreRegressionTests extends LocalStoreTest {
+public class LocalStoreRegressionTests {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * 1FU4PJA: ITPCORE:ALL - refreshLocal for new file with depth zero doesn't work
 	 */
+	@Test
 	public void test_1FU4PJA() throws Throwable {
-		/* initialize common objects */
-		IProject project = projects[0];
+		IProject project = getWorkspace().getRoot().getProject("Test");
+		createInWorkspace(project);
 
 		/* */
 		IFile file = project.getFile("file");
@@ -53,8 +62,12 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 	/**
 	 * From: 1FU4TW7: ITPCORE:ALL - Behaviour not specified for refreshLocal when parent doesn't exist
 	 */
+	@Test
 	public void test_1FU4TW7() throws Throwable {
-		IFolder folder = projects[0].getFolder("folder");
+		IProject project = getWorkspace().getRoot().getProject("Test");
+		createInWorkspace(project);
+
+		IFolder folder = project.getFolder("folder");
 		IFile file = folder.getFile("file");
 		createInFileSystem(folder);
 		createInFileSystem(file);
@@ -68,10 +81,11 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 	/**
 	 * The PR reported a problem with longs, but we are testing more types here.
 	 */
+	@Test
 	public void test_1G65KR1() throws IOException {
 		/* evaluate test environment */
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
-		deleteOnTearDown(root);
+		workspaceRule.deleteOnTearDown(root);
 		File temp = root.toFile();
 		temp.mkdirs();
 
@@ -92,4 +106,5 @@ public class LocalStoreRegressionTests extends LocalStoreTest {
 				assertEquals("3.0", dis.readLong(), 1234567890l);
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/NLTest.java
@@ -28,9 +28,14 @@ import java.util.Locale;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class NLTest extends ResourceTest {
+public class NLTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	public void getFileNames(List<String> list, char begin, char end) {
 		char current = begin;
@@ -79,6 +84,7 @@ public class NLTest extends ResourceTest {
 		return names.toArray(new String[names.size()]);
 	}
 
+	@Test
 	public void testFileNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("project");
 		project.create(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.resources.IFile;
@@ -29,9 +30,17 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.tests.resources.ResourceDeltaVerifier;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class PR_1GEAB3C_Test extends ResourceTest {
+public class PR_1GEAB3C_Test {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	ResourceDeltaVerifier verifier;
 
 	protected static final String VERIFIER_NAME = "TestListener";
@@ -51,9 +60,8 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() {
 		//ensure background work is done before adding verifier
 		waitForBuild();
 		waitForRefresh();
@@ -65,9 +73,8 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 	 * Tears down the fixture, for example, close a network connection.
 	 * This method is called after a test is executed.
 	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() {
 		getWorkspace().removeResourceChangeListener(verifier);
 	}
 
@@ -75,6 +82,7 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 	 * Ensure that we get ADDED and OPEN in the delta when we create and open
 	 * a project in a workspace runnable.
 	 */
+	@Test
 	public void test_1GEAB3C() throws CoreException {
 		verifier.reset();
 		final IProject project = getWorkspace().getRoot().getProject("MyAddedAndOpenedProject");
@@ -96,4 +104,5 @@ public class PR_1GEAB3C_Test extends ResourceTest {
 		getWorkspace().run(body, createTestMonitor());
 		assertDelta();
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
@@ -14,23 +14,31 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class PR_1GH2B0N_Test extends ResourceTest {
+public class PR_1GH2B0N_Test {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void test_1GH2B0N() throws CoreException {
 		IPath path = getTempDir().append("1GH2B0N");
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IProjectDescription description = getWorkspace().newProjectDescription("MyProject");
 		IPath projectLocation = path.append(project.getName());
-		deleteOnTearDown(projectLocation);
+		workspaceRule.deleteOnTearDown(projectLocation);
 		description.setLocation(projectLocation);
 		project.create(description, createTestMonitor());
 		project.open(createTestMonitor());
@@ -41,4 +49,5 @@ public class PR_1GH2B0N_Test extends ResourceTest {
 		//since Eclipse 3.2 a project is allowed to be nested in another project
 		assertTrue("2.0", status.isOK());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GHOM0N_Test.java
@@ -24,14 +24,20 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class PR_1GHOM0N_Test extends ResourceTest {
+public class PR_1GHOM0N_Test {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/*
 	 * Ensure that we get ADDED and OPEN in the delta when we create and open
 	 * a project in a workspace runnable.
 	 */
+	@Test
 	public void test_1GEAB3C() throws CoreException {
 		// setup the project
 		final IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -51,4 +57,5 @@ public class PR_1GHOM0N_Test extends ResourceTest {
 		};
 		getWorkspace().run(body, createTestMonitor());
 	}
+
 }


### PR DESCRIPTION
* Replace the ResourceTest class hierarchy with WorkspaceTestRule
* Add @Test annotations
* Replace hand-written assumption checks with assume*() statements

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903