### PR TITLE
Lists/records instead of arrays in ProductPreferences + SequenceResolver

### DIFF
--- a/ua/org.eclipse.help/src/org/eclipse/help/internal/util/ProductPreferences.java
+++ b/ua/org.eclipse.help/src/org/eclipse/help/internal/util/ProductPreferences.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.help.internal.util;
 
+import static java.util.Collections.emptyList;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -54,7 +56,7 @@ public class ProductPreferences {
 	private static Map<Properties, String> preferencesToPluginIdMap;
 	private static Map<Properties, String> preferencesToProductIdMap;
 	private static List<String> primaryTocOrdering;
-	private static List<String>[] secondaryTocOrderings;
+	private static List<List<String>> secondaryTocOrderings;
 	private static final String PLUGINS_ROOT_SLASH = "PLUGINS_ROOT/"; //$NON-NLS-1$
 	private static boolean rtl;
 	private static boolean directionInitialized = false;
@@ -66,8 +68,7 @@ public class ProductPreferences {
 	 */
 	public static List<String> getTocOrder(List<String> itemsToOrder, Map<String, String> nameIdMap) {
 		List<String> primaryOrdering = getPrimaryTocOrdering();
-		@SuppressWarnings("unchecked")
-		List<String>[] secondaryOrdering = new List[0];
+		List<List<String>> secondaryOrdering = emptyList();
 		if (primaryOrdering == null || primaryOrdering.isEmpty()) {
 			secondaryOrdering = getSecondaryTocOrderings();
 		}
@@ -101,8 +102,7 @@ public class ProductPreferences {
 	 * Returns all secondary toc ordering. These are the preferred toc orders of all
 	 * defined products except the active product.
 	 */
-	@SuppressWarnings("unchecked")
-	public static List<String>[] getSecondaryTocOrderings() {
+	public static List<List<String>> getSecondaryTocOrderings() {
 		if (secondaryTocOrderings == null) {
 			List<List<String>> list = new ArrayList<>();
 			Properties[] productPreferences = getProductPreferences(false);
@@ -115,8 +115,7 @@ public class ProductPreferences {
 					list.add(ordering);
 				}
 			}
-			// can't instantiate arrays of generic type
-			secondaryTocOrderings = list.toArray(new List[list.size()]);
+			secondaryTocOrderings = list;
 		}
 		return secondaryTocOrderings;
 	}
@@ -189,21 +188,12 @@ public class ProductPreferences {
 	}
 
 	/*
-	 * Returns the given items in the order specified. Items listed in the order
-	 * but not present are skipped, and items present but not ordered are added
-	 * at the end.
-	 */
-	public static List<String> getOrderedList(List<String> items, List<String> order) {
-		return getOrderedList(items, order, null, null);
-	}
-
-	/*
 	 * Returns the given items in an order that best satisfies the given orderings.
 	 * The primary ordering must be satisfied in all cases. As many secondary orderings
 	 * as reasonably possible will be satisfied.
 	 */
-	public static List<String> getOrderedList(List<String> items, List<String> primary, List<String>[] secondary,
-			Map<String, String> nameIdMap) {
+	public static List<String> getOrderedList(List<String> items, List<String> primary,
+			List<List<String>> secondary, Map<String, String> nameIdMap) {
 		List<String> result = new ArrayList<>();
 		List<String> set = new ArrayList<>(items);
 		if (orderResolver == null) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
@@ -13,11 +13,14 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.preferences;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.IntStream;
 
 import org.eclipse.help.internal.util.ProductPreferences;
 import org.junit.Assert;
@@ -142,11 +145,8 @@ public class ProductPreferencesTest {
 			List<String> items = ProductPreferences.tokenize(data[0]);
 			List<String> expectedOrder = ProductPreferences.tokenize(data[1]);
 			List<String> primaryOrdering = ProductPreferences.tokenize(data[2]);
-			@SuppressWarnings("unchecked")
-			List<String>[] secondaryOrderings = (List<String>[]) new List<?>[data.length - 3];
-			for (int j=0;j<secondaryOrderings.length;++j) {
-				secondaryOrderings[j] = ProductPreferences.tokenize(data[j + 3]);
-			}
+			List<List<String>> secondaryOrderings = IntStream.range(0, data.length - 3)
+					.mapToObj(i -> ProductPreferences.tokenize(data[i + 3])).collect(toList());
 
 			List<String> actualOrder = ProductPreferences.getOrderedList(items, primaryOrdering, secondaryOrderings, null);
 			Assert.assertEquals("Items in list were not ordered as expected", expectedOrder, actualOrder);

--- a/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
+++ b/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
@@ -559,16 +559,15 @@ public class UniversalIntroConfigurer extends IntroConfigurer implements
 		if (primaryAnchors == null) {
 			primaryAnchors = Collections.emptyList();
 		}
-		List<List<IntroElement>> secondaryAnchorsList = new ArrayList<>();
+		List<List<IntroElement>> secondaryAnchors = new ArrayList<>();
 		for (int i=0;i<secondaryIntroData.length;++i) {
 			IntroData idata = secondaryIntroData[i];
 			List<IntroElement> anchors = getAnchors(idata, pageId, groupId);
 			if (anchors != null) {
-				secondaryAnchorsList.add(anchors);
+				secondaryAnchors.add(anchors);
 			}
 		}
 
-		List<IntroElement>[] secondaryAnchors = secondaryAnchorsList.toArray(new List[secondaryAnchorsList.size()]);
 		if (sequenceResolver == null) {
 			sequenceResolver = new SequenceResolver<>();
 		}


### PR DESCRIPTION
The SequenceResolver accepts an array of lists, which requires several warnings suppressions because there is no easy type-safe way of creating an array of a generic type.

This change resolves these warnings as follows:
* Replaces the arrays of lists in SequenceResolver with a list of records that associate a list with an iterator and simplifies accesses
* Replaces the array-of-list parameter in SequenceResolver with a list of lists
* Replaces arrays of lists in ProductPreferences accordingly to resolve warnings
* Removes an unused and broken (always throwing exception) convenience method in ProducPreferences