### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/ant/org.eclipse.ant.core/forceQualifierUpdate.txt
+++ b/ant/org.eclipse.ant.core/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 465126 - Comparator errors related to Eclipse-SourceBundle
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ant/org.eclipse.ant.launching/forceQualifierUpdate.txt
+++ b/ant/org.eclipse.ant.launching/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 465126 - Comparator errors related to Eclipse-SourceBundle
 Bug 480835 - Failures in build due to changes not being picked up by tests
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ant/org.eclipse.ant.tests.core/forceQualifierUpdate.txt
+++ b/ant/org.eclipse.ant.tests.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ant/org.eclipse.ant.tests.ui/forceQualifierUpdate.txt
+++ b/ant/org.eclipse.ant.tests.ui/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ant/org.eclipse.ant.ui/forceQualifierUpdate.txt
+++ b/ant/org.eclipse.ant.ui/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 465126 - Comparator errors related to Eclipse-SourceBundle
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.core/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.examples.core/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.examples.core/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.examples.ui/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.examples.ui/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.tests/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 516076 - Fix comparator errors caused by GVT47 : Non-externalized strings in Launch mode drop down list
 Bug 517740: [Launch Group] Externalisation of strings broke Group Launch UI
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.ui.launchview/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.ui.launchview/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.debug.ui/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.ui/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.ui.console/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.ui.console/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.ui.externaltools/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.ui.externaltools/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/debug/org.eclipse.unittest.ui/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.unittest.ui/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/resources/examples/org.eclipse.ui.examples.filesystem/forceQualifierUpdate.txt
+++ b/resources/examples/org.eclipse.ui.examples.filesystem/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/bundles/org.eclipse.core.contenttype/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.contenttype/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/bundles/org.eclipse.core.expressions/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.expressions/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/bundles/org.eclipse.core.jobs/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.jobs/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 493109: Build failed due to qualifier heuristics on core.runtime.feature
 Bug 547066 - IBuild I20190507-1800 failed due to unresolved project dependencies.
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 XML Refactoring
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/bundles/org.eclipse.e4.core.di/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.e4.core.di/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/tests/org.eclipse.core.expressions.tests/forceQualifierUpdate.txt
+++ b/runtime/tests/org.eclipse.core.expressions.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/runtime/tests/org.eclipse.e4.core.tests/forceQualifierUpdate.txt
+++ b/runtime/tests/org.eclipse.e4.core.tests/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 562167 - Comparator errors in I20200415-0620
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 466408: Split 'org.eclipse.compare.patch' packages do not have identical certificate
 Pick up new signing certificate (same as bug 466408)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.compare.win32/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare.win32/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.compare/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 571840 - 4.20 I-Build: I20210310-0250 - Comparator Errors Found
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.core.net.linux/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.core.net.linux/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.core.net.win32/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.core.net.win32/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.core.net/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.core.net/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.jsch.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.jsch.core/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.jsch.ui/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.jsch.ui/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.team.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.team.core/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Comparator errors in I20230607-0720
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 Comparator errors in I20230906-0400
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1557
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/bundles/org.eclipse.team.ui/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.team.ui/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/examples/org.eclipse.compare.examples.xml/forceQualifierUpdate.txt
+++ b/team/examples/org.eclipse.compare.examples.xml/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/examples/org.eclipse.team.examples.filesystem/forceQualifierUpdate.txt
+++ b/team/examples/org.eclipse.team.examples.filesystem/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/tests/org.eclipse.compare.tests/forceQualifierUpdate.txt
+++ b/team/tests/org.eclipse.compare.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/tests/org.eclipse.core.tests.net/forceQualifierUpdate.txt
+++ b/team/tests/org.eclipse.core.tests.net/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/team/tests/org.eclipse.team.tests.core/forceQualifierUpdate.txt
+++ b/team/tests/org.eclipse.team.tests.core/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.help.ui/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.help.ui/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 510796 - Comparator errors in I20170120-2000
 Bug 511251 - Comparator errors in I20170127-2200
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.help/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.help/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.tips.ide/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.tips.ide/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.tips.json/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.tips.json/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.tips.ui/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.tips.ui/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.ua.tests.doc/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.ua.tests.doc/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.ua.tests/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.ua.tests/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 489235: Comparator Failures in build I20160308-0800
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.ui.cheatsheets/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.ui.cheatsheets/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/ua/org.eclipse.ui.intro.universal/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.ui.intro.universal/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 560202: Comparator error in I20200215-1800
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/update/org.eclipse.update.configurator/forceQualifierUpdate.txt
+++ b/update/org.eclipse.update.configurator/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659