### PR TITLE
Remove class hierarchy from runtime performance tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchElementTree.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchElementTree.java
@@ -16,7 +16,6 @@ package org.eclipse.core.tests.resources.perf;
 
 import java.util.ArrayList;
 import org.eclipse.core.internal.watson.ElementTree;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.junit.Rule;
@@ -51,7 +50,7 @@ public class BenchElementTree {
 	 * Tests the performance of the createElement operation.
 	 */
 	@Test
-	public void testCreateElement() throws CoreException {
+	public void testCreateElement() throws Exception {
 		new PerformanceTestRunner() {
 			@Override
 			protected void test() {
@@ -64,7 +63,7 @@ public class BenchElementTree {
 	 * Tests the performance of the deleteElement operation.
 	 */
 	@Test
-	public void testDeleteElement() throws CoreException {
+	public void testDeleteElement() throws Exception {
 		final int repeat = 400;
 
 		/* create copies of the original tree */
@@ -89,7 +88,7 @@ public class BenchElementTree {
 	 * Tests the performance of the getElementData operation.
 	 */
 	@Test
-	public void testGetElementData() throws CoreException {
+	public void testGetElementData() throws Exception {
 		ElementTree tree = createTestTree(false);
 
 		new PerformanceTestRunner() {
@@ -106,7 +105,7 @@ public class BenchElementTree {
 	 * Tests the performance of the mergeDeltaChain operation.
 	 */
 	@Test
-	public void testMergeDeltaChain() throws CoreException {
+	public void testMergeDeltaChain() throws Exception {
 		final int repeat = 50;
 
 		/* create all the test trees */
@@ -133,7 +132,7 @@ public class BenchElementTree {
 	 * a new delta is generated for each operation.
 	 */
 	@Test
-	public void testRoutineOperations() throws CoreException {
+	public void testRoutineOperations() throws Exception {
 		new PerformanceTestRunner() {
 			@Override
 			protected void test() {
@@ -146,7 +145,7 @@ public class BenchElementTree {
 	 * Tests the performance of the setElementData operation.
 	 */
 	@Test
-	public void testSetElementData() throws CoreException {
+	public void testSetElementData() throws Exception {
 		ElementTree tree = createTestTree(false);
 		Object data = new Object();
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchMiscWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchMiscWorkspace.java
@@ -55,7 +55,7 @@ public class BenchMiscWorkspace {
 	}
 
 	@Test
-	public void testGetProject() throws CoreException {
+	public void testGetProject() throws Exception {
 		new PerformanceTestRunner() {
 			@Override
 			protected void test() {

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/PerformanceTestRunner.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/PerformanceTestRunner.java
@@ -89,13 +89,13 @@ public abstract class PerformanceTestRunner {
 	 * @param outer          The number of repetitions of the test.
 	 * @param inner          The number of repetitions within the performance timer.
 	 */
-	public final void run(Class<?> testClass, String testMethodName, int outer, int inner) throws CoreException {
+	public final void run(Class<?> testClass, String testMethodName, int outer, int inner) throws Exception {
 		Performance perf = Performance.getDefault();
 		PerformanceMeter meter = perf.createPerformanceMeter(perf.getDefaultScenarioId(testClass, testMethodName));
 		runTest(meter, null, outer, inner);
 	}
 
-	private void runTest(PerformanceMeter meter, String localName, int outer, int inner) throws CoreException {
+	private void runTest(PerformanceMeter meter, String localName, int outer, int inner) throws Exception {
 		Performance perf = Performance.getDefault();
 		if (regressionReason != null) {
 			perf.setComment(meter, Performance.EXPLAINS_DEGRADATION_COMMENT, regressionReason);
@@ -123,11 +123,11 @@ public abstract class PerformanceTestRunner {
 		}
 	}
 
-	protected void setUp() throws CoreException {
+	protected void setUp() throws Exception {
 		// subclasses to override
 	}
 
-	protected void tearDown() throws CoreException {
+	protected void tearDown() throws Exception {
 		// subclasses to override
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLSessionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLSessionTest.java
@@ -14,10 +14,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.runtime;
 
+import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -27,13 +29,13 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.stream.Collectors;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.runtime.RuntimeTest;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.osgi.service.datalocation.Location;
 
-public class PlatformURLSessionTest extends RuntimeTest {
+public class PlatformURLSessionTest extends TestCase {
 
 	private static final String CONFIG_URL = "platform:/config/" + PI_RUNTIME_TESTS + "/";
 	private static final String DATA_CHILD = "child";
@@ -80,8 +82,8 @@ public class PlatformURLSessionTest extends RuntimeTest {
 		assertEquals(tag + ".1", "file", childConfigURL.getProtocol());
 		File childConfigPrivateDir = new File(childConfigURL.getPath(), PI_RUNTIME_TESTS);
 		childConfigPrivateDir.mkdirs();
-		createFileWithContents(new File(childConfigPrivateDir, FILE_CHILD_ONLY), getContents(DATA_CHILD));
-		createFileWithContents(new File(childConfigPrivateDir, FILE_BOTH_PARENT_AND_CHILD), getContents(DATA_CHILD));
+		createFileWithContents(new File(childConfigPrivateDir, FILE_CHILD_ONLY), DATA_CHILD);
+		createFileWithContents(new File(childConfigPrivateDir, FILE_BOTH_PARENT_AND_CHILD), DATA_CHILD);
 
 		Location parent = Platform.getConfigurationLocation().getParentLocation();
 		// tests run with cascaded configuration
@@ -91,14 +93,14 @@ public class PlatformURLSessionTest extends RuntimeTest {
 		assertEquals(tag + ".4", "file", parentConfigURL.getProtocol());
 		File parentConfigPrivateDir = new File(parentConfigURL.getPath(), PI_RUNTIME_TESTS);
 		parentConfigPrivateDir.mkdirs();
-		createFileWithContents(new File(parentConfigPrivateDir, FILE_PARENT_ONLY), getContents(DATA_PARENT));
-		createFileWithContents(new File(parentConfigPrivateDir, FILE_ANOTHER_PARENT_ONLY), getContents(DATA_PARENT));
-		createFileWithContents(new File(parentConfigPrivateDir, FILE_BOTH_PARENT_AND_CHILD), getContents(DATA_PARENT));
+		createFileWithContents(new File(parentConfigPrivateDir, FILE_PARENT_ONLY), DATA_PARENT);
+		createFileWithContents(new File(parentConfigPrivateDir, FILE_ANOTHER_PARENT_ONLY), DATA_PARENT);
+		createFileWithContents(new File(parentConfigPrivateDir, FILE_BOTH_PARENT_AND_CHILD), DATA_PARENT);
 	}
 
-	private void createFileWithContents(File file, InputStream contents) throws IOException {
-		try (contents; FileOutputStream output = new FileOutputStream(file)) {
-			contents.transferTo(output);
+	private void createFileWithContents(File file, String contents) throws IOException {
+		try (InputStream input = new ByteArrayInputStream(contents.getBytes()); FileOutputStream output = new FileOutputStream(file)) {
+			input.transferTo(output);
 		}
 
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/BenchPath.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/BenchPath.java
@@ -14,11 +14,12 @@
 package org.eclipse.core.tests.runtime.perf;
 
 import java.util.HashMap;
+import junit.framework.TestCase;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.runtime.RuntimeTest;
 
-public class BenchPath extends RuntimeTest {
+public class BenchPath extends TestCase {
+	
 	public BenchPath() {
 		super();
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
@@ -14,14 +14,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.perf;
 
+import static org.eclipse.core.tests.harness.FileSystemHelper.clear;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
+import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
+
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.net.MalformedURLException;
 import java.net.URL;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.core.internal.content.ContentTypeBuilder;
 import org.eclipse.core.internal.content.ContentTypeHandler;
@@ -35,7 +39,6 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.harness.TestRegistryChangeListener;
-import org.eclipse.core.tests.runtime.RuntimeTest;
 import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
 import org.eclipse.core.tests.session.PerformanceSessionTestSuite;
 import org.eclipse.core.tests.session.SessionTestSuite;
@@ -43,7 +46,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
 @SuppressWarnings("restriction")
-public class ContentTypePerformanceTest extends RuntimeTest {
+public class ContentTypePerformanceTest extends TestCase {
 
 	private final static String CONTENT_TYPE_PREF_NODE = Platform.PI_RUNTIME + IPath.SEPARATOR + "content-types"; //$NON-NLS-1$
 	private static final String DEFAULT_NAME = "file_" + ContentTypePerformanceTest.class.getName();
@@ -183,7 +186,8 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 		return getTempDir().append(TEST_DATA_ID);
 	}
 
-	private Bundle installContentTypes(String tag, int numberOfLevels, int nodesPerLevel) {
+	private Bundle installContentTypes(String tag, int numberOfLevels, int nodesPerLevel)
+			throws IOException, BundleException {
 		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME, ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		Bundle installed = null;
 		listener.register();
@@ -191,12 +195,7 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 			IPath pluginLocation = getExtraPluginLocation();
 			assertTrue(pluginLocation.toFile().mkdirs());
 			assertTrue(pluginLocation.append("META-INF").toFile().mkdirs());
-			URL installURL = null;
-			try {
-				installURL = pluginLocation.toFile().toURI().toURL();
-			} catch (MalformedURLException e) {
-				fail(tag + ".0.5", e);
-			}
+			URL installURL = pluginLocation.toFile().toURI().toURL();
 			String eol = System.lineSeparator();
 			try (Writer writer = new BufferedWriter(new FileWriter(pluginLocation.append("plugin.xml").toFile()),
 					0x10000)) {
@@ -207,8 +206,6 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 				String root = createContentType(writer, 0, null);
 				createContentTypes(writer, root, 1, numberOfLevels, nodesPerLevel);
 				writer.write("</extension></plugin>");
-			} catch (IOException e) {
-				fail(tag + ".1.0", e);
 			}
 			try (Writer writer = new BufferedWriter(
 					new FileWriter(pluginLocation.append("META-INF").append("MANIFEST.MF").toFile()),
@@ -224,14 +221,8 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 				writer.write("Bundle-Version: 1.0\n");
 				writer.write("Require-Bundle: " + PI_RUNTIME_TESTS);
 				writer.write(eol);
-			} catch (IOException e) {
-				fail(tag + ".2.0", e);
 			}
-			try {
-				installed = RuntimeTestsPlugin.getContext().installBundle(installURL.toExternalForm());
-			} catch (BundleException e) {
-				fail(tag + ".3.0", e);
-			}
+			installed = RuntimeTestsPlugin.getContext().installBundle(installURL.toExternalForm());
 			BundleTestingHelper.refreshPackages(RuntimeTestsPlugin.getContext(), new Bundle[] {installed});
 			assertTrue(tag + ".4.0", listener.eventReceived(10000));
 		} finally {
@@ -291,15 +282,16 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 		new PerformanceTestRunner() {
 			@Override
 			protected void test() {
-				try {
-					for (int i = 0; i < TOTAL_NUMBER_OF_ELEMENTS; i++) {
-						String id = getContentTypeId(i);
-						IContentType[] result = manager.findContentTypesFor(new ByteArrayInputStream(getSignature(i)), DEFAULT_NAME);
-						assertEquals("1.0." + i, 1, result.length);
-						assertEquals("1.1." + i, id, result[0].getId());
+				for (int i = 0; i < TOTAL_NUMBER_OF_ELEMENTS; i++) {
+					String id = getContentTypeId(i);
+					IContentType[] result;
+					try {
+						result = manager.findContentTypesFor(new ByteArrayInputStream(getSignature(i)), DEFAULT_NAME);
+					} catch (IOException e) {
+						throw new IllegalStateException("unexpected exception occurred", e);
 					}
-				} catch (IOException e) {
-					fail("2.0", e);
+					assertEquals("1.0." + i, 1, result.length);
+					assertEquals("1.1." + i, id, result[0].getId());
 				}
 			}
 		}.run(this, 10, 2);
@@ -311,24 +303,17 @@ public class ContentTypePerformanceTest extends RuntimeTest {
 		if (getName().equals("testDoSetUp") || getName().equals("testDoTearDown")) {
 			return;
 		}
-		Bundle installed = null;
-		try {
-			installed = RuntimeTestsPlugin.getContext()
+		Bundle installed = RuntimeTestsPlugin.getContext()
 					.installBundle(getExtraPluginLocation().toFile().toURI().toURL().toExternalForm());
-		} catch (BundleException e) {
-			fail("1.0", e);
-		} catch (MalformedURLException e) {
-			fail("2.0", e);
-		}
 		BundleTestingHelper.refreshPackages(RuntimeTestsPlugin.getContext(), new Bundle[] { installed });
 	}
 
-	public void testDoSetUp() {
+	public void testDoSetUp() throws IOException, BundleException {
 		installContentTypes("1.0", NUMBER_OF_LEVELS, ELEMENTS_PER_LEVEL);
 	}
 
 	public void testDoTearDown() {
-		ensureDoesNotExistInFileSystem(getExtraPluginLocation().toFile());
+		clear(getExtraPluginLocation().toFile());
 	}
 
 	public void testIsKindOf() {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/PreferencePerformanceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/PreferencePerformanceTest.java
@@ -14,15 +14,16 @@
 package org.eclipse.core.tests.runtime.perf;
 
 import java.util.ArrayList;
+import java.util.UUID;
+import junit.framework.TestCase;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.internal.preferences.TestScope;
-import org.eclipse.core.tests.runtime.RuntimeTest;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
-public class PreferencePerformanceTest extends RuntimeTest {
+public class PreferencePerformanceTest extends TestCase {
 	private static final int INNER_LOOP = 10000;
 	private static final int KEYS_PER_NODE = 1000;
 
@@ -116,12 +117,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			//  clean-up
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// test retrieval
@@ -163,12 +160,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			// clean-up
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// how long to get the values?
@@ -207,12 +200,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			// clean-up
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// how long to get the values?
@@ -250,12 +239,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			// clean-up
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// how long to get the values?
@@ -295,12 +280,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			// clean-up
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// how long to set the values?
@@ -344,12 +325,8 @@ public class PreferencePerformanceTest extends RuntimeTest {
 
 			// clean-up at the end of each run
 			@Override
-			protected void tearDown() {
-				try {
-					prefs.removeNode();
-				} catch (BackingStoreException e) {
-					fail("0.99", e);
-				}
+			protected void tearDown() throws BackingStoreException {
+				prefs.removeNode();
 			}
 
 			// can only run this once because there is only so many keys you can remove
@@ -363,4 +340,9 @@ public class PreferencePerformanceTest extends RuntimeTest {
 			}
 		}.run(this, 50, 1);
 	}
+
+	private String getUniqueString() {
+		return UUID.randomUUID().toString();
+	}
+
 }


### PR DESCRIPTION
This removes the CoreTest/RuntimeTest inheritance from remaining runtime performance tests and replaces it with inheritance from the general TestCase. The inheritance cannot be completely removes as the performance tests rely on the session test framework which still requires JUnit 3 TestCase inheritance.