### PR TITLE
Fix several warnings due to name clashes

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchGroupTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchGroupTests.java
@@ -110,8 +110,8 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		super.tearDown();
 	}
 
-	private ILaunchConfiguration createLaunchGroup(String name, GroupLaunchElement... children) throws CoreException {
-		ILaunchConfigurationWorkingCopy grp = getLaunchManager().getLaunchConfigurationType(GROUP_TYPE).newInstance(null, name);
+	private ILaunchConfiguration createLaunchGroup(String groupName, GroupLaunchElement... children) throws CoreException {
+		ILaunchConfigurationWorkingCopy grp = getLaunchManager().getLaunchConfigurationType(GROUP_TYPE).newInstance(null, groupName);
 		GroupLaunchConfigurationDelegate.storeLaunchElements(grp, Arrays.asList(children));
 		return grp.doSave();
 	}

--- a/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/launchview/LaunchViewSmokeTest.java
+++ b/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/launchview/LaunchViewSmokeTest.java
@@ -33,7 +33,7 @@ public class LaunchViewSmokeTest extends AbstractLaunchViewTest {
 		assertNotNull("The active workbench page should not be null", page); //$NON-NLS-1$
 		try {
 			page.showView("org.eclipse.debug.ui.launchView"); //$NON-NLS-1$
-		} catch (PartInitException e) {
+		} catch (PartInitException exception) {
 			assertNotNull("Failed to open launch configuration view", null); //$NON-NLS-1$
 		}
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeNode.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeNode.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.internal.dtree;
 
-import org.eclipse.core.internal.utils.*;
+import org.eclipse.core.internal.utils.IStringPoolParticipant;
+import org.eclipse.core.internal.utils.Messages;
+import org.eclipse.core.internal.utils.StringPool;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IPath;
 
@@ -143,13 +145,12 @@ public class DataTreeNode extends AbstractDataTreeNode {
 	 *	new child node
 	 */
 	DataTreeNode copyWithNewChild(String localName, DataTreeNode childNode) {
-
-		AbstractDataTreeNode[] children = this.children;
+		AbstractDataTreeNode[] oldChildren = this.children;
 		int left = 0;
-		int right = children.length - 1;
+		int right = oldChildren.length - 1;
 		while (left <= right) {
 			int mid = (left + right) / 2;
-			int compare = localName.compareTo(children[mid].name);
+			int compare = localName.compareTo(oldChildren[mid].name);
 			if (compare < 0) {
 				right = mid - 1;
 			} else if (compare > 0) {
@@ -159,11 +160,11 @@ public class DataTreeNode extends AbstractDataTreeNode {
 			}
 		}
 
-		AbstractDataTreeNode[] newChildren = new AbstractDataTreeNode[children.length + 1];
-		System.arraycopy(children, 0, newChildren, 0, left);
+		AbstractDataTreeNode[] newChildren = new AbstractDataTreeNode[oldChildren.length + 1];
+		System.arraycopy(oldChildren, 0, newChildren, 0, left);
 		childNode.setName(localName);
 		newChildren[left] = childNode;
-		System.arraycopy(children, left, newChildren, left + 1, children.length - left);
+		System.arraycopy(oldChildren, left, newChildren, left + 1, oldChildren.length - left);
 		return new DataTreeNode(this.getName(), this.getData(), newChildren);
 	}
 
@@ -175,18 +176,17 @@ public class DataTreeNode extends AbstractDataTreeNode {
 	 *	name of child to exclude
 	 */
 	DataTreeNode copyWithoutChild(String localName) {
-
 		int index, newSize;
 		DataTreeNode newNode;
-		AbstractDataTreeNode children[];
+		AbstractDataTreeNode newChildren[];
 
 		index = this.indexOfChild(localName);
 		if (index == -1) {
 			newNode = (DataTreeNode) this.copy();
 		} else {
 			newSize = this.size() - 1;
-			children = new AbstractDataTreeNode[newSize];
-			newNode = new DataTreeNode(this.getName(), this.getData(), children);
+			newChildren = new AbstractDataTreeNode[newSize];
+			newNode = new DataTreeNode(this.getName(), this.getData(), newChildren);
 			newNode.copyChildren(0, index - 1, this, 0); //#from:to:with:startingAt:
 			newNode.copyChildren(index, newSize - 1, this, index + 1);
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeReader.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeReader.java
@@ -145,8 +145,8 @@ public class DataTreeReader {
 	 * the project (first node under root) in the returned tree
 	 * instead of the name read from the stream.
 	 */
-	public DeltaDataTree readTree(DeltaDataTree parent, DataInput input, String newProjectName) throws IOException {
-		this.input = input;
+	public DeltaDataTree readTree(DeltaDataTree parent, DataInput dataInput, String newProjectName) throws IOException {
+		this.input = dataInput;
 		AbstractDataTreeNode root = readNode(IPath.ROOT, newProjectName);
 		return new DeltaDataTree(root, parent);
 	}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeWriter.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/dtree/DataTreeWriter.java
@@ -155,8 +155,8 @@ public class DataTreeWriter {
 	 *  only write up to this depth.  A depth of infinity is given
 	 *  by the constant D_INFINITE.
 	 */
-	public void writeTree(DeltaDataTree tree, IPath path, int depth, DataOutput output) throws IOException {
-		this.output = output;
+	public void writeTree(DeltaDataTree tree, IPath path, int depth, DataOutput dataOutput) throws IOException {
+		this.output = dataOutput;
 		/* tunnel down relevant path */
 		AbstractDataTreeNode node = tree.getRootNode();
 		IPath currentPath = IPath.ROOT;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceDelta.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceDelta.java
@@ -110,8 +110,8 @@ public class ResourceDelta extends PlatformObject implements IResourceDelta {
 	}
 
 	@Override
-	public IResourceDelta findMember(IPath path) {
-		int segmentCount = path.segmentCount();
+	public IResourceDelta findMember(IPath memberPath) {
+		int segmentCount = memberPath.segmentCount();
 		if (segmentCount == 0)
 			return this;
 
@@ -119,7 +119,7 @@ public class ResourceDelta extends PlatformObject implements IResourceDelta {
 		ResourceDelta current = this;
 		segments: for (int i = 0; i < segmentCount; i++) {
 			for (ResourceDelta element : current.children) {
-				if (element.getFullPath().lastSegment().equals(path.segment(i))) {
+				if (element.getFullPath().lastSegment().equals(memberPath.segment(i))) {
 					current = element;
 					continue segments;
 				}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -470,8 +470,8 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	public void forgetSavedTree(String pluginId) {
 		if (pluginId == null) {
 			synchronized (savedStates) {
-				for (SavedState savedState : savedStates.values())
-					savedState.forgetTrees();
+				for (SavedState state : savedStates.values())
+					state.forgetTrees();
 			}
 		} else {
 			SavedState state = savedStates.get(pluginId);

--- a/resources/bundles/org.eclipse.core.resources/src_ant/org/eclipse/core/resources/ant/IncrementalBuild.java
+++ b/resources/bundles/org.eclipse.core.resources/src_ant/org/eclipse/core/resources/ant/IncrementalBuild.java
@@ -29,7 +29,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  */
 public class IncrementalBuild extends Task {
 	private String builder;
-	private String project;
+	private String projectToBuild;
 	private int kind = IncrementalProjectBuilder.INCREMENTAL_BUILD;
 
 	/**
@@ -75,10 +75,10 @@ public class IncrementalBuild extends Task {
 			Hashtable<String, Object> references = getProject().getReferences();
 			if (references != null)
 				monitor = (IProgressMonitor) references.get(AntCorePlugin.ECLIPSE_PROGRESS_MONITOR);
-			if (project == null) {
+			if (projectToBuild == null) {
 				ResourcesPlugin.getWorkspace().build(kind, monitor);
 			} else {
-				IProject targetProject = ResourcesPlugin.getWorkspace().getRoot().getProject(project);
+				IProject targetProject = ResourcesPlugin.getWorkspace().getRoot().getProject(projectToBuild);
 				if (builder == null)
 					targetProject.build(kind, monitor);
 				else
@@ -124,6 +124,6 @@ public class IncrementalBuild extends Task {
 	 * @param value the receiver's target project
 	 */
 	public void setProject(String value) {
-		project = value;
+		projectToBuild = value;
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -254,18 +254,18 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 	 * Compares the values in a workspace description with the corresponding
 	 * properties in a preferences object.
 	 */
-	public void assertEquals(String message, IWorkspaceDescription description, Preferences preferences) throws ComparisonFailure {
-		assertEquals(message + " - 1", description.isAutoBuilding(), preferences.getBoolean(ResourcesPlugin.PREF_AUTO_BUILDING));
-		assertEquals(message + " - 2", description.getBuildOrder() == null, preferences.getBoolean(ResourcesPlugin.PREF_DEFAULT_BUILD_ORDER));
-		assertEquals(message + " - 3", WorkspacePreferences.convertStringArraytoString(description.getBuildOrder()), preferences.getString(ResourcesPlugin.PREF_BUILD_ORDER));
-		assertEquals(message + " - 4", description.isApplyFileStatePolicy(), preferences.getBoolean(ResourcesPlugin.PREF_APPLY_FILE_STATE_POLICY));
-		assertEquals(message + " - 5", description.getFileStateLongevity(), preferences.getLong(ResourcesPlugin.PREF_FILE_STATE_LONGEVITY));
-		assertEquals(message + " - 6", description.getMaxFileStates(), preferences.getInt(ResourcesPlugin.PREF_MAX_FILE_STATES));
-		assertEquals(message + " - 7", description.getMaxFileStateSize(), preferences.getLong(ResourcesPlugin.PREF_MAX_FILE_STATE_SIZE));
-		assertEquals(message + " - 8", description.getSnapshotInterval(), preferences.getLong(ResourcesPlugin.PREF_SNAPSHOT_INTERVAL));
-		assertEquals(message + " - 9", description.getMaxBuildIterations(), preferences.getLong(ResourcesPlugin.PREF_MAX_BUILD_ITERATIONS));
+	public void assertEquals(String message, IWorkspaceDescription description, Preferences expectedPreferences) throws ComparisonFailure {
+		assertEquals(message + " - 1", description.isAutoBuilding(), expectedPreferences.getBoolean(ResourcesPlugin.PREF_AUTO_BUILDING));
+		assertEquals(message + " - 2", description.getBuildOrder() == null, expectedPreferences.getBoolean(ResourcesPlugin.PREF_DEFAULT_BUILD_ORDER));
+		assertEquals(message + " - 3", WorkspacePreferences.convertStringArraytoString(description.getBuildOrder()), expectedPreferences.getString(ResourcesPlugin.PREF_BUILD_ORDER));
+		assertEquals(message + " - 4", description.isApplyFileStatePolicy(), expectedPreferences.getBoolean(ResourcesPlugin.PREF_APPLY_FILE_STATE_POLICY));
+		assertEquals(message + " - 5", description.getFileStateLongevity(), expectedPreferences.getLong(ResourcesPlugin.PREF_FILE_STATE_LONGEVITY));
+		assertEquals(message + " - 6", description.getMaxFileStates(), expectedPreferences.getInt(ResourcesPlugin.PREF_MAX_FILE_STATES));
+		assertEquals(message + " - 7", description.getMaxFileStateSize(), expectedPreferences.getLong(ResourcesPlugin.PREF_MAX_FILE_STATE_SIZE));
+		assertEquals(message + " - 8", description.getSnapshotInterval(), expectedPreferences.getLong(ResourcesPlugin.PREF_SNAPSHOT_INTERVAL));
+		assertEquals(message + " - 9", description.getMaxBuildIterations(), expectedPreferences.getLong(ResourcesPlugin.PREF_MAX_BUILD_ITERATIONS));
 		assertEquals(message + " -10", description.isKeepDerivedState(),
-				preferences.getBoolean(ResourcesPlugin.PREF_KEEP_DERIVED_STATE));
+				expectedPreferences.getBoolean(ResourcesPlugin.PREF_KEEP_DERIVED_STATE));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -366,7 +366,7 @@ public class IPathVariableTest {
 		assertEquals("4.0", null, actual);
 	}
 
-	private IPath getVariableRelativePathLocation(IProject project, IPath location) {
+	private static IPath getVariableRelativePathLocation(IProject project, IPath location) {
 		URI variableRelativePathLocation = project.getPathVariableManager().getVariableRelativePathLocation(URIUtil.toURI(location));
 		if (variableRelativePathLocation != null) {
 			return URIUtil.toPath(variableRelativePathLocation);
@@ -444,7 +444,8 @@ public class IPathVariableTest {
 
 	}
 
-	private IPath convertToRelative(IPathVariableManager manager, IPath path, boolean force, String variableHint) throws CoreException {
+	private static IPath convertToRelative(IPathVariableManager manager, IPath path, boolean force, String variableHint)
+			throws CoreException {
 		return URIUtil.toPath(manager.convertToRelative(URIUtil.toURI(path), force, variableHint));
 	}
 


### PR DESCRIPTION
Resolves warnings of kind "local variable ... is hiding field from" by either
- renaming the variable, or
- making the method static in case a parameter is hiding a field.