### PR TITLE
Fix several warnings in o.e.tests.resources

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.core.tests.resources.saveparticipant
 Bundle-Name: Eclipse Core Tests Save Participant
 Bundle-SymbolicName: org.eclipse.core.tests.resources.saveparticipant; singleton:=true
 Bundle-Version: 3.6.100.qualifier

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
@@ -29,15 +29,13 @@ import org.junit.Test;
 
 public class ObjectMapTest {
 	private static final int MAXIMUM = 100;
-	private Object[] values;
 
 	@Test
 	public void testPut() {
 		// create the objects to insert into the map
 		ObjectMap<Integer, Object> map = new ObjectMap<>();
-		int max = 100;
-		Object[] values = new Object[max];
-		for (int i = 0; i < max; i++) {
+		Object[] values = new Object[MAXIMUM];
+		for (int i = 0; i < MAXIMUM; i++) {
 			values[i] = Long.valueOf(System.currentTimeMillis());
 		}
 
@@ -51,7 +49,7 @@ public class ObjectMapTest {
 		}
 
 		// make sure they are all still there
-		assertEquals("3.0", max, map.size());
+		assertEquals("3.0", MAXIMUM, map.size());
 		for (int i = 0; i < values.length; i++) {
 			Integer key = Integer.valueOf(i);
 			assertTrue("3.1." + i, map.containsKey(key));
@@ -68,7 +66,8 @@ public class ObjectMapTest {
 	@Test
 	public void testRemove() {
 		// populate the map
-		ObjectMap<Integer, Object> map = populateMap(MAXIMUM);
+		Object[] values = new Object[MAXIMUM];
+		ObjectMap<Integer, Object> map = populateMap(values);
 
 		// remove each element
 		for (int i = MAXIMUM - 1; i >= 0; i--) {
@@ -88,7 +87,8 @@ public class ObjectMapTest {
 
 	@Test
 	public void testContains() {
-		ObjectMap<Integer, Object> map = populateMap(MAXIMUM);
+		Object[] values = new Object[MAXIMUM];
+		ObjectMap<Integer, Object> map = populateMap(values);
 
 		for (int i = 0; i < MAXIMUM; i++) {
 			assertTrue("2.0." + i, map.containsKey(Integer.valueOf(i)));
@@ -103,7 +103,8 @@ public class ObjectMapTest {
 
 	@Test
 	public void testValues() {
-		ObjectMap<Integer, Object> map = populateMap(MAXIMUM);
+		Object[] values = new Object[MAXIMUM];
+		ObjectMap<Integer, Object> map = populateMap(values);
 
 		Collection<Object> result = map.values();
 		for (int i = 0; i < MAXIMUM; i++) {
@@ -113,14 +114,16 @@ public class ObjectMapTest {
 
 	@Test
 	public void testKeySet() {
-		ObjectMap<Integer, Object> map = populateMap(MAXIMUM);
+		Object[] values = new Object[MAXIMUM];
+		ObjectMap<Integer, Object> map = populateMap(values);
 		Set<Integer> keys = map.keySet();
 		assertEquals("1.0", MAXIMUM, keys.size());
 	}
 
 	@Test
 	public void testEntrySet() {
-		ObjectMap<Integer, Object> map = populateMap(MAXIMUM);
+		Object[] values = new Object[MAXIMUM];
+		ObjectMap<Integer, Object> map = populateMap(values);
 		Set<Map.Entry<Integer, Object>> entries = map.entrySet();
 		for (int i = 0; i < MAXIMUM; i++) {
 			assertTrue("1.0." + i, contains(entries, values[i]));
@@ -139,15 +142,14 @@ public class ObjectMapTest {
 		return false;
 	}
 
-	private ObjectMap<Integer, Object> populateMap(int max) {
+	private ObjectMap<Integer, Object> populateMap(Object[] values) {
 		// populate the map
 		ObjectMap<Integer, Object> map = new ObjectMap<>();
-		values = new Object[max];
-		for (int i = 0; i < max; i++) {
+		for (int i = 0; i < values.length; i++) {
 			values[i] = Long.valueOf(System.currentTimeMillis());
 			map.put(Integer.valueOf(i), values[i]);
 		}
-		assertEquals("#populateMap", max, map.size());
+		assertEquals("#populateMap", values.length, map.size());
 		return map;
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -105,7 +105,7 @@ public class IProjectDescriptionTest {
 		description.setBuildSpec(description.getBuildSpec());
 		description.setComment(description.getComment());
 		description.setDynamicReferences(description.getDynamicReferences());
-		description.setLocation(description.getLocation());
+		description.setLocationURI(description.getLocationURI());
 		description.setName(description.getName());
 		description.setNatureIds(description.getNatureIds());
 		description.setReferencedProjects(description.getReferencedProjects());


### PR DESCRIPTION
- Resolve hidden field by inlining it
- Replace calls to deprecated IResource.setDefaultCharset(String)
- Replace usage of deprecated Preferences with EclipsePreferences
- Replace call to deprecated IProjectDescription.get/setLocation with get/setLocationURI
- Add missing automatic module name for saveparticipant test plugin