### PR TITLE
Add missing test data not referenced by build.properties

### DIFF
--- a/team/tests/org.eclipse.compare.tests/build.properties
+++ b/team/tests/org.eclipse.compare.tests/build.properties
@@ -18,7 +18,8 @@ bin.includes = plugin.properties,\
                .,\
                META-INF/,\
                patchdata/,\
-               linereaderdata/
+               linereaderdata/,\
+               labelContributionData/
 
 src.includes = about.html
 


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/504