### PR TITLE
Fix random failing JobTest#testSetRule #1038

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -20,6 +20,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1676,31 +1677,28 @@ public class JobTest extends AbstractJobTest {
 	 * see bug #43459
 	 */
 	@Test
-	public void testSetRule() {
+	public void testSetRule() throws InterruptedException {
 		//setting a scheduling rule for a job after it was already scheduled should throw an exception
-		shortJob.setRule(new IdentityRule());
-		assertTrue("1.0", shortJob.getRule() instanceof IdentityRule);
-		shortJob.schedule(1000000);
-		assertThrows(RuntimeException.class, () -> shortJob.setRule(new PathRule("/testSetRule")));
+		longJob.setRule(new IdentityRule());
+		assertThat(longJob.getRule(), instanceOf(IdentityRule.class));
+		longJob.schedule(1000000);
+		assertThrows(RuntimeException.class, () -> longJob.setRule(new PathRule("/testSetRule")));
 
 		//wake up the sleeping job
-		shortJob.wakeUp();
+		longJob.wakeUp();
+		waitForState(longJob, Job.RUNNING);
 
 		//setting the rule while running should fail
-		assertThrows(RuntimeException.class, () -> shortJob.setRule(new PathRule("/testSetRule/B")));
+		assertThrows(RuntimeException.class, () -> longJob.setRule(new PathRule("/testSetRule/B")));
 
-		try {
-			//wait for the job to complete
-			shortJob.join();
-		} catch (InterruptedException e2) {
-			//ignore
-		}
+		longJob.cancel();
+		longJob.join();
 
 		//after the job has finished executing, the scheduling rule for it can once again be reset
-		shortJob.setRule(new PathRule("/testSetRule/B/C/D"));
-		assertTrue("1.2", shortJob.getRule() instanceof PathRule);
-		shortJob.setRule(null);
-		assertNull("1.3", shortJob.getRule());
+		longJob.setRule(new PathRule("/testSetRule/B/C/D"));
+		assertThat(longJob.getRule(), instanceOf(PathRule.class));
+		longJob.setRule(null);
+		assertNull("job still has a rule assigned: " + longJob, longJob.getRule());
 	}
 
 	@Test


### PR DESCRIPTION
The test case JobTest#testSetRule randomly fails because the used short-running job, on which a rule is set, may finish before the test attempts to set a rule on it.

This change rewrites the test to:
- Use a long-running job to ensure that it does not finish too early
- Properly wait for the job to start running once it has been woken up
- Use proper assertions with helpful error messages
- Does not silently proceed once an unexpected exception occurred.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1038