### PR TITLE
Migrate all tests in o.e.c.tests.resources.usecase to JUnit 4 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/AllUsecaseTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/AllUsecaseTests.java
@@ -18,7 +18,10 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-		ConcurrencyTest.class, IFileTest.class, IFolderTest.class, IProjectTest.class,
+		ConcurrencyTest.class, //
+		IFileTest.class, //
+		IFolderTest.class, //
+		IProjectTest.class, //
 		IWorkspaceRunnableUseCaseTest.class
 })
 public class AllUsecaseTests {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
@@ -15,12 +15,18 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class ConcurrencyTest extends ResourceTest {
+public class ConcurrencyTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	protected void assertIsNotRunning(ConcurrentOperation01 op, String label) {
 		/* try more than once, "just in case" */
@@ -38,8 +44,8 @@ public class ConcurrencyTest extends ResourceTest {
 	 * This test is used to find out if two operations can start concurrently. It assumes
 	 * that they cannot.
 	 */
+	@Test
 	public void testConcurrentOperations() throws CoreException {
-
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(null);
 		project.open(null);
@@ -69,4 +75,5 @@ public class ConcurrencyTest extends ResourceTest {
 		/* remove trash */
 		removeFromWorkspace(getWorkspace().getRoot());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
@@ -15,6 +15,13 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FILE;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FOLDER;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -28,8 +35,14 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IFileTest extends IResourceTest {
+public class IFileTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests failure on get/set methods invoked on a nonexistent file.
@@ -60,6 +73,7 @@ public class IFileTest extends IResourceTest {
 	 * Test deleting file that doesn't exist (failure?).
 	 * Finish testing IResource API
 	 */
+	@Test
 	public void testFile() throws CoreException {
 		IProgressMonitor monitor = null;
 		IWorkspace workspace = getWorkspace();
@@ -150,4 +164,5 @@ public class IFileTest extends IResourceTest {
 		// These tests produce failure because the file no longer exists.
 		nonexistentFileFailureTests(file, workspace);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
@@ -14,6 +14,12 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FOLDER;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -29,8 +35,14 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IFolderTest extends IResourceTest {
+public class IFolderTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests failure on get/set methods invoked on a nonexistent folder.
@@ -70,6 +82,7 @@ public class IFolderTest extends IResourceTest {
 	 * Test IResource API
 	 * Test IFolder API
 	 */
+	@Test
 	public void testFolder() throws CoreException {
 		IProgressMonitor monitor = null;
 		IWorkspace workspace = getWorkspace();
@@ -224,4 +237,5 @@ public class IFolderTest extends IResourceTest {
 		assertThat("folder at path '" + folder.getFullPath() + "' unexpectedly exists in workspace",
 				!wb.getRoot().exists(folder.getFullPath()));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
@@ -15,12 +15,18 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
+import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Hashtable;
 import org.eclipse.core.resources.ICommand;
@@ -31,13 +37,20 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IProjectTest extends IResourceTest {
+public class IProjectTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	public static String LOCAL_LOCATION_PATH_STRING_0;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() {
 		LOCAL_LOCATION_PATH_STRING_0 = getWorkspace().getRoot().getLocation().append("temp/location0").toOSString();
 	}
 
@@ -100,6 +113,7 @@ public class IProjectTest extends IResourceTest {
 	 * Test IResource API
 	 * Test IFolder API
 	 */
+	@Test
 	public void testProject() throws CoreException {
 		IWorkspace wb = getWorkspace();
 		IProgressMonitor monitor = null;
@@ -223,4 +237,5 @@ public class IProjectTest extends IResourceTest {
 		assertTrue("project at path '" + proj.getFullPath() + "' unexpectedly exists in workspace",
 				wb.getRoot().exists(proj.getFullPath()));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
@@ -15,25 +15,20 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
 
-public abstract class IResourceTest extends ResourceTest {
+final class IResourceTestUtil {
 	public static QualifiedName Q_NAME_SESSION = new QualifiedName("prop", "session");
 	public static String STRING_VALUE = "value";
 	public static String PROJECT = "Project";
 	public static String FOLDER = "Folder";
 	public static String FILE = "File";
 
-	public IResourceTest() {
-		super();
-	}
-
-	public IResourceTest(String name) {
-		super(name);
+	private IResourceTestUtil() {
 	}
 
 	/**
@@ -41,7 +36,7 @@ public abstract class IResourceTest extends ResourceTest {
 	 * Get methods either throw an exception or return null (abnormally).
 	 * Set methods throw an exception.
 	 */
-	protected void commonFailureTestsForResource(IResource resource, boolean created) {
+	public static void commonFailureTestsForResource(IResource resource, boolean created) {
 		/* Prefix to assertion messages. */
 		String method = "commonFailureTestsForResource(IResource," + (created ? "CREATED" : "NONEXISTENT") + "): ";
 		if (!created) {
@@ -57,7 +52,7 @@ public abstract class IResourceTest extends ResourceTest {
 	 * Wrapper for deprecated method {@link IResource#isLocal(int)} to reduce
 	 * warnings.
 	 */
-	protected boolean isLocal(IResource resource, int depth) {
+	public static boolean isLocal(IResource resource, int depth) {
 		return resource.isLocal(depth);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
@@ -17,7 +17,9 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
@@ -26,9 +28,14 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
+public class IWorkspaceRunnableUseCaseTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	protected IWorkspaceRunnable createRunnable(final IProject project, final IWorkspaceRunnable nestedOperation, final boolean triggerBuild, final Exception exceptionToThrow) {
 		return monitor -> {
@@ -50,6 +57,7 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 		};
 	}
 
+	@Test
 	public void testNestedOperationsAndBuilds() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		setAutoBuilding(true);
@@ -110,4 +118,5 @@ public class IWorkspaceRunnableUseCaseTest extends ResourceTest {
 			assertTrue("4.1", !builder.wasExecuted());
 		}
 	}
+
 }


### PR DESCRIPTION
* Replace the ResourceTest class hierarchy with WorkspaceTestRule
* Add @Test annotations
* Replace abstract IResourceTest class with IResourceTestUtil class

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903