### PR TITLE
[memory] ElementTree: evict childIDsCache

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTree.java
@@ -635,6 +635,8 @@ public class ElementTree {
 	public synchronized ElementTree newEmptyDelta() {
 		// Don't want old trees hanging onto cached infos.
 		lookupCache = lookupCacheIgnoreCase = null;
+		// reclaim memory of childIDsCache - which is only used on the current tree:
+		childIDsCache = null;
 		if (!this.isImmutable()) {
 			this.immutable();
 		}


### PR DESCRIPTION
childIDsCache is only used on the current workspace tree, but was hold on the whole history of the workspace

https://github.com/eclipse-equinox/equinox/issues/433