### PR TITLE
Unify assume messages for selectively skipped tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -30,6 +30,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +58,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.osgi.util.NLS;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -146,8 +147,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null);
+		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
+				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
 
 		/* build scenario */
 		// create source root folder
@@ -231,7 +232,7 @@ public class FileStoreTest {
 	public void testCaseInsensitive() throws Throwable {
 		IFileStore temp = createDir(getWorkspace().getRoot().getLocation().append("temp").toString(), true);
 		boolean isCaseSensitive = temp.getFileSystem().isCaseSensitive();
-		Assume.assumeFalse("Skipping copy test on caseSensitive System", isCaseSensitive);
+		assumeFalse("only relevant for platforms with case-sensitive file system", isCaseSensitive);
 
 		// create a file
 		String content = "this is just a simple content \n to a simple file \n to test a 'simple' copy";
@@ -320,8 +321,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null);
+		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
+				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
 
 		/* build scenario */
 		/* get the source folder */
@@ -474,8 +475,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		Assume.assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
-				|| tempDirectories[1] == null);
+		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
+				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
 
 		/* build scenario */
 		/* get the source folder */
@@ -590,7 +591,7 @@ public class FileStoreTest {
 	}
 
 	private void testAttribute(int attribute) throws Exception {
-		Assume.assumeTrue(isAttributeSupported(attribute));
+		assumeTrue("only relevant for platforms supporting attribute: " + attribute, isAttributeSupported(attribute));
 
 		IPath root = getWorkspace().getRoot().getLocation().append("" + new Date().getTime());
 		IFileStore targetFolder = createDir(root.toString(), true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
@@ -37,9 +38,9 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
 import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +66,7 @@ public class SymlinkTest {
 
 	@Before
 	public void assumeSymbolicLinksAvailable() throws Exception {
-		assumeTrue("Can't create symbolic links in this platform: " + Platform.getOS(),
+		assumeTrue("only relevant for platforms supporting symbolic links",
 				FileSystemHelper.canCreateSymLinks());
 	}
 
@@ -377,8 +378,7 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutLastModified() throws Exception {
-		// flag EFS.SET_LAST_MODIFIED is set by java.io and it fails on Mac OS
-		Assume.assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse("setting EFS.SET_LAST_MODIFIED fails on Mac", OS.isMac());
 
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
@@ -441,7 +441,8 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutExecutable() throws Exception {
-		Assume.assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
+		assumeTrue("only relevant for platforms supporting hidden attribute",
+				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
 
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
@@ -466,7 +467,8 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutHidden() throws Exception {
-		Assume.assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
+		assumeTrue("only relevant for platforms supporting hidden attribute",
+				isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
 
 		// Check that putInfo() applies the attribute to the symlink itself.
 		makeLinkStructure();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -62,7 +64,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
 import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -272,11 +273,11 @@ public class BasicAliasTest {
 	 */
 	@Test
 	public void testBug198571() throws Exception {
-		Assume.assumeTrue(OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		Assume.assumeFalse(devices[0] == null || devices[1] == null);
+		assumeFalse("only executable if at least two volumes are present", devices[0] == null || devices[1] == null);
 
 		String location = createUniqueString();
 		IProject testProject1 = getWorkspace().getRoot().getProject(location + "1");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.internal.resources.File;
@@ -48,7 +49,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -67,11 +67,11 @@ public class MoveTest {
 	 */
 	@Test
 	public void testMoveFileAcrossVolumes() throws CoreException {
-		assumeTrue(OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		Assume.assumeFalse(devices[0] == null || devices[1] == null);
+		assumeFalse("only executable if at least two volumes are present", devices[0] == null || devices[1] == null);
 
 		// create common objects
 		String location = createUniqueString();
@@ -171,11 +171,11 @@ public class MoveTest {
 	 */
 	@Test
 	public void testMoveFolderAcrossVolumes() throws CoreException {
-		assumeTrue(OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		Assume.assumeFalse(devices[0] == null || devices[1] == null);
+		assumeFalse("only executable if at least two volumes are present", devices[0] == null || devices[1] == null);
 
 		// create common objects
 		String location = createUniqueString();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SymlinkResourceTest.java
@@ -85,7 +85,7 @@ public class SymlinkResourceTest {
 	 */
 	@Test
 	public void testBug232426() throws Exception {
-		assumeTrue("test is only relevant for Platforms supporting symbolic links", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
@@ -120,7 +120,7 @@ public class SymlinkResourceTest {
 
 	@Test
 	public void testBug358830() throws Exception {
-		assumeTrue("test is only relevant for Platforms supporting symbolic links", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -641,7 +641,7 @@ public class IProjectTest  {
 	 */
 	@Test
 	public void testProjectCreationLocationExistsWithDifferentCase() throws CoreException {
-		assumeTrue("Case-sensitive file system test only relevant for Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		String projectName = createUniqueString() + "a";
 		IProject project = getWorkspace().getRoot().getProject(projectName);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -58,7 +58,7 @@ public class IWorkspaceRootTest {
 	 */
 	@Test
 	public void testFindFilesNonCanonicalPath() throws Exception {
-		assumeTrue("this test is for windows only", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
 		createInWorkspace(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -888,7 +888,7 @@ public class LinkedResourceTest {
 	 */
 	@Test
 	public void testFindFilesForLocationCaseVariant() throws CoreException {
-		assumeTrue("this test only applies to file systems with a device in the path", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IFolder link = nonExistingFolderInExistingProject;
 		IPath localLocation = resolve(localFolder);
@@ -1279,7 +1279,7 @@ public class LinkedResourceTest {
 	 */
 	@Test
 	public void testLocationWithColon() throws CoreException {
-		assumeFalse("Windows does not allow a location with colon in the name", OS.isWindows());
+		assumeFalse("not relevant on Windows, as it does not allow a location with colon in the name", OS.isWindows());
 
 		IFolder folder = nonExistingFolderInExistingProject;
 		// Note that on *nix, "c:/temp" is a relative path with two segments
@@ -1762,7 +1762,7 @@ public class LinkedResourceTest {
 
 	@Test
 	public void testLinkedFolderWithSymlink_Bug338010() throws Exception {
-		assumeTrue("test is only applicable when symbolic links can be created", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IPath baseLocation = getRandomLocation();
 		IPath resolvedBaseLocation = resolve(baseLocation);
@@ -1787,7 +1787,7 @@ public class LinkedResourceTest {
 	 */
 	@Test
 	public void testDeleteLinkTarget_Bug507084() throws Exception {
-		assumeTrue("test is only applicable when symbolic links can be created", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IPath baseLocation = getRandomLocation();
 		IPath resolvedBaseLocation = resolve(baseLocation);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -80,7 +80,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeArchive() throws CoreException {
-		assumeTrue("test only relevant for platforms supporting archive attribute",
+		assumeTrue("only relevant for platforms supporting archive attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_ARCHIVE));
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -104,7 +104,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeExecutable() throws CoreException {
-		assumeTrue("test only relevant for platforms supporting executable attribute",
+		assumeTrue("only relevant for platforms supporting executable attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -129,7 +129,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeHidden() throws CoreException {
-		assumeTrue("test only relevant for platforms supporting hidden attribute",
+		assumeTrue("only relevant for platforms supporting hidden attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -153,7 +153,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeReadOnly() throws CoreException {
-		assumeTrue("test only relevant for platforms supporting read-only attribute",
+		assumeTrue("only relevant for platforms supporting read-only attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_READ_ONLY));
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
@@ -219,7 +219,7 @@ public class ResourceAttributeTest {
 	@Test
 	@Ignore("currently failing on Hudson: see https://bugs.eclipse.org/bugs/show_bug.cgi?id=397353")
 	public void testRefreshExecutableOnFolder() throws CoreException {
-		assumeTrue("test only relevant for platforms supporting executable attribute",
+		assumeTrue("only relevant for platforms supporting executable attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
 
 		IProject project = getWorkspace().getRoot().getProject("testRefreshExecutableOnFolder");
@@ -247,7 +247,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeSymlink() throws Exception {
-		assumeTrue("test only relevant for platforms supporting symlinks", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile link = project.getFile("link");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -337,7 +337,7 @@ public class WorkspaceTest {
 
 	@Test
 	public void testWorkingLocationDeletion_bug433061() throws Throwable {
-		assumeTrue("test only makes sense when Platform support symbolic links", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 
 		IProject project = getTestProject();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -51,7 +51,7 @@ public class Bug_025457 {
 
 	@Test
 	public void testFile() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IFile sourceFile = source.getFile("file.txt");
@@ -79,7 +79,7 @@ public class Bug_025457 {
 	@Test
 	public void testFolder() throws IOException, CoreException {
 		//native code must also be present so move can detect the case change
-		assumeTrue("test only works on Windows", OS.isWindows() && isReadOnlySupported());
+		assumeTrue("only relevant on Windows", OS.isWindows() && isReadOnlySupported());
 
 		IProject source = getWorkspace().getRoot().getProject("SourceProject");
 		IFolder sourceFolder = source.getFolder("folder");
@@ -108,7 +108,7 @@ public class Bug_025457 {
 
 	@Test
 	public void testProject() throws IOException, CoreException {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IProject source = getWorkspace().getRoot().getProject("project");
 		IProject destination = getWorkspace().getRoot().getProject("Project");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_026294.java
@@ -56,7 +56,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteOpenProjectWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -127,7 +127,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteOpenProjectLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
+		assumeTrue("only relevant on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -175,7 +175,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteClosedProjectWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -213,7 +213,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteClosedProjectLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -258,7 +258,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteFolderWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -293,7 +293,7 @@ public class Bug_026294 {
 	 */
 	@Test
 	public void testDeleteFolderLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -64,7 +64,7 @@ public class Bug_027271 {
 
 	@Test
 	public void testBug() {
-		assumeTrue("tested bug is only relevant on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IPathVariableManager pvm = getWorkspace().getPathVariableManager();
 		Preferences prefs = ResourcesPlugin.getPlugin().getPluginPreferences();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_032076.java
@@ -54,7 +54,7 @@ public class Bug_032076 {
 
 	@Test
 	public void testFileBugOnWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -107,7 +107,7 @@ public class Bug_032076 {
 
 	@Test
 	public void testFolderBugOnWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -169,7 +169,7 @@ public class Bug_032076 {
 
 	@Test
 	public void testProjectBugOnWindows() throws Exception {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IWorkspace workspace = getWorkspace();
 		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");
@@ -218,7 +218,7 @@ public class Bug_032076 {
 	@Test
 	@Ignore("test is currently failing and needs further investigation (bug 203078)")
 	public void testFileBugOnLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
+		assumeTrue("only relevant on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -277,7 +277,7 @@ public class Bug_032076 {
 	@Test
 	@Ignore("test is currently failing and needs further investigation (bug 203078)")
 	public void testFolderBugOnLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
+		assumeTrue("only relevant on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(createUniqueString());
@@ -352,7 +352,7 @@ public class Bug_032076 {
 	@Test
 	@Ignore("test is currently failing and needs further investigation (bug 203078)")
 	public void testProjectBugOnLinux() throws CoreException {
-		assumeTrue("test only works on Linux", OS.isLinux() && isReadOnlySupported());
+		assumeTrue("only relevant on Linux", OS.isLinux() && isReadOnlySupported());
 
 		IWorkspace workspace = getWorkspace();
 		IProject sourceProject = workspace.getRoot().getProject(createUniqueString() + ".source");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -94,7 +94,7 @@ public class Bug_044106 {
 	 */
 	private void doTestDeleteLinkedFolder(IFolder linkedFolder, boolean deleteParent, int deleteFlags)
 			throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IFileStore linkDestLocation = workspaceRule.getTempStore();
 		IFileStore linkDestFile = linkDestLocation.getChild(createUniqueString());
@@ -134,14 +134,14 @@ public class Bug_044106 {
 
 	@Test
 	public void testDeleteLinkedFile() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		doTestDeleteLinkedFile(IResource.NONE);
 	}
 
 	@Test
 	public void testDeleteLinkedFolder() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
@@ -150,7 +150,7 @@ public class Bug_044106 {
 
 	@Test
 	public void testDeleteLinkedResourceInProject() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
@@ -159,14 +159,14 @@ public class Bug_044106 {
 
 	@Test
 	public void testDeleteLinkedFileKeepHistory() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		doTestDeleteLinkedFile(IResource.KEEP_HISTORY);
 	}
 
 	@Test
 	public void testDeleteLinkedFolderParentKeepHistory() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder parent = project.getFolder("parent");
@@ -176,7 +176,7 @@ public class Bug_044106 {
 
 	@Test
 	public void testDeleteLinkedFolderKeepHistory() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");
@@ -185,7 +185,7 @@ public class Bug_044106 {
 
 	@Test
 	public void testDeleteLinkedResourceInProjectKeepHistory() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
 		IFolder linkedFolder = project.getFolder("linkedFolder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
@@ -35,7 +35,7 @@ public class Bug_092108 {
 
 	@Test
 	public void testBug() throws CoreException {
-		assumeTrue("test only works on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IFileStore root = EFS.getStore(new java.io.File("c:\\").toURI());
 		IFileInfo info = root.fetchInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_LinuxTests.java
@@ -58,7 +58,7 @@ public class Bug_185247_LinuxTests {
 
 	@Before
 	public void setUp() throws Exception {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IPath randomLocation = getRandomLocation();
 		workspaceRule.deleteOnTearDown(randomLocation);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_recursiveLinks.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_185247_recursiveLinks.java
@@ -47,7 +47,7 @@ public class Bug_185247_recursiveLinks {
 
 	@Before
 	public void requireCanCreateSymlinks() throws IOException {
-		assumeTrue("test only for platform providing symlinks", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -50,7 +50,7 @@ public class Bug_233939 {
 
 	@Before
 	public void requireCanCreateSymlinks() throws IOException {
-		assumeTrue("test only for platform providing symlinks", canCreateSymLinks());
+		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -40,7 +40,7 @@ public class Bug_329836 {
 
 	@Test
 	public void testBug() throws Exception {
-		assumeTrue("test only works on Mac", OS.isMac());
+		assumeTrue("only relevant on Mac", OS.isMac());
 
 		IFileStore fileStore = workspaceRule.getTempStore().getChild(createUniqueString());
 		createInFileSystem(fileStore);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
@@ -62,7 +62,7 @@ public class Bug_530868 {
 	 */
 	@Test
 	public void testMillisecondResolution() throws Exception {
-		assumeFalse("Mac still has no milliseconds resolution", OS.isMac());
+		assumeFalse("not relevant on Mac, as it does not have milliseconds resolution", OS.isMac());
 		try {
 			assertTrue("can only run if native provider can be enabled", LocalFileNativesManager.setUsingNative(true));
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -52,10 +52,10 @@ public class IFileTest {
 	public void testBug25658() throws CoreException {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		assumeTrue(isReadOnlySupported());
+		assumeTrue("only relevant for platforms supporting read-only files", isReadOnlySupported());
 
 		// Don't test this on Windows
-		assumeFalse(OS.isWindows());
+		assumeFalse("not relevant on Windows", OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");
@@ -83,11 +83,11 @@ public class IFileTest {
 
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		assumeTrue(isReadOnlySupported());
+		assumeTrue("only relevant for platforms supporting read-only files", isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		assumeTrue(OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder folder = project.getFolder("folder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -51,11 +51,11 @@ public class IFolderTest {
 	public void testBug25662() throws CoreException {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
-		assumeTrue(isReadOnlySupported());
+		assumeTrue("only relevant for platforms supporting read-only files", isReadOnlySupported());
 
 		// Only run this test on Linux for now since Windows lets you create
 		// a file within a read-only folder.
-		assumeTrue(OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFolder parentFolder = project.getFolder("parentFolder");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -104,7 +104,7 @@ public class IResourceTest {
 
 	@Test
 	public void testBug28790() throws CoreException {
-		assumeTrue("test only makes sens on platforms that support archive attribute",
+		assumeTrue("only relevant for platforms supporting archive attribute",
 				isAttributeSupported(EFS.ATTRIBUTE_ARCHIVE));
 
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -216,7 +216,7 @@ public class IResourceTest {
 
 	@Test
 	public void testBug111821() throws CoreException {
-		assumeTrue("test only makes sens on Windows", OS.isWindows());
+		assumeTrue("only relevant on Windows", OS.isWindows());
 
 		IProject project = getWorkspace().getRoot().getProject("testBug111821");
 		IFolder folder = project.getFolder(new Path(null, "c:"));
@@ -256,7 +256,7 @@ public class IResourceTest {
 	 */
 	@Test
 	public void testCreate_1FW87XF() throws Throwable {
-		assumeTrue("test only works on Linux", OS.isLinux());
+		assumeTrue("only relevant on Linux", OS.isLinux());
 
 		// test if the file system is case sensitive
 		boolean caseSensitive = new java.io.File("abc").compareTo(new java.io.File("ABC")) != 0;


### PR DESCRIPTION
The messages provided in assumeTrue/assumeFalse statements to selectively skip tests on specific environments differ significantly and in some cases no message is provided at all, leading to non-helpful outputs like `Aborted, got: <false>, expected: is <true>`. This change adds missing messages and unifies the existing messages.