### PR TITLE
Migrate all tests in o.e.c.tests.resources to JUnit 4 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllResourcesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllResourcesTests.java
@@ -18,17 +18,41 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ CharsetTest.class, ContentDescriptionManagerTest.class, FilteredResourceTest.class,
-		HiddenResourceTest.class, VirtualFolderTest.class, IFileTest.class, IFolderTest.class,
-		IPathVariableTest.class,
-		IProjectDescriptionTest.class, IProjectTest.class, IResourceChangeEventTest.class,
-		IResourceChangeListenerTest.class, IResourceDeltaTest.class, IResourceTest.class, ISynchronizerTest.class,
-		IWorkspaceRootTest.class, IWorkspaceTest.class, LinkedResourceTest.class,
-		LinkedResourceWithPathVariableTest.class, LinkedResourceSyncMoveAndCopyTest.class, MarkerSetTest.class,
-		MarkerTest.class, NatureTest.class, NonLocalLinkedResourceTest.class, ProjectEncodingTest.class,
-		ProjectOrderTest.class,
-		ProjectScopeTest.class, ProjectSnapshotTest.class, ResourceAttributeTest.class, ResourceURLTest.class,
-		TeamPrivateMemberTest.class, WorkspaceTest.class })
+@Suite.SuiteClasses({ //
+		CharsetTest.class, //
+		ContentDescriptionManagerTest.class, //
+		FilteredResourceTest.class, //
+		HiddenResourceTest.class, //
+		IFileTest.class, //
+		IFolderTest.class, //
+		IPathVariableTest.class, //
+		IProjectDescriptionTest.class, //
+		IProjectTest.class, //
+		IResourceChangeEventTest.class, //
+		IResourceChangeListenerTest.class, //
+		IResourceDeltaTest.class, //
+		IResourceTest.class, //
+		ISynchronizerTest.class, //
+		IWorkspaceRootTest.class, //
+		IWorkspaceTest.class, //
+		LinkedDotProjectTest.class, //
+		LinkedResourceSyncMoveAndCopyTest.class, //
+		LinkedResourceTest.class, //
+		LinkedResourceWithPathVariableTest.class, //
+		MarkerSetTest.class, //
+		MarkerTest.class, //
+		NatureTest.class, //
+		NonLocalLinkedResourceTest.class, //
+		ProjectEncodingTest.class, //
+		ProjectOrderTest.class, //
+		ProjectScopeTest.class, //
+		ProjectSnapshotTest.class, //
+		ResourceAttributeTest.class, //
+		ResourceURLTest.class, //
+		TeamPrivateMemberTest.class, //
+		VirtualFolderTest.class, //
+		WorkspaceTest.class, //
+})
 public class AllResourcesTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
@@ -35,6 +35,6 @@ import org.junit.runners.Suite;
 		org.eclipse.core.tests.resources.session.AllSessionTests.class,
 		org.eclipse.core.tests.resources.content.AllContentTests.class, org.eclipse.core.tests.internal.events.AllEventsTests.class,
 		org.eclipse.core.tests.internal.resources.AllInternalResourcesTests.class,
-		org.eclipse.core.tests.resources.LinkedDotProjectTest.class })
+})
 public class AutomatedResourceTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -16,6 +16,12 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -38,9 +44,14 @@ import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.runtime.content.IContentTypeSettings;
 import org.eclipse.core.runtime.jobs.Job;
+import org.junit.Rule;
+import org.junit.Test;
 import org.osgi.service.prefs.Preferences;
 
-public class ContentDescriptionManagerTest extends ResourceTest {
+public class ContentDescriptionManagerTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String CONTENT_TYPE_RELATED_NATURE1 = "org.eclipse.core.tests.resources.contentTypeRelated1";
 	private static final String CONTENT_TYPE_RELATED_NATURE2 = "org.eclipse.core.tests.resources.contentTypeRelated2";
@@ -69,6 +80,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 	/**
 	 * Ensure we react to changes to the content type registry in an appropriated way.
 	 */
+	@Test
 	public void testBug79151() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("MyProject");
@@ -122,12 +134,13 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertNull("5.4", description2);
 	}
 
+	@Test
 	public void testBug94516() throws Exception {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
 		assertNotNull("0.1", text);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
-		IFile unrelatedFile = project.getFile("file." + getName());
+		IFile unrelatedFile = project.getFile("file.unrelated");
 		createInWorkspace(unrelatedFile, "");
 
 		IContentDescription description = null;
@@ -169,6 +182,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 	/**
 	 * Ensures content type-nature associations work as expected.
 	 */
+	@Test
 	public void testNatureContentTypeAssociation() throws Exception {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType baseType = contentTypeManager.getContentType("org.eclipse.core.tests.resources.nature_associated_1");
@@ -229,6 +243,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertSame("5.3", ((ContentTypeHandler) baseType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
 	}
 
+	@Test
 	public void testProjectSpecificCharset() throws Exception {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
@@ -237,8 +252,8 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertNotNull("0.2", xml);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 
-		IFile txtFile = project.getFile(getName() + ".txt");
-		IFile xmlFile = project.getFile(getName() + ".xml");
+		IFile txtFile = project.getFile("example.txt");
+		IFile xmlFile = project.getFile("example.xml");
 
 		createInWorkspace(txtFile, "");
 		createInWorkspace(xmlFile, "");
@@ -266,6 +281,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertEquals("4.2", "FOO", xmlFile.getCharset());
 	}
 
+	@Test
 	public void testProjectSpecificFileAssociations() throws Exception {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
@@ -273,10 +289,11 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertNotNull("0.1", text);
 		assertNotNull("0.2", xml);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
+		String unrelatedFileExtension = "unrelated";
 
-		IFile txtFile = project.getFile(getName() + ".txt");
-		IFile xmlFile = project.getFile(getName() + ".xml");
-		IFile unrelatedFile = project.getFile("file." + getName());
+		IFile txtFile = project.getFile("example.txt");
+		IFile xmlFile = project.getFile("example.xml");
+		IFile unrelatedFile = project.getFile("file." + unrelatedFileExtension);
 
 		createInWorkspace(txtFile, "");
 		createInWorkspace(xmlFile, "");
@@ -315,7 +332,7 @@ public class ContentDescriptionManagerTest extends ResourceTest {
 		assertNotSame("2.2", text, settings);
 		assertTrue("2.3", settings instanceof ContentTypeSettings);
 
-		settings.addFileSpec(getName(), IContentTypeSettings.FILE_EXTENSION_SPEC);
+		settings.addFileSpec(unrelatedFileExtension, IContentTypeSettings.FILE_EXTENSION_SPEC);
 		contentTypePrefs.flush();
 		description = unrelatedFile.getContentDescription();
 		assertNotNull("3.2b", description);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -24,7 +24,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -37,8 +40,19 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
-public class HiddenResourceTest extends ResourceTest {
+public class HiddenResourceTest {
+
+	@Rule
+	public TestName testName = new TestName();
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testRefreshLocal() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -47,7 +61,7 @@ public class HiddenResourceTest extends ResourceTest {
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
 		createInWorkspace(resources);
-		waitForEncodingRelatedJobs(getName());
+		waitForEncodingRelatedJobs(testName.getMethodName());
 
 		ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
 		listener.addExpectedChange(subFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
@@ -65,6 +79,7 @@ public class HiddenResourceTest extends ResourceTest {
 	/**
 	 * Resources which are marked as hidden resources should always be found.
 	 */
+	@Test
 	public void testFindMember() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -99,6 +114,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * Resources which are marked as hidden are not included in #members
 	 * calls unless specifically included by calling #members(IContainer.INCLUDE_HIDDEN)
 	 */
+	@Test
 	public void testMembers() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -185,6 +201,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * Resources which are marked as hidden resources should not be visited by
 	 * resource visitors.
 	 */
+	@Test
 	public void testAccept() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -258,6 +275,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertTrue(visitor.getMessage(), visitor.isValid());
 	}
 
+	@Test
 	public void testCopy() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -311,6 +329,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
+	@Test
 	public void testMove() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -364,6 +383,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
+	@Test
 	public void testDelete() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
@@ -422,6 +442,7 @@ public class HiddenResourceTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { project, file });
 	}
 
+	@Test
 	public void testDeltas() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		final IProject project = root.getProject(createUniqueString());
@@ -441,7 +462,7 @@ public class HiddenResourceTest extends ResourceTest {
 			addResourceChangeListener(listener);
 			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
-			waitForEncodingRelatedJobs(getName());
+			waitForEncodingRelatedJobs(testName.getMethodName());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
 			assertTrue(listener.getMessage(), listener.isDeltaValid());
@@ -512,6 +533,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * Resources which are marked as hidden resources return TRUE
 	 * in all calls to #exists.
 	 */
+	@Test
 	public void testExists() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -537,6 +559,7 @@ public class HiddenResourceTest extends ResourceTest {
 	/**
 	 * Test the set and get methods for hidden resources.
 	 */
+	@Test
 	public void testSetGet() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -596,6 +619,7 @@ public class HiddenResourceTest extends ResourceTest {
 	 * and {@link IProject#create(IProjectDescription, int, IProgressMonitor)}
 	 * handles {@link IResource#HIDDEN} flag properly.
 	 */
+	@Test
 	public void testCreateHiddenResources() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -638,4 +662,5 @@ public class HiddenResourceTest extends ResourceTest {
 		};
 		root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -30,7 +30,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -51,12 +54,15 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class IFileTest extends ResourceTest {
+public class IFileTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	//name of files according to sync category
 	public static final String DOES_NOT_EXIST = "DoesNotExistFile";
 
@@ -264,16 +270,9 @@ public class IFileTest extends ResourceTest {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		generateInterestingFiles();
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		super.tearDown();
 	}
 
 	@Test
@@ -963,4 +962,5 @@ public class IFileTest extends ResourceTest {
 		QualifiedName nullQualifierName = new QualifiedName(null, "foo");
 		assertThrows(CoreException.class, () -> target.setPersistentProperty(nullQualifierName, value));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -26,7 +26,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -38,14 +40,15 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class IFolderTest extends ResourceTest {
-	@Override
-	protected void tearDown() throws Exception {
-		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		super.tearDown();
-	}
+public class IFolderTest {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testChangeCase() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder before = project.getFolder("folder");
@@ -70,6 +73,7 @@ public class IFolderTest extends ResourceTest {
 		assertExistsInWorkspace(afterFile);
 	}
 
+	@Test
 	public void testCopyMissingFolder() throws CoreException {
 		//tests copying a folder that is missing from the file system
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -87,6 +91,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("1.2", !after.exists());
 	}
 
+	@Test
 	public void testCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
@@ -102,6 +107,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("2.1", !derived.isTeamPrivateMember());
 	}
 
+	@Test
 	public void testDeltaOnCreateDerived() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder derived = project.getFolder("derived");
@@ -117,6 +123,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("2.0", verifier.isDeltaValid());
 	}
 
+	@Test
 	public void testCreateDerivedTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
@@ -133,6 +140,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
 
+	@Test
 	public void testCreateTeamPrivate() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder teamPrivate = project.getFolder("teamPrivate");
@@ -149,6 +157,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("2.1", !teamPrivate.isDerived());
 	}
 
+	@Test
 	public void testFolderCreation() throws Exception {
 		// basic folder creation
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -207,6 +216,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("8.3", !target.exists());
 	}
 
+	@Test
 	public void testFolderDeletion() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IResource[] before = buildResources(project, new String[] {"c/", "c/b/", "c/x", "c/b/y", "c/b/z"});
@@ -217,6 +227,7 @@ public class IFolderTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(before);
 	}
 
+	@Test
 	public void testFolderMove() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IResource[] before = buildResources(project, new String[] {"b/", "b/b/", "b/x", "b/b/y", "b/b/z"});
@@ -239,6 +250,7 @@ public class IFolderTest extends ResourceTest {
 		assertTrue("2.1", compareContent(createInputStream(content), file.getContents(false)));
 	}
 
+	@Test
 	public void testFolderOverFile() throws Throwable {
 		IPath path = IPath.fromOSString("/Project/File");
 		IFile existing = getWorkspace().getRoot().getFile(path);
@@ -252,6 +264,7 @@ public class IFolderTest extends ResourceTest {
 	/**
 	 * Tests creation and manipulation of folder names that are reserved on some platforms.
 	 */
+	@Test
 	public void testInvalidFolderNames() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
@@ -289,6 +302,7 @@ public class IFolderTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testLeafFolderMove() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder source = project.getFolder("Folder1");
@@ -299,6 +313,7 @@ public class IFolderTest extends ResourceTest {
 		assertDoesNotExistInWorkspace(source);
 	}
 
+	@Test
 	public void testReadOnlyFolderCopy() throws Exception {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
@@ -320,6 +335,7 @@ public class IFolderTest extends ResourceTest {
 		dest.setReadOnly(false);
 	}
 
+	@Test
 	public void testSetGetFolderPersistentProperty() throws Throwable {
 		IResource target = getWorkspace().getRoot().getFolder(IPath.fromOSString("/Project/Folder"));
 		String value = "this is a test property value";
@@ -337,4 +353,5 @@ public class IFolderTest extends ResourceTest {
 		QualifiedName nonExistentPropertyName = new QualifiedName("itp-test", "testNonProperty");
 		assertNull("2.1", target.getPersistentProperty(nonExistentPropertyName));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -17,7 +17,9 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,13 +33,19 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.CustomTriggerBuilder;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests protocol of IProjectDescription and other specified behavior
  * that relates to the project description.
  */
-public class IProjectDescriptionTest extends ResourceTest {
+public class IProjectDescriptionTest {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testDescriptionConstant() {
 		assertEquals("1.0", ".project", IProjectDescription.DESCRIPTION_FILE_NAME);
 	}
@@ -45,6 +53,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	/**
 	 * Tests that setting the build spec preserves any instantiated builder.
 	 */
+	@Test
 	public void testBuildSpecBuilder() throws Exception {
 		Project project = (Project) getWorkspace().getRoot().getProject("ProjectTBSB");
 		createInWorkspace(project);
@@ -77,6 +86,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	 * Tests that the description file is not dirtied if the description has not actually
 	 * changed.
 	 */
+	@Test
 	public void testDirtyDescription() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IProject target1 = getWorkspace().getRoot().getProject("target1");
@@ -116,6 +126,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	 * Tests that the description file is dirtied if the description has actually
 	 * changed. This is a regression test for bug 64128.
 	 */
+	@Test
 	public void testDirtyBuildSpec() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile projectDescription = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -145,6 +156,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 		assertTrue("3.0", modificationStamp != projectDescription.getModificationStamp());
 	}
 
+	@Test
 	public void testDynamicProjectReferences() throws CoreException {
 		IProject target1 = getWorkspace().getRoot().getProject("target1");
 		IProject target2 = getWorkspace().getRoot().getProject("target2");
@@ -173,6 +185,7 @@ public class IProjectDescriptionTest extends ResourceTest {
 	/**
 	 * Tests IProjectDescription project references
 	 */
+	@Test
 	public void testProjectReferences() throws CoreException {
 		IProject target = getWorkspace().getRoot().getProject("Project1");
 		createInWorkspace(target);
@@ -194,4 +207,5 @@ public class IProjectDescriptionTest extends ResourceTest {
 		IProject[] refs = getWorkspace().getRoot().getProject("DoesNotExist2").getReferencingProjects();
 		assertEquals("4.0", 0, refs.length);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -17,6 +17,8 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -28,11 +30,18 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * This class tests the public API of IResourceChangeEvent.
  */
-public class IResourceChangeEventTest extends ResourceTest {
+public class IResourceChangeEventTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/* some random resource handles */
 	protected IProject project1;
 	protected IProject project2;
@@ -52,10 +61,8 @@ public class IResourceChangeEventTest extends ResourceTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		// Create some resource handles
 		project1 = getWorkspace().getRoot().getProject("Project" + 1);
 		project2 = getWorkspace().getRoot().getProject("Project" + 2);
@@ -79,6 +86,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 	/**
 	 * Tests the IResourceChangeEvent#findMarkerDeltas method.
 	 */
+	@Test
 	public void testFindMarkerDeltas() throws CoreException {
 		/*
 		 * The following changes will occur:
@@ -132,6 +140,7 @@ public class IResourceChangeEventTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testFindMarkerDeltasInEmptyDelta() throws CoreException {
 		/*
 		 * The following changes will occur:
@@ -211,4 +220,5 @@ public class IResourceChangeEventTest extends ResourceTest {
 		assertTrue("5.1", found2);
 		assertTrue("5.2", found3);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -17,6 +17,9 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -27,11 +30,18 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests the public API of IResourceDelta
  */
-public class IResourceDeltaTest extends ResourceTest {
+public class IResourceDeltaTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/* some random resource handles */
 	protected IProject project1;
 	protected IProject project2;
@@ -48,10 +58,8 @@ public class IResourceDeltaTest extends ResourceTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		// Create some resource handles
 		project1 = getWorkspace().getRoot().getProject("Project" + 1);
 		project2 = getWorkspace().getRoot().getProject("Project" + 2);
@@ -72,6 +80,7 @@ public class IResourceDeltaTest extends ResourceTest {
 	/**
 	 * Tests the IResourceDelta#findMember method.
 	 */
+	@Test
 	public void testFindMember() throws CoreException {
 		/*
 		 * The following changes will occur:
@@ -122,4 +131,5 @@ public class IResourceDeltaTest extends ResourceTest {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -26,7 +26,10 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -61,8 +64,16 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class ISynchronizerTest extends ResourceTest {
+public class ISynchronizerTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	public static int NUMBER_OF_PARTNERS = 100;
 	public IResource[] resources;
 
@@ -87,15 +98,14 @@ public class ISynchronizerTest extends ResourceTest {
 		getWorkspace().run(body, null);
 	}
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
 		resources = buildResources(getWorkspace().getRoot(),
 				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
 		createInWorkspace(resources);
 	}
 
-	@Override
+	@After
 	public void tearDown() throws Exception {
 		// remove all registered sync partners so we don't create
 		// phantoms when we delete
@@ -103,9 +113,6 @@ public class ISynchronizerTest extends ResourceTest {
 		for (QualifiedName name : names) {
 			getWorkspace().getSynchronizer().remove(name);
 		}
-
-		// delete the root and everything under it
-		super.tearDown();
 	}
 
 	private void assertExpectedSyncInfo(IResource resource, byte[] actualSyncInfo, byte[] expectedSyncInfo) {
@@ -120,6 +127,7 @@ public class ISynchronizerTest extends ResourceTest {
 				is(actualSyncInfo));
 	}
 
+	@Test
 	public void testDeleteResources() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -183,6 +191,7 @@ public class ISynchronizerTest extends ResourceTest {
 		getWorkspace().getRoot().accept(visitor);
 	}
 
+	@Test
 	public void testDeleteResources2() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -260,6 +269,7 @@ public class ISynchronizerTest extends ResourceTest {
 		getWorkspace().getRoot().accept(visitor, IResource.DEPTH_INFINITE, true);
 	}
 
+	@Test
 	public void testMoveResource() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -291,6 +301,7 @@ public class ISynchronizerTest extends ResourceTest {
 				synchronizer.getSyncInfo(qname, destination), nullValue());
 	}
 
+	@Test
 	public void testMoveResource2() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -345,6 +356,7 @@ public class ISynchronizerTest extends ResourceTest {
 		assertThat("unexpected sync info for resource: " + sourceFile.getFullPath(), syncInfo, is(b));
 	}
 
+	@Test
 	public void testRegistration() {
 		// setup
 		QualifiedName[] partners = new QualifiedName[NUMBER_OF_PARTNERS];
@@ -371,6 +383,7 @@ public class ISynchronizerTest extends ResourceTest {
 		assertThat(synchronizer.getPartners(), arrayWithSize(0));
 	}
 
+	@Test
 	public void testSave() throws Exception {
 		final Hashtable<IPath, byte[]> table = new Hashtable<>(10);
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
@@ -392,7 +405,7 @@ public class ISynchronizerTest extends ResourceTest {
 		// write out the data
 		IPath syncInfoPath = Platform.getLocation().append(".testsyncinfo");
 		File file = syncInfoPath.toFile();
-		deleteOnTearDown(syncInfoPath);
+		workspaceRule.deleteOnTearDown(syncInfoPath);
 		try (OutputStream fileOutput = new FileOutputStream(file)) {
 			try (DataOutputStream output = new DataOutputStream(fileOutput)) {
 				final List<QualifiedName> list = new ArrayList<>(5);
@@ -457,6 +470,7 @@ public class ISynchronizerTest extends ResourceTest {
 		getWorkspace().getRoot().accept(visitor);
 	}
 
+	@Test
 	public void testSnap() {
 		/*
 		 final Hashtable table = new Hashtable(10);
@@ -586,6 +600,7 @@ public class ISynchronizerTest extends ResourceTest {
 		 */
 	}
 
+	@Test
 	public void testSyncInfo() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -682,6 +697,7 @@ public class ISynchronizerTest extends ResourceTest {
 	 * Removes resources, sets sync info to <code>null</code> and ensures the
 	 * phantoms do not exist any more (see bug 3024)
 	 */
+	@Test
 	public void testPhantomRemoval() throws CoreException {
 		final QualifiedName partner = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final IWorkspace workspace = getWorkspace();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -14,12 +14,17 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -40,27 +45,26 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
-import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class IWorkspaceRootTest extends ResourceTest {
+public class IWorkspaceRootTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
 	@Test
 	public void testFindFilesNonCanonicalPath() throws Exception {
-		// this test is for windows only
-		Assume.assumeTrue(OS.isWindows());
+		assumeTrue("this test is for windows only", OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
 		createInWorkspace(project);
 
 		IFile link = project.getFile("file.txt");
-		IFileStore fileStore = getTempStore();
+		IFileStore fileStore = workspaceRule.getTempStore();
 		createInFileSystem(fileStore);
 		assertEquals("0.1", EFS.SCHEME_FILE, fileStore.getFileSystem().getScheme());
 		IPath fileLocationLower = URIUtil.toPath(fileStore.toURI());
@@ -140,7 +144,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 		assertThrows(RuntimeException.class, () -> root.findContainersForLocationURI(relative));
 		//linked folder that does not overlap a project location
 		IFolder otherLink = p1.getFolder("otherLink");
-		IFileStore linkStore = getTempStore();
+		IFileStore linkStore = workspaceRule.getTempStore();
 		URI location = linkStore.toURI();
 		linkStore.mkdir(EFS.NONE, createTestMonitor());
 		otherLink.createLink(location, IResource.NONE, createTestMonitor());
@@ -221,7 +225,7 @@ public class IWorkspaceRootTest extends ResourceTest {
 
 		//linked resource
 		IFolder link = project.getFolder("link");
-		IFileStore linkStore = getTempStore();
+		IFileStore linkStore = workspaceRule.getTempStore();
 		URI location = linkStore.toURI();
 		linkStore.mkdir(EFS.NONE, createTestMonitor());
 		link.createLink(location, IResource.NONE, createTestMonitor());
@@ -518,4 +522,5 @@ public class IWorkspaceRootTest extends ResourceTest {
 		}
 		return folder;
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
@@ -14,8 +14,13 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_EARTH;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_MISSING;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -30,9 +35,13 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
+import org.junit.Rule;
 import org.junit.Test;
 
-public class LinkedDotProjectTest extends ResourceTest {
+public class LinkedDotProjectTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void linkDotProject(IProject project) throws CoreException {
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -15,6 +15,9 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.canCreateSymLinks;
+import static org.eclipse.core.tests.harness.FileSystemHelper.createSymLink;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -27,7 +30,14 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.readStringInFile
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -61,6 +71,9 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.harness.CancelingProgressMonitor;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
 /**
@@ -80,7 +93,11 @@ import org.junit.function.ThrowingRunnable;
  * <code>IFile#createLink</code> and <code>IFolder#createLink</code> and when
  * the location is obtained using <code>IResource#getLocation()</code>.
  */
-public class LinkedResourceTest extends ResourceTest {
+public class LinkedResourceTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	protected String childName = "File.txt";
 	protected IProject closedProject;
 	protected IFile existingFileInExistingProject;
@@ -134,9 +151,8 @@ public class LinkedResourceTest extends ResourceTest {
 		return uri;
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingProjectInSubDirectory = getWorkspace().getRoot().getProject("ExistingProjectInSubDirectory");
 		otherExistingProject = getWorkspace().getRoot().getProject("OtherExistingProject");
@@ -156,7 +172,9 @@ public class LinkedResourceTest extends ResourceTest {
 		nonExistingFileInOtherExistingProject = otherExistingProject.getFile("nonExistingFileInOtherExistingProject");
 		nonExistingFileInExistingFolder = existingFolderInExistingProject.getFile("nonExistingFileInExistingFolder");
 		localFolder = getRandomLocation();
+		workspaceRule.deleteOnTearDown(resolve(localFolder));
 		nonExistingLocation = getRandomLocation();
+		workspaceRule.deleteOnTearDown(resolve(nonExistingLocation));
 		localFile = localFolder.append(childName);
 		doCleanup();
 
@@ -165,7 +183,7 @@ public class LinkedResourceTest extends ResourceTest {
 			File dir = existingProject.getLocation().toFile();
 			dir = dir.getParentFile();
 			dir = new File(dir + File.separator + "sub");
-			deleteOnTearDown(IPath.fromOSString(dir.getAbsolutePath()));
+			workspaceRule.deleteOnTearDown(IPath.fromOSString(dir.getAbsolutePath()));
 			dir = new File(dir + File.separator + "dir" + File.separator + "more" + File.separator + "proj");
 			dir.mkdirs();
 			desc.setLocation(IPath.fromOSString(dir.getAbsolutePath()));
@@ -176,18 +194,12 @@ public class LinkedResourceTest extends ResourceTest {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		Workspace.clear(resolve(localFolder).toFile());
-		Workspace.clear(resolve(nonExistingLocation).toFile());
-	}
-
 	/**
 	 * Tests creation of a linked resource whose corresponding file system
 	 * path does not exist. This should succeed but no operations will be
 	 * available on the resulting resource.
 	 */
+	@Test
 	public void testAllowMissingLocal() throws CoreException {
 		//get a non-existing location
 		IPath location = getRandomLocation();
@@ -228,6 +240,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests case where a resource in the file system cannot be added to the workspace
 	 * because it is blocked by a linked resource of the same name.
 	 */
+	@Test
 	public void testBlockedFolder() throws Exception {
 		//create local folder that will be blocked
 		createInFileSystem(nonExistingFolderInExistingProject);
@@ -273,6 +286,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * still exist, should have the correct gender, and still be a linked
 	 * resource.
 	 */
+	@Test
 	public void testChangeLinkGender() throws Exception {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile file = folder.getProject().getFile(folder.getProjectRelativePath());
@@ -299,6 +313,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertEquals("4.3", resolvedLocation, folder.getLocation());
 	}
 
+	@Test
 	public void testCopyFile() throws Exception {
 		IResource[] sources = new IResource[] {nonExistingFileInExistingProject, nonExistingFileInExistingFolder};
 		IResource[] destinationResources = new IResource[] {existingProject, closedProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder};
@@ -407,6 +422,7 @@ public class LinkedResourceTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
+	@Test
 	public void testCopyFolder() throws Exception {
 		IFolder[] sources = new IFolder[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder};
 		IResource[] destinations = new IResource[] {existingProject, closedProject, nonExistingProject, existingFolderInExistingProject, nonExistingFolderInOtherExistingProject, nonExistingFolderInExistingFolder};
@@ -521,6 +537,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests copying a linked file resource that doesn't exist in the file system
 	 */
+	@Test
 	public void testCopyMissingFile() throws CoreException {
 		IPath location = getRandomLocation();
 		IFile linkedFile = nonExistingFileInExistingProject;
@@ -536,6 +553,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests copying a linked folder that doesn't exist in the file system
 	 */
+	@Test
 	public void testCopyMissingFolder() throws CoreException {
 		IPath location = getRandomLocation();
 		IFolder linkedFolder = nonExistingFolderInExistingProject;
@@ -548,9 +566,10 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.3", !dest.exists());
 	}
 
+	@Test
 	public void testCopyProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IFile linkedFile = nonExistingFileInExistingProject;
 		IFolder linkedFolder = nonExistingFolderInExistingProject;
 		createInFileSystem(resolve(fileLocation));
@@ -613,8 +632,9 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests creating a linked folder and performing refresh in the background
 	 */
+	@Test
 	public void testCreateFolderInBackground() throws Exception {
-		final IFileStore rootStore = getTempStore();
+		final IFileStore rootStore = workspaceRule.getTempStore();
 		rootStore.mkdir(IResource.NONE, createTestMonitor());
 		IFileStore childStore = rootStore.getChild("file.txt");
 		createInFileSystem(childStore);
@@ -633,6 +653,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests creating a linked resource with the same name but different
 	 * case as an existing resource.  On case insensitive platforms this should fail.
 	 */
+	@Test
 	public void testCreateLinkCaseVariant() throws Throwable {
 		IFolder link = nonExistingFolderInExistingProject;
 		IFolder variant = link.getParent().getFolder(IPath.fromOSString(link.getName().toUpperCase()));
@@ -651,6 +672,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests creating a linked resource by modifying the .project file directly.
 	 * This is a regression test for bug 63331.
 	 */
+	@Test
 	public void testCreateLinkInDotProject() throws Exception {
 		final IFile dotProject = existingProject.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		IFile link = nonExistingFileInExistingProject;
@@ -674,6 +696,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests creating a project whose .project file already defines links at
 	 * depth greater than one. See bug 121322.
 	 */
+	@Test
 	public void testCreateProjectWithDeepLinks() throws CoreException {
 		IProject project = existingProject;
 		IFolder parent = existingFolderInExistingProject;
@@ -692,6 +715,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests whether {@link IFile#createLink} and {@link IFolder#createLink}
 	 * handle {@link IResource#HIDDEN} flag properly.
 	 */
+	@Test
 	public void testCreateHiddenLinkedResources() throws CoreException {
 		IFolder folder = existingProject.getFolder("folder");
 		IFile file = existingProject.getFile("file.txt");
@@ -703,9 +727,10 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("4.0", file.isHidden());
 	}
 
+	@Test
 	public void testDeepMoveProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IFile file = nonExistingFileInExistingProject;
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile childFile = folder.getFile(childName);
@@ -742,6 +767,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests deleting the parent of a linked resource.
 	 */
+	@Test
 	public void testDeleteLinkParent() throws CoreException {
 		IFolder link = nonExistingFolderInExistingFolder;
 		IFolder linkParent = existingFolderInExistingProject;
@@ -769,6 +795,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests deleting and then recreating a project
 	 */
+	@Test
 	public void testDeleteProjectWithLinks() throws CoreException {
 		IFolder link = nonExistingFolderInExistingProject;
 		link.createLink(localFolder, IResource.NONE, createTestMonitor());
@@ -789,6 +816,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests deleting a linked resource when .project is read-only
 	 */
+	@Test
 	public void testDeleteLink_Bug351823() throws CoreException {
 		IProject project = existingProject;
 
@@ -827,6 +855,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests bug 209175.
 	 */
+	@Test
 	public void testDeleteFolderWithLinks() throws CoreException {
 		IProject project = existingProject;
 		IFolder folder = existingFolderInExistingProject;
@@ -857,11 +886,10 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests that IWorkspaceRoot.findFilesForLocation works correctly
 	 * in presence of a linked resource that does not match the case in the file system
 	 */
+	@Test
 	public void testFindFilesForLocationCaseVariant() throws CoreException {
-		//this test only applies to file systems with a device in the path
-		if (!OS.isWindows()) {
-			return;
-		}
+		assumeTrue("this test only applies to file systems with a device in the path", OS.isWindows());
+
 		IFolder link = nonExistingFolderInExistingProject;
 		IPath localLocation = resolve(localFolder);
 		IPath upperCase = localLocation.setDevice(localLocation.getDevice().toUpperCase());
@@ -876,6 +904,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests the {@link org.eclipse.core.resources.IResource#isLinked(int)} method.
 	 */
+	@Test
 	public void testIsLinked() throws CoreException {
 		//initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
@@ -898,6 +927,7 @@ public class LinkedResourceTest extends ResourceTest {
 
 	}
 
+	@Test
 	public void testSetLinkLocation() throws CoreException {
 		// initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
@@ -929,6 +959,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests swapping the link location.
 	 * This is a regression test for bug 268507
 	 */
+	@Test
 	public void testSetLinkLocationSwapLinkedResource() throws CoreException {
 		final IPath parentLoc = existingFolderInExistingProject.getLocation();
 		final IPath childLoc = existingFolderInExistingFolder.getLocation();
@@ -961,6 +992,7 @@ public class LinkedResourceTest extends ResourceTest {
 				.equals(existingFolderInExistingFolder.getName()));
 	}
 
+	@Test
 	public void testSetLinkLocationPath() throws CoreException {
 		//initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
@@ -991,6 +1023,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Specific testing of links within links.
 	 */
+	@Test
 	public void testLinkedFileInLinkedFolder() throws CoreException, IOException {
 		//setup handles
 		IProject project = existingProject;
@@ -998,9 +1031,9 @@ public class LinkedResourceTest extends ResourceTest {
 		IFolder linkedFolder = top.getFolder("linkedFolder");
 		IFolder subFolder = linkedFolder.getFolder("subFolder");
 		IFile linkedFile = subFolder.getFile("Link.txt");
-		IFileStore folderStore = getTempStore();
+		IFileStore folderStore = workspaceRule.getTempStore();
 		IFileStore subFolderStore = folderStore.getChild(subFolder.getName());
-		IFileStore fileStore = getTempStore();
+		IFileStore fileStore = workspaceRule.getTempStore();
 		IPath folderLocation = URIUtil.toPath(folderStore.toURI());
 		IPath fileLocation = URIUtil.toPath(fileStore.toURI());
 
@@ -1026,6 +1059,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Automated test of IFile#createLink
 	 */
+	@Test
 	public void testLinkFile() throws Exception {
 		IResource[] interestingResources = new IResource[] {existingFileInExistingProject, nonExistingFileInExistingProject, nonExistingFileInExistingFolder};
 		IPath[] interestingLocations = new IPath[] {localFile, localFolder, nonExistingLocation};
@@ -1126,6 +1160,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Automated test of IFolder#createLink
 	 */
+	@Test
 	public void testLinkFolder() throws Exception {
 		IResource[] interestingResources = new IResource[] {existingFolderInExistingProject, existingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInExistingFolder};
 		IPath[] interestingLocations = new IPath[] {localFile, localFolder, nonExistingLocation};
@@ -1228,6 +1263,7 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Automated test of IWorkspace#validateLinkLocation and IWorkspace#validateLinkLocationURI with empty location
 	 * This is a regression test for bug 266662
 	 */
+	@Test
 	public void testValidateEmptyLinkLocation() {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IPath newLocation = IPath.fromOSString("");
@@ -1241,11 +1277,10 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests creating a linked resource whose location contains a colon character.
 	 */
+	@Test
 	public void testLocationWithColon() throws CoreException {
-		//windows does not allow a location with colon in the name
-		if (OS.isWindows()) {
-			return;
-		}
+		assumeFalse("Windows does not allow a location with colon in the name", OS.isWindows());
+
 		IFolder folder = nonExistingFolderInExistingProject;
 		// Note that on *nix, "c:/temp" is a relative path with two segments
 		// so this is treated as relative to an undefined path variable called "c:".
@@ -1258,9 +1293,10 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests the timestamp of a linked file when the local file is created or
 	 * deleted. See bug 34150 for more details.
 	 */
+	@Test
 	public void testModificationStamp() throws Exception {
 		IPath location = getRandomLocation();
-		deleteOnTearDown(location);
+		workspaceRule.deleteOnTearDown(location);
 		IFile linkedFile = nonExistingFileInExistingProject;
 		linkedFile.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		assertEquals("1.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
@@ -1275,6 +1311,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertEquals("4.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
 	}
 
+	@Test
 	public void testMoveFile() throws Exception {
 		IResource[] sources = new IResource[] {nonExistingFileInExistingProject, nonExistingFileInExistingFolder};
 		IResource[] destinations = new IResource[] {existingProject, closedProject, nonExistingFileInOtherExistingProject, nonExistingFileInExistingFolder};
@@ -1384,6 +1421,7 @@ public class LinkedResourceTest extends ResourceTest {
 		}.performTest(inputs);
 	}
 
+	@Test
 	public void testMoveFolder() throws Exception {
 		IResource[] sourceResources = new IResource[] {nonExistingFolderInExistingProject, nonExistingFolderInExistingFolder};
 		IResource[] destinationResources = new IResource[] {existingProject, closedProject, nonExistingProject, existingFolderInExistingProject, nonExistingFolderInOtherExistingProject, nonExistingFolderInExistingFolder};
@@ -1474,6 +1512,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests moving a linked file resource that doesn't exist in the file system
 	 */
+	@Test
 	public void testMoveMissingFile() throws CoreException {
 		IPath location = getRandomLocation();
 		IFile linkedFile = nonExistingFileInExistingProject;
@@ -1489,6 +1528,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests moving a linked folder that doesn't exist in the file system
 	 */
+	@Test
 	public void testMoveMissingFolder() throws CoreException {
 		IPath location = getRandomLocation();
 		IFolder linkedFolder = nonExistingFolderInExistingProject;
@@ -1501,9 +1541,10 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.3", !dest.exists());
 	}
 
+	@Test
 	public void testMoveProjectWithLinks() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IFile file = nonExistingFileInExistingProject;
 		IFolder folder = nonExistingFolderInExistingProject;
 		IFile childFile = folder.getFile(childName);
@@ -1549,9 +1590,10 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests bug 117402.
 	 */
+	@Test
 	public void testMoveProjectWithLinks2() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IFile linkedFile = existingProject.getFile("(test)");
 		createInFileSystem(resolve(fileLocation));
 		linkedFile.createLink(fileLocation, IResource.NONE, createTestMonitor());
@@ -1568,13 +1610,14 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests bug 298849.
 	 */
+	@Test
 	public void testMoveFolderWithLinks() throws Exception {
 		// create a folder
 		IFolder folderWithLinks = existingProject.getFolder(createUniqueString());
 		folderWithLinks.create(true, true, createTestMonitor());
 
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		createInFileSystem(resolve(fileLocation));
 
 		// create a linked file in the folder
@@ -1602,6 +1645,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertEquals("9.0", -1, string.indexOf(linkedFile.getProjectRelativePath().toString()));
 	}
 
+	@Test
 	public void testNatureVeto() throws CoreException {
 		//note: simpleNature has the link veto turned on.
 
@@ -1631,9 +1675,10 @@ public class LinkedResourceTest extends ResourceTest {
 	 * Tests creating a link within a link, and ensuring that both links still
 	 * exist when the project is closed/opened (bug 177367).
 	 */
+	@Test
 	public void testNestedLink() throws CoreException {
-		final IFileStore store1 = getTempStore();
-		final IFileStore store2 = getTempStore();
+		final IFileStore store1 = workspaceRule.getTempStore();
+		final IFileStore store2 = workspaceRule.getTempStore();
 		URI location1 = store1.toURI();
 		URI location2 = store2.toURI();
 		//folder names are important here, because we want a certain order in the link hash map
@@ -1666,6 +1711,7 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Create a project with a linked resource at depth &gt; 2, and refresh it.
 	 */
+	@Test
 	public void testRefreshDeepLink() throws Exception {
 		IFolder link = nonExistingFolderInExistingFolder;
 		IPath linkLocation = localFolder;
@@ -1683,6 +1729,7 @@ public class LinkedResourceTest extends ResourceTest {
 		assertTrue("2.1", linkChild.exists());
 	}
 
+	@Test
 	public void testLinkedFolderWithOverlappingLocation_Bug293935_() {
 		IWorkspace workspace = getWorkspace();
 
@@ -1713,14 +1760,13 @@ public class LinkedResourceTest extends ResourceTest {
 				() -> folderByUnixLikeURI.createLink(projectLocationURIWithoutDevice, IResource.NONE, createTestMonitor()));
 	}
 
-	public void testLinkedFolderWithSymlink_Bug338010() throws CoreException {
-		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+	@Test
+	public void testLinkedFolderWithSymlink_Bug338010() throws Exception {
+		assumeTrue("test is only applicable when symbolic links can be created", canCreateSymLinks());
+
 		IPath baseLocation = getRandomLocation();
 		IPath resolvedBaseLocation = resolve(baseLocation);
-		deleteOnTearDown(resolvedBaseLocation);
+		workspaceRule.deleteOnTearDown(resolvedBaseLocation);
 		IPath symlinkTarget = resolvedBaseLocation.append("dir1/target");
 		symlinkTarget.toFile().mkdirs();
 		createSymLink(resolvedBaseLocation.toFile(), "symlink", symlinkTarget.toOSString(), true);
@@ -1739,14 +1785,13 @@ public class LinkedResourceTest extends ResourceTest {
 	/**
 	 * Tests deleting of the target of a linked folder that itself is a symbolic link.
 	 */
+	@Test
 	public void testDeleteLinkTarget_Bug507084() throws Exception {
-		// Only activate this test if testing of symbolic links is possible.
-		if (!canCreateSymLinks()) {
-			return;
-		}
+		assumeTrue("test is only applicable when symbolic links can be created", canCreateSymLinks());
+
 		IPath baseLocation = getRandomLocation();
 		IPath resolvedBaseLocation = resolve(baseLocation);
-		deleteOnTearDown(resolvedBaseLocation);
+		workspaceRule.deleteOnTearDown(resolvedBaseLocation);
 		IPath symlinkTarget = resolvedBaseLocation.append("dir1/A");
 		symlinkTarget.append("B/C").toFile().mkdirs();
 		IPath linkParentDir = resolvedBaseLocation.append("dir2");
@@ -1772,4 +1817,5 @@ public class LinkedResourceTest extends ResourceTest {
 		assertFalse("3.2", folder.getFolder("B").exists());
 		assertFalse("3.3", folder.getFolder("B/C").exists());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerAttributeChangeListener.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerAttributeChangeListener.java
@@ -14,18 +14,22 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IMarkerDelta;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Assert;
 
 /**
  * This class works by recording the current state of given markers,
  * then verifying that the marker deltas accurately reflect the old
  * marker state.
  */
-public class MarkerAttributeChangeListener extends Assert implements IResourceChangeListener {
+public class MarkerAttributeChangeListener implements IResourceChangeListener {
 	//Map of (Long(id) -> Map of (String(attribute key) -> Object(attribute value)))
 	private final Map<Long, Map<String, Object>> attributeMap = new HashMap<>();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
@@ -15,6 +15,12 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -23,10 +29,15 @@ import org.eclipse.core.internal.resources.MarkerAttributeMap;
 import org.eclipse.core.internal.resources.MarkerInfo;
 import org.eclipse.core.internal.resources.MarkerSet;
 import org.eclipse.core.resources.IMarker;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class MarkerSetTest extends ResourceTest {
+public class MarkerSetTest {
 
-	public void assertEquals(String message, IMarkerSetElement[] array1, IMarkerSetElement[] array2) {
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	private void assertMarkerElementsEqual(String message, IMarkerSetElement[] array1, IMarkerSetElement[] array2) {
 		assertNotNull(message, array1);
 		assertNotNull(message, array2);
 		assertEquals(message, array1.length, array2.length);
@@ -49,8 +60,8 @@ public class MarkerSetTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testAdd() {
-
 		// create the objects to insert into the set
 		MarkerSet set = new MarkerSet();
 		int max = 100;
@@ -79,8 +90,8 @@ public class MarkerSetTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testElements() {
-
 		// populate the set
 		MarkerSet set = new MarkerSet();
 		int max = 100;
@@ -95,11 +106,11 @@ public class MarkerSetTest extends ResourceTest {
 		assertEquals("1.0", max, set.size());
 
 		// remove each element
-		assertEquals("2.0", set.elements(), infos);
+		assertMarkerElementsEqual("2.0", set.elements(), infos);
 	}
 
+	@Test
 	public void testRemove() {
-
 		// populate the set
 		MarkerSet set = new MarkerSet();
 		int max = 100;
@@ -129,6 +140,7 @@ public class MarkerSetTest extends ResourceTest {
 		assertEquals("3.0", 0, set.size());
 	}
 
+	@Test
 	public void testMarkerAttributeMap() {
 		MarkerAttributeMap map = new MarkerAttributeMap();
 		String notInternalString = String.valueOf("notIntern".toCharArray());
@@ -156,4 +168,5 @@ public class MarkerSetTest extends ResourceTest {
 		map2.put(null, 1); // allowed for clients using IMarker.getAttributes()
 		map2.put("0", null);// allowed for clients
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -28,7 +28,9 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -67,8 +69,19 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
-public class MarkerTest extends ResourceTest {
+public class MarkerTest {
+
+	@Rule
+	public TestName testName = new TestName();
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	public static final String TRANSIENT_MARKER = "org.eclipse.core.tests.resources.transientmarker";
 	public static final String TEST_PROBLEM_MARKER = "org.eclipse.core.tests.resources.testproblem";
@@ -178,9 +191,8 @@ public class MarkerTest extends ResourceTest {
 		marker.setAttribute(IMarker.SEVERITY, severity);
 	}
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
 		resources = buildResources(getWorkspace().getRoot(),
 				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
 		createInWorkspace(resources);
@@ -194,19 +206,19 @@ public class MarkerTest extends ResourceTest {
 	}
 
 
-	@Override
+	@After
 	public void tearDown() throws Exception {
 		if (registeredResourceChangeLister != null) {
 			setResourceChangeListener(null);
 		}
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
 		prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
-		super.tearDown();
 	}
 
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerChangesInDelta3() throws CoreException {
 		// Create and register a listener.
 		final MarkersChangeListener listener = new MarkersChangeListener();
@@ -250,9 +262,11 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests whether markers correctly copy with resources.
 	 */
+	@Test
 	public void testCopyResource() {
 	}
 
+	@Test
 	public void testCreateMarker() throws CoreException {
 		// create markers on our hierarchy of resources
 		for (IResource resource : resources) {
@@ -277,6 +291,7 @@ public class MarkerTest extends ResourceTest {
 				() -> testResource.createMarker(IMarker.PROBLEM));
 	}
 
+	@Test
 	public void testCreateMarkerWithAttributes() throws CoreException {
 		// Create and register a listener.
 		MarkersChangeListener listener = new MarkersChangeListener();
@@ -296,6 +311,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testCreateNullMarkerWithAttributesShouldFail() {
 		// create markers on our hierarchy of resources
 		for (IResource resource : resources) {
@@ -303,6 +319,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testCreateMarkerWithAttributesOnAResourceWhichDoesNotExistShouldFail() {
 		// try creating a marker on a resource which does't exist
 		IResource testResource = getWorkspace().getRoot().getFile(IPath.fromOSString("non/existant/resource"));
@@ -315,7 +332,7 @@ public class MarkerTest extends ResourceTest {
 	// resource change
 	// events (which is bad for performance hence the better createMarker(String
 	// type, Map<String, Object> attributes) method
-
+	@Test
 	public void testThatSettingAttributesTriggerAdditionalResourceChangeEvent() throws CoreException {
 		// Create and register a listener.
 		MarkersNumberOfDeltasChangeListener listener = new MarkersNumberOfDeltasChangeListener();
@@ -330,7 +347,8 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
-	// testing that markers creation with arbiutes
+	// testing that markers creation with attributes
+	@Test
 	public void testThatMarkersWithAttributesOnlyTriggerOnResourceChangeEvent() throws CoreException {
 		// Create and register a listener.
 		MarkersNumberOfDeltasChangeListener listener = new MarkersNumberOfDeltasChangeListener();
@@ -346,6 +364,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testCreationTime() throws CoreException {
 		for (IResource element : resources) {
 			IMarker marker = element.createMarker(IMarker.PROBLEM);
@@ -354,6 +373,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testDeleteMarker() throws CoreException {
 		IMarker marker = null;
 
@@ -396,6 +416,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testDeleteMarkers() throws CoreException {
 		IMarker[] markers = createMarkers(resources, IMarker.PROBLEM);
 
@@ -407,6 +428,7 @@ public class MarkerTest extends ResourceTest {
 		getWorkspace().deleteMarkers(new IMarker[0]);
 	}
 
+	@Test
 	public void testFindMarkers() throws CoreException {
 		// test finding some markers which actually exist
 		IMarker[] markers = createMarkers(resources, IMarker.PROBLEM);
@@ -434,6 +456,7 @@ public class MarkerTest extends ResourceTest {
 	/*
 	 * Bug 35300 - ClassCastException if marker transient attribute is set to a non-boolean
 	 */
+	@Test
 	public void test_35300() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		createInWorkspace(project);
@@ -449,6 +472,7 @@ public class MarkerTest extends ResourceTest {
 		marker.setAttribute(IMarker.MESSAGE, createRandomString());
 	}
 
+	@Test
 	public void test_10989() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		createInWorkspace(project);
@@ -465,6 +489,7 @@ public class MarkerTest extends ResourceTest {
 	/*
 	 * Bug 289811 - ArrayIndexOutOfBoundsException in MarkerAttributeMap
 	 */
+	@Test
 	public void test_289811() throws CoreException {
 		String testValue = createRandomString();
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
@@ -482,6 +507,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests public API method IResource#findMaxProblemSeverity
 	 */
+	@Test
 	public void testFindMaxProblemSeverity() throws CoreException {
 		final IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("testFindMaxProblemSeverity");
@@ -537,6 +563,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests public API method IMarker#isSubTypeOf
 	 */
+	@Test
 	public void testIsSubTypeOf() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("testisSubType");
 		IMarker marker, task, problem, testProblem, invalid;
@@ -587,6 +614,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerChangesInDelta() throws CoreException {
 		// Create and register a listener.
 		MarkersChangeListener listener = new MarkersChangeListener();
@@ -666,6 +694,7 @@ public class MarkerTest extends ResourceTest {
 	 * Particularly, checks that the MarkerDelta attributes reflect the
 	 * state of the marker before the change occurred.
 	 */
+	@Test
 	public void testMarkerDeltaAttributes() throws CoreException {
 		// create markers on various resources
 		final IMarker[] markers = new IMarker[3];
@@ -733,6 +762,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerDeltasCopyResource() throws CoreException {
 		// Create and register a listener.
 		final MarkersChangeListener listener = new MarkersChangeListener();
@@ -773,6 +803,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerDeltasMerge() throws CoreException {
 		// Create and register a listener.
 		final MarkersChangeListener listener = new MarkersChangeListener();
@@ -868,6 +899,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerDeltasMoveFolder() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		final IProject project = root.getProject("MyProject");
@@ -875,7 +907,7 @@ public class MarkerTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subFile.txt");
 		createInWorkspace(new IResource[] { project, folder, file, subFile });
-		waitForEncodingRelatedJobs(getName());
+		waitForEncodingRelatedJobs(testName.getMethodName());
 		IFolder destFolder = project.getFolder("myOtherFolder");
 		IFile destSubFile = destFolder.getFile(subFile.getName());
 
@@ -907,6 +939,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerDeltasMoveFile() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		final IProject project = root.getProject("MyProject");
@@ -914,7 +947,7 @@ public class MarkerTest extends ResourceTest {
 		IFile file = project.getFile("file.txt");
 		IFile subFile = folder.getFile("subFile.txt");
 		createInWorkspace(new IResource[] { project, folder, file, subFile });
-		waitForEncodingRelatedJobs(getName());
+		waitForEncodingRelatedJobs(testName.getMethodName());
 		IFile destFile = folder.getFile(file.getName());
 		IFile destSubFile = project.getFile(subFile.getName());
 
@@ -946,6 +979,7 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests the appearance of marker changes in the resource delta.
 	 */
+	@Test
 	public void testMarkerDeltasMoveProject() throws CoreException {
 		// Create and register a listener.
 		final MarkersChangeListener listener = new MarkersChangeListener();
@@ -998,6 +1032,7 @@ public class MarkerTest extends ResourceTest {
 		getWorkspace().getRoot().accept(visitor);
 	}
 
+	@Test
 	public void testMarkerSave() throws Exception {
 		IMarker[] newMarkers = createMarkers(resources, IMarker.PROBLEM);
 		IMarker[] expected = new IMarker[newMarkers.length * 3];
@@ -1070,6 +1105,7 @@ public class MarkerTest extends ResourceTest {
 		assertTrue("deleting file failed", file.delete());
 	}
 
+	@Test
 	public void testMarkerSaveTransient() throws Exception {
 		// create the markers on the resources. create both transient
 		// and persistent markers.
@@ -1161,12 +1197,14 @@ public class MarkerTest extends ResourceTest {
 	/**
 	 * Tests whether markers correctly move with resources.
 	 */
+	@Test
 	public void testMoveResource() {
 	}
 
 	/*
 	 * Test for PR: "1FWT3V5: ITPCORE:WINNT - Task view shows entries for closed projects"
 	 */
+	@Test
 	public void testProjectCloseOpen() throws CoreException {
 		// create a marker on the project
 		IProject project = getWorkspace().getRoot().getProjects()[0];
@@ -1180,6 +1218,7 @@ public class MarkerTest extends ResourceTest {
 		assertMarkerExists(marker);
 	}
 
+	@Test
 	public void testSetGetAttribute() throws CoreException {
 		for (IResource resource : resources) {
 			String resourcePath = resource.getFullPath().toString();
@@ -1233,6 +1272,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testGetAttributesEquality() throws Exception {
 		final String value = "Some value";
 		for (int i = 0; i < resources.length; i++) {
@@ -1248,6 +1288,7 @@ public class MarkerTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testSetGetAttribute2() throws CoreException {
 		for (IResource resource : resources) {
 			String resourcePath = resource.getFullPath().toString();
@@ -1324,4 +1365,5 @@ public class MarkerTest extends ResourceTest {
 			assertThat(resourcePath, marker.getAttributes(), is(nullValue()));
 		}
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_127562;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_EARTH;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_MISSING;
@@ -63,6 +62,10 @@ import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.internal.resources.SimpleNature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
 /**
@@ -70,7 +73,11 @@ import org.junit.function.ThrowingRunnable;
  * exercise API classes and methods.  Note that the nature-related
  * APIs on IWorkspace are tested by IWorkspaceTest.
  */
-public class NatureTest extends ResourceTest {
+public class NatureTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	IProject project;
 
 	/**
@@ -105,18 +112,15 @@ public class NatureTest extends ResourceTest {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		project.delete(true, null);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, PreferenceInitializer.PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
-		getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
-		super.tearDown();
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		this.project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
 	}
 
@@ -137,6 +141,7 @@ public class NatureTest extends ResourceTest {
 	/**
 	 * Tests invalid additions to the set of natures for a project.
 	 */
+	@Test
 	public void testInvalidAdditions() throws Throwable {
 		createInWorkspace(project);
 		setNatures(project, new String[] { NATURE_SIMPLE }, false);
@@ -161,6 +166,7 @@ public class NatureTest extends ResourceTest {
 	/**
 	 * Tests invalid removals from the set of natures for a project.
 	 */
+	@Test
 	public void testInvalidRemovals() throws Throwable {
 		createInWorkspace(project);
 
@@ -171,6 +177,7 @@ public class NatureTest extends ResourceTest {
 		assertHasEnabledNature(NATURE_SNOW);
 	}
 
+	@Test
 	public void testNatureLifecyle() throws Throwable {
 		createInWorkspace(project);
 
@@ -207,6 +214,7 @@ public class NatureTest extends ResourceTest {
 	/**
 	 * Test simple addition and removal of natures.
 	 */
+	@Test
 	public void testSimpleNature() throws Throwable {
 		createInWorkspace(project);
 
@@ -232,6 +240,7 @@ public class NatureTest extends ResourceTest {
 	 * Test addition of nature that requires the workspace root.
 	 * See bugs 127562 and  128709.
 	 */
+	@Test
 	public void testBug127562Nature() throws Throwable {
 		createInWorkspace(project);
 		IWorkspace ws = project.getWorkspace();
@@ -263,6 +272,7 @@ public class NatureTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testBug297871() throws Throwable {
 		createInWorkspace(project);
 
@@ -307,6 +317,7 @@ public class NatureTest extends ResourceTest {
 	 *
 	 * See Bug 338055.
 	 */
+	@Test
 	public void testBug338055() throws Exception {
 		final boolean finished[] = new boolean[1];
 		createInWorkspace(project);
@@ -357,6 +368,7 @@ public class NatureTest extends ResourceTest {
 		assertHasEnabledNature(NATURE_SIMPLE);
 	}
 
+	@Test
 	public void testMissingNatureAddsMarker() throws Exception {
 		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
@@ -381,6 +393,7 @@ public class NatureTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testMissingNatureWithWhitespacesSetChars() throws Exception {
 		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
@@ -405,6 +418,7 @@ public class NatureTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testKnownNatureDoesntAddMarker() throws Exception {
 		createInWorkspace(project);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
@@ -420,6 +434,7 @@ public class NatureTest extends ResourceTest {
 				emptyArray());
 	}
 
+	@Test
 	public void testListenToPreferenceChange() throws Exception {
 		testMissingNatureAddsMarker();
 		// to INFO
@@ -446,4 +461,5 @@ public class NatureTest extends ResourceTest {
 		assertThat(markers, arrayWithSize(1));
 		assertThat(markers[0].getAttribute(IMarker.SEVERITY, -42), is(IMarker.SEVERITY_ERROR));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -32,12 +33,19 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.internal.filesystem.bogus.BogusFileSystem;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryFileSystem;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests behaviour of manipulating linked resources that are not linked into
  * the local file system.
  */
-public class NonLocalLinkedResourceTest extends ResourceTest {
+public class NonLocalLinkedResourceTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	/**
 	 * Creates a folder in the test file system with the given name
 	 */
@@ -52,12 +60,12 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		return EFS.getFileSystem(MemoryFileSystem.SCHEME_MEMORY);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		MemoryTree.TREE.deleteAll();
-		super.tearDown();
 	}
 
+	@Test
 	public void testCopyFile() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IFileStore destinationStore = createFolderStore("destination");
@@ -87,6 +95,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		assertThrows(CoreException.class, () -> localFile.copy(localFile.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
+	@Test
 	public void testCopyFolder() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IProject project = getWorkspace().getRoot().getProject("project");
@@ -115,6 +124,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 		assertThrows(CoreException.class, () -> source.copy(source.getFullPath(), IResource.NONE, createTestMonitor()));
 	}
 
+	@Test
 	public void testMoveFile() throws CoreException {
 		IFileStore sourceStore = createFolderStore("source");
 		IFileStore destinationStore = createFolderStore("destination");
@@ -148,6 +158,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 	}
 
 	// Test for Bug 342060 - Renaming a project failing with custom EFS
+	@Test
 	public void test342060() throws CoreException {
 		IFileStore sourceStore = createBogusFolderStore("source");
 		IFileStore destinationStore = createBogusFolderStore("destination");
@@ -168,7 +179,7 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 	protected IFileStore createBogusFolderStore(String name) throws CoreException {
 		IFileSystem system = getBogusFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
-		deleteOnTearDown(
+		workspaceRule.deleteOnTearDown(
 					IPath.fromOSString(system.getStore(IPath.ROOT).toLocalFile(EFS.NONE, createTestMonitor()).getPath()));
 		store.mkdir(EFS.NONE, createTestMonitor());
 		return store;
@@ -177,4 +188,5 @@ public class NonLocalLinkedResourceTest extends ResourceTest {
 	protected IFileSystem getBogusFileSystem() throws CoreException {
 		return EFS.getFileSystem(BogusFileSystem.SCHEME_BOGUS);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.internal.resources.PreferenceInitializer;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
@@ -34,20 +35,25 @@ import org.eclipse.osgi.util.NLS;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Test for integration of marker
  * {@link org.eclipse.core.resources.ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
  */
-public class ProjectEncodingTest extends ResourceTest {
+public class ProjectEncodingTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final int IGNORE = -1;
 
 	private IProject project;
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (project != null) {
 			project.delete(true, true, null);
 		}
@@ -55,8 +61,6 @@ public class ProjectEncodingTest extends ResourceTest {
 				ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
 				PreferenceInitializer.PREF_MISSING_ENCODING_MARKER_SEVERITY_DEFAULT);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
-
-		super.tearDown();
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -26,13 +27,18 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Performs black box testing of the following API methods:
  * <code>IWorkspace.computeProjectOrder(IProject[])</code>
  * <code>IWorkspace.computePrerequisiteOrder(IProject[])</code>
  */
-public class ProjectOrderTest extends ResourceTest {
+public class ProjectOrderTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Adds a project reference from the given source project, which must
@@ -58,6 +64,7 @@ public class ProjectOrderTest extends ResourceTest {
 	/**
 	 * P0, P1&lt;-P2&lt;-P3&lt;-P4, P5
 	 */
+	@Test
 	public void test0() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();
@@ -109,6 +116,7 @@ public class ProjectOrderTest extends ResourceTest {
 		assertTrue("0.16", x.indexOf(p5) > x.indexOf(p4)); // alpha
 	}
 
+	@Test
 	public void test1() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();
@@ -387,6 +395,7 @@ public class ProjectOrderTest extends ResourceTest {
 	 * Cormen, Leiserson, Rivest
 	 * Figure 23.9(b)
 	 */
+	@Test
 	public void test2() throws CoreException {
 		IWorkspace ws = getWorkspace();
 		IWorkspaceRoot root = ws.getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
@@ -15,12 +15,19 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class ProjectScopeTest extends ResourceTest {
+public class ProjectScopeTest {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testEqualsAndHashCode() {
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		ProjectScope projectScope1 = new ProjectScope(project);
@@ -29,4 +36,5 @@ public class ProjectScopeTest extends ResourceTest {
 		assertTrue(projectScope2.equals(projectScope1));
 		assertTrue(projectScope1.hashCode() == projectScope2.hashCode());
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.Assert.fail;
+
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
@@ -24,7 +26,6 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Assert;
 
 /**
  * Verifies the state of an <code>IResourceDelta</code> by comparing
@@ -49,7 +50,7 @@ import org.junit.Assert;
  * assert("2.0 "+verifier.getMessage(), verifier.isDeltaValid());
  * </code>
  */
-public class ResourceDeltaVerifier extends Assert implements IResourceChangeListener {
+public class ResourceDeltaVerifier implements IResourceChangeListener {
 	private class ExpectedChange {
 		IResource fResource;
 		IPath movedFromPath;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -19,7 +19,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,30 +34,23 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test suites for {@link org.eclipse.core.internal.resources.PlatformURLResourceConnection}
  */
-public class ResourceURLTest extends ResourceTest {
+public class ResourceURLTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	private final String[] resourcePaths = new String[] { "/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2",
 			"/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5" };
 
 	private static final String CONTENT = "content";
 	protected static IPath[] interestingPaths;
 	protected static IResource[] interestingResources;
-
-	/**
-	 * Need a zero argument constructor to satisfy the test harness.
-	 * This constructor should not do any real work nor should it be
-	 * called by user code.
-	 */
-	public ResourceURLTest() {
-		super();
-	}
-
-	public ResourceURLTest(String name) {
-		super(name);
-	}
 
 	private void checkURL(IResource resource) throws Throwable {
 		URL url = getURL(resource);
@@ -80,6 +75,7 @@ public class ResourceURLTest extends ResourceTest {
 		return getURL(resource.getFullPath());
 	}
 
+	@Test
 	public void testBasicURLs() throws Throwable {
 		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
 		createInWorkspace(resources);
@@ -88,6 +84,7 @@ public class ResourceURLTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testExternalURLs() throws Throwable {
 		IProject project = getWorkspace().getRoot().getProject("test");
 		IProjectDescription desc = getWorkspace().newProjectDescription("test");
@@ -101,6 +98,7 @@ public class ResourceURLTest extends ResourceTest {
 		}
 	}
 
+	@Test
 	public void testNonExistantURLs() throws Throwable {
 		IResource[] resources = buildResources(getWorkspace().getRoot(), resourcePaths);
 		for (int i = 1; i < resources.length; i++) {
@@ -112,6 +110,7 @@ public class ResourceURLTest extends ResourceTest {
 	/**
 	 * Tests decoding of normalized URLs containing spaces
 	 */
+	@Test
 	public void testSpaces() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("My Project");
 		IFile file = project.getFile("a.txt");
@@ -120,4 +119,5 @@ public class ResourceURLTest extends ResourceTest {
 		InputStream stream = url.openStream();
 		assertTrue("1.0", compareContent(stream, createInputStream(CONTENT)));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceVisitorVerifier.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceVisitorVerifier.java
@@ -19,9 +19,8 @@ import java.util.HashSet;
 import java.util.Set;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
-import org.junit.Assert;
 
-public class ResourceVisitorVerifier extends Assert implements IResourceVisitor {
+public class ResourceVisitorVerifier implements IResourceVisitor {
 	Set<IResource> expected;
 	StringBuilder message;
 	boolean success = true;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -37,8 +38,15 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TeamPrivateMemberTest extends ResourceTest {
+public class TeamPrivateMemberTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void testRefreshLocal() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
@@ -64,6 +72,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 	/**
 	 * Resources which are marked as team private members should always be found.
 	 */
+	@Test
 	public void testFindMember() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
@@ -98,6 +107,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 	 * Resources which are marked as team private members are not included in #members
 	 * calls unless specifically included by calling #members(IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS)
 	 */
+	@Test
 	public void testMembers() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -163,6 +173,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 	 * Resources which are marked as team private members should not be visited by
 	 * resource visitors.
 	 */
+	@Test
 	public void testAccept() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -255,6 +266,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertTrue(visitor.getMessage(), visitor.isValid());
 	}
 
+	@Test
 	public void testCopy() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
@@ -308,6 +320,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
+	@Test
 	public void testMove() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
@@ -361,6 +374,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { destFolder, destSubFile });
 	}
 
+	@Test
 	public void testDelete() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("MyProject");
@@ -419,6 +433,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 		assertExistsInWorkspace(new IResource[] { project, file });
 	}
 
+	@Test
 	public void testDeltas() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		final IProject project = root.getProject("MyProject");
@@ -486,6 +501,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 	 * Resources which are marked as team private members return TRUE
 	 * in all calls to #exists.
 	 */
+	@Test
 	public void testExists() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -511,6 +527,7 @@ public class TeamPrivateMemberTest extends ResourceTest {
 	/**
 	 * Test the set and get methods for team private members.
 	 */
+	@Test
 	public void testSetGet() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 
 import static java.io.InputStream.nullInputStream;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
@@ -24,7 +25,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -36,17 +40,23 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests Virtual Folders
  */
-public class VirtualFolderTest extends ResourceTest {
+public class VirtualFolderTest {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	protected IProject existingProject;
 	protected IFolder existingVirtualFolderInExistingProject;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingVirtualFolderInExistingProject = existingProject.getFolder("existingVirtualFolderInExistingProject");
 		createInWorkspace(new IResource[] { existingProject });
@@ -56,6 +66,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a virtual folder
 	 */
+	@Test
 	public void testCreateVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 
@@ -71,6 +82,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a file under a virtual folder
 	 */
+	@Test
 	public void testCreateFileUnderVirtualFolder() {
 		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		assertThrows(CoreException.class, () -> file.create(nullInputStream(), true, createTestMonitor()));
@@ -80,6 +92,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a folder under a virtual folder
 	 */
+	@Test
 	public void testCreateFolderUnderVirtualFolder() {
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		assertThrows(CoreException.class, () -> folder.create(true, true, createTestMonitor()));
@@ -89,6 +102,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a virtual folder under a virtual folder
 	 */
+	@Test
 	public void testCreateVirtualFolderUnderVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		virtualFolder.create(IResource.VIRTUAL, true, null);
@@ -103,6 +117,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a linked folder under a virtual folder
 	 */
+	@Test
 	public void testCreateLinkedFolderUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
@@ -124,6 +139,7 @@ public class VirtualFolderTest extends ResourceTest {
 	/**
 	 * Tests creating a linked file under a virtual folder
 	 */
+	@Test
 	public void testCreateLinkedFileUnderVirtualFolder() throws CoreException {
 		// get a non-existing location
 		IPath location = getRandomLocation();
@@ -139,11 +155,12 @@ public class VirtualFolderTest extends ResourceTest {
 		file.delete(IResource.NONE, createTestMonitor());
 	}
 
+	@Test
 	public void testCopyProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
-		deleteOnTearDown(folderLocation);
+		workspaceRule.deleteOnTearDown(folderLocation);
 
 		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
@@ -182,11 +199,12 @@ public class VirtualFolderTest extends ResourceTest {
 		destinationProject.delete(IResource.NONE, createTestMonitor());
 	}
 
+	@Test
 	public void testMoveProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		deleteOnTearDown(fileLocation);
+		workspaceRule.deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
-		deleteOnTearDown(folderLocation);
+		workspaceRule.deleteOnTearDown(folderLocation);
 
 		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
@@ -226,6 +244,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertTrue("12.0", newFolder.getParent().isVirtual());
 	}
 
+	@Test
 	public void testDeleteProjectWithVirtualFolder() throws CoreException {
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 
@@ -243,9 +262,10 @@ public class VirtualFolderTest extends ResourceTest {
 		assertTrue("5.0", virtualFolder.isVirtual());
 	}
 
+	@Test
 	public void testDeleteProjectWithVirtualFolderAndLink() throws CoreException {
 		IPath folderLocation = getRandomLocation();
-		deleteOnTearDown(folderLocation);
+		workspaceRule.deleteOnTearDown(folderLocation);
 
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 		IFolder linkedFolder = virtualFolder.getFolder("a_link");
@@ -273,6 +293,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertEquals("9.0", folderLocation, linkedFolder.getLocation());
 	}
 
+	@Test
 	public void testLinkedFolderInVirtualFolder_FileStoreURI() throws CoreException {
 		IPath folderLocation = getRandomLocation();
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
@@ -290,6 +311,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertNotNull("6.0", fs.toURI());
 	}
 
+	@Test
 	public void testIsVirtual() throws CoreException {
 		// create a virtual folder
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
@@ -297,6 +319,7 @@ public class VirtualFolderTest extends ResourceTest {
 		assertTrue("2.0", virtualFolder.isVirtual());
 	}
 
+	@Test
 	public void testVirtualFolderInLinkedFolder() throws CoreException {
 		// setup handles
 		IFolder topFolder = existingProject.getFolder("topFolder");
@@ -305,9 +328,9 @@ public class VirtualFolderTest extends ResourceTest {
 		IFolder virtualFolder = subFolder.getFolder("virtualFolder");
 
 		IPath linkedFolderLocation = getRandomLocation();
-		deleteOnTearDown(linkedFolderLocation);
+		workspaceRule.deleteOnTearDown(linkedFolderLocation);
 		IPath subFolderLocation = linkedFolderLocation.append(subFolder.getName());
-		deleteOnTearDown(subFolderLocation);
+		workspaceRule.deleteOnTearDown(subFolderLocation);
 
 		// create the structure on disk
 		linkedFolderLocation.toFile().mkdir();
@@ -331,6 +354,7 @@ public class VirtualFolderTest extends ResourceTest {
 	}
 
 	/* Regression for Bug 296470 */
+	@Test
 	public void testGetVirtualFolderAttributes() {
 		long timeStamp = existingVirtualFolderInExistingProject.getLocalTimeStamp();
 		assertEquals("1.0", timeStamp, IResource.NULL_STAMP);
@@ -338,4 +362,5 @@ public class VirtualFolderTest extends ResourceTest {
 		ResourceAttributes attributes = existingVirtualFolderInExistingProject.getResourceAttributes();
 		assertEquals("1.1", attributes, null);
 	}
+
 }


### PR DESCRIPTION
* Replace the ResourceTest class hierarchy with WorkspaceTestRule
* Add `@Test` annotations
* Replace hand-written assumption checks with assume*() statements

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903