### PR TITLE
Revert change making jdt compiler use project settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,14 +77,6 @@
             <testClassesDirectory>${tycho.surefire.testClassesDirectory}</testClassesDirectory>
           </configuration>
         </plugin>
-		<plugin>
-			<groupId>org.eclipse.tycho</groupId>
-			<artifactId>tycho-compiler-plugin</artifactId>
-			<configuration>
-				<useProjectSettings>true</useProjectSettings>
-			</configuration>
-		</plugin>
-      </plugins>
     </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Should fix
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1653 .
Further work on the topic could be continued as described in https://github.com/eclipse-platform/eclipse.platform/pull/973#issuecomment-1849538208