### PR TITLE
IllegalStateException: call to beginTask() missing in the Help view

### DIFF
--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
@@ -125,23 +125,24 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 			}
 		});
 		browser.addProgressListener(new ProgressListener() {
+			IProgressMonitor monitor;
 
 			@Override
 			public void changed(ProgressEvent e) {
 				if (e.current == e.total)
 					return;
-				IStatusLineManager slm = BrowserPart.this.parent
-						.getStatusLineManager();
-				IProgressMonitor monitor = slm != null ? slm
-						.getProgressMonitor() : null;
+
 				if (lastProgress == -1) {
 					lastProgress = 0;
+					IStatusLineManager slm = BrowserPart.this.parent.getStatusLineManager();
+					monitor = slm != null ? slm.getProgressMonitor() : null;
 					if (monitor != null) {
 						monitor.beginTask("", e.total); //$NON-NLS-1$
 						slm.setCancelEnabled(true);
 					}
 				} else if (monitor != null && monitor.isCanceled()) {
 					browser.stop();
+					monitor = null;
 					return;
 				}
 				if (monitor != null)
@@ -151,13 +152,13 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 
 			@Override
 			public void completed(ProgressEvent e) {
-				IStatusLineManager slm = BrowserPart.this.parent
-						.getStatusLineManager();
-				IProgressMonitor monitor = slm != null ? slm
-						.getProgressMonitor() : null;
 				if (monitor != null) {
-					slm.setCancelEnabled(false);
+					IStatusLineManager slm = BrowserPart.this.parent.getStatusLineManager();
+					if (slm != null) {
+						slm.setCancelEnabled(false);
+					}
 					monitor.done();
+					monitor = null;
 				}
 				lastProgress = -1;
 				if (fontScalePercentage != 100) {


### PR DESCRIPTION
This patch fixes following warning reported to the error log while navigating between help topics in the Help view after https://github.com/eclipse-platform/eclipse.platform.ui/pull/1077:
```
java.lang.IllegalStateException: call to beginTask() missing
	at org.eclipse.jface.action.StatusLineManager$1.worked(StatusLineManager.java:221)
	at org.eclipse.help.ui.internal.views.BrowserPart$2.changed(BrowserPart.java:148)
	at org.eclipse.swt.browser.WebKit.lambda$15(WebKit.java:2492)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
```
To avoid errors reported by the different monitor instances returned by `IStatusLineManager.getProgressMonitor()`, browser listener has to keep a single local monitor instance.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1398