### PR TITLE
Fix faulty Javadoc references in o.e.debug.examples.core

### DIFF
--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/protocol/package.html
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/protocol/package.html
@@ -22,10 +22,10 @@
 </ul>
 <h4>Events</h4>
 <ul>
-<li>{@link PDAVMStarted}</li>
-<li>{@link PDAVMTerminated}</li>
-<li>{@link PDAVMSuspneded}</li>
-<li>{@link PDAVMResumed}</li>
+<li>{@link PDAVMStartedEvent}</li>
+<li>{@link PDAVMTerminatedEvent}</li>
+<li>{@link PDAVMSuspendedEvent}</li>
+<li>{@link PDAVMResumedEvent}</li>
 <li>{@link PDAUnimplementedInstructionEvent}</li>
 <li>{@link PDANoSuchLabelEvent}</li>
 </ul>
@@ -40,10 +40,10 @@
 </ul>
 <h4>Events</h4>
 <ul>
-<li>{@link PDAStarted}</li>
-<li>{@link PDAExited}</li>
-<li>{@link PDASuspended}</li>
-<li>{@link PDAResumed}</li>
+<li>{@link PDAStartedEvent}</li>
+<li>{@link PDAExitedEvent}</li>
+<li>{@link PDASuspendedEvent}</li>
+<li>{@link PDAResumedEvent}</li>
 </ul>
 
 <h3>Breakpoints</h3>


### PR DESCRIPTION
Can be seen in every build, e.g.: https://ci.eclipse.org/platform/job/eclipse.platform/job/master/572/consoleText