### PR TITLE
Migrate job tests in o.e.core.tests.runtime to JUnit 4 #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
@@ -14,86 +14,30 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.internal.jobs.JobListeners;
 import org.eclipse.core.internal.jobs.JobManager;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * Common superclass for all tests of the org.eclipse.core.runtime.jobs API. Provides
  * convenience methods useful for testing jobs.
  */
 @SuppressWarnings("restriction")
-public class AbstractJobTest extends TestCase {
+public class AbstractJobTest  {
 	protected IJobManager manager;
 	private FussyProgressProvider progressProvider;
-
-	public AbstractJobTest() {
-		super("");
-	}
-
-	public AbstractJobTest(String name) {
-		super(name);
-	}
-
-	/**
-	 * Fails the test due to the given exception.
-	 */
-	public void fail(String message, Throwable e) {
-		// If the exception is a CoreException with a multistatus
-		// then print out the multistatus so we can see all the info.
-		if (e instanceof CoreException) {
-			IStatus status = ((CoreException) e).getStatus();
-			if (status.getChildren().length > 0) {
-				write(status, 0);
-			}
-		}
-		fail(message + ": " + e);
-	}
-
-	protected void indent(OutputStream output, int indent) {
-		for (int i = 0; i < indent; i++) {
-			try {
-				output.write("\t".getBytes());
-			} catch (IOException e) {
-				//ignore
-			}
-		}
-	}
 
 	protected void sleep(long duration) {
 		try {
 			Thread.sleep(duration);
 		} catch (InterruptedException e) {
 			//ignore
-		}
-	}
-
-	protected void write(IStatus status, int indent) {
-		PrintStream output = System.out;
-		indent(output, indent);
-		output.println("Severity: " + status.getSeverity());
-
-		indent(output, indent);
-		output.println("Plugin ID: " + status.getPlugin());
-
-		indent(output, indent);
-		output.println("Code: " + status.getCode());
-
-		indent(output, indent);
-		output.println("Message: " + status.getMessage());
-
-		if (status.isMultiStatus()) {
-			IStatus[] children = status.getChildren();
-			for (IStatus element : children) {
-				write(element, indent + 1);
-			}
 		}
 	}
 
@@ -139,24 +83,22 @@ public class AbstractJobTest extends TestCase {
 		return ((JobManager) (Job.getJobManager())).now();
 	}
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setProgressProvider() throws Exception {
 		assertNoTimeoutOccured();
-		super.setUp();
 		manager = Job.getJobManager();
 		progressProvider = new FussyProgressProvider();
 		manager.setProgressProvider(progressProvider);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void resetProgressProvider() throws Exception {
 		progressProvider.sanityCheck();
-		manager.setProgressProvider(null);
+		Job.getJobManager().setProgressProvider(null);
 		assertNoTimeoutOccured();
-		super.tearDown();
 	}
 
-	public static void assertNoTimeoutOccured() throws Exception {
+	protected final void assertNoTimeoutOccured() throws Exception {
 		int jobListenerTimeout = JobListeners.getJobListenerTimeout();
 		JobListeners.resetJobListenerTimeout();
 		int defaultTimeout = JobListeners.getJobListenerTimeout();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/BeginEndRuleTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/BeginEndRuleTest.java
@@ -17,7 +17,10 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,6 +40,7 @@ import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.runtime.jobs.ProgressProvider;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -100,6 +104,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testComplexRuleStarting() {
 		//test how the manager reacts when several different threads try to begin conflicting rules
 		final int NUM_THREADS = 3;
@@ -191,6 +196,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testSimpleRuleStarting() {
 		//start two jobs, each of which will begin and end a rule several times
 		//while one job starts a rule, the second job's call to begin rule should block that thread
@@ -280,6 +286,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		assertEquals("6.6", IStatus.OK, jobs[1].getResult().getSeverity());
 	}
 
+	@Test
 	public void testComplexRuleContainment() {
 		ISchedulingRule rules[] = new ISchedulingRule[4];
 
@@ -314,12 +321,15 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		}
 	}
 
-	public void _testEndNullRule() {
+	@Test
+	@Ignore("see bug 43460")
+	public void testEndNullRule() {
 		//see bug #43460
 		//end null IScheduleRule without begin
 		assertThrows(RuntimeException.class, () -> manager.endRule(null));
 	}
 
+	@Test
 	public void testFailureCase() {
 		ISchedulingRule rule1 = new IdentityRule();
 		ISchedulingRule rule2 = new IdentityRule();
@@ -343,6 +353,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 	 * Tests create a job with one scheduling rule, and then attempting
 	 * to acquire an unrelated rule from within that job.
 	 */
+	@Test
 	public void testFailedNestRuleInJob() {
 		final ISchedulingRule rule1 = new PathRule("/testFailedNestRuleInJob/A/");
 		final ISchedulingRule rule2 = new PathRule("/testFailedNestRuleInJob/B/");
@@ -370,6 +381,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		assertTrue("1.1", exception[0].getMessage().indexOf("does not match outer scope rule") > 0);
 	}
 
+	@Test
 	public void testNestedCase() {
 		ISchedulingRule rule1 = new PathRule("/testNestedCase");
 		ISchedulingRule rule2 = new PathRule("/testNestedCase/B");
@@ -420,6 +432,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 	 * Tests a failure where canceling an attempt to beginRule resulted in implicit jobs
 	 * being recycled before they were finished.
 	 */
+	@Test
 	public void testBug44299() {
 		ISchedulingRule rule = new IdentityRule();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -448,6 +461,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		manager.endRule(rule);
 	}
 
+	@Test
 	public void testRuleContainment() {
 		ISchedulingRule rules[] = new ISchedulingRule[4];
 
@@ -473,6 +487,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		manager.endRule(rules[1]);
 	}
 
+	@Test
 	public void testSimpleOtherThreadAccess() {
 		//ending a rule started on this thread from another thread
 		ISchedulingRule rule1 = new IdentityRule();
@@ -567,6 +582,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testIgnoreScheduleThreadJob() throws Exception {
 		Set<Job> jobsStartedRunning = Collections.synchronizedSet(new HashSet<>());
 		JobChangeAdapter runningThreadStoreListener = new JobChangeAdapter() {
@@ -592,6 +608,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 				not(hasItem(rescheduledJob)));
 	}
 
+	@Test
 	public void testRunThreadJobIsNotRescheduled() throws Exception {
 		Set<Job> jobsStartedRunning = Collections.synchronizedSet(new HashSet<>());
 		JobChangeAdapter runningThreadStoreListener = new JobChangeAdapter() {
@@ -615,9 +632,11 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		assertThat("ThreadJob was rescheduled", jobsStartedRunning, not(hasItem(scheduledJob)));
 	}
 
+	@Test
 	public void testRunNestedAcquireThreadIsNotRescheduled() throws Exception {
-		final PathRule rule = new PathRule(getName());
-		final PathRule subRule = new PathRule(getName() + "/subRule");
+		String name = "test";
+		final PathRule rule = new PathRule(name);
+		final PathRule subRule = new PathRule(name + "/subRule");
 
 		Set<Job> jobsStartedRunning = Collections.synchronizedSet(new HashSet<>());
 		JobChangeAdapter runningThreadStoreListener = new JobChangeAdapter() {
@@ -629,7 +648,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		Job.getJobManager().addJobChangeListener(runningThreadStoreListener);
 		TestBarrier2 waitForThreadJob = new TestBarrier2();
 		AtomicReference<Job> scheduledJob = new AtomicReference<>();
-		final Job job = new Job(getName() + "acquire") {
+		final Job job = new Job(name + "acquire") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
@@ -16,6 +16,8 @@ package org.eclipse.core.tests.runtime.jobs;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Regression test for bug 129551.  A job changes to the ABOUT_TO_RUN
@@ -53,14 +55,14 @@ public class Bug_129551 extends AbstractJobTest {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() {
 		//don't use fussy progress monitor, because in this case we kill
 		// a job before it has started running
 		manager.setProgressProvider(null);
 	}
 
+	@Test
 	public void testBug() throws InterruptedException {
 		ISchedulingRule rule = new IdentityRule();
 		BugJob job = new BugJob();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_211799.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_211799.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
+import org.junit.Test;
 
 /**
  * Regression test for bug 211799
@@ -67,6 +68,7 @@ public class Bug_211799 extends AbstractJobTest {
 
 	List<Long> runList = new ArrayList<>(JOBS_TO_SCHEDULE);
 
+	@Test
 	public void testBug() throws Exception {
 		for (int i = 0; i < JOBS_TO_SCHEDULE; i++) {
 			synchronized (list) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
@@ -13,9 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Test;
 
 /**
  * Regression test for bug 307282
@@ -34,6 +37,7 @@ public class Bug_307282 extends AbstractJobTest {
 	 * t1 release l1
 	 * main attempt acquire() l1
 	 */
+	@Test
 	public void testInterruptDuringLockAcquireint() throws Exception {
 
 		final ILock lock1 = Job.getJobManager().newLock();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307391.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307391.java
@@ -13,9 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Test;
 
 /**
  * Regression test for bug 307391
@@ -33,6 +36,7 @@ public class Bug_307391 extends AbstractJobTest {
 	 * java.lang.IllegalArgumentException: Cannot yieldRule job that is YIELDING
 	 * 		in JobManager#yieldRule
 	 */
+	@Test
 	public void testYieldWithlockAcquire() throws Exception {
 		final IdentityRule idSchedRule = new IdentityRule();
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -21,6 +23,7 @@ import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Test;
 
 /**
  * Make sure that IProgressMonitor's blocked/unblocked is invoked.
@@ -35,6 +38,7 @@ public class Bug_311756 extends AbstractJobTest {
 	 * Tests that the progress monitor blocked state is cleared in the normal case
 	 * that the rule becomes available after being blocked.
 	 */
+	@Test
 	public void testBlockingAndUnblockingMonitor() throws Exception {
 		final int[] blocked = new int[] {UNSET};
 		ProgressMonitorWrapper wrapper = new ProgressMonitorWrapper(new NullProgressMonitor()) {
@@ -87,6 +91,7 @@ public class Bug_311756 extends AbstractJobTest {
 	 * Tests that the progress monitor blocked state is cleared in the case that a rule
 	 * is transferring to the waiting job while blocked.
 	 */
+	@Test
 	public void testBlockingAndUnblockingMonitorUsingTransfer() throws Exception {
 		final int[] blocked = new int[] {UNSET};
 		final ProgressMonitorWrapper wrapper = new ProgressMonitorWrapper(new NullProgressMonitor()) {
@@ -150,6 +155,7 @@ public class Bug_311756 extends AbstractJobTest {
 	 * Tests that the progress monitor blocked state is cleared in the case that a rule
 	 * becomes available to a yielded job while it is blocked.
 	 */
+	@Test
 	public void testBlockingAndUnblockingMonitorUsingYield() throws Exception {
 		final int[] blocked = new int[] {-1};
 		final ProgressMonitorWrapper wrapper = new ProgressMonitorWrapper(new NullProgressMonitor()) {
@@ -208,6 +214,7 @@ public class Bug_311756 extends AbstractJobTest {
 	 * Tests that the progress monitor blocked state is cleared in the case that a rule
 	 * is transferred back to a yielded job while it is blocked.
 	 */
+	@Test
 	public void testBlockingAndUnblockingMonitorUsingYieldAndTransfer() throws Exception {
 		final int[] blocked = new int[] {-1};
 		final ProgressMonitorWrapper wrapper = new ProgressMonitorWrapper(new NullProgressMonitor()) {
@@ -258,4 +265,5 @@ public class Bug_311756 extends AbstractJobTest {
 		}
 		assertEquals(blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called", CLEARED, blocked[0]);
 	}
+	
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311863.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311863.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.runtime.jobs;
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Test;
 
 /**
  * Regression test for bug 311863
@@ -83,6 +84,7 @@ public class Bug_311863 extends AbstractJobTest {
 	 *
 	 * Particularly insidious as the UI thread is interrupted frequently
 	 */
+	@Test
 	public void testInterruptDuringLockRelease() throws Exception {
 		final TestBarrier2 tb1 = new TestBarrier2(-1);
 		final TestBarrier2 tb2 = new TestBarrier2(-1);

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_316839.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_316839.java
@@ -15,9 +15,16 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.internal.jobs.JobManager;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.ILock;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.tests.harness.TestBarrier2;
+import org.junit.Test;
 
 /**
  * Regression test for bug 316839.
@@ -33,6 +40,7 @@ public class Bug_316839 extends AbstractJobTest {
 	TestJob interruptingJob;
 	boolean lockGraphWasEmpty = true;
 
+	@Test
 	public void testBug() {
 		// Schedule jobs
 		yieldingJob = new YieldingTestJob("job with project rule "); //$NON-NLS-1$

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_320329.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_320329.java
@@ -14,14 +14,18 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.MultiRule;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.Test;
 
 /**
  * Regression test for bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=320329.
  */
 public class Bug_320329 extends AbstractJobTest {
 
+	@Test
 	public void testBug() {
 		Job j1 = new TestJob("job1", 10, 5);// 50 ms
 		Job j2 = new TestJob("job2");

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_366170.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_366170.java
@@ -14,9 +14,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.Semaphore;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.junit.Test;
 
 /**
  * Tests that scheduling multiple jobs with a delay and then blocking all active
@@ -28,6 +33,7 @@ import org.eclipse.core.runtime.jobs.Job;
 public class Bug_366170 extends AbstractJobTest {
 	private final Semaphore m_jobBStopHint = new Semaphore(1);
 
+	@Test
 	public void testBug() throws Exception {
 		System.out.println("--- Running the examle ---");
 		m_jobBStopHint.acquire();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertFalse;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_550738.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_550738.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,6 +24,8 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Regression test for bug 550738.
@@ -65,14 +70,14 @@ public class Bug_550738 extends AbstractJobTest {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void removeProgressProvider() throws Exception {
 		// don't use fussy progress monitor, because in this test we may kill
 		// a job before it has started running
 		manager.setProgressProvider(null);
 	}
 
+	@Test
 	public void testCancelSchedule() throws InterruptedException {
 		BusyLoopJob job = new BusyLoopJob();
 		try {
@@ -103,6 +108,7 @@ public class Bug_550738 extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testReportDoneOncePerSchedule() throws InterruptedException {
 		BusyLoopJob job = new BusyLoopJob();
 		EventCount eventCount = new EventCount();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -17,7 +17,11 @@ import static java.util.Collections.synchronizedList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +53,9 @@ import org.eclipse.core.runtime.jobs.MultiRule;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests the API of the class IJobManager
@@ -99,14 +106,6 @@ public class IJobManagerTest extends AbstractJobTest {
 
 	protected AtomicInteger scheduledJobs;
 
-	public IJobManagerTest() {
-		super("");
-	}
-
-	public IJobManagerTest(String name) {
-		super(name);
-	}
-
 	/**
 	 * Asserts the current job state
 	 */
@@ -140,9 +139,8 @@ public class IJobManagerTest extends AbstractJobTest {
 		return "UNKNOWN";
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		completedJobs = new AtomicInteger();
 		scheduledJobs = new AtomicInteger();
 		jobListeners = new IJobChangeListener[] {/* new VerboseJobListener(),*/
@@ -152,8 +150,8 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		for (IJobChangeListener jobListener : jobListeners) {
 			if (jobListener instanceof TestJobListener) {
 				((TestJobListener) jobListener).cancelAllJobs();
@@ -163,9 +161,9 @@ public class IJobManagerTest extends AbstractJobTest {
 		for (IJobChangeListener jobListener : jobListeners) {
 			manager.removeJobChangeListener(jobListener);
 		}
-		super.tearDown();
 	}
 
+	@Test
 	public void testBadGlobalListener() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { -1 });
 		Job job = new Job("testBadGlobalListener") {
@@ -190,6 +188,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testBadLocalListener() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { -1 });
 		Job job = new Job("testBadLocalListener") {
@@ -214,6 +213,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testBeginInvalidNestedRules() {
 		final ISchedulingRule root = new PathRule("/");
 		final ISchedulingRule invalid = new ISchedulingRule() {
@@ -240,6 +240,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * Tests that if we call beginRule with a monitor that has already been
 	 * cancelled, it won't try to obtain the rule.
 	 */
+	@Test
 	public void testCancellationPriorToBeginRuleWontHoldRule() throws Exception {
 		final Semaphore mainThreadSemaphore = new Semaphore(0);
 		final Semaphore lockSemaphore = new Semaphore(0);
@@ -285,6 +286,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * it will stop waiting, will throw an {@link OperationCanceledException},
 	 * and will clear the Thread.interrupted() flag.
 	 */
+	@Test
 	public void testCancellationWhileWaitingOnRule() throws Exception {
 		final Semaphore mainThreadSemaphore = new Semaphore(0);
 		final Semaphore lockSemaphore = new Semaphore(0);
@@ -337,6 +339,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests running a job that begins a rule but never ends it
 	 */
+	@Test
 	public void testBeginRuleNoEnd() throws InterruptedException {
 		final PathRule rule = new PathRule("testBeginRuleNoEnd");
 		Job job = new Job("testBeginRuleNoEnd") {
@@ -362,6 +365,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testBug48073() {
 		ISchedulingRule ruleA = new PathRule("/testBug48073");
 		ISchedulingRule ruleB = new PathRule("/testBug48073/B");
@@ -393,6 +397,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Regression test for bug 57656
 	 */
+	@Test
 	public void testBug57656() {
 		TestJob jobA = new TestJob("Job1");
 		TestJob jobB = new TestJob("Job2");
@@ -411,6 +416,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * returning the correct value when executed in a thread that is performing
 	 * asynchronous completion of a job (i.e., a UI Job)
 	 */
+	@Test
 	public void testCurrentJob() {
 		final Thread[] thread = new Thread[1];
 		final boolean[] done = new boolean[] {false};
@@ -453,6 +459,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests for {@link IJobManager#currentRule()}.
 	 */
+	@Test
 	public void testCurrentRule() {
 		//first test when not running in a job
 		runRuleSequence();
@@ -556,6 +563,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		return true;
 	}
 
+	@Test
 	public void testDelayedJob() {
 		//schedule a delayed job and ensure it doesn't start until instructed
 		int[] sleepTimes = new int[] { 0, 1, 5, 10, 50, 100, 200, 250 };
@@ -575,6 +583,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJobFamilyCancel() {
 		//test the cancellation of a family of jobs
 		final int NUM_JOBS = 20;
@@ -652,6 +661,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJobFamilyFind() {
 		//test of finding jobs based on the job family they belong to
 		final int NUM_JOBS = 20;
@@ -839,6 +849,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		allJobs.clear();
 	}
 
+	@Test
 	public void testJobFamilyJoin() {
 		//test the join method on a family of jobs
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
@@ -908,6 +919,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJobFamilyJoinCancelJobs() {
 		//test the join method on a family of jobs, then cancel the jobs that are blocking the join call
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
@@ -974,6 +986,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJobFamilyJoinCancelManager() {
 		//test the join method on a family of jobs, then cancel the call
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
@@ -1052,6 +1065,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * {@link IJobManager#join(Object, IProgressMonitor)}. See bug
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=195839.
 	 */
+	@Test
 	public void testJobFamilyJoinLockListener() throws OperationCanceledException, InterruptedException {
 		final TestJobFamily family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		int count = 5;
@@ -1071,6 +1085,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		lockListener.assertNotWaiting("JobManager has not finished waiting for lock");
 	}
 
+	@Test
 	public void testJobFamilyJoinNothing() throws OperationCanceledException, InterruptedException {
 		//test joining a bogus family, and the monitor should be used up
 		final FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -1083,6 +1098,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests joining a job that repeats in a loop
 	 */
+	@Test
 	public void testJobFamilyJoinRepeating() throws OperationCanceledException, InterruptedException {
 		Object family = new Object();
 		int count = 25;
@@ -1097,6 +1113,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests joining a job family that repeats but returns false to shouldSchedule
 	 */
+	@Test
 	public void testJobFamilyJoinShouldSchedule() throws OperationCanceledException, InterruptedException {
 		Object family = new Object();
 		final int count = 1;
@@ -1116,6 +1133,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests simple usage of the IJobManager.join() method.
 	 */
+	@Test
 	public void testJobFamilyJoinSimple() {
 		//test the join method on a family of jobs that is empty
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
@@ -1195,6 +1213,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 *  - waiting job is scheduled when job manager is suspended
 	 * In this scenario main job should not wait for the waiting job.
 	 */
+	@Test
 	public void testJobFamilyJoinWhenSuspended_1() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final int[] familyJobsCount = new int[] {-1};
@@ -1286,6 +1305,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 *  - waiting job is scheduled when job manager is suspended
 	 * In this scenario main job should not wait for the waiting job.
 	 */
+	@Test
 	public void testJobFamilyJoinWhenSuspended_2() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final int[] familyJobsCount = new int[] {-1};
@@ -1378,6 +1398,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 *  - job manager is resumed causing waiting job to start
 	 * In this scenario main thread should wait for the waiting job since the job was started before the join ended.
 	 */
+	@Test
 	public void testJobFamilyJoinWhenSuspended_3() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -1438,6 +1459,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJobFamilyNULL() {
 		//test methods that accept the null job family (i.e. all jobs)
 		final int NUM_JOBS = 20;
@@ -1493,9 +1515,9 @@ public class IJobManagerTest extends AbstractJobTest {
 		for (int i = 0; i < NUM_JOBS; i++) {
 			assertState("4." + i, jobs[i], Job.NONE);
 		}
-
 	}
 
+	@Test
 	public void testJobFamilySleep() {
 		//test the sleep method on a family of jobs
 		final int NUM_JOBS = 20;
@@ -1572,6 +1594,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests the API method IJobManager.wakeUp(family)
 	 */
+	@Test
 	public void testJobFamilyWakeUp() {
 		final int JOBS_PER_FAMILY = 10;
 		//create two different families of jobs
@@ -1688,6 +1711,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testMutexRule() {
 		final int JOB_COUNT = 10;
 		TestJob[] jobs = new TestJob[JOB_COUNT];
@@ -1716,6 +1740,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		jobs[JOB_COUNT - 1].cancel();
 	}
 
+	@Test
 	public void testOrder() throws Exception {
 		// ensure jobs are run in order from lowest to highest sleep time.
 		int[] sleepTimes = new int[] { 0, 1, 2, 5, 10, 15, 25, 50 };
@@ -1749,6 +1774,7 @@ public class IJobManagerTest extends AbstractJobTest {
 				empty());
 	}
 
+	@Test
 	public void testReverseOrder() throws InterruptedException {
 		// ensure that a job does not wait for one that is scheduled with a high delay
 		Job directlyExecutedJob = new TestJob("Directly executed job", 0, 0);
@@ -1765,6 +1791,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests conditions where there is a race to schedule the same job multiple times.
 	 */
+	@Test
 	public void testScheduleRace() {
 		final int[] count = new int[1];
 		final boolean[] running = new boolean[] {false};
@@ -1806,6 +1833,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		assertTrue("1.0", !failure[0]);
 	}
 
+	@Test
 	public void testSimple() {
 		final int JOB_COUNT = 10;
 		for (int i = 0; i < JOB_COUNT; i++) {
@@ -1822,6 +1850,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests setting various kinds of invalid rules on jobs.
 	 */
+	@Test
 	public void testSetInvalidRule() {
 		class InvalidRule implements ISchedulingRule {
 			@Override
@@ -1851,6 +1880,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		assertThrows(IllegalArgumentException.class, () -> job.setRule(multi));
 	}
 
+	@Test
 	public void testSleep() {
 		TestJob job = new TestJob("ParentJob", 1000000, 10);
 		//sleeping a job that isn't scheduled should have no effect
@@ -1881,6 +1911,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		assertTrue("3.4", job.cancel()); //should be possible to cancel a sleeping job
 	}
 
+	@Test
 	public void testSleepOnWait() {
 		final ISchedulingRule rule = new PathRule("testSleepOnWait");
 		TestJob blockingJob = new TestJob("Long Job", 1000000, 10);
@@ -1911,6 +1942,7 @@ public class IJobManagerTest extends AbstractJobTest {
 		waitForCompletion(job);
 	}
 
+	@Test
 	public void testSuspend() {
 		assertTrue("1.0", !manager.isSuspended());
 		manager.suspend();
@@ -1933,6 +1965,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * @deprecated tests deprecated API
 	 */
 	@Deprecated
+	@Test
 	public void testSuspendMismatchedBegins() {
 		PathRule rule1 = new PathRule("/TestSuspendMismatchedBegins");
 		PathRule rule2 = new PathRule("/TestSuspendMismatchedBegins/Child");
@@ -1961,6 +1994,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * @deprecated tests deprecated API
 	 */
 	@Deprecated
+	@Test
 	public void testSuspendMultiThreadAccess() {
 		PathRule rule1 = new PathRule("/TestSuspend");
 		PathRule rule2 = new PathRule("/TestSuspend/Child");
@@ -2025,6 +2059,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests IJobManager#transfer(ISchedulingRule, Thread) failure conditions.
 	 */
+	@Test
 	public void testTransferFailure() throws InterruptedException {
 		PathRule rule = new PathRule("/testTransferFailure");
 		PathRule subRule = new PathRule("/testTransferFailure/Sub");
@@ -2060,9 +2095,8 @@ public class IJobManagerTest extends AbstractJobTest {
 
 	/**
 	 * Tests transferring a scheduling rule from one job to another
-	 *
-	 * @throws CoreException
 	 */
+	@Test
 	public void testTransferJobToJob() throws CoreException {
 		final PathRule ruleToTransfer = new PathRule("testTransferJobToJob");
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -2107,6 +2141,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests transferring a scheduling rule to the same thread
 	 */
+	@Test
 	public void testTransferSameThread() {
 		PathRule rule = new PathRule("testTransferSameThread");
 		try {
@@ -2121,6 +2156,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Simple test of rule transfer
 	 */
+	@Test
 	public void testTransferSimple() throws Exception {
 		class RuleEnder implements Runnable {
 			Exception error;
@@ -2154,6 +2190,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests transferring a scheduling rule to a job and back again.
 	 */
+	@Test
 	public void testTransferToJob() throws Exception {
 		final PathRule rule = new PathRule("testTransferToJob");
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -2205,6 +2242,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	 * Tests transferring a scheduling rule to a job that is waiting for a child of
 	 * the transferred rule.
 	 */
+	@Test
 	public void testTransferToJobWaitingOnChildRule() throws Exception {
 		final PathRule rule = new PathRule("testTransferToJobWaitingOnChildRule");
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -2259,6 +2297,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests transferring a scheduling rule to a job that is waiting for that rule.
 	 */
+	@Test
 	public void testTransferToWaitingJob() throws Exception {
 		final PathRule rule = new PathRule("testTransferToWaitingJob");
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -2312,6 +2351,7 @@ public class IJobManagerTest extends AbstractJobTest {
 	/**
 	 * Tests a batch of jobs that use two mutually exclusive rules.
 	 */
+	@Test
 	public void testTwoRules() {
 		final int JOB_COUNT = 10;
 		TestJob[] jobs = new TestJob[JOB_COUNT];

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
@@ -17,8 +17,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.core.internal.jobs.JobListeners;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.IJobChangeListener;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.runtime.jobs.OrderAsserter.Event;
 import org.junit.Test;
@@ -27,7 +32,7 @@ import org.junit.Test;
  * Test for bug https://github.com/eclipse-platform/eclipse.platform/issues/193
  */
 @SuppressWarnings("restriction")
-public class JobEventTest {
+public class JobEventTest extends AbstractJobTest {
 	@Test
 	public void testScheduleOrderOfEvents() {
 		OrderAsserter asserter = new OrderAsserter();
@@ -387,11 +392,6 @@ public class JobEventTest {
 	}
 
 	@Test
-	public void testNoTimeoutOccured() throws Exception {
-		AbstractJobTest.assertNoTimeoutOccured();
-	}
-
-	@Test
 	public void testDeadlockRecovery() throws Exception {
 		Object commonLockObject = new Object();
 		TestBarrier2 waitingForJobListenerBarrier = new TestBarrier2();
@@ -433,7 +433,7 @@ public class JobEventTest {
 		final int DEADLOCK_TIMEOUT = 250;
 		final int ABORT_TEST_TIMEOUT = 60_000;
 		try {
-			testNoTimeoutOccured(); // before changing timeout
+			assertNoTimeoutOccured(); // before changing timeout
 			JobListeners.setJobListenerTimeout(DEADLOCK_TIMEOUT);
 			threadDeadlockingWithJobListener.start();
 			jobWithListener.schedule();

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -14,7 +14,14 @@
 
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +46,7 @@ import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.Test;
 
 /**
  * Tests for {@link JobGroup}.
@@ -46,6 +54,7 @@ import org.eclipse.core.tests.harness.TestJob;
 @SuppressWarnings("restriction")
 public class JobGroupTest extends AbstractJobTest {
 
+	@Test
 	public void testThrottlingWhenAllJobsAreKnown() {
 		final int NUM_JOBS = 100;
 		final int MAX_THREADS = 10;
@@ -96,6 +105,7 @@ public class JobGroupTest extends AbstractJobTest {
 		assertTrue("4.0", maxThreadsUsed[0] <= MAX_THREADS);
 	}
 
+	@Test
 	public void testSeedJobsWhenAllJobsAreKnown() {
 		final int NUM_SEED_JOBS = 3;
 		final JobGroup jobGroup = new JobGroup("JobGroup", 1, NUM_SEED_JOBS);
@@ -125,6 +135,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testSeedJobsWhenSeedJobsAddNewJobs() {
 		final int NUM_SEED_JOBS = 10;
 		final int NUM_CHILD_JOBS = 10;
@@ -170,6 +181,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testSeedJobsWithRepeatingJobs() {
 		final int NUM_SEED_JOBS = 10;
 		final int REPEATING_COUNT = 5;
@@ -191,6 +203,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testCancel() {
 		final int NUM_JOBS = 20;
 		TestJob[] jobs = new TestJob[NUM_JOBS];
@@ -256,6 +269,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testGetActiveJobs() {
 		final int NUM_JOBS = 20;
 		final int JOBS_PER_GROUP = NUM_JOBS / 5;
@@ -411,14 +425,15 @@ public class JobGroupTest extends AbstractJobTest {
 		// so check that there no jobs started by this test are present in all running jobs.
 		testJobs.addAll(Arrays.asList(jobs));
 		allJobs = manager.find(null);
-		for (int i = 0; i < allJobs.length; i++) {
+		for (Job job : allJobs) {
 			// Verify that no jobs that we know about are found (they should have all been removed)
-			assertFalse(allJobs[i].toString(), testJobs.remove(allJobs[i]));
+			assertFalse(job.toString(), testJobs.remove(job));
 		}
 		assertEquals("15.0", NUM_JOBS, testJobs.size());
 		testJobs.clear();
 	}
 
+	@Test
 	public void testJoinWithoutTimeout() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
 		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
@@ -487,6 +502,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJoinWithTimeout() {
 		TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 		final int NUM_JOBS = 20;
@@ -552,6 +568,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests joining on a job group, and then canceling the jobs that are blocking the join call.
 	 */
+	@Test
 	public void testJoinWithCancelingJobs() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
 		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
@@ -618,6 +635,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests joining on a job group, and then canceling the monitor.
 	 */
+	@Test
 	public void testJoinWithCancelingMonitor() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
 		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
@@ -689,6 +707,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests joining a job that repeats in a loop.
 	 */
+	@Test
 	public void testJoinWithRepeatingJobs() throws OperationCanceledException, InterruptedException {
 		JobGroup jobGroup = new JobGroup("JobGroup", 1, 1);
 		int count = 25;
@@ -704,6 +723,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 * Tests that joining a job from another job that is in the same job group
 	 * yields an IllegalStateException.
 	 */
+	@Test
 	public void testJoiningAJobInTheSameJobGroupFails() {
 		JobGroup jobGroup = new JobGroup("JobGroup", 2, 2);
 		final TestJob firstJob = new TestJob("FirstJob", 1000000, 10);
@@ -738,6 +758,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests that the progress is reported on the monitor used for join.
 	 */
+	@Test
 	public void testJoinWithProgressMonitor() {
 		final int NUM_JOBS = 100;
 		JobGroup jobGroup = new JobGroup("JobGroup", 10, NUM_JOBS);
@@ -769,6 +790,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 * Test for bug 543660 - JobGroup.join() blocks if scheduling more jobs as seed
 	 * count
 	 */
+	@Test
 	public void testJoinIfJobCoundExceedsSeedCount() throws Exception {
 		class ExclusiveRule implements ISchedulingRule {
 			@Override
@@ -860,6 +882,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 * WaitingJob as the WaitingJob is not going to be executed when the job manger
 	 * is suspended.
 	 */
+	@Test
 	public void testJoinWithJobManagerSuspended_1() throws InterruptedException {
 		final JobGroup jobGroup = new JobGroup("JobGroup", 1, 1);
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -925,6 +948,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   The join call on the JobGroup should not wait for the WaitingJob as the WaitingJob is not going
 	 *   to be executed when the job manger is suspended.
 	 */
+	@Test
 	public void testJoinWithJobManagerSuspended_2() throws InterruptedException {
 		final JobGroup jobGroup = new JobGroup("JobGroup", 1, 1);
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -1001,6 +1025,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   The join call on the JobGroup should wait for the WaitingJob as the WaitingJob was started
 	 *   to execute before the join ended.
 	 */
+	@Test
 	public void testJoinWithJobManagerSuspended_3() throws InterruptedException {
 		final JobGroup jobGroup = new JobGroup("JobGroup", 1, 1);
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -1070,6 +1095,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   The JobGroup should be canceled when the failing job is completed, because by default
 	 *   a job group is canceled when a job belonging to the group is failed.
 	 */
+	@Test
 	public void testShouldCancel_1() {
 		final int NUM_SEED_JOBS = 10;
 		final int NUM_ADDITIONAL_JOBs = 10;
@@ -1152,6 +1178,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   belonging to that group except the last one (shouldCancel method is not called after the
 	 *   completion of the last job in the jobGroup as there are no jobs left to cancel).
 	 */
+	@Test
 	public void testShouldCancel_2() {
 		final int NUM_JOBS = 10;
 		final int numShouldCancelCalled[] = {0};
@@ -1182,6 +1209,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   (the shouldCancel method is not called after the completion of the last job in the
 	 *   jobGroup as there are no jobs left to cancel).
 	 */
+	@Test
 	public void testShouldCancel_3() {
 		final int status[] = {IStatus.OK, IStatus.INFO, IStatus.WARNING, IStatus.ERROR, IStatus.CANCEL, IStatus.OK};
 		final int numShouldCancelCalled[] = {0};
@@ -1248,6 +1276,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *   The remaining jobs are canceled in a reasonable time after the shouldCancel method of the
 	 *   JobGroup returns true.
 	 */
+	@Test
 	public void testShouldCancel_4() {
 		final int NUM_JOBS = 1000;
 		final int NUM_JOBS_LIMIT = 100;
@@ -1293,6 +1322,7 @@ public class JobGroupTest extends AbstractJobTest {
 	 *
 	 * Expected result: The second job is explicitly canceled
 	 */
+	@Test
 	public void testShouldCancel_5() {
 		// the job group allows for 2 threads so both jobs will be started in
 		// parallel
@@ -1352,6 +1382,7 @@ public class JobGroupTest extends AbstractJobTest {
 		 */
 	}
 
+	@Test
 	public void testDefaultComputeGroupResult() {
 		final int status[] = {IStatus.OK, IStatus.INFO, IStatus.WARNING, IStatus.ERROR, IStatus.CANCEL};
 		final JobGroup jobGroup = new JobGroup("JobGroup", 1, status.length) {
@@ -1383,6 +1414,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testCustomComputeGroupResult() {
 		final MultiStatus returnedGroupResult[] = new MultiStatus[1];
 		final IStatus originalJobResults[][] = {new IStatus[0]};
@@ -1425,6 +1457,7 @@ public class JobGroupTest extends AbstractJobTest {
 	}
 
 	// https://bugs.eclipse.org/461621
+	@Test
 	public void testSlowComputeGroupResult() throws Exception {
 		final JobGroup jobGroup = new JobGroup("group", 1, 1) {
 			@Override
@@ -1453,6 +1486,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests that job groups work fine with normal jobs that are not belonging to any group.
 	 */
+	@Test
 	public void testJobGroupAlongWithNormalJobs() {
 		final int NUM_GROUP_JOBS = 1000;
 		final int NUM_NORMAL_JOBS = 100;
@@ -1485,6 +1519,7 @@ public class JobGroupTest extends AbstractJobTest {
 	/**
 	 * Tests that the JobManager publishes a final job group status to IJobChangeListeners.
 	 */
+	@Test
 	public void testJobManagerPublishesJobGroupResults() throws InterruptedException {
 		final int NUM_GROUP_JOBS = 3;
 		final String GROUP_NAME = "TestJobGroup";

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -21,8 +21,14 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -49,6 +55,10 @@ import org.eclipse.core.runtime.jobs.LockListener;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Tests the implemented get/set methods of the abstract class Job
@@ -58,12 +68,9 @@ public class JobTest extends AbstractJobTest {
 	protected Job longJob;
 	protected Job shortJob;
 
-	public JobTest(String name) {
-		super(name);
-	}
-
-	//see bug #43591
-	public void _testDone() {
+	@Test
+	@Ignore("see bug 43591")
+	public void testDone() {
 		//calling the done method on a job that is not executing asynchronously should have no effect
 
 		shortJob.done(Status.OK_STATUS);
@@ -104,16 +111,14 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		shortJob = new TestJob("Short Test Job", 10, 1); // job that tests wait on
 		longJob = new TestJob("Long Test Job", 10000000, 10); // job that never finishes in time
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		Job.getJobManager().setProgressProvider(null);
 		Job.getJobManager().setLockListener(null);
 		shortJob.cancel();
@@ -123,6 +128,7 @@ public class JobTest extends AbstractJobTest {
 	}
 
 	//see bug #43566
+	@Test
 	public void testAsynchJob() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 
@@ -201,6 +207,7 @@ public class JobTest extends AbstractJobTest {
 		assertNull("6.2", main.getThread());
 	}
 
+	@Test
 	public void testAsynchJobComplex() throws InterruptedException {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START,
 				TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START,
@@ -264,6 +271,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testAsynchJobConflict() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START,
 				TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START,
@@ -389,6 +397,7 @@ public class JobTest extends AbstractJobTest {
 	 * Tests cancelation of a job from the aboutToRun job event. See bug 70434 for
 	 * details.
 	 */
+	@Test
 	public void testCancelFromAboutToRun() throws InterruptedException {
 		final int[] doneCount = new int[] {0};
 		final int[] runningCount = new int[] {0};
@@ -419,6 +428,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Basic test of {@link Job#shouldRun()}.
 	 */
+	@Test
 	public void testShouldRun() throws InterruptedException {
 		class ShouldRunJob extends Job {
 			public ShouldRunJob() {
@@ -450,6 +460,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Test of an ill-behaving {@link Job#shouldRun()}.
 	 */
+	@Test
 	public void testShouldRunFailure() {
 		class ShouldRunJob extends Job {
 			public ShouldRunJob() {
@@ -481,6 +492,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Tests canceling a job from the shouldRun method. See bug 255384.
 	 */
+	@Test
 	public void testCancelShouldRun() throws OperationCanceledException, InterruptedException {
 		final String[] failure = new String[1];
 		final Job j = new Job("Test") {
@@ -534,6 +546,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Tests the hook method {@link Job#canceling}.
 	 */
+	@Test
 	public void testCanceling() {
 		final TestBarrier2 barrier = new TestBarrier2();
 		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
@@ -567,6 +580,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Tests the hook method {@link Job#canceling}.
 	 */
+	@Test
 	public void testCancelingByMonitor() {
 		final TestBarrier2 barrier = new TestBarrier2();
 		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
@@ -603,12 +617,14 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testCancelAboutToScheduleLegacy() throws InterruptedException {
 		JobListeners.setJobListenerTimeout(0);
 		testCancelAboutToSchedule();
 		JobListeners.resetJobListenerTimeout();
 	}
 
+	@Test
 	public void testCancelAboutToSchedule() throws InterruptedException {
 		final boolean[] failure = new boolean[1];
 		final Job j = new Job("testCancelAboutToSchedule") {
@@ -664,6 +680,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testGetName() {
 		assertEquals("1.0", "Short Test Job", shortJob.getName());
 		assertEquals("1.1", "Long Test Job", longJob.getName());
@@ -672,6 +689,7 @@ public class JobTest extends AbstractJobTest {
 		assertThrows(RuntimeException.class, () -> new TestJob(null));
 	}
 
+	@Test
 	public void testGetPriority() {
 		//set priorities to all allowed options
 		//check if getPriority() returns proper result
@@ -684,6 +702,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testGetProperty() {
 		QualifiedName n1 = new QualifiedName("org.eclipse.core.tests.runtime", "p1");
 		QualifiedName n2 = new QualifiedName("org.eclipse.core.tests.runtime", "p2");
@@ -700,6 +719,7 @@ public class JobTest extends AbstractJobTest {
 		assertNull("1.6", shortJob.getProperty(n2));
 	}
 
+	@Test
 	public void testGetResult() {
 		//execute a short job
 		assertNull("1.0", shortJob.getResult());
@@ -716,6 +736,7 @@ public class JobTest extends AbstractJobTest {
 		assertEquals("2.0", IStatus.CANCEL, longJob.getResult().getSeverity());
 	}
 
+	@Test
 	public void testGetRule() {
 		//set several rules for the job, check if getRule returns the rule that was set
 		//no rule was set yet
@@ -732,6 +753,7 @@ public class JobTest extends AbstractJobTest {
 		assertNull("1.3", shortJob.getRule());
 	}
 
+	@Test
 	public void testGetThread() {
 		//check that getThread returns the thread that was passed in setThread, when the job is not running
 		//if the job is scheduled, only jobs that return the asynch_exec status will run in the indicated thread
@@ -750,6 +772,7 @@ public class JobTest extends AbstractJobTest {
 		assertNull("1.3", shortJob.getThread());
 	}
 
+	@Test
 	public void testIsBlocking() {
 		IdentityRule rule = new IdentityRule();
 		TestJob high = new TestJob("TestIsBlocking.long", 10000, 100);
@@ -797,6 +820,7 @@ public class JobTest extends AbstractJobTest {
 	}
 
 	// @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=60964
+	@Test
 	public void testIsBlocking2() throws InterruptedException {
 		final ISchedulingRule rule = new IdentityRule();
 		Thread thread = new Thread("testIsBlocking2") {
@@ -822,6 +846,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testIsSystem() {
 		//reset the system parameter several times
 		shortJob.setUser(false);
@@ -836,6 +861,7 @@ public class JobTest extends AbstractJobTest {
 		assertTrue("1.5", !shortJob.isSystem());
 	}
 
+	@Test
 	public void testIsUser() {
 		//reset the user parameter several times
 		shortJob.setUser(false);
@@ -850,6 +876,7 @@ public class JobTest extends AbstractJobTest {
 		assertTrue("1.5", !shortJob.isSystem());
 	}
 
+	@Test
 	public void testJoin() throws InterruptedException {
 		longJob.schedule(100000);
 		//create a thread that will join the test job
@@ -886,6 +913,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJoinWithTimeout() throws Exception {
 		longJob.schedule();
 		waitForState(longJob, Job.RUNNING);
@@ -922,6 +950,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJoinWithProgressMonitor() throws Exception {
 		shortJob.schedule(100000);
 		// Create a progress monitor for the join call
@@ -951,6 +980,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJoinWithCancelingMonitor() throws InterruptedException {
 		longJob.schedule();
 		waitForState(longJob, Job.RUNNING);
@@ -988,6 +1018,7 @@ public class JobTest extends AbstractJobTest {
 		}
 	}
 
+	@Test
 	public void testJoinInterruptNonUIThread() throws InterruptedException {
 		TestBarrier2 barrier = new TestBarrier2();
 		Job.getJobManager().setLockListener(new LockListener() {
@@ -1014,6 +1045,7 @@ public class JobTest extends AbstractJobTest {
 		assertEquals("Thread not interrupted", Status.OK_STATUS, job.getResult());
 	}
 
+	@Test
 	public void testJoinInterruptUIThread() throws InterruptedException {
 		final Job job = new TestJob("job", 3, org.eclipse.core.internal.jobs.JobManager.MAX_WAIT_INTERVAL);
 		Thread t = new Thread(() -> {
@@ -1044,6 +1076,7 @@ public class JobTest extends AbstractJobTest {
 	 * {@link Job#join()}.
 	 * See bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=195839.
 	 */
+	@Test
 	public void testJoinLockListener() throws InterruptedException {
 		TestJob longRunningTestJob = new TestJob("testJoinLockListener", 100000, 10);
 		longRunningTestJob.schedule();
@@ -1061,6 +1094,7 @@ public class JobTest extends AbstractJobTest {
 	 *
 	 * @throws InterruptedException
 	 */
+	@Test
 	public void testJoinFailingListener() throws InterruptedException {
 		shortJob.addJobChangeListener(new JobChangeAdapter() {
 			@Override
@@ -1095,6 +1129,7 @@ public class JobTest extends AbstractJobTest {
 	 *
 	 * @throws InterruptedException
 	 */
+	@Test
 	public void testJoinSelf() throws InterruptedException {
 		final Exception[] failure = new Exception[1];
 		Job selfJoiner = new Job("testJoinSelf") {
@@ -1120,6 +1155,7 @@ public class JobTest extends AbstractJobTest {
 	 *
 	 * @throws InterruptedException
 	 */
+	@Test
 	public void testJoinRemoveListener() throws InterruptedException {
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
@@ -1153,6 +1189,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Test that a canceled job is rescheduled
 	 */
+	@Test
 	public void testRescheduleCancel() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 		Job job = new Job("Testing") {
@@ -1187,6 +1224,7 @@ public class JobTest extends AbstractJobTest {
 	 * Test that multiple reschedules of the same job while it is running
 	 * only remembers the last reschedule request
 	 */
+	@Test
 	public void testRescheduleComplex() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 		final int[] runCount = new int[] {0};
@@ -1226,6 +1264,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Reschedule a running job with a delay
 	 */
+	@Test
 	public void testRescheduleDelay() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 		final int[] runCount = new int[] {0};
@@ -1268,6 +1307,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Schedule a simple job that repeats several times from within the run method.
 	 */
+	@Test
 	public void testRescheduleRepeat() {
 		final int[] count = new int[] {0};
 		final int REPEATS = 10;
@@ -1300,6 +1340,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Schedule a long running job several times without blocking current thread.
 	 */
+	@Test
 	public void testRescheduleRepeating() {
 		AtomicLong runCount = new AtomicLong();
 		AtomicLong scheduledCount = new AtomicLong();
@@ -1364,7 +1405,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Schedule a simple job that repeats several times from within the run method.
 	 */
-
+	@Test
 	public void testRescheduleRepeatWithDelay() {
 		final int[] count = new int[] {0};
 		final int REPEATS = 10;
@@ -1397,6 +1438,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Schedule a job to run, and then reschedule it
 	 */
+	@Test
 	public void testRescheduleSimple() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 		Job job = new Job("testRescheduleSimple") {
@@ -1441,6 +1483,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * Reschedule a waiting job.
 	 */
+	@Test
 	public void testRescheduleWaiting() {
 		final AtomicIntegerArray status = new AtomicIntegerArray(
 				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
@@ -1504,6 +1547,7 @@ public class JobTest extends AbstractJobTest {
 	 * @see <a href=
 	 *      "https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/122">eclipse.jdt.debug/issues/122</a>
 	 */
+	@Test
 	public void testRescheduleFromDone() throws InterruptedException {
 		AtomicInteger runningCount = new AtomicInteger();
 		final Job j = new Job("testCancelAboutToSchedule") {
@@ -1547,6 +1591,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * see bug #43458
 	 */
+	@Test
 	public void testSetPriority() {
 		int[] wrongPriority = {1000, -Job.DECORATE, 25, 0, 5, Job.INTERACTIVE - Job.BUILD};
 
@@ -1560,6 +1605,7 @@ public class JobTest extends AbstractJobTest {
 	/**
 	 * Tests the API methods Job.setProgressGroup
 	 */
+	@Test
 	public void testSetProgressGroup() {
 		final TestBarrier2 barrier = new TestBarrier2();
 		Job job = new Job("testSetProgressGroup") {
@@ -1594,6 +1640,7 @@ public class JobTest extends AbstractJobTest {
 		group.done();
 	}
 
+	@Test
 	public void testSetProgressGroup_propagatesGroupCancellation() throws InterruptedException {
 		Job checkMonitorJob = createJobReactingToCancelRequest();
 
@@ -1628,6 +1675,7 @@ public class JobTest extends AbstractJobTest {
 	/*
 	 * see bug #43459
 	 */
+	@Test
 	public void testSetRule() {
 		//setting a scheduling rule for a job after it was already scheduled should throw an exception
 		shortJob.setRule(new IdentityRule());
@@ -1655,6 +1703,7 @@ public class JobTest extends AbstractJobTest {
 		assertNull("1.3", shortJob.getRule());
 	}
 
+	@Test
 	public void testSetThread() {
 		//setting the thread of a job that is not an asynchronous job should not affect the actual thread the job will run in
 		assertNull("0.0", longJob.getThread());

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/MultiRuleTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/MultiRuleTest.java
@@ -13,14 +13,19 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.MultiRule;
+import org.junit.Test;
 
 /**
  * Tests for {@link MultiRule}.
  */
 public class MultiRuleTest extends AbstractJobTest {
 
+	@Test
 	public void testCombine() {
 		ISchedulingRule child1 = new PathRule("/a");
 		ISchedulingRule child2 = new PathRule("/b/c");
@@ -45,6 +50,7 @@ public class MultiRuleTest extends AbstractJobTest {
 
 	}
 
+	@Test
 	public void testContains() {
 		ISchedulingRule child1 = new PathRule("/a");
 		ISchedulingRule child2 = new PathRule("/b/c");
@@ -62,6 +68,7 @@ public class MultiRuleTest extends AbstractJobTest {
 		assertTrue("1.6", multi1.contains(multi1));
 	}
 
+	@Test
 	public void testIsConflicting() {
 		ISchedulingRule child1 = new PathRule("/a");
 		ISchedulingRule child2 = new PathRule("/b/c");


### PR DESCRIPTION
* Remove the TestCase inheritance of AbstractJobTest
* Add `@Test` annotations
* Replace override of `@Before`/`@After` methods
* Remove unused code

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903