### PR TITLE
Update the build config to eager and non parallel execution

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,5 +1,2 @@
 -Pbuild-individual-bundles
---threads
-1C
---builder
-smart
+-Dtycho.target.eager=true


### PR DESCRIPTION
Parallel execution can speedup the build (as well as lazy resolve) but seem to "confuse everyone except me", so this is to disable both features for the sake of contributor confidence.