### PR TITLE
Migrate all tests in o.e.c.tests.internal.resources to JUnit 4 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/AllInternalResourcesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/AllInternalResourcesTests.java
@@ -22,9 +22,15 @@ import org.junit.runners.Suite;
  * in this test package.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ ModelObjectReaderWriterTest.class, ProjectPreferencesTest.class,
-		ResourceInfoTest.class,
-		WorkspaceConcurrencyTest.class, WorkspacePreferencesTest.class, ProjectReferencesTest.class,
-		ProjectDynamicReferencesTest.class, ProjectBuildConfigsTest.class, Bug544975Test.class, })
+@Suite.SuiteClasses({ //
+		Bug544975Test.class, //
+		ModelObjectReaderWriterTest.class, //
+		ProjectBuildConfigsTest.class, //
+		ProjectDynamicReferencesTest.class, //
+		ProjectPreferencesTest.class, //
+		ProjectReferencesTest.class, //
+		ResourceInfoTest.class, //
+		WorkspaceConcurrencyTest.class, //
+		WorkspacePreferencesTest.class, })
 public class AllInternalResourcesTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
@@ -15,6 +15,8 @@ package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
@@ -30,10 +32,16 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug544975Test extends ResourceTest {
+public class Bug544975Test {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testBug544975ProjectOpenBackgroundRefresh() throws Exception {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject project = root.getProject("Bug544975");
@@ -73,6 +81,7 @@ public class Bug544975Test extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testBug544975ProjectOpenWithoutBackgroundRefresh() throws Exception {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject project = root.getProject("Bug544975");
@@ -111,4 +120,5 @@ public class Bug544975Test extends ResourceTest {
 		file.setContents(stream, IResource.FORCE, new NullProgressMonitor());
 		return file;
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -25,12 +25,18 @@ import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests configuration project build configuration on the project description
  */
-public class ProjectBuildConfigsTest extends ResourceTest {
+public class ProjectBuildConfigsTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 	private static final String variantId0 = "Variant0";
@@ -41,9 +47,8 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 	private IBuildConfiguration variant2;
 	private IBuildConfiguration defaultVariant;
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
 		project = getWorkspace().getRoot().getProject("ProjectBuildConfigsTest_Project");
 		createInWorkspace(new IProject[] {project});
 		variant0 = new BuildConfiguration(project, variantId0);
@@ -52,6 +57,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		defaultVariant = new BuildConfiguration(project, IBuildConfiguration.DEFAULT_CONFIG_NAME);
 	}
 
+	@Test
 	public void testBasics() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		String[] configs = new String[] {variantId0, variantId1};
@@ -84,6 +90,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		assertThat(variant.getName(), is(variantId0));
 	}
 
+	@Test
 	public void testDuplicates() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[] {variantId0, variantId1, variantId0});
@@ -91,6 +98,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		assertThat(project.getBuildConfigs(), arrayContaining(variant0, variant1));
 	}
 
+	@Test
 	public void testDefaultVariant() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[] {});
@@ -107,6 +115,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 		assertThat(project.getActiveBuildConfig(), is(defaultVariant));
 	}
 
+	@Test
 	public void testRemoveActiveVariant() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		desc.setBuildConfigs(new String[0]);
@@ -127,6 +136,7 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 	/**
 	 * Tests that build configuration references are correct after moving a project
 	 */
+	@Test
 	public void testProjectMove() throws CoreException {
 		IProjectDescription desc = project.getDescription();
 		IBuildConfiguration[] configs = new IBuildConfiguration[] {variant0, variant1};
@@ -148,4 +158,5 @@ public class ProjectBuildConfigsTest extends ResourceTest {
 			assertThat("unexpected project name at index " + i, newConfigs[i].getName(), is(configs[i].getName()));
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -36,23 +36,30 @@ import org.eclipse.core.resources.IWorkspace.ProjectOrder;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test project dynamic references provided by extension point
  * <code>org.eclipse.core.resources.builders</code> and dynamicReference
  * {@link IDynamicReferenceProvider}
  */
-public class ProjectDynamicReferencesTest extends ResourceTest {
+public class ProjectDynamicReferencesTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	private static final String PROJECT_0_NAME = "ProjectDynamicReferencesTest_p0";
 
 	private IProject project0;
 	private IProject project1;
 	private IProject project2;
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
 		project0 = getWorkspace().getRoot().getProject(PROJECT_0_NAME);
 		project1 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p2");
@@ -62,12 +69,12 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		updateProjectDescription(project2).addingCommand(Builder.NAME).apply();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		DynamicReferenceProvider.clear();
 	}
 
+	@Test
 	public void testReferencedProjects() throws CoreException {
 		assertThat("Project0 must not have referenced projects", project0.getReferencedProjects(), emptyArray());
 		assertThat("Project1 must not have referenced projects", project1.getReferencedProjects(), emptyArray());
@@ -111,6 +118,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		assertThat("Project2 must not have referenced projects", project2.getReferencedProjects(), emptyArray());
 	}
 
+	@Test
 	public void testReferencedBuildConfigs() throws CoreException {
 		assertThat("Project0 must not have referenced projects",
 				project0.getReferencedBuildConfigs(IBuildConfiguration.DEFAULT_CONFIG_NAME, false), emptyArray());
@@ -136,6 +144,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 				project2.getReferencedBuildConfigs(IBuildConfiguration.DEFAULT_CONFIG_NAME, false), emptyArray());
 	}
 
+	@Test
 	public void testReferencingProjects() throws CoreException {
 		assertThat("Project0 must not have referencing projects", project0.getReferencingProjects(), emptyArray());
 		assertThat("Project1 must not have referencing projects", project1.getReferencingProjects(), emptyArray());
@@ -186,6 +195,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 				arrayContaining(project0, project1));
 	}
 
+	@Test
 	public void testComputeProjectOrder() throws CoreException {
 		IProject[] allProjects = new IProject[] { project0, project1, project2 };
 
@@ -217,6 +227,7 @@ public class ProjectDynamicReferencesTest extends ResourceTest {
 		assertThat("Project order should not have cycles: " + projectOrder, !projectOrder.hasCycles);
 	}
 
+	@Test
 	public void testBug543776() throws Exception {
 		IFile projectFile = project0.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		String projectDescription = readStringInFileSystem(projectFile);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -25,6 +25,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -65,14 +71,19 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChange
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 /**
  * @since 3.0
  */
-public class ProjectPreferencesTest extends ResourceTest {
+public class ProjectPreferencesTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String DIR_NAME = ".settings";
 	private static final String FILE_EXTENSION = "prefs";
@@ -120,6 +131,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testSimple() throws CoreException {
 		IProject project = getProject("foo");
 		String qualifier = "org.eclipse.core.tests.resources";
@@ -212,6 +224,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testListener() throws Exception {
 		// setup
 		IProject project = getProject(createUniqueString());
@@ -270,6 +283,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	/**
 	 * Regression test for bug 60896 - Project preferences remains when deleting/creating project
 	 */
+	@Test
 	public void testProjectDelete() throws Exception {
 		// create the project
 		IProject project = getProject(createUniqueString());
@@ -298,6 +312,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	}
 
 	/** See bug 91244, bug 93398 and bug 211006. */
+	@Test
 	public void testProjectMove() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		IProject project2 = getProject(createUniqueString());
@@ -336,6 +351,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * directly to disk. We need to convert to use Resource APIs so changes
 	 * show up in the workspace immediately.
 	 */
+	@Test
 	public void test_60925() throws Exception {
 		// setup
 		IProject project = getProject(createUniqueString());
@@ -367,6 +383,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 *
 	 * Problems with a dot "." as a key name
 	 */
+	@Test
 	public void test_55410() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		createInWorkspace(project1);
@@ -397,6 +414,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Investigate what happens with project preferences when the
 	 * project is moved.
 	 */
+	@Test
 	public void test_61277a() throws Exception {
 		IProject project = getProject(createUniqueString());
 		IProject destProject = getProject(createUniqueString());
@@ -427,6 +445,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Investigate what happens with project preferences when the
 	 * project is moved.
 	 */
+	@Test
 	public void test_61277b() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		IProject project2 = getProject(createUniqueString());
@@ -451,6 +470,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 *
 	 * Problems with a key which is the empty string.
 	 */
+	@Test
 	public void test_61277c() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		createInWorkspace(project1);
@@ -481,6 +501,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * The project preferences are being accessing (for the first time) from
 	 * within a resource change listener reacting to a change in the workspace.
 	 */
+	@Test
 	public void test_61843() throws Exception {
 		// create the project and manually give it a settings file
 		final String qualifier = createUniqueString();
@@ -526,6 +547,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Bug 65068 - When the preferences file is deleted, the corresponding preferences
 	 * should be forgotten.
 	 */
+	@Test
 	public void test_65068() throws Exception {
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -545,6 +567,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	/*
 	 * Bug 95052 - external property removals are not detected.
 	 */
+	@Test
 	public void test_95052() throws Exception {
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -588,6 +611,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	/*
 	 * Bug 579372 - property removals are not detected.
 	 */
+	@Test
 	public void test_579372() throws Exception {
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -655,6 +679,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Bug 256900 - When the preferences file is copied between projects, the corresponding preferences
 	 * should be updated.
 	 */
+	@Test
 	public void test_256900() throws Exception {
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -689,6 +714,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Bug 325000 Project properties not sorted on IBM VMs
 	 * Creates property file with various characters on front and verifies that they are written in alphabetical order.
 	 */
+	@Test
 	public void test_325000() throws Exception {
 		IProject project1 = getProject(createUniqueString());
 		createInWorkspace(project1);
@@ -737,6 +763,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void test_335591() throws Exception {
 		String projectName = createUniqueString();
 		String nodeName = "node";
@@ -798,6 +825,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals("NEW_VALUE", node.get("NEW_KEY", null));
 	}
 
+	@Test
 	public void test_384151() throws BackingStoreException, CoreException {
 		// make sure each line separator is different
 		String systemValue = System.lineSeparator();
@@ -882,6 +910,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void test_336211() throws BackingStoreException, CoreException, IOException {
 		String projectName = createUniqueString();
 		String nodeName = "node";
@@ -912,6 +941,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals("VALUE", node.get("KEY", null));
 	}
 
+	@Test
 	public void testProjectOpenClose() throws Exception {
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -929,6 +959,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals("2.1", value, node.get(key, null));
 	}
 
+	@Test
 	public void testContentType() {
 		IContentType prefsType = Platform.getContentTypeManager().getContentType(ResourcesPlugin.PI_RESOURCES + ".preferences");
 		assertNotNull("1.0", prefsType);
@@ -936,6 +967,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		assertEquals("1.1", prefsType, associatedType);
 	}
 
+	@Test
 	public void testListenerOnChangeFile() throws Exception {
 		// setup
 		IProject project = getProject(createUniqueString());
@@ -1006,8 +1038,8 @@ public class ProjectPreferencesTest extends ResourceTest {
 	 * Test to ensure that discovering a new pref file (e.g. loading from a repo)
 	 * is the same as doing an import. (ensure the modify listeners are called)
 	 */
+	@Test
 	public void testLoadIsImport() throws Exception {
-
 		// setup
 		IProject project = getProject(createUniqueString());
 		createInWorkspace(project);
@@ -1085,6 +1117,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		return true;
 	}
 
+	@Test
 	public void testChildrenNamesAgainstInitialize() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1124,6 +1157,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testChildrenNamesAgainstLoad() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1159,6 +1193,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testClear() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1194,6 +1229,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testGet() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1227,6 +1263,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testKeys() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1262,6 +1299,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testNodeExistsAgainstInitialize() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1297,6 +1335,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testNodeExistsAgainstLoad() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1330,6 +1369,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testPut() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1365,6 +1405,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testRemove() throws BackingStoreException, CoreException {
 		String nodeA = "nodeA";
 		String nodeB = "nodeB";
@@ -1399,6 +1440,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		project2.delete(true, createTestMonitor());
 	}
 
+	@Test
 	public void testDeleteOnFilesystemAndLoad() throws CoreException, BackingStoreException {
 		String nodeA = "nodeA";
 		String key = "key";
@@ -1426,6 +1468,7 @@ public class ProjectPreferencesTest extends ResourceTest {
 		ProjectPreferences.updatePreferences(prefsFile);
 	}
 
+	@Test
 	public void testSettingsFolderCreatedOutsideWorkspace() throws CoreException, BackingStoreException, IOException {
 		String nodeA = "nodeA";
 		String key = "key";
@@ -1451,6 +1494,6 @@ public class ProjectPreferencesTest extends ResourceTest {
 		prefs1.put(key, value);
 		prefs1.flush();
 		assertEquals(value, prefs1.get(key, null));
-
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -27,12 +27,18 @@ import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test project variant references
  */
-public class ProjectReferencesTest extends ResourceTest {
+public class ProjectReferencesTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project0;
 	private IProject project1;
@@ -49,9 +55,8 @@ public class ProjectReferencesTest extends ResourceTest {
 	private static final String bc1 = "Variant1";
 	private static final String nonExistentBC = "foo";
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
 		project0 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p0");
 		project1 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p1");
 		project2 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p2");
@@ -86,6 +91,7 @@ public class ProjectReferencesTest extends ResourceTest {
 		project.setDescription(desc, createTestMonitor());
 	}
 
+	@Test
 	public void testAddReferencesToNonExistantConfigs() throws CoreException {
 		IProjectDescription desc = project0.getDescription();
 
@@ -108,6 +114,7 @@ public class ProjectReferencesTest extends ResourceTest {
 	 *
 	 * Removing a build configuration removes associated build configuration references
 	 */
+	@Test
 	public void testChangingBuildConfigurations() throws CoreException {
 		IProjectDescription desc = project0.getDescription();
 		IBuildConfiguration[] refs = new IBuildConfiguration[] {project0v1, project1v0};
@@ -149,6 +156,7 @@ public class ProjectReferencesTest extends ResourceTest {
 	 * Tests that setting build configuration level dynamic references
 	 * trumps the project level dynamic references when it comes to order.
 	 */
+	@Test
 	public void testMixedProjectAndBuildConfigRefs() throws CoreException {
 		// Set project variant references
 		IProjectDescription desc = project0.getDescription();
@@ -182,6 +190,7 @@ public class ProjectReferencesTest extends ResourceTest {
 				arrayContaining(project1.getActiveBuildConfig(), project3.getActiveBuildConfig()));
 	}
 
+	@Test
 	public void testSetAndGetProjectReferences() throws CoreException {
 		// Set project references
 		IProjectDescription desc = project0.getDescription();
@@ -216,6 +225,7 @@ public class ProjectReferencesTest extends ResourceTest {
 				arrayContaining(project3v0, project1v0, project2v0));
 	}
 
+	@Test
 	public void testSetAndGetProjectConfigReferences() throws CoreException {
 		// Set project variant references
 		IProjectDescription desc = project0.getDescription();
@@ -254,6 +264,7 @@ public class ProjectReferencesTest extends ResourceTest {
 				project2v0, project1.getActiveBuildConfig(), project3.getActiveBuildConfig()));
 	}
 
+	@Test
 	public void testReferencesToActiveConfigs() throws CoreException {
 		IProjectDescription desc = project0.getDescription();
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {getRef(project1)});
@@ -263,4 +274,5 @@ public class ProjectReferencesTest extends ResourceTest {
 		assertThat(project0.getReferencedBuildConfigs(project0v0.getName(), true),
 				arrayContaining(project1v0));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
@@ -14,58 +14,30 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Map;
 import org.eclipse.core.internal.resources.ResourceInfo;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class ResourceInfoTest extends ResourceTest {
+public class ResourceInfoTest {
 
-	static public void assertEquals(String message, byte[] expected, byte[] actual) {
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	static public void assertEquals(ResourceInfo expected, ResourceInfo actual) {
 		if (expected == null && actual == null) {
 			return;
 		}
 		if (expected == null || actual == null) {
-			assertTrue(message, false);
-		}
-		assertEquals(message, expected.length, actual.length);
-		for (int i = 0; i < expected.length; i++) {
-			assertEquals(message, expected[i], actual[i]);
-		}
-	}
-
-	static public void assertEquals(String message, Map<?, ?> expected, Map<?, ?> actual) {
-		if (expected == null && actual == null) {
-			return;
-		}
-		if (expected == null || actual == null) {
-			assertTrue(message, false);
-		}
-		assertEquals(message, expected.size(), actual.size());
-		for (Map.Entry<?, ?> entry : expected.entrySet()) {
-			Object key = entry.getKey();
-			assertTrue(message, actual.containsKey(key));
-			Object expectedValue = entry.getValue();
-			Object actualValue = actual.get(key);
-			if (expectedValue instanceof byte[] expectedB && actualValue instanceof byte[] actualB) {
-				assertEquals(message, expectedB, actualB);
-			} else {
-				assertEquals(message, expectedValue, actualValue);
-			}
-		}
-	}
-
-	static public void assertEquals(String message, ResourceInfo expected, ResourceInfo actual) {
-		if (expected == null && actual == null) {
-			return;
-		}
-		if (expected == null || actual == null) {
-			assertTrue(message, false);
+			assertTrue(false);
 		}
 		boolean different = false;
 		different &= expected.getFlags() == actual.getFlags();
@@ -77,10 +49,11 @@ public class ResourceInfoTest extends ResourceTest {
 		//	assertEquals(message, expected.getSyncInfo(false), actual.getSyncInfo(false));
 		different &= expected.getMarkerGenerationCount() == actual.getMarkerGenerationCount();
 		if (different) {
-			assertTrue(message, false);
+			assertTrue(false);
 		}
 	}
 
+	@Test
 	public void testSerialization() throws IOException {
 		ByteArrayInputStream input = null;
 		ByteArrayOutputStream output = null;
@@ -92,7 +65,7 @@ public class ResourceInfoTest extends ResourceTest {
 		info.writeTo(new DataOutputStream(output));
 		input = new ByteArrayInputStream(output.toByteArray());
 		newInfo.readFrom(0, new DataInputStream(input));
-		assertEquals("1.2", info, newInfo);
+		assertEquals(info, newInfo);
 
 		// write and info with syncinfo set
 		info = new ResourceInfo();
@@ -109,6 +82,7 @@ public class ResourceInfoTest extends ResourceTest {
 		newInfo = new ResourceInfo();
 		input = new ByteArrayInputStream(output.toByteArray());
 		newInfo.readFrom(0, new DataInputStream(input));
-		assertEquals("2.2", info, newInfo);
+		assertEquals(info, newInfo);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -39,12 +40,17 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.CancelingProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
-import org.eclipse.core.tests.resources.ResourceTest;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests concurrency issues when dealing with operations on the workspace
  */
-public class WorkspaceConcurrencyTest extends ResourceTest {
+public class WorkspaceConcurrencyTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void sleep(long duration) {
 		try {
@@ -54,6 +60,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testEndRuleInWorkspaceOperation() {
 		final IProject project = getWorkspace().getRoot().getProject("testEndRuleInWorkspaceOperation");
 		assertThrows(RuntimeException.class,
@@ -65,6 +72,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 	 * Tests that it is possible to cancel a workspace operation when it is blocked
 	 * by activity in another thread. This is a regression test for bug 56118.
 	 */
+	@Test
 	public void testCancelOnBlocked() throws Throwable {
 		//create a dummy project
 		createInWorkspace(getWorkspace().getRoot().getProject("P1"));
@@ -131,6 +139,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 	 * Tests calling IWorkspace.run with a non-workspace rule.  This should be
 	 * allowed. This is a regression test for bug 60114.
 	 */
+	@Test
 	public void testRunnableWithOtherRule() throws CoreException {
 		ISchedulingRule rule = new ISchedulingRule() {
 			@Override
@@ -159,6 +168,7 @@ public class WorkspaceConcurrencyTest extends ResourceTest {
 	 * will not be available and it will fail.
 	 * This is a regression test for bug 	62927.
 	 */
+	@Test
 	public void testRunWhileBuilding() throws Throwable {
 		final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		//create a POST_BUILD listener that will touch a project


### PR DESCRIPTION
* Remove ResourceTest class hierarchy
* Add @Test annotations
* Remove obsolete assertion methods

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903