### PR TITLE
Prepare Job tests for JUnit 4 migration #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
@@ -61,7 +61,7 @@ public class Bug_129551 extends AbstractJobManagerTest {
 		manager.setProgressProvider(null);
 	}
 
-	public void testBug() {
+	public void testBug() throws InterruptedException {
 		ISchedulingRule rule = new IdentityRule();
 		BugJob job = new BugJob();
 		job.setRule(rule);
@@ -72,18 +72,15 @@ public class Bug_129551 extends AbstractJobManagerTest {
 		//wait until the first job is about to run
 		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		//wait to ensure the other job is blocked
-		try {
-			Thread.sleep(1000);
-		} catch (InterruptedException e) {
-			fail("4.99", e);
-		}
+		Thread.sleep(1000);
+
 		//let the first job go
 		barrier.setStatus(TestBarrier2.STATUS_START);
 		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 
 		//check for failure
 		if (failure[0] != null) {
-			fail(failure[0].getMessage());
+			throw failure[0];
 		}
 		//tell the job not to sleep this time around
 		shouldSleep[0] = false;
@@ -91,4 +88,5 @@ public class Bug_129551 extends AbstractJobManagerTest {
 		waitForCompletion(job);
 		waitForCompletion(other);
 	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_211799.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_211799.java
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import java.util.*;
-import org.eclipse.core.runtime.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 
@@ -41,8 +45,9 @@ public class Bug_211799 extends AbstractJobManagerTest {
 		protected IStatus run(IProgressMonitor monitor) {
 			synchronized (list) {
 				Long val = list.getFirst();
-				if (val.longValue() != id)
+				if (val.longValue() != id) {
 					failure = new RuntimeException("We broke, running should have been: " + val.longValue());
+				}
 				list.remove(Long.valueOf(id));
 			}
 
@@ -62,7 +67,7 @@ public class Bug_211799 extends AbstractJobManagerTest {
 
 	List<Long> runList = new ArrayList<>(JOBS_TO_SCHEDULE);
 
-	public void testBug() {
+	public void testBug() throws Exception {
 		for (int i = 0; i < JOBS_TO_SCHEDULE; i++) {
 			synchronized (list) {
 				counter++;
@@ -79,8 +84,9 @@ public class Bug_211799 extends AbstractJobManagerTest {
 				}
 			}
 		}
-		if (failure != null)
-			fail("1.0", failure);
-
+		if (failure != null) {
+			throw failure;
+		}
 	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
@@ -13,8 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.junit.Test;
 
 public class Bug_478634 extends AbstractJobTest {
@@ -33,7 +38,6 @@ public class Bug_478634 extends AbstractJobTest {
 		j.schedule();
 		waitForCompletion(j);
 		assertFalse("Job was blocked", j.wasBlocked());
-
 	}
 
 	class ShouldNotBeBlockedJob extends Job {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -707,19 +707,13 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests joining a job that repeats in a loop.
 	 */
-	public void testJoinWithRepeatingJobs() {
+	public void testJoinWithRepeatingJobs() throws OperationCanceledException, InterruptedException {
 		JobGroup jobGroup = new JobGroup("JobGroup", 1, 1);
 		int count = 25;
 		RepeatingJob job = new RepeatingJob("RepeatingJob", count);
 		job.setJobGroup(jobGroup);
 		job.schedule();
-		try {
-			jobGroup.join(0, null);
-		} catch (OperationCanceledException e) {
-			fail("1.0", e);
-		} catch (InterruptedException e) {
-			fail("1.1", e);
-		}
+		jobGroup.join(0, null);
 		// Verify that the job has run the expected number of times.
 		assertEquals("1.2", count, job.getRunCount());
 	}


### PR DESCRIPTION
* Remove unnecessary try-catch blocks or replace with assertThrows(...)
* Rethrow exceptions instead of calling fail()
* Move assertion statements from other threads to main thread

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903