### PR TITLE
Jenkinsfile: Disable Quality gate for maven warnings #969

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,8 @@ pipeline {
 					archiveArtifacts artifacts: '.*log,*/target/work/data/.metadata/.*log,*/tests/target/work/data/.metadata/.*log,apiAnalyzer-workspace/.metadata/.*log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform/master'
-					recordIssues tools: [eclipse(), mavenConsole(), javaDoc()], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					recordIssues tools: [eclipse(), javaDoc()], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					recordIssues tool: mavenConsole(), qualityGates: [[threshold: 1, type: 'DELTA_ERROR', unstable: true]]
 				}
 			}
 		}


### PR DESCRIPTION
should be revert if #969 is fixed
The Problem is, that almost every build fails because the number of warnings is too flaky and independent of the PRs that they should verify. If they would be at least constant they would not fail the PRs.
![image](https://github.com/eclipse-platform/eclipse.platform/assets/51790620/cd678e3e-dfde-47d6-979e-9ff99a88969c)
