### PR TITLE
Migrate o.e.team.tests.core.regression/mapping tests to JUnit 4 #903

### DIFF
--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/mapping/ScopeTests.java
@@ -13,49 +13,61 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core.mapping;
 
-import junit.framework.Test;
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
+import static org.junit.Assert.fail;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.mapping.ResourceMapping;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.team.core.mapping.ISynchronizationScopeManager;
 import org.eclipse.team.core.subscribers.SubscriberScopeManager;
 import org.eclipse.team.internal.ui.Utils;
-import org.eclipse.team.tests.core.TeamTest;
-import org.eclipse.ui.*;
+import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.IWorkingSetManager;
+import org.eclipse.ui.PlatformUI;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class ScopeTests extends TeamTest {
+public class ScopeTests {
 
-	public static Test suite() {
-		return suite(ScopeTests.class);
-	}
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
 	private IProject project1, project2, project3;
 	private IWorkingSet workingSet;
 	private SubscriberScopeManager manager;
 
-	public ScopeTests() {
-		super();
-	}
 
-	public ScopeTests(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		project1 = createProject("p1", new String[]{"file.txt"});
-		project2 = createProject("p2", new String[]{"file.txt"});
-		project3 = createProject("p3", new String[]{"file.txt"});
+	@Before
+	public void setUp() throws Exception {
+		project1 = createProjectWithFile("p1", "file.txt");
+		project2 = createProjectWithFile("p2", "file.txt");
+		project3 = createProjectWithFile("p3", "file.txt");
 		IWorkingSetManager manager = PlatformUI.getWorkbench().getWorkingSetManager();
 		workingSet = manager.createWorkingSet("TestWS", new IProject[] { project1 });
 		manager.addWorkingSet(workingSet);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	/*
+	 * This method creates a project with the given resources
+	 */
+	private IProject createProjectWithFile(String name, String fileName) throws CoreException {
+		IProject project = getWorkspace().getRoot().getProject(name);
+		createInWorkspace(project);
+		createInWorkspace(project.getFile(fileName));
+		return project;
+	}
+
+	@After
+	public void tearDown() throws Exception {
 		this.manager.dispose();
 		IWorkingSetManager manager = PlatformUI.getWorkbench().getWorkingSetManager();
 		manager.removeWorkingSet(workingSet);
@@ -100,6 +112,7 @@ public class ScopeTests extends TeamTest {
 		return manager;
 	}
 
+	@Test
 	public void testScopeExpansion() throws CoreException, OperationCanceledException, InterruptedException {
 		ISynchronizationScopeManager sm = createScopeManager();
 		assertProperContainment(sm);
@@ -107,6 +120,7 @@ public class ScopeTests extends TeamTest {
 		assertProperContainment(sm);
 	}
 
+	@Test
 	public void testScopeContraction() throws OperationCanceledException, InterruptedException, CoreException {
 		workingSet.setElements( new IProject[] { project1, project2 });
 		ISynchronizationScopeManager sm = createScopeManager();

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/Bug_217673.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/Bug_217673.java
@@ -13,27 +13,31 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core.regression;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourceAttributes;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.team.core.RepositoryProvider;
-import org.eclipse.team.tests.core.TeamTest;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.*;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class Bug_217673 extends TeamTest {
+public class Bug_217673 {
 
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+
+	@Test
 	public void test() throws CoreException {
-
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspace workspace = getWorkspace();
 		final IProject project = workspace.getRoot().getProject(
 				createUniqueString());
 		project.create(null);
@@ -61,10 +65,6 @@ public class Bug_217673 extends TeamTest {
 		ResourceAttributes resourceAttributes = resource
 				.getResourceAttributes();
 		return resourceAttributes.isReadOnly();
-	}
-
-	public static Test suite() {
-		return new TestSuite(Bug_217673.class);
 	}
 
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/DoNotRemoveTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/regression/DoNotRemoveTest.java
@@ -13,61 +13,43 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core.regression;
 
+import static org.junit.Assert.assertEquals;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.team.core.synchronize.SyncInfo;
 import org.eclipse.team.internal.ui.Utils;
 import org.eclipse.team.internal.ui.actions.CompareRevisionAction;
-import org.eclipse.team.tests.core.TeamTest;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
+import org.junit.Test;
 
 /**
  * Some internal methods can not be removed since they are used in products.
  */
-public class DoNotRemoveTest extends TeamTest {
+public class DoNotRemoveTest {
 
 	/**
 	 * Tests
 	 * {@link Utils#updateLabels(org.eclipse.team.core.synchronize.SyncInfo, org.eclipse.compare.CompareConfiguration)}
 	 */
-	public void test_Utils_updateLabels() {
-		try {
-			Method method = Utils.class.getMethod("updateLabels", SyncInfo.class, CompareConfiguration.class);
-			assertEquals(Modifier.STATIC | Modifier.PUBLIC,
-					method.getModifiers());
-			assertEquals(Void.TYPE, method.getReturnType());
-		} catch (SecurityException e) {
-			fail("test_Utils_updateLabels", e);
-		} catch (NoSuchMethodException e) {
-			fail("test_Utils_updateLabels", e);
-		}
+	@Test
+	public void test_Utils_updateLabels() throws NoSuchMethodException, SecurityException {
+		Method method = Utils.class.getMethod("updateLabels", SyncInfo.class, CompareConfiguration.class);
+		assertEquals(Modifier.STATIC | Modifier.PUBLIC, method.getModifiers());
+		assertEquals(Void.TYPE, method.getReturnType());
 	}
 
 	/**
-	 * Tests
-	 * {@link CompareRevisionAction#findReusableCompareEditor(IWorkbenchPage)}
+	 * Tests {@link CompareRevisionAction#findReusableCompareEditor(IWorkbenchPage)}
 	 */
-	public void testBug312217() {
-		try {
-			Method method = CompareRevisionAction.class.getMethod("findReusableCompareEditor", IWorkbenchPage.class);
-			assertEquals(Modifier.STATIC | Modifier.PUBLIC,
-					method.getModifiers());
-			assertEquals(IEditorPart.class, method.getReturnType());
-		} catch (SecurityException e) {
-			fail("testBug312217", e);
-		} catch (NoSuchMethodException e) {
-			fail("testBug312217", e);
-		}
-	}
-
-	public static Test suite() {
-		return new TestSuite(DoNotRemoveTest.class);
+	@Test
+	public void testBug312217() throws NoSuchMethodException, SecurityException {
+		Method method = CompareRevisionAction.class.getMethod("findReusableCompareEditor", IWorkbenchPage.class);
+		assertEquals(Modifier.STATIC | Modifier.PUBLIC, method.getModifiers());
+		assertEquals(IEditorPart.class, method.getReturnType());
 	}
 
 }


### PR DESCRIPTION
* Replace the ResourceTest hierarchy with WorkspaceTestRule
* Add `@Test` annotations
* Remove unnecessary try-catch blocks

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903