### PR TITLE
Bump lower bound of re-exported required Equinox bundles

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -26,9 +26,9 @@ Export-Package: org.eclipse.core.internal.dtree;x-internal:=true,
  org.eclipse.core.resources.undo.snapshot,
  org.eclipse.core.resources.variableresolvers
 Require-Bundle: org.eclipse.ant.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.core.expressions;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="[1.3.0,2.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
+ org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
+ org.eclipse.core.filesystem;bundle-version="[1.10.0,2.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/ResourceChangeListenerRegistrar.xml,
  OSGI-INF/org.eclipse.core.internal.resources.CheckMissingNaturesListener.xml

--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator
@@ -9,13 +9,13 @@ Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.preferences.legacy;x-internal:=true,
  org.eclipse.core.internal.runtime;x-internal:=true,
  org.eclipse.core.runtime;version="3.7.0"
-Require-Bundle: org.eclipse.osgi;bundle-version="[3.17.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
- org.eclipse.core.jobs;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.registry;bundle-version="[3.11.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.preferences;bundle-version="[3.10.0,4.0.0)";visibility:=reexport,
- org.eclipse.core.contenttype;bundle-version="[3.8.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.app;bundle-version="1.6.0";visibility:=reexport
+Require-Bundle: org.eclipse.osgi;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
+ org.eclipse.equinox.common;bundle-version="[3.19.0,4.0.0)";visibility:=reexport,
+ org.eclipse.core.jobs;bundle-version="[3.15.0,4.0.0)";visibility:=reexport,
+ org.eclipse.equinox.registry;bundle-version="[3.12.0,4.0.0)";visibility:=reexport,
+ org.eclipse.equinox.preferences;bundle-version="[3.11.0,4.0.0)";visibility:=reexport,
+ org.eclipse.core.contenttype;bundle-version="[3.9.0,4.0.0)";visibility:=reexport,
+ org.eclipse.equinox.app;bundle-version="1.7.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 DynamicImport-Package: org.eclipse.core.internal.runtime.auth


### PR DESCRIPTION
Lift the lower bound of `o.e.core.resources`' requirement for `o.e.equinox.common` since it uses new (internal) methods introduced with https://github.com/eclipse-equinox/equinox/pull/424 and used with https://github.com/eclipse-platform/eclipse.platform/pull/972.

The plugin `o.e.core.runtime` re-exports many equinox bundles of which multiple had a minor version bump in the meantime lift their lower versions too. And since `o.e.core.runtime` re-exports those bundles it effectively makes them part of their API and needs a minor version bump too (this is also practically necessary to enforce the right version of `o.e.equinox.common` is used for `o.e.core.resources`).