### PR TITLE
Replace remaining usages of CoreTest

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/filesystem/wrapper/WrapperFileSystem.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/filesystem/wrapper/WrapperFileSystem.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.filesystem.wrapper;
 
+import static org.eclipse.core.runtime.Platform.getBundle;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 
 import java.net.URI;
@@ -23,8 +24,10 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.provider.FileSystem;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 
 /**
  * A simple file system implementation that acts as a wrapper around the
@@ -93,7 +96,8 @@ public class WrapperFileSystem extends FileSystem {
 		try {
 			baseStore = EFS.getStore(getBasicURI(uri));
 		} catch (CoreException e) {
-			CoreTest.log(PI_RESOURCES_TESTS, e);
+			ILog.of(getBundle(PI_RESOURCES_TESTS))
+					.log(new Status(IStatus.ERROR, PI_RESOURCES_TESTS, IStatus.ERROR, "Error", e));
 			return NULL_ROOT;
 		}
 		return WrapperFileStore.newInstance(customFS, baseStore);

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/BundleTestingHelper.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/BundleTestingHelper.java
@@ -104,10 +104,9 @@ public class BundleTestingHelper {
 				try {
 					installed[i] = installBundle(tag + ".setup.0", context, locations[i]);
 					Assert.assertEquals(tag + ".setup.1." + locations[i], Bundle.INSTALLED, installed[i].getState());
-				} catch (BundleException e) {
-					CoreTest.fail(tag + ".setup.2" + locations[i], e);
-				} catch (IOException e) {
-					CoreTest.fail(tag + ".setup.3" + locations[i], e);
+				} catch (BundleException | IOException e) {
+					throw new IllegalStateException(
+							"Exception occurred when setting up bundle at location " + locations[i] + ": " + e);
 				}
 			}
 			if (listener != null) {
@@ -131,7 +130,8 @@ public class BundleTestingHelper {
 					try {
 						installed[i].uninstall();
 					} catch (BundleException e) {
-						CoreTest.fail(tag + ".tearDown.1." + locations[i], e);
+						throw new IllegalStateException(
+								"Exception occurred when removing bundle at location " + locations[i] + ": " + e);
 					}
 				}
 				BundleTestingHelper.resolveBundles(context, installed);

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemHelper.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemHelper.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness;
 
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.log;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -94,8 +97,8 @@ public class FileSystemHelper {
 			}
 		}
 		if (!file.delete()) {
-			String message = "ensureDoesNotExistInFileSystem(File) could not delete: " + file.getPath();
-			CoreTest.log(CoreTest.PI_HARNESS, new Status(IStatus.WARNING, CoreTest.PI_HARNESS, IStatus.OK, message, null));
+			String message = "FileSystemHelper#clear() could not delete: " + file.getPath();
+			log(new Status(IStatus.WARNING, PI_HARNESS, IStatus.OK, message, null));
 		}
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/PerformanceTestRunner.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/PerformanceTestRunner.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness;
 
+import static org.junit.Assert.fail;
+
 import junit.framework.TestCase;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.test.performance.Dimension;
@@ -70,7 +72,7 @@ public abstract class PerformanceTestRunner {
 		try {
 			runTest(meter, localName, outer, inner);
 		} catch (Exception e) {
-			CoreTest.fail("Failed performance test", e);
+			fail("Failed performance test with exception:" + e);
 		}
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestHarnessPlugin.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestHarnessPlugin.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.core.tests.harness;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+
+public final class TestHarnessPlugin {
+	/**
+	 * ID of this plug-in
+	 */
+	public static final String PI_HARNESS = "org.eclipse.core.tests.harness";
+
+	private TestHarnessPlugin() {
+	}
+
+	/**
+	 * Logs the given status via {@link ILog} for the ID of this plug-in
+	 * {@link #PI_HARNESS}.
+	 */
+	public static void log(IStatus status) {
+		ILog.of(Platform.getBundle(PI_HARNESS)).log(status);
+	}
+
+}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.session;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,7 +37,6 @@ import org.eclipse.core.internal.runtime.InternalPlatform;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.session.SetupManager.SetupException;
 import org.eclipse.osgi.service.datalocation.Location;
@@ -86,7 +86,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 		addBundle(org.eclipse.core.runtime.content.IContentType.class); // org.eclipse.core.contenttype
 		addBundle(org.eclipse.equinox.app.IApplication.class); // org.eclipse.equinox.app
 
-		addBundle(org.eclipse.core.tests.harness.CoreTest.class); // org.eclipse.core.tests.harness
+		addBundle(org.eclipse.core.tests.harness.TestHarnessPlugin.class); // org.eclipse.core.tests.harness
 		addBundle(org.eclipse.test.performance.Performance.class); // org.eclipse.test.performance
 
 		addBundle(org.eclipse.jdt.internal.junit.runner.ITestLoader.class); // org.eclipse.jdt.junit.runtime
@@ -214,8 +214,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 		try {
 			externalForm = location.get().toURI().toURL().toExternalForm();
 		} catch (Exception e) {
-			CoreTest.fail("Failed to convert file to URL string:" + location.get(), e);
-			return null; // Cannot happen
+			throw new IllegalArgumentException("Failed to convert file to URL string:" + location.get(), e);
 		}
 		// workaround for bug 88070
 		return "reference:" + externalForm + (suffix != null ? suffix : "");
@@ -254,7 +253,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 				try {
 					createConfigINI();
 				} catch (IOException e) {
-					CoreTest.fail("0.1", e);
+					fail(e);
 				}
 			}
 			if (!shouldSort || isSharedSession()) {
@@ -276,7 +275,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 					try {
 						createConfigINI();
 					} catch (IOException e) {
-						CoreTest.fail("0.1", e);
+						fail(e);
 					}
 				// end of KLUDGE
 				}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/SessionTestRunner.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/SessionTestRunner.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session;
 
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.log;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -29,7 +32,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.harness.CoreTest;
 
 /**
  * This class is responsible for launching JUnit tests on a separate Eclipse session and collect
@@ -203,7 +205,7 @@ public class SessionTestRunner {
 					// no need to throw exception
 					return;
 				}
-				CoreTest.log(CoreTest.PI_HARNESS, e);
+				log(new Status(IStatus.WARNING, PI_HARNESS, IStatus.ERROR, "Error", e));
 			} finally {
 				// remember we are already finished
 				markAsFinished();
@@ -227,7 +229,7 @@ public class SessionTestRunner {
 				try {
 					serverSocket.close();
 				} catch (IOException e) {
-					CoreTest.log(CoreTest.PI_HARNESS, e);
+					log(new Status(IStatus.ERROR, PI_HARNESS, IStatus.ERROR, "Error", e));
 				}
 				notifyAll();
 			}
@@ -292,7 +294,7 @@ public class SessionTestRunner {
 		collector.shutdown();
 		// ensure the session ran without any errors
 		if (!status.isOK()) {
-			CoreTest.log(CoreTest.PI_HARNESS, status);
+			log(status);
 			if (status.getSeverity() == IStatus.ERROR) {
 				result.addError(test, new CoreException(status));
 				return;

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/MultipleRunsTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/MultipleRunsTest.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
 import junit.framework.TestCase;
 import junit.framework.TestResult;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.session.SessionTestRunner;
 import org.eclipse.core.tests.session.SessionTestSuite;
 import org.eclipse.core.tests.session.SetupManager;
@@ -29,7 +30,7 @@ public class MultipleRunsTest extends TestCase {
 		// the test case to run multiple times
 		TestDescriptor test = new TestDescriptor(SampleSessionTest.class.getName(), "testApplicationStartup");
 		test.setApplicationId(SessionTestSuite.CORE_TEST_APPLICATION);
-		test.setPluginId(CoreTest.PI_HARNESS);
+		test.setPluginId(PI_HARNESS);
 		test.setTestRunner(new SessionTestRunner());
 		// setup the command line to be passed to the multiple runs so it has the right system properties
 		test.setSetup(SetupManager.getInstance().getDefaultSetup());

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/MultipleRunsTest2.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/MultipleRunsTest2.java
@@ -13,14 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
-import junit.framework.*;
-import org.eclipse.core.tests.harness.CoreTest;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
 import org.eclipse.core.tests.session.PerformanceSessionTestSuite;
 import org.eclipse.core.tests.session.TestDescriptor;
 
 public class MultipleRunsTest2 extends TestCase {
 	public static Test suite() {
-		PerformanceSessionTestSuite suite = new PerformanceSessionTestSuite(CoreTest.PI_HARNESS, 10);
+		PerformanceSessionTestSuite suite = new PerformanceSessionTestSuite(PI_HARNESS, 10);
 		suite.addTest(new TestDescriptor(SampleSessionTest.class.getName(), "testApplicationStartup"));
 		return suite;
 	}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleCrashTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleCrashTest.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.session.SessionTestSuite;
 
 public class SampleCrashTest extends TestCase {
@@ -40,7 +41,7 @@ public class SampleCrashTest extends TestCase {
 	}
 
 	public static Test suite() {
-		SessionTestSuite sameSession = new SessionTestSuite(CoreTest.PI_HARNESS);
+		SessionTestSuite sameSession = new SessionTestSuite(PI_HARNESS);
 		sameSession.addTest(new SampleCrashTest("test1"));
 		sameSession.addCrashTest(new SampleCrashTest("test2"));
 		sameSession.addTest(new SampleCrashTest("test3"));

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleSessionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleSessionTest.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
-import junit.framework.*;
-import org.eclipse.core.tests.harness.CoreTest;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
 import org.eclipse.core.tests.session.SessionTestSuite;
-import org.eclipse.test.performance.*;
+import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.Performance;
+import org.eclipse.test.performance.PerformanceMeter;
 
 public class SampleSessionTest extends TestCase {
 	public SampleSessionTest(String methodName) {
@@ -47,7 +51,7 @@ public class SampleSessionTest extends TestCase {
 	}
 
 	public static Test suite() {
-		return new SessionTestSuite(CoreTest.PI_HARNESS, SampleSessionTest.class);
+		return new SessionTestSuite(PI_HARNESS, SampleSessionTest.class);
 	}
 
 }

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleTests.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleTests.java
@@ -13,20 +13,21 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.session.SessionTestSuite;
 
 public class SampleTests extends TestSuite {
 	public SampleTests() {
 		addTest(SampleSessionTest.suite());
 		addTest(UISampleSessionTest.suite());
-		TestSuite another = new SessionTestSuite(CoreTest.PI_HARNESS);
+		TestSuite another = new SessionTestSuite(PI_HARNESS);
 		another.addTestSuite(SampleSessionTest.class);
 		addTest(another);
 		// these tests should run in the same session (don't add to a non-shared session test suite)
-		SessionTestSuite shared = new SessionTestSuite(CoreTest.PI_HARNESS);
+		SessionTestSuite shared = new SessionTestSuite(PI_HARNESS);
 		shared.addTestSuite(SameSessionTest.class);
 		shared.setSharedSession(true);
 		addTest(shared);

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/UISampleSessionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/UISampleSessionTest.java
@@ -13,13 +13,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.session.samples;
 
-import java.util.Date;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
 
+import java.util.Date;
 import junit.framework.Test;
 import junit.framework.TestCase;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.session.SessionTestSuite;
-import org.eclipse.test.performance.*;
+import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.Performance;
+import org.eclipse.test.performance.PerformanceMeter;
 
 public class UISampleSessionTest extends TestCase {
 	public UISampleSessionTest(String methodName) {
@@ -53,7 +55,7 @@ public class UISampleSessionTest extends TestCase {
 	}
 
 	public static Test suite() {
-		SessionTestSuite suite = new SessionTestSuite(CoreTest.PI_HARNESS);
+		SessionTestSuite suite = new SessionTestSuite(PI_HARNESS);
 		suite.setApplicationId(SessionTestSuite.UI_TEST_APPLICATION);
 		for (int i = 0; i < 3; i++)
 			suite.addTest(new UISampleSessionTest("testApplicationStartup"));

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestScope2.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestScope2.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
+
 import java.util.Properties;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.osgi.service.prefs.BackingStoreException;
 
 /*
@@ -38,7 +39,7 @@ public class TestScope2 extends EclipsePreferences implements IScopeContext {
 	private IPath location;
 
 	static {
-		baseLocation = new CoreTest().getRandomLocation();
+		baseLocation = getRandomLocation();
 	}
 
 	public TestScope2() {


### PR DESCRIPTION
This change replaces all remaining usages of the JUnit 3-specific CoreTest class as follows:
- Provide plug-in ID of test harness plug-in via utility class rather than JUnit 3 base test class (CoreTest)
- Provide test logging utility using ILog via utility class rather than JUnit 3 base test class (CoreTest)
- Directly use delegated getRandomLocation() method from FileSystemHelper