### PR TITLE
Revert "Fix Cut Off Label on Welcome Page"

### DIFF
--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/html/IntroHTMLGenerator.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/html/IntroHTMLGenerator.java
@@ -509,6 +509,13 @@ public class IntroHTMLGenerator {
 			anchor2 = generateAnchorElement(element, indentLevel + 1);
 			labelAnchor = anchor2;
 		}
+		// add <IMG src="blank.gif">
+		String blankImageURL = BundleUtil.getResolvedResourceLocation(IIntroHTMLConstants.IMAGE_SRC_BLANK,
+				IIntroConstants.PLUGIN_ID);
+		if (blankImageURL != null) {
+			anchor1.addContent(generateImageElement(blankImageURL, null, null, IIntroHTMLConstants.IMAGE_CLASS_BG,
+					indentBase + 1));
+		}
 		// add link image, if one is specified
 		if (element.getImg() != null) {
 			HTMLElement img = generateIntroElement(element.getImg(), indentBase + 1);


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform#745

This caused a regression. See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1408
I don't know how I could overlook this.