### PR TITLE
Revert "Jenkinsfile: Disable Quality gate for maven warnings #969"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,7 @@ pipeline {
 					archiveArtifacts artifacts: '.*log,*/target/work/data/.metadata/.*log,*/tests/target/work/data/.metadata/.*log,apiAnalyzer-workspace/.metadata/.*log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform/master'
-					recordIssues tools: [eclipse(), javaDoc()], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
-					recordIssues tool: mavenConsole(), qualityGates: [[threshold: 1, type: 'DELTA_ERROR', unstable: true]]
+					recordIssues tools: [eclipse(), mavenConsole(), javaDoc()], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
 				}
 			}
 		}


### PR DESCRIPTION
This reverts commit 5a4d891f0e1f445cbdf30a01f25f5ac909f393c4/PR https://github.com/eclipse-platform/eclipse.platform/pull/1007 now that https://github.com/eclipse-platform/eclipse.platform/issues/969 was fixed temporarily with https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1672 and is permanently fixed with https://github.com/eclipse-equinox/equinox/pull/403.