### PR TITLE
Make the "run/debug as..." menus run asynchronously

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.java
@@ -303,6 +303,8 @@ public class DebugUIMessages extends NLS {
 
 	public static String LaunchShortcutAction_combineLaunchShortcutName;
 
+	public static String ContextualLaunchAction_0;
+
 	static {
 		// load message values from bundle file
 		NLS.initializeMessages(BUNDLE_NAME, DebugUIMessages.class);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.properties
@@ -162,6 +162,7 @@ CodePagesPrefDialog_7=ASCII codepage entered is invalid.
 CodePagesPrefDialog_8=Invalid codepage
 CodePagesPrefDialog_9=EBCDIC codepage entered is invalid.
 CodePagesPrefDialog_0=The codepage is not supported.
+ContextualLaunchAction_0=Loading...
 
 ##############################################################
 # View Tab


### PR DESCRIPTION
# What it does
Let the `Run`/`Debug As...` (context) menus load asynchronously so that long-running operations don't block the UI. Show a "placeholder" while computing the contents of the menu.

This PR can only be merged together with:
* https://github.com/eclipse-platform/eclipse.platform.ui/pull/1404

# How to test
* Go to a (test) class
* Right click
* Hover over `Run As...` or `Debug As...`
* Move back and forth between both of them, play with it.
* Run/Debug something (_i.e._ click on the sub-menus)

Everything should work as usual

## A small hack to help testing
Add a random wait to `ContextualLaunchAction.isApplicable(...)`, like this:

```java
private boolean isApplicable(LaunchShortcutExtension ext, IEvaluationContext context) throws CoreException {
	Expression expr = ext.getContextualLaunchEnablementExpression();
	try {
		Thread.sleep((long) Math.random() * 200);
	} catch (InterruptedException e) {
		// ignore
	}
	return ext.evalEnablementExpression(context, expr);
}
```

This should give you enough time to see the placeholder in the menu:

![image](https://github.com/eclipse-platform/eclipse.platform/assets/2205684/e59c79f0-5d07-405f-8411-29efa5f47ad2)

After a couple of seconds, you should see the "normal" menu items:

![image](https://github.com/eclipse-platform/eclipse.platform/assets/2205684/a57ce5b5-5c49-43c6-8175-2301104c75d5)

