### PR TITLE
Simplify AsynchExecThread to avoid duplicate barrier state upgrade

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AsynchExecThread.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AsynchExecThread.java
@@ -49,17 +49,13 @@ public class AsynchExecThread extends Thread {
 
 		//must have positive work
 		current.beginTask(jobName, 1);
-		try {
-			if (current.isCanceled()) {
-				barrier.upgradeTo(TestBarrier2.STATUS_DONE);
-				job.done(Status.CANCEL_STATUS);
-			}
-			current.worked(1);
-		} finally {
-			barrier.upgradeTo(TestBarrier2.STATUS_DONE);
-			current.done();
+		if (current.isCanceled()) {
+			job.done(Status.CANCEL_STATUS);
+		} else {
 			job.done(Status.OK_STATUS);
 		}
+		barrier.upgradeTo(TestBarrier2.STATUS_DONE);
+		current.done();
 	}
 
 }


### PR DESCRIPTION
Fixes silent log entries:
```
wrong state 5 should be < 5
Error: Exception in thread "Thread-392" java.lang.IllegalStateException: wrong state 5 should be < 5
	at org.eclipse.core.tests.harness.TestBarrier2.upgradeTo(TestBarrier2.java:215)
	at org.eclipse.core.tests.runtime.jobs.AsynchExecThread.run(AsynchExecThread.java:59)
```