### PR TITLE
Migrate test suites in o.e.team.test.core to JUnit 4 #903

### DIFF
--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
@@ -13,36 +13,19 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.eclipse.core.tests.resources.ResourceTest;
 import org.eclipse.team.tests.core.regression.AllTeamRegressionTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
+@RunWith(Suite.class)
+@SuiteClasses({ //
+		AllTeamRegressionTests.class, //
+		RepositoryProviderTests.class, //
+		StorageMergerTests.class, //
+		StreamTests.class, //
+		UserMappingTest.class, //
+})
 public class AllTeamTests extends ResourceTest {
-
-	/**
-	 * Constructor for CVSClientTest.
-	 */
-	public AllTeamTests() {
-		super();
-	}
-
-	/**
-	 * Constructor for CVSClientTest.
-	 */
-	public AllTeamTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite();
-		suite.addTest(RepositoryProviderTests.suite());
-		suite.addTest(StreamTests.suite());
-		suite.addTest(StorageMergerTests.suite());
-		suite.addTest(AllTeamRegressionTests.suite());
-		suite.addTest(UserMappingTest.suite());
-		return suite;
-	}
 }
-

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
@@ -13,27 +13,18 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-import org.eclipse.core.tests.resources.ResourceTest;
-import org.eclipse.team.tests.core.mapping.ScopeTests;
+import org.eclipse.team.tests.core.mapping.AllTeamMappingTests;
 import org.eclipse.team.tests.ui.SaveableCompareEditorInputTest;
+import org.eclipse.team.tests.ui.synchronize.AllTeamSynchronizeTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
-public class AllTeamUITests extends ResourceTest {
-
-	public AllTeamUITests() {
-		super();
-	}
-
-	public AllTeamUITests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite();
-		suite.addTest(ScopeTests.suite());
-		suite.addTest(SaveableCompareEditorInputTest.suite());
-		return suite;
-	}
+@RunWith(Suite.class)
+@SuiteClasses({ //
+		AllTeamMappingTests.class, //
+		AllTeamSynchronizeTests.class, //
+		SaveableCompareEditorInputTest.class, //
+})
+public class AllTeamUITests {
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/AllTeamMappingTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/AllTeamMappingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,10 +8,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.team.tests.core.regression;
+package org.eclipse.team.tests.core.mapping;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -19,8 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({ //
-		Bug_217673.class, //
-		DoNotRemoveTest.class, //
+		ScopeTests.class, //
 })
-public class AllTeamRegressionTests {
+public class AllTeamMappingTests {
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/synchronize/AllTeamSynchronizeTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/synchronize/AllTeamSynchronizeTests.java
@@ -13,25 +13,13 @@
  *******************************************************************************/
 package org.eclipse.team.tests.ui.synchronize;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
-import org.eclipse.core.tests.resources.ResourceTest;
-
-public class AllTeamSynchronizeTests extends ResourceTest {
-
-	public AllTeamSynchronizeTests() {
-		super();
-	}
-
-	public AllTeamSynchronizeTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite();
-		suite.addTest(ResourceContentTests.suite());
-		return suite;
-	}
+@RunWith(Suite.class)
+@SuiteClasses({ //
+	ResourceContentTests.class, //
+})
+public class AllTeamSynchronizeTests {
 }
-


### PR DESCRIPTION
The test suite in the org.eclipse.team.tests.core project still use JUnit 3. This change migrates the test suite to JUnit 4.

In addition, the `AllTeamSynchronizeTests` test suite has not been executed before, as it was not part of the Core or UI test suite. This is corrected by the PR.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903