### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/debug/org.eclipse.unittest.ui/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.unittest.ui/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/runtime/bundles/org.eclipse.core.expressions/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.expressions/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/ua/org.eclipse.ui.cheatsheets/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.ui.cheatsheets/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686