### PR TITLE
Fix warnings in o.e.team.tests.core related to FileModificationValidator

### DIFF
--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderBic.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderBic.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
-import org.eclipse.core.resources.IFileModificationValidator;
+import org.eclipse.core.resources.team.FileModificationValidator;
 import org.eclipse.core.resources.team.IMoveDeleteHook;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.team.core.RepositoryProvider;
@@ -23,7 +23,7 @@ public class RepositoryProviderBic extends RepositoryProvider {
 	final public static String NATURE_ID = "org.eclipse.team.tests.core.bic-provider";
 
 	private IMoveDeleteHook mdh;
-	private IFileModificationValidator mv;
+	private FileModificationValidator mv;
 
 	@Override
 	public void configureProject() throws CoreException {
@@ -38,7 +38,7 @@ public class RepositoryProviderBic extends RepositoryProvider {
 	}
 
 	@Override
-	public IFileModificationValidator getFileModificationValidator() {
+	public FileModificationValidator getFileModificationValidator2() {
 		return mv;
 	}
 
@@ -47,7 +47,7 @@ public class RepositoryProviderBic extends RepositoryProvider {
 		return mdh;
 	}
 
-	public void setModificationValidator(IFileModificationValidator mv) {
+	public void setModificationValidator(FileModificationValidator mv) {
 		this.mv = mv;
 	}
 

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderNaish.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/RepositoryProviderNaish.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
-import org.eclipse.core.resources.IFileModificationValidator;
+import org.eclipse.core.resources.team.FileModificationValidator;
 import org.eclipse.core.resources.team.IMoveDeleteHook;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.team.core.RepositoryProvider;
@@ -22,7 +22,8 @@ public class RepositoryProviderNaish extends RepositoryProvider {
 
 	final public static String NATURE_ID = "org.eclipse.team.tests.core.naish-provider";
 	private IMoveDeleteHook mdh;
-	private IFileModificationValidator mv;
+	private FileModificationValidator mv;
+
 	@Override
 	public void configureProject() throws CoreException {
 	}
@@ -35,7 +36,7 @@ public class RepositoryProviderNaish extends RepositoryProvider {
 	public void deconfigure() throws CoreException {
 	}
 
-	public void setModificationValidator(IFileModificationValidator mv) {
+	public void setModificationValidator(FileModificationValidator mv) {
 		this.mv = mv;
 	}
 
@@ -43,7 +44,7 @@ public class RepositoryProviderNaish extends RepositoryProvider {
 		this.mdh = mdh;
 	}
 	@Override
-	public IFileModificationValidator getFileModificationValidator() {
+	public FileModificationValidator getFileModificationValidator() {
 		return mv;
 	}
 

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/PessimisticRepositoryProvider.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/PessimisticRepositoryProvider.java
@@ -14,27 +14,30 @@
 package org.eclipse.team.tests.core.regression;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFileModificationValidator;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.team.FileModificationValidationContext;
+import org.eclipse.core.resources.team.FileModificationValidator;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.team.core.RepositoryProvider;
 
 /**
  * Repository provider that can be configured to be pessimistic.
  */
-public class PessimisticRepositoryProvider extends RepositoryProvider implements IFileModificationValidator {
-	private static PessimisticRepositoryProvider soleInstance;
-
+public class PessimisticRepositoryProvider extends RepositoryProvider {
 	public static final String NATURE_ID = "org.eclipse.team.tests.core.regression.pessimistic-provider";
+
+	private FileModificationValidator validator;
 
 	public static boolean markWritableOnEdit;
 	public static boolean markWritableOnSave;
 
 	public PessimisticRepositoryProvider() {
-		soleInstance = this;
+		validator = new WritabilityEnforcingFileModificationValidator();
 	}
 
 	@Override
@@ -49,21 +52,23 @@ public class PessimisticRepositoryProvider extends RepositoryProvider implements
 	@Override
 	public void deconfigure() {
 	}
+
 	@Override
 	public boolean canHandleLinkedResourceURI() {
 		return true;
 	}
-	@Override
-	public IFileModificationValidator getFileModificationValidator() {
-		return soleInstance;
-	}
 
 	@Override
-	public IStatus validateEdit(final IFile[] files, Object context) {
-		if (markWritableOnEdit) {
-			try {
-				ResourcesPlugin.getWorkspace().run(
-					(IWorkspaceRunnable) monitor -> {
+	public FileModificationValidator getFileModificationValidator2() {
+		return validator;
+	}
+
+	private static class WritabilityEnforcingFileModificationValidator extends FileModificationValidator {
+		@Override
+		public IStatus validateEdit(final IFile[] files, FileModificationValidationContext context) {
+			if (markWritableOnEdit) {
+				try {
+					ResourcesPlugin.getWorkspace().run((IWorkspaceRunnable) monitor -> {
 						for (int i = 0, length = files.length; i < length; i++) {
 							try {
 								setReadOnly(files[i], false);
@@ -71,30 +76,30 @@ public class PessimisticRepositoryProvider extends RepositoryProvider implements
 								e.printStackTrace();
 							}
 						}
-					},
-					null);
-			} catch (CoreException e) {
-				e.printStackTrace();
-				return e.getStatus();
+					}, null);
+				} catch (CoreException e) {
+					e.printStackTrace();
+					return e.getStatus();
+				}
 			}
+			return Status.OK_STATUS;
 		}
-		return Status.OK_STATUS;
+
+		@Override
+		public IStatus validateSave(IFile file) {
+			if (markWritableOnSave) {
+				try {
+					setReadOnly(file, false);
+				} catch (CoreException e) {
+					e.printStackTrace();
+					return e.getStatus();
+				}
+			}
+			return Status.OK_STATUS;
+		}
 	}
 
-	@Override
-	public IStatus validateSave(IFile file) {
-		if (markWritableOnSave) {
-			try {
-				setReadOnly(file, false);
-			} catch (CoreException e) {
-				e.printStackTrace();
-				return e.getStatus();
-			}
-		}
-		return Status.OK_STATUS;
-	}
-
-	public void setReadOnly(IResource resource, boolean readOnly) throws CoreException {
+	private static void setReadOnly(IResource resource, boolean readOnly) throws CoreException {
 		ResourceAttributes resourceAttributes = resource.getResourceAttributes();
 		if (resourceAttributes != null) {
 			resourceAttributes.setReadOnly(readOnly);
@@ -102,11 +107,4 @@ public class PessimisticRepositoryProvider extends RepositoryProvider implements
 		}
 	}
 
-	public boolean isReadOnly(IResource resource) throws CoreException {
-		ResourceAttributes resourceAttributes = resource.getResourceAttributes();
-		if (resourceAttributes != null) {
-			return resourceAttributes.isReadOnly();
-		}
-		return false;
-	}
 }


### PR DESCRIPTION
The test implementations PessimisticRepositoryProvider, RepositoryProviderBic, and RepositoryProviderNaish use deprecated
API for the FileModificationValidator. This change adapts to the new API by changing from IFileModificationValidator to FileModificationValidator and by extracting the validation within PessimisticRepositoryProvider into a static inner class.