### PR TITLE
Remove obsolete Javadoc with broken formatting

### DIFF
--- a/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FilterHTMLHeadAndBodyOutputStream.java
+++ b/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FilterHTMLHeadAndBodyOutputStream.java
@@ -95,8 +95,6 @@ public class FilterHTMLHeadAndBodyOutputStream extends FilterOutputStream {
 	 * <p>
 	 * The underlying stream might have a more bytes written to it, following
 	 * the &lt;head&gt; HTML element.
-	 * <p>
-	 * Implements the abstract <tt>write</tt> method of <tt>OutputStream</tt>.
 	 *
 	 * @param b
 	 *            the <code>byte</code>.

--- a/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FilterHTMLHeadOutputStream.java
+++ b/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FilterHTMLHeadOutputStream.java
@@ -64,8 +64,6 @@ public class FilterHTMLHeadOutputStream extends FilterOutputStream {
 	 * <p>
 	 * The underlying stream might have a more bytes written to it, following
 	 * the &lt;head&gt; HTML element.
-	 * <p>
-	 * Implements the abstract <tt>write</tt> method of <tt>OutputStream</tt>.
 	 *
 	 * @param b
 	 *            the <code>byte</code>.


### PR DESCRIPTION
Javadoc is unnecessary and uses unsupported `tt` tag, see https://ci.eclipse.org/platform/job/eclipse.platform/job/PR-1012/4/maven-warnings/Error/moduleName.-1104384959/source.a8e9e1d6-fe7a-4885-bc7c-4070bf08b35a/#3825