### PR TITLE
[E4] Remove unnecessary javax.inject.Qualifier meta annotations

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.e4.core.di
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
- javax.inject;version="[1.0.0,2.0.0)";resolution:=optional,
  org.osgi.framework;version="[1.5.0,2.0.0)",
  org.osgi.service.event;version="[1.3.0,2.0.0)"
 Export-Package: org.eclipse.e4.core.contexts;version="1.7.0",

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/Active.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/Active.java
@@ -23,12 +23,10 @@ import java.lang.annotation.Target;
  * This annotation can be added to injectable fields ands methods to indicate
  * that the injected value should come from the active context.
  *
- * @see javax.inject.Inject
  * @see jakarta.inject.Inject
  * @see IEclipseContext#activate
  * @since 1.3
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.e4.core.di.annotations
 Bundle-Version: 1.8.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.annotations;version="1.6.0"
-Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
- javax.inject;version="[1.0.0,2.0.0)";resolution:=optional
+Import-Package: jakarta.inject;version="[2.0.0,3.0.0)"
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.e4.core.di.annotations

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Creatable.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Creatable.java
@@ -23,7 +23,6 @@ import java.lang.annotation.Target;
  * Specifies that the target class can be created by an injector as needed.
  * @since 1.3
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.TYPE})

--- a/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Optional.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.annotations/src/org/eclipse/e4/core/di/annotations/Optional.java
@@ -51,7 +51,6 @@ import java.lang.annotation.Target;
  *
  * @since 1.3
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.core.di.extensions;version="0.16.0"
 Bundle-Localization: fragment
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
- javax.inject;version="[1.0.0,2.0.0)";resolution:=optional,
  org.osgi.framework;version="[1.0.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.e4.core.di.extensions

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/EventTopic.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/EventTopic.java
@@ -46,7 +46,6 @@ import java.lang.annotation.Target;
  * @since 0.16
  */
 @jakarta.inject.Qualifier
-@javax.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/OSGiBundle.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/OSGiBundle.java
@@ -50,7 +50,6 @@ import org.osgi.framework.BundleContext;
  *
  * @since 0.16
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.PARAMETER, ElementType.FIELD})

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Preference.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Preference.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Target;
 /**
  * @since 0.16
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Service.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions/src/org/eclipse/e4/core/di/extensions/Service.java
@@ -24,7 +24,6 @@ import java.lang.annotation.Target;
  *
  * @since 0.16
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ ElementType.FIELD, ElementType.PARAMETER })

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
@@ -30,7 +30,7 @@ import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
  * synchronized with the context once it has been injected.
  * <p>
  * Matching of methods and fields to be injected is performed using the
- * annotations defined in packages javax.inject and
+ * annotations defined in packages jakarta.inject and
  * org.eclipse.e4.core.services.annotations.
  * </p>
  * <p>

--- a/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.annotation;version="[2.0.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",
- javax.inject;version="[1.0.0,2.0.0)";resolution:=optional,
  org.eclipse.osgi.service.debug;version="1.1.0",
  org.eclipse.osgi.service.localization;version="1.1.0",
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Translation.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/nls/Translation.java
@@ -37,7 +37,6 @@ import java.lang.annotation.Target;
  *
  * @since 1.2
  */
-@javax.inject.Qualifier
 @jakarta.inject.Qualifier
 @Documented
 @Target({ ElementType.FIELD, ElementType.PARAMETER })


### PR DESCRIPTION
The E4-Injector considers both the `javax.inject.Qualifier` and `jakarta.inject.Qualifier`. Therefore specifying both is not necessary and just specifying the latter is sufficient.

The only I reason I can think of where it would be necessary to keep the annotation would be third-party tools that process the E4 annotations, but I'm not aware of any and they could just implement the same approach as the E4 injector to handle both.

This should also help for https://github.com/eclipse-platform/eclipse.platform/issues/1017.