### PR TITLE
Improve array length assertions in resource tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -647,9 +648,8 @@ public class BuilderTest {
 		//ensure the build spec hasn't changed
 		desc = project.getDescription();
 		ICommand[] commands = desc.getBuildSpec();
-		assertEquals(2, commands.length);
-		assertEquals(commands[0].getBuilderName(), SortBuilder.BUILDER_NAME);
-		assertEquals(commands[1].getBuilderName(), SortBuilder.BUILDER_NAME);
+		assertThat(commands).hasSize(2)
+				.allSatisfy(command -> assertThat(command.getBuilderName()).isEqualTo(SortBuilder.BUILDER_NAME));
 		Map<String, String> args = commands[0].getArguments();
 		assertEquals("Build1", args.get(TestBuilder.BUILD_ID));
 		args = commands[1].getArguments();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
@@ -90,7 +91,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -221,7 +222,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -343,7 +344,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -469,7 +470,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -605,7 +606,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -740,7 +741,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -881,7 +882,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -1037,7 +1038,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -1194,7 +1195,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -1353,7 +1354,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 		RebuildingBuilder b2 = builders.get(1);
 		RebuildingBuilder b3 = builders.get(2);
@@ -1508,7 +1509,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 
 		// Create and set a build spec for the project
@@ -1711,7 +1712,7 @@ public class RebuildTest {
 		// do an initial build to create builders
 		project1.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		List<RebuildingBuilder> builders = RebuildingBuilder.getInstances();
-		assertEquals(project1.getDescription().getBuildSpec().length, builders.size());
+		assertThat(project1.getDescription().getBuildSpec()).hasSameSizeAs(builders);
 		RebuildingBuilder b1 = builders.get(0);
 
 		// Create and set a build spec for the project

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/DeltaDataTreeTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.dtree;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -252,7 +253,7 @@ public class DeltaDataTreeTest {
 		NodeComparison nodeComparison = (NodeComparison) rootData;
 		assertEquals(nodeComparison.getNewData(), nodeComparison.getOldData());
 		// assertEquals(0, nodeComparison.getComparison()); XXX fails for tree!=other
-		assertEquals(0, delta.getChildren(AbstractDataTree.rootKey()).length);
+		assertThat(delta.getChildren(AbstractDataTree.rootKey())).isEmpty();
 
 	}
 
@@ -386,7 +387,7 @@ public class DeltaDataTreeTest {
 		tree.createChild(leftKey, "double");
 		tree.createChild(leftKey, "double");
 		/* Make sure size has only increased by one */
-		assertEquals(size + 1, (tree.getNamesOfChildren(leftKey)).length);
+		assertThat(tree.getNamesOfChildren(leftKey)).hasSize(size + 1);
 	}
 
 	/**
@@ -514,9 +515,9 @@ public class DeltaDataTreeTest {
 	@Test
 	public void testEmpty() {
 
-		assertTrue("1", emptyTree.includes(rootKey));
-		assertNotNull("2", TestHelper.getRootNode(emptyTree));
-		assertEquals("3", 0, TestHelper.getRootNode(emptyTree).getChildren().length);
+		assertTrue(emptyTree.includes(rootKey));
+		assertNotNull(TestHelper.getRootNode(emptyTree));
+		assertThat(TestHelper.getRootNode(emptyTree).getChildren()).isEmpty();
 	}
 
 	/**
@@ -746,27 +747,22 @@ public class DeltaDataTreeTest {
 		try {
 			/* empty tree */
 			testChildren = emptyTree.getChildren(rootKey);
-			assertEquals("1", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 
 			/* root node */
 			testChildren = tree.getChildren(rootKey);
-			assertEquals("2", 2, testChildren.length);
-			assertTrue("3", testChildren[0].equals(rootChildren[0]));
-			assertTrue("4", testChildren[1].equals(rootChildren[1]));
+			assertThat(testChildren).containsExactly(rootChildren[0], rootChildren[1]);
 
 			/* interior nodes */
 			testChildren = tree.getChildren(leftKey);
-			assertEquals("5", 3, testChildren.length);
-			assertTrue("6", testChildren[0].equals(leftChildren[0]));
-			assertTrue("7", testChildren[2].equals(leftChildren[1]));
-			assertTrue("8", testChildren[1].equals(leftChildren[2]));
+			assertThat(testChildren).containsExactly(leftChildren[0], leftChildren[2], leftChildren[1]);
 
 			/* leaf nodes */
 			testChildren = tree.getChildren(leftChildren[0]);
-			assertEquals("9", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 
 			testChildren = tree.getChildren(rightChildren[0]);
-			assertEquals("10", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 		} catch (ObjectNotFoundException e) {
 			caught = true;
 		} finally {
@@ -809,31 +805,25 @@ public class DeltaDataTreeTest {
 		try {
 			/* empty tree */
 			testChildren = emptyTree.getNamesOfChildren(rootKey);
-			assertEquals("1", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 
 			/* root node */
 			testChildren = tree.getNamesOfChildren(rootKey);
-			assertEquals("2", 2, testChildren.length);
-			assertTrue("3", testChildren[0].equals(rootChildren[0]));
-			assertTrue("4", testChildren[1].equals(rootChildren[1]));
+			assertThat(testChildren).containsExactly(rootChildren[0], rootChildren[1]);
 
 			/* interior nodes */
 			testChildren = tree.getNamesOfChildren(leftKey);
-			assertEquals("5", 3, testChildren.length);
-			assertTrue("6", testChildren[0].equals(leftChildren[0]));
-			assertTrue("7", testChildren[2].equals(leftChildren[1]));
-			assertTrue("8", testChildren[1].equals(leftChildren[2]));
+			assertThat(testChildren).containsExactly(leftChildren[0], leftChildren[2], leftChildren[1]);
 
 			testChildren = tree.getNamesOfChildren(rightKey);
-			assertEquals("8.1", 1, testChildren.length);
-			assertTrue("8.2", testChildren[0].equals(rightChildren[0]));
+			assertThat(testChildren).containsExactly(rightChildren[0]);
 
 			/* leaf nodes */
 			testChildren = tree.getNamesOfChildren(leftKey.append("one"));
-			assertEquals("9", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 
 			testChildren = tree.getNamesOfChildren(rightKey.append("rightOfRight"));
-			assertEquals("10", 0, testChildren.length);
+			assertThat(testChildren).isEmpty();
 		} catch (ObjectNotFoundException e) {
 			caught = true;
 		} finally {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
@@ -32,7 +33,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.provider.FileInfo;
@@ -243,14 +243,14 @@ public class HistoryStoreTest {
 		}
 		IFileState[] states = file.getHistory(createTestMonitor());
 		// Make sure we have 8 states as we haven't trimmed yet.
-		assertEquals("1.02", 8, states.length);
+		assertThat(states).hasSize(8);
 
 		IFileState[] oldStates = states;
 
 		getWorkspace().save(true, null);
 		states = file.getHistory(createTestMonitor());
 		// We added 8 states.  Make sure we only have 5 (the max).
-		assertEquals("1.2", description.getMaxFileStates(), states.length);
+		assertThat(states).hasSize(description.getMaxFileStates());
 
 		// assert that states are in the correct order (newer ones first)
 		long lastModified = states[0].getModificationTime();
@@ -295,7 +295,7 @@ public class HistoryStoreTest {
 		getWorkspace().setDescription(description);
 		states = file.getHistory(createTestMonitor());
 		// Make sure we have 5 states for file file.txt
-		assertEquals("3.1", description.getMaxFileStates(), states.length);
+		assertThat(states).hasSize(description.getMaxFileStates());
 		// change policies
 		// 10 seconds
 		description.setFileStateLongevity(1000 * 10);
@@ -310,7 +310,7 @@ public class HistoryStoreTest {
 		states = file.getHistory(createTestMonitor());
 		// The 5 states for file.txt should have exceeded their longevity
 		// and been removed. Make sure we have 0 states left.
-		assertEquals("3.5", 0, states.length);
+		assertThat(states).isEmpty();
 	}
 
 	@Test
@@ -327,20 +327,20 @@ public class HistoryStoreTest {
 		// location of the data on disk
 		IFileStore fileStore = workspaceRule.getTempStore();
 		createInFileSystem(fileStore);
-		assertEquals("1.0" + " file already has state", 0, store.getStates(file.getFullPath(), createTestMonitor()).length);
+		assertThat(store.getStates(file.getFullPath(), createTestMonitor())).as("check file has no state").isEmpty();
 
 		// add the data to the history store
 		FileInfo fileInfo = new FileInfo(file.getName());
 		fileInfo.setLastModified(System.currentTimeMillis());
 		store.addState(file.getFullPath(), fileStore, fileInfo, true);
 		IFileState[] states = store.getStates(file.getFullPath(), createTestMonitor());
-		assertEquals("2.0", 1, states.length);
+		assertThat(states).hasSize(1);
 
 		// copy the data
 		store.copyHistory(folder, destinationFolder, true);
 
 		states = store.getStates(destinationFile.getFullPath(), createTestMonitor());
-		assertEquals("3.0", 1, states.length);
+		assertThat(states).hasSize(1);
 	}
 
 	@Test
@@ -363,20 +363,20 @@ public class HistoryStoreTest {
 		int maxStates = ResourcesPlugin.getWorkspace().getDescription().getMaxFileStates();
 
 		IFileState[] states = file1.getHistory(createTestMonitor());
-		assertEquals("1.1", 3, states.length);
+		assertThat(states).hasSize(3);
 		int currentStates = 3;
-		assertEquals("1.2" + " file2 already has history", 0, file2.getHistory(createTestMonitor()).length);
+		assertThat(file2.getHistory(createTestMonitor())).as("check file2 has no history").isEmpty();
 		for (int i = 0; i < maxStates + 10; i++) {
 			states = file1.getHistory(createTestMonitor());
-			assertEquals("2.1." + i + " file1 states", currentStates, states.length);
+			assertThat(states).as(i + " file1 states").hasSize(currentStates);
 			file1.move(file2.getFullPath(), true, true, createTestMonitor());
 			states = file2.getHistory(createTestMonitor());
 			currentStates = currentStates < maxStates ? currentStates + 1 : maxStates;
-			assertEquals("2.4." + i + " file2 states", currentStates, states.length);
+			assertThat(states).as(i + " file2 states").hasSize(currentStates);
 			file2.move(file1.getFullPath(), true, true, createTestMonitor());
 			states = file1.getHistory(createTestMonitor());
 			currentStates = currentStates < maxStates ? currentStates + 1 : maxStates;
-			assertEquals("2.7." + i + " file1 states", currentStates, states.length);
+			assertThat(states).as(i + " file1 states").hasSize(currentStates);
 		}
 	}
 
@@ -424,7 +424,7 @@ public class HistoryStoreTest {
 		// All 8 states should exist.
 		long oldLastModTimes[] = new long[8];
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.1", 8, states.length);
+		assertThat(states).hasSize(8);
 		for (int i = 0; i < 8; i++) {
 			oldLastModTimes[i] = states[i].getModificationTime();
 		}
@@ -441,7 +441,7 @@ public class HistoryStoreTest {
 		// Check to ensure only 3 states remain.  Make sure these are the 3
 		// newer states.
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.3", 3, states.length);
+		assertThat(states).hasSize(3);
 		// assert that states are in the correct order (newer ones first)
 		long lastModified = states[0].getModificationTime();
 		for (int i = 1; i < states.length; i++) {
@@ -461,7 +461,7 @@ public class HistoryStoreTest {
 		// the description should be the same as the first test
 		getWorkspace().setDescription(description);
 		states = file.getHistory(createTestMonitor());
-		assertEquals("3.1", 3, states.length);
+		assertThat(states).hasSize(3);
 		// change policies
 		// 10 seconds
 		description.setFileStateLongevity(1000 * 10);
@@ -484,7 +484,7 @@ public class HistoryStoreTest {
 		// Ensure we have no state information left.  It should have been
 		// considered stale.
 		states = file.getHistory(createTestMonitor());
-		assertEquals("5.1", 0, states.length);
+		assertThat(states).isEmpty();
 	}
 
 	/**
@@ -523,9 +523,9 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		// Now do the move
 		folder.copy(folder2.getFullPath(), true, createTestMonitor());
@@ -540,15 +540,15 @@ public class HistoryStoreTest {
 
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.0", 2, states.length);
-		assertTrue("2.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("2.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 
 		project.delete(true, createTestMonitor());
 	}
@@ -595,9 +595,9 @@ public class HistoryStoreTest {
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
@@ -636,10 +636,10 @@ public class HistoryStoreTest {
 		// Test a valid copy of a file
 		store.copyHistory(file, file2, false);
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
+		assertThat(states).hasSize(3).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
 	}
 
 	@Test
@@ -665,9 +665,9 @@ public class HistoryStoreTest {
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 		folder2.create(true, true, createTestMonitor());
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
@@ -676,10 +676,10 @@ public class HistoryStoreTest {
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(folder, folder2, false);
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
+		assertThat(states).hasSize(3).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
 	}
 
 	@Test
@@ -705,9 +705,9 @@ public class HistoryStoreTest {
 		Thread.sleep(1000);
 
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 		folder2.create(true, true, createTestMonitor());
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
@@ -716,10 +716,10 @@ public class HistoryStoreTest {
 		IHistoryStore store = ((Resource) file).getLocalManager().getHistoryStore();
 		store.copyHistory(project, project2, false);
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.4", 3, states.length);
-		assertTrue("2.5", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[1].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[2].getContents()));
+		assertThat(states).hasSize(3).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
 	}
 
 	@Test
@@ -737,17 +737,17 @@ public class HistoryStoreTest {
 
 		// Check to see that there are only 2 states before the deletion
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
+		assertThat(states).hasSize(2);
 
 		// Delete the file. This should add a state to the history store.
 		file.delete(true, true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("1.1", 3, states.length);
+		assertThat(states).hasSize(3);
 
 		// Re-create the file. This should not affect the history store.
 		file.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("1.2", 3, states.length);
+		assertThat(states).hasSize(3);
 
 		// test folder
 		IFolder folder = project.getFolder("folder");
@@ -761,18 +761,18 @@ public class HistoryStoreTest {
 
 		// There should only be 2 history store entries.
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.0", 2, states.length);
+		assertThat(states).hasSize(2);
 
 		// Delete the folder. This should cause one more history store entry.
 		folder.delete(true, true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.1", 3, states.length);
+		assertThat(states).hasSize(3);
 
 		// Re-create the folder. There should be no new history store entries.
 		folder.create(true, true, createTestMonitor());
 		file.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.2", 3, states.length);
+		assertThat(states).hasSize(3);
 
 		project.delete(true, createTestMonitor());
 	}
@@ -801,10 +801,10 @@ public class HistoryStoreTest {
 		/* Valid Case: Test retrieved values. */
 		IFileState[] states = file.getHistory(createTestMonitor());
 		// Make sure we have ITERATIONS number of states
-		assertEquals("5.1", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 		// Make sure that each of these states really exists in the filesystem.
-		for (int i = 0; i < states.length; i++) {
-			assertTrue("5.2." + i, states[i].exists());
+		for (IFileState state : states) {
+			assertThat(state).matches(IFileState::exists, "exists");
 		}
 	}
 
@@ -816,8 +816,7 @@ public class HistoryStoreTest {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.1", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test that a deleted file can be found
 		IFile pfile = project.getFile("findDeletedFile.txt");
@@ -826,58 +825,37 @@ public class HistoryStoreTest {
 		pfile.delete(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.1", 1, df.length);
-		assertEquals("0.2", pfile, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.3", 1, df.length);
-		assertEquals("0.4", pfile, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.5", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// the deleted file should show up as a deleted member of workspace root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.5.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.5.2", 1, df.length);
-		assertEquals("0.5.3", pfile, df[0]);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.5.4", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// recreate the file
 		pfile.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the deleted file should no longer show up as a deleted member of project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.6", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.7", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.8", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// the deleted file should no longer show up as a deleted member of ws root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.8.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.8.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.8.3", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// scrub the project
 		project.delete(true, createTestMonitor());
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.9", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test folder
 		IFolder folder = project.getFolder("folder");
@@ -890,42 +868,27 @@ public class HistoryStoreTest {
 		file.delete(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.1", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.2", 1, df.length);
-		assertEquals("1.3", file, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.4", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(file);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// recreate the file
 		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the deleted file should no longer show up as a deleted member
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.6", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.7", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// deleting the folder should bring it back
 		folder.delete(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.8", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.9", 1, df.length);
-		assertEquals("1.10", file, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.11", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(file);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// create and delete a file where the folder was
 		folderAsFile.create(createRandomContentsStream(), true, createTestMonitor());
@@ -933,29 +896,19 @@ public class HistoryStoreTest {
 		folder.create(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.12", 1, df.length);
-		assertEquals("1.13", folderAsFile, df[0]);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.14", 2, df.length);
-		List<IFile> dfList = Arrays.asList(df);
-		assertTrue("1.15", dfList.contains(file));
-		assertTrue("1.16", dfList.contains(folderAsFile));
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.17", 2, df.length);
-		dfList = Arrays.asList(df);
-		assertTrue("1.18", dfList.contains(file));
-		assertTrue("1.19", dfList.contains(folderAsFile));
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor()))
+				.containsExactly(folderAsFile);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file, folderAsFile);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file, folderAsFile);
 
 		// scrub the project
 		project.delete(true, createTestMonitor());
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.50", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test a bunch of deletes
 		folder = project.getFolder("folder");
@@ -973,95 +926,49 @@ public class HistoryStoreTest {
 		folder.delete(true, true, createTestMonitor());
 
 		// under root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.3", 3, df.length);
-		dfList = Arrays.asList(df);
-		assertTrue("3.3.1", dfList.contains(file1));
-		assertTrue("3.3.2", dfList.contains(file2));
-		assertTrue("3.3.3", dfList.contains(file3));
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file1, file2, file3);
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.4", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.6", 3, df.length);
-		dfList = Arrays.asList(df);
-		assertTrue("3.6.1", dfList.contains(file1));
-		assertTrue("3.6.2", dfList.contains(file2));
-		assertTrue("3.6.3", dfList.contains(file3));
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file1, file2, file3);
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.7", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.8", 2, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.9", 3, df.length);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).hasSize(2);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).hasSize(3);
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.10", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.11", 1, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.12", 1, df.length);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).hasSize(1);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).hasSize(1);
 
 		project.delete(true, createTestMonitor());
 
 		// once the project is gone, so is all the history for that project
 		// under root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.3", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.4", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.6", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.7", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.8", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.9", 0, df.length);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.10", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.11", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.12", 0, df.length);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 	}
 
 	/**
@@ -1160,15 +1067,15 @@ public class HistoryStoreTest {
 
 		IFileState[] history = file.getHistory(createTestMonitor());
 		// no history yet
-		assertEquals("1.2", 0, history.length);
+		assertThat(history).isEmpty();
 		// save the file's current time stamp - it will be remembered in the file state
 		long fileTimeStamp = file.getLocalTimeStamp();
 		file.setContents(createRandomContentsStream(), true, true, createTestMonitor());
 		history = file.getHistory(createTestMonitor());
 		// one state in the history
-		assertEquals("2.2", 1, history.length);
+		assertThat(history).hasSize(1);
 		// the timestamp in the state should match the previous file's timestamp
-		assertEquals("3.0", fileTimeStamp, history[0].getModificationTime());
+		assertThat(history[0].getModificationTime()).isEqualByComparingTo(fileTimeStamp);
 	}
 
 	/**
@@ -1207,9 +1114,9 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		// Now do the move
 		folder.move(folder2.getFullPath(), true, createTestMonitor());
@@ -1224,15 +1131,15 @@ public class HistoryStoreTest {
 
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
-		assertEquals("2.0", 2, states.length);
-		assertTrue("2.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("2.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1273,9 +1180,9 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[1]), true, true, createTestMonitor());
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("1.0", 2, states.length);
-		assertTrue("1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		// Now do the move
 		project.move(IPath.fromOSString("SecondMoveProjectProject"), true, createTestMonitor());
@@ -1292,13 +1199,13 @@ public class HistoryStoreTest {
 		states = file.getHistory(createTestMonitor());
 
 		// original file should not remember history when project is moved
-		assertEquals("2.0", 0, states.length);
+		assertThat(states).isEmpty();
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("2.3", 4, states.length);
-		assertTrue("2.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("2.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("2.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("2.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1321,12 +1228,12 @@ public class HistoryStoreTest {
 
 		/* Valid Case: Ensure correct number of states available. */
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("4.1", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 
 		/* Remove all states, and verify that no states remain. */
 		file.clearHistory(createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("5.0", 0, states.length);
+		assertThat(states).isEmpty();
 
 		/* test remove in a folder -- make sure it does not affect other resources' states*/
 		IFolder folder = project.getFolder("folder");
@@ -1339,16 +1246,16 @@ public class HistoryStoreTest {
 		}
 
 		states = file.getHistory(createTestMonitor());
-		assertEquals("6.2", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 		states = anotherOne.getHistory(createTestMonitor());
-		assertEquals("6.3", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 
 		/* Remove all states, and verify that no states remain. */
 		project.clearHistory(createTestMonitor());
 		states = file.getHistory(createTestMonitor());
-		assertEquals("7.0", 0, states.length);
+		assertThat(states).isEmpty();
 		states = anotherOne.getHistory(createTestMonitor());
-		assertEquals("7.1", 0, states.length);
+		assertThat(states).isEmpty();
 
 		/* test remove in a folder -- make sure it does not affect other resources' states*/
 		IFile aaa = project.getFile("aaa");
@@ -1367,20 +1274,20 @@ public class HistoryStoreTest {
 		}
 
 		states = anotherOne.getHistory(createTestMonitor());
-		assertEquals("8.3", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 		states = aaa.getHistory(createTestMonitor());
-		assertEquals("8.4", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 		states = ccc.getHistory(createTestMonitor());
-		assertEquals("8.5", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 
 		/* Remove all states, and verify that no states remain. aaa and ccc should not be affected. */
 		bbb.clearHistory(createTestMonitor());
 		states = anotherOne.getHistory(createTestMonitor());
-		assertEquals("9.1", 0, states.length);
+		assertThat(states).isEmpty();
 		states = aaa.getHistory(createTestMonitor());
-		assertEquals("9.2", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 		states = ccc.getHistory(createTestMonitor());
-		assertEquals("9.3", ITERATIONS, states.length);
+		assertThat(states).hasSize(ITERATIONS);
 	}
 
 	/**
@@ -1422,9 +1329,9 @@ public class HistoryStoreTest {
 
 		/* Check history for both files. */
 		IFileState[] states = file.getHistory(null);
-		assertEquals("4.0", 2, states.length);
+		assertThat(states).hasSize(2);
 		states = copyFile.getHistory(null);
-		assertEquals("4.1", 2, states.length);
+		assertThat(states).hasSize(2);
 
 		/* Set new contents on second file. Should add two entries to the history store. */
 		copyFile.setContents(createInputStream(contents[3]), true, true, null);
@@ -1433,17 +1340,17 @@ public class HistoryStoreTest {
 		/* Check history for both files. */
 		// Check log for original file.
 		states = file.getHistory(null);
-		assertEquals("6.0", 2, states.length);
-		assertTrue("6.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("6.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		// Check log for copy.
 		states = copyFile.getHistory(null);
-		assertEquals("6.3", 4, states.length);
-		assertTrue("6.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("6.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("6.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("6.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 	}
 
 	/**
@@ -1487,9 +1394,9 @@ public class HistoryStoreTest {
 
 		/* Check history for both files. */
 		IFileState[] states = file.getHistory(null);
-		assertEquals("4.0", 2, states.length);
+		assertThat(states).hasSize(2);
 		states = moveFile.getHistory(null);
-		assertEquals("4.1", 2, states.length);
+		assertThat(states).hasSize(2);
 
 		/* Set new contents on moved file. Should add two entries to the history store. */
 		moveFile.setContents(createInputStream(contents[3]), true, true, null);
@@ -1498,17 +1405,17 @@ public class HistoryStoreTest {
 		/* Check history for both files. */
 		// Check log for original file.
 		states = file.getHistory(null);
-		assertEquals("6.0", 2, states.length);
-		assertTrue("6.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("6.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		// Check log for moved file.
 		states = moveFile.getHistory(null);
-		assertEquals("6.3", 4, states.length);
-		assertTrue("6.4", compareContent(createInputStream(contents[3]), states[0].getContents()));
-		assertTrue("6.5", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("6.6", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("6.7", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 	}
 
 	/**
@@ -1543,20 +1450,19 @@ public class HistoryStoreTest {
 
 		/* Ensure two entries are available for the file, and that content matches. */
 		IFileState[] states = file.getHistory(createTestMonitor());
-		assertEquals("3.0", 2, states.length);
-		assertTrue("3.1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("3.1.2", compareContent(createInputStream(contents[0]), states[1].getContents()));
+		assertThat(states).hasSize(2).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
 
 		/* Delete the file. Should add an entry to the store. */
 		file.delete(true, true, createTestMonitor());
 
 		/* Ensure three entries are available for the file, and that content matches. */
 		states = file.getHistory(createTestMonitor());
-		assertEquals("5.0", 3, states.length);
-		assertTrue("5.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
-		assertTrue("5.1.2", compareContent(createInputStream(contents[1]), states[1].getContents()));
-		assertTrue("5.1.3", compareContent(createInputStream(contents[0]), states[2].getContents()));
-
+		assertThat(states).hasSize(3).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
 		/* Roll file back to first version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
 		// Create the file with the contents from one of the states.
@@ -1565,24 +1471,24 @@ public class HistoryStoreTest {
 
 		// Check history store.
 		states = file.getHistory(createTestMonitor());
-		assertEquals("6.0", 3, states.length);
-		assertTrue("6.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
-		assertTrue("6.1.2", compareContent(createInputStream(contents[1]), states[1].getContents()));
-		assertTrue("6.1.3", compareContent(createInputStream(contents[0]), states[2].getContents()));
+		assertThat(states).hasSize(3).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
 
 		// Check file contents.
-		assertTrue("6.2", compareContent(createInputStream(contents[2]), file.getContents(false)));
+		assertThat(compareContent(createInputStream(contents[2]), file.getContents(false))).isTrue();
 
 		/* Set new contents on the file. Should add an entry to the history store. */
 		file.setContents(createInputStream(contents[1]), true, true, null);
 
 		/* Ensure four entries are available for the file, and that entries match. */
 		states = file.getHistory(createTestMonitor());
-		assertEquals("8.0", 4, states.length);
-		assertTrue("8.1.1", compareContent(createInputStream(contents[2]), states[0].getContents()));
-		assertTrue("8.1.2", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("8.1.3", compareContent(createInputStream(contents[1]), states[2].getContents()));
-		assertTrue("8.1.4", compareContent(createInputStream(contents[0]), states[3].getContents()));
+		assertThat(states).hasSize(4).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
 
 		/* Roll file back to third version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
@@ -1591,15 +1497,15 @@ public class HistoryStoreTest {
 
 		// Check history log.
 		states = file.getHistory(createTestMonitor());
-		assertEquals("9.0", 5, states.length);
-		assertTrue("9.1.1", compareContent(createInputStream(contents[1]), states[0].getContents()));
-		assertTrue("9.1.2", compareContent(createInputStream(contents[2]), states[1].getContents()));
-		assertTrue("9.1.3", compareContent(createInputStream(contents[2]), states[2].getContents()));
-		assertTrue("9.1.4", compareContent(createInputStream(contents[1]), states[3].getContents()));
-		assertTrue("9.1.5", compareContent(createInputStream(contents[0]), states[4].getContents()));
+		assertThat(states).hasSize(5).satisfiesExactly(
+				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
+				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
+				third -> assertThat(compareContent(createInputStream(contents[2]), third.getContents())).isTrue(),
+				fourth -> assertThat(compareContent(createInputStream(contents[1]), fourth.getContents())).isTrue(),
+				fifth -> assertThat(compareContent(createInputStream(contents[0]), fifth.getContents())).isTrue());
 
 		// Check file contents.
-		assertTrue("9.2", compareContent(createInputStream(contents[1]), file.getContents(false)));
+		assertThat(compareContent(createInputStream(contents[1]), file.getContents(false))).isTrue();
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.internal.localstore.LocalStoreTestUtil.createTree;
 import static org.eclipse.core.tests.internal.localstore.LocalStoreTestUtil.getTree;
@@ -300,7 +301,7 @@ public class RefreshLocalTest implements ICoreConstants {
 		assertFalse(folder.exists());
 		folder.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertTrue(folder.exists());
-		assertEquals(((Resource) folder).countResources(IResource.DEPTH_INFINITE, false), getTree(target).length + 1);
+		assertThat(getTree(target)).hasSize(((Resource) folder).countResources(IResource.DEPTH_INFINITE, false) - 1);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -92,7 +91,7 @@ public class SafeChunkyInputOutputStreamTest {
 		// read chunks
 		try (SafeChunkyInputStream input = new SafeChunkyInputStream(target)) {
 			byte[] read = new byte[chunk.length];
-			assertEquals(chunk.length, input.read(read));
+			assertThat(chunk).hasSize(input.read(read));
 			assertThat(read).isEqualTo(chunk);
 		}
 		Workspace.clear(target); // make sure there was nothing here before
@@ -163,19 +162,16 @@ public class SafeChunkyInputOutputStreamTest {
 		// read chunks
 		try (SafeChunkyInputStream input = new SafeChunkyInputStream(target)) {
 			byte[] read1 = new byte[chunk1.length];
-			// byte[] read2 = new byte[chunk2.length];
 			byte[] read3 = new byte[chunk3.length];
 			byte[] read4 = new byte[chunk4.length];
 			byte[] read5 = new byte[chunk5.length];
 			byte[] read6 = new byte[fakeEnd.length + chunk6.length];
-			assertEquals(chunk1.length, input.read(read1));
-			// assert("3.1", input.read(read2) == chunk2.length);
-			assertEquals(chunk3.length, input.read(read3));
-			assertEquals(chunk4.length, input.read(read4));
-			assertEquals(chunk5.length, input.read(read5));
-			assertEquals((fakeEnd.length + chunk6.length), input.read(read6));
+			assertThat(chunk1).hasSize(input.read(read1));
+			assertThat(chunk3).hasSize(input.read(read3));
+			assertThat(chunk4).hasSize(input.read(read4));
+			assertThat(chunk5).hasSize(input.read(read5));
+			assertThat(chunk6).hasSize(input.read(read6) - fakeEnd.length);
 			assertThat(read1).isEqualTo(chunk1);
-			// assert("3.7", compare(chunk2, read2));
 			assertThat(read3).isEqualTo(chunk3);
 			assertThat(read4).isEqualTo(chunk4);
 			assertThat(read5).isEqualTo(chunk5);
@@ -239,11 +235,11 @@ public class SafeChunkyInputOutputStreamTest {
 			byte[] read3 = new byte[chunk3.length];
 			byte[] read4 = new byte[chunk4.length];
 			byte[] read5 = new byte[chunk5.length];
-			assertEquals(chunk1.length, input.read(read1));
-			assertEquals(chunk2.length, input.read(read2));
-			assertEquals(chunk3.length, input.read(read3));
-			assertEquals(chunk4.length, input.read(read4));
-			assertEquals(chunk5.length, input.read(read5));
+			assertThat(chunk1).hasSize(input.read(read1));
+			assertThat(chunk2).hasSize(input.read(read2));
+			assertThat(chunk3).hasSize(input.read(read3));
+			assertThat(chunk4).hasSize(input.read(read4));
+			assertThat(chunk5).hasSize(input.read(read5));
 			assertThat(read1).isEqualTo(chunk1);
 			assertThat(read2).isEqualTo(chunk2);
 			assertThat(read3).isEqualTo(chunk3);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -1144,12 +1144,11 @@ public class ProjectPreferencesTest {
 
 		Preferences node = new ProjectScope(project1).getNode("");
 		String[] childrenNames = node.childrenNames();
-		assertEquals(2, childrenNames.length);
-		assertEquals(nodeA, childrenNames[1]);
+		assertThat(childrenNames).hasSize(2);
+		assertThat(childrenNames[1]).isEqualTo(nodeA);
 		node = node.node(nodeA);
 		childrenNames = node.childrenNames();
-		assertEquals(1, childrenNames.length);
-		assertEquals(nodeB, childrenNames[0]);
+		assertThat(childrenNames).containsExactly(nodeB);
 
 		project1.delete(true, createTestMonitor());
 		project2.delete(true, createTestMonitor());
@@ -1184,8 +1183,7 @@ public class ProjectPreferencesTest {
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA);
 		String[] childrenNames = node.childrenNames();
-		assertEquals(1, childrenNames.length);
-		assertEquals(nodeB, childrenNames[0]);
+		assertThat(childrenNames).containsExactly(nodeB);
 
 		project1.delete(true, createTestMonitor());
 		project2.delete(true, createTestMonitor());
@@ -1220,7 +1218,7 @@ public class ProjectPreferencesTest {
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		node.clear();
-		assertEquals(0, node.keys().length);
+		assertThat(node.keys()).isEmpty();
 		assertNull(node.get(key, null));
 
 		project1.delete(true, createTestMonitor());
@@ -1290,8 +1288,7 @@ public class ProjectPreferencesTest {
 
 		Preferences node = new ProjectScope(project1).getNode(nodeA).node(nodeB);
 		String[] keys = node.keys();
-		assertEquals(1, keys.length);
-		assertEquals(key, keys[0]);
+		assertThat(keys).containsExactly(key);
 
 		project1.delete(true, createTestMonitor());
 		project2.delete(true, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -96,7 +96,7 @@ public class WorkspacePreferencesTest extends WorkspaceSessionTest {
 		assertEquals("2.2", expectedList, actualList);
 
 		preferences.setValue(ResourcesPlugin.PREF_BUILD_ORDER, "");
-		assertTrue("2.3", workspace.getDescription().getBuildOrder().length == 0);
+		assertThat(workspace.getDescription().getBuildOrder()).isEmpty();
 
 		long snapshotInterval = 800000000L;
 		preferences.setValue(ResourcesPlugin.PREF_SNAPSHOT_INTERVAL, snapshotInterval);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -149,7 +150,7 @@ public class ObjectMapTest {
 			values[i] = Long.valueOf(System.currentTimeMillis());
 			map.put(Integer.valueOf(i), values[i]);
 		}
-		assertEquals("#populateMap", values.length, map.size());
+		assertThat(values).hasSize(map.size());
 		return map;
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/TestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/TestUtil.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.watson;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -72,7 +73,7 @@ class TestUtil implements IPathConstants {
 			/* get the children */
 			IPath[] expectedChildren = expected.getChildren(path);
 			IPath[] actualChildren = actual.getChildren(path);
-			assertEquals("Number of children", expectedChildren.length, actualChildren.length);
+			assertThat(actualChildren).describedAs("Number of children").hasSameSizeAs(expectedChildren);
 
 			int newDepth = depth;
 			if (depth != ElementTreeWriter.D_INFINITE) {
@@ -110,29 +111,29 @@ class TestUtil implements IPathConstants {
 		assertHasPaths(tree, getTreePaths());
 
 		IPath[] children = tree.getChildren(IPath.ROOT);
-		assertEquals(1, children.length);
+		assertThat(children).hasSize(1);
 
 		/* solution children */
 		children = tree.getChildren(children[0]);
-		assertEquals(2, children.length);
-		assertEquals(0, tree.getChildren(project1).length);
+		assertThat(children).hasSize(2);
+		assertThat(tree.getChildren(project1)).isEmpty();
 
 		/* project2 children */
 		children = tree.getChildren(children[1]);
-		assertEquals(3, children.length);
-		assertEquals(0, tree.getChildren(file1).length);
-		assertEquals(0, tree.getChildren(folder2).length);
+		assertThat(children).hasSize(3);
+		assertThat(tree.getChildren(file1)).isEmpty();
+		assertThat(tree.getChildren(folder2)).isEmpty();
 
 		/* folder1 children */
 		children = tree.getChildren(children[1]);
-		assertEquals(3, children.length);
-		assertEquals(0, tree.getChildren(file2).length);
-		assertEquals(0, tree.getChildren(folder4).length);
+		assertThat(children).hasSize(3);
+		assertThat(tree.getChildren(file2)).isEmpty();
+		assertThat(tree.getChildren(folder4)).isEmpty();
 
 		/* folder3 children */
 		children = tree.getChildren(children[1]);
-		assertEquals(1, children.length);
-		assertEquals(0, tree.getChildren(file3).length);
+		assertThat(children).hasSize(1);
+		assertThat(tree.getChildren(file3)).isEmpty();
 	}
 
 	static ElementTree createTestElementTree() {
@@ -320,7 +321,7 @@ class TestUtil implements IPathConstants {
 	 * arrays undergo the same permutation.
 	 */
 	static protected void scramble(Object[] first, Object[] second) {
-		assertTrue(first.length == second.length);
+		assertThat(first).hasSameSizeAs(second);
 		Random random = new Random(System.currentTimeMillis());
 
 		final int len = first.length;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.PI_RESOURCES;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
@@ -141,13 +142,8 @@ public class CharsetTest {
 
 		boolean ignoreEvent() {
 			// to make testing easier, we allow events from the main or other thread to be ignored
-			if (isSet(IGNORE_BACKGROUND_THREAD) && Thread.currentThread() != creationThread) {
-				return true;
-			}
-			if (isSet(IGNORE_CREATION_THREAD) && Thread.currentThread() == creationThread) {
-				return true;
-			}
-			return false;
+			return (isSet(IGNORE_BACKGROUND_THREAD) && Thread.currentThread() != creationThread)
+					|| (isSet(IGNORE_CREATION_THREAD) && Thread.currentThread() == creationThread);
 		}
 
 		@Override
@@ -947,7 +943,7 @@ public class CharsetTest {
 			assertEquals(ResourcesPlugin.getEncoding(), project.getDefaultCharset(false));
 
 			IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("No missing encoding marker should be set", 0, markers.length);
+			assertThat(markers).as("check no missing encoding markers").isEmpty();
 
 			project.setDefaultCharset(null, createTestMonitor());
 			assertEquals(null, project.getDefaultCharset(false));
@@ -955,7 +951,7 @@ public class CharsetTest {
 			waitForEncodingRelatedJobs(testName.getMethodName());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("Missing encoding marker should be set", 1, markers.length);
+			assertThat(markers).as("check missing encoding markers").hasSize(1);
 
 			createInWorkspace(new IResource[] {file1, file2, file3});
 			// project and children should be using the workspace's default now
@@ -965,7 +961,7 @@ public class CharsetTest {
 			// sets workspace default charset
 			workspace.getRoot().setDefaultCharset("FOO", createTestMonitor());
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("Missing encoding marker should be still set", 1, markers.length);
+			assertThat(markers).as("check missing encoding markers").hasSize(1);
 
 			assertCharsetIs("2.0", "FOO", new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
 			assertCharsetIs("2.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
@@ -975,7 +971,7 @@ public class CharsetTest {
 			waitForEncodingRelatedJobs(testName.getMethodName());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("No missing encoding marker should be set", 0, markers.length);
+			assertThat(markers).as("check no missing encoding markers").isEmpty();
 
 			assertCharsetIs("3.0", "BAR", new IResource[] {project, file1, folder1, file2, folder2, file3}, true);
 			assertCharsetIs("3.1", null, new IResource[] {file1, folder1, file2, folder2, file3}, false);
@@ -1103,7 +1099,7 @@ public class CharsetTest {
 			assertTrue("2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
 
 			IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("No missing encoding marker should be set", 0, markers.length);
+			assertThat(markers).as("check no missing enconding markers").isEmpty();
 
 			backgroundVerifier.reset();
 			backgroundVerifier.addExpectedChange(
@@ -1120,7 +1116,7 @@ public class CharsetTest {
 			assertTrue("3.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-			assertEquals("Missing encoding marker should be set", 1, markers.length);
+			assertThat(markers).as("check missing encoding markers").hasSize(1);
 		} finally {
 			getWorkspace().removeResourceChangeListener(backgroundVerifier);
 			clearAllEncodings(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -131,9 +132,9 @@ public class HiddenResourceTest {
 		members = project.members();
 
 		// +1 for the project description file
-		assertEquals("2.1", 4, members.length);
+		assertThat(members).hasSize(4);
 		members = folder.members();
-		assertEquals("2.3", 1, members.length);
+		assertThat(members).hasSize(1);
 
 		// Set the values.
 		setHidden(project, true, IResource.DEPTH_INFINITE);
@@ -144,9 +145,9 @@ public class HiddenResourceTest {
 
 		// Check the calls to #members
 		members = project.members();
-		assertEquals("5.1", 0, members.length);
+		assertThat(members).isEmpty();
 		members = folder.members();
-		assertEquals("5.3", 0, members.length);
+		assertThat(members).isEmpty();
 
 		// FIXME: add the tests for #members(int)
 
@@ -157,44 +158,44 @@ public class HiddenResourceTest {
 		// Check the calls to members(IResource.NONE);
 		members = project.members(IResource.NONE);
 		// +1 for the project description file
-		assertEquals("7.1", 4, members.length);
+		assertThat(members).hasSize(4);
 		members = project.members(IContainer.INCLUDE_HIDDEN);
 		// +1 for the project description file
-		assertEquals("7.3", 4, members.length);
+		assertThat(members).hasSize(4);
 		members = folder.members();
-		assertEquals("7.5", 1, members.length);
+		assertThat(members).hasSize(1);
 
 		// Set one of the children to be HIDDEN and try again
 		setHidden(folder, true, IResource.DEPTH_ZERO);
 		members = project.members();
 
 		// +1 for project description, -1 for hidden folder
-		assertEquals("8.2", 3, members.length);
+		assertThat(members).hasSize(3);
 		members = folder.members();
-		assertEquals("8.4", 1, members.length);
+		assertThat(members).hasSize(1);
 		members = project.members(IResource.NONE);
 		// +1 for project description, -1 for hidden folder
-		assertEquals("8.6", 3, members.length);
+		assertThat(members).hasSize(3);
 		members = folder.members();
-		assertEquals("8.8", 1, members.length);
+		assertThat(members).hasSize(1);
 		members = project.members(IContainer.INCLUDE_HIDDEN);
 		// +1 for project description
-		assertEquals("8.10", 4, members.length);
+		assertThat(members).hasSize(4);
 		members = folder.members();
-		assertEquals("8.12", 1, members.length);
+		assertThat(members).hasSize(1);
 
 		// Set all the resources to be hidden
 		setHidden(project, true, IResource.DEPTH_INFINITE);
 		assertHidden(project, true, IResource.DEPTH_INFINITE);
 		members = project.members(IResource.NONE);
-		assertEquals("9.3", 0, members.length);
+		assertThat(members).isEmpty();
 		members = folder.members(IResource.NONE);
-		assertEquals("9.5", 0, members.length);
+		assertThat(members).isEmpty();
 		members = project.members(IContainer.INCLUDE_HIDDEN);
 		// +1 for project description
-		assertEquals("9.7", 4, members.length);
+		assertThat(members).hasSize(4);
 		members = folder.members(IContainer.INCLUDE_HIDDEN);
-		assertEquals("9.9", 1, members.length);
+		assertThat(members).hasSize(1);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
@@ -171,11 +172,9 @@ public class IProjectDescriptionTest {
 		description.setDynamicReferences(new IProject[] {target2});
 		project.setDescription(description, createTestMonitor());
 		IProject[] refs = project.getReferencedProjects();
-		assertEquals("2.1", 2, refs.length);
-		assertEquals("2.2", target1, refs[0]);
-		assertEquals("2.3", target2, refs[1]);
-		assertEquals("2.4", 1, target1.getReferencingProjects().length);
-		assertEquals("2.5", 1, target2.getReferencingProjects().length);
+		assertThat(refs).containsExactly(target1, target2);
+		assertThat(target1.getReferencingProjects()).hasSize(1);
+		assertThat(target2.getReferencingProjects()).hasSize(1);
 
 		//get references for a non-existent project
 		assertThrows(CoreException.class,
@@ -197,7 +196,7 @@ public class IProjectDescriptionTest {
 		IProjectDescription description = project.getDescription();
 		description.setReferencedProjects(new IProject[] {target});
 		project.setDescription(description, createTestMonitor());
-		assertEquals("2.1", 1, target.getReferencingProjects().length);
+		assertThat(target.getReferencingProjects()).hasSize(1);
 
 		//get references for a non-existent project
 		assertThrows(CoreException.class,
@@ -205,7 +204,7 @@ public class IProjectDescriptionTest {
 
 		//get referencing projects for a non-existent project
 		IProject[] refs = getWorkspace().getRoot().getProject("DoesNotExist2").getReferencingProjects();
-		assertEquals("4.0", 0, refs.length);
+		assertThat(refs).isEmpty();
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
@@ -127,7 +128,7 @@ public class IProjectTest  {
 		project.copy(destination.getFullPath(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
 		assertTrue("1.1", destination.exists());
-		assertEquals("1.2", 0, destination.findMarkers(IMarker.TASK, true, IResource.DEPTH_INFINITE).length);
+		assertThat(destination.findMarkers(IMarker.TASK, true, IResource.DEPTH_INFINITE)).isEmpty();
 	}
 
 	/**
@@ -1997,29 +1998,23 @@ public class IProjectTest  {
 		IProject project2 = getWorkspace().getRoot().getProject("P2");
 
 		//dynamic project references
-		assertEquals("2.0", 0, desc.getDynamicReferences().length);
+		assertThat(desc.getDynamicReferences()).isEmpty();
 		IProject[] refs = new IProject[] {project1, project2};
 		desc.setDynamicReferences(refs);
 		IProject[] result = desc.getDynamicReferences();
-		assertEquals("2.1", 2, result.length);
-		assertEquals("2.2", project1, result[0]);
-		assertEquals("2.3", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 
 		//destroying the result should not affect the description
 		result[0] = null;
 		result[1] = null;
 		result = desc.getDynamicReferences();
-		assertEquals("2.4", 2, result.length);
-		assertEquals("2.5", project1, result[0]);
-		assertEquals("2.6", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 
 		//duplicates (should be automatically omitted)
 		refs = new IProject[] {project1, project2, project2, project1, project1};
 		desc.setDynamicReferences(refs);
 		result = desc.getDynamicReferences();
-		assertEquals("3.1", 2, result.length);
-		assertEquals("3.2", project1, result[0]);
-		assertEquals("3.3", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 	}
 
 	/**
@@ -2035,29 +2030,23 @@ public class IProjectTest  {
 		assertEquals("1.0", "foo", desc.getName());
 
 		//project references
-		assertEquals("2.0", 0, desc.getReferencedProjects().length);
+		assertThat(desc.getReferencedProjects()).isEmpty();
 		IProject[] refs = new IProject[] {project1, project2};
 		desc.setReferencedProjects(refs);
 		IProject[] result = desc.getReferencedProjects();
-		assertEquals("2.1", 2, result.length);
-		assertEquals("2.2", project1, result[0]);
-		assertEquals("2.3", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 
 		//destroying the result should not affect the description
 		result[0] = null;
 		result[1] = null;
 		result = desc.getReferencedProjects();
-		assertEquals("2.4", 2, result.length);
-		assertEquals("2.5", project1, result[0]);
-		assertEquals("2.6", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 
 		//duplicates (should be automatically omitted)
 		refs = new IProject[] {project1, project2, project2, project1, project1};
 		desc.setReferencedProjects(refs);
 		result = desc.getReferencedProjects();
-		assertEquals("3.1", 2, result.length);
-		assertEquals("3.2", project1, result[0]);
-		assertEquals("3.3", project2, result[1]);
+		assertThat(result).containsExactly(project1, project2);
 	}
 
 	@Test
@@ -2216,7 +2205,7 @@ public class IProjectTest  {
 		assertEquals("1.8", value, actual);
 		// ensure the marker was moved
 		markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
-		assertEquals("1.10", 1, markers.length);
+		assertThat(markers).hasSize(1);
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);
@@ -2252,7 +2241,7 @@ public class IProjectTest  {
 		assertEquals("2.11", value, actual);
 		// ensure the marker was moved
 		markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
-		assertEquals("2.13", 1, markers.length);
+		assertThat(markers).hasSize(1);
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);
@@ -2384,7 +2373,7 @@ public class IProjectTest  {
 		assertEquals("2.11", propertyValue, actualPropertyValue);
 		// ensure the marker was moved
 		IMarker[] markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
-		assertEquals("2.13", 1, markers.length);
+		assertThat(markers).hasSize(1);
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -731,9 +731,10 @@ public class IResourceChangeListenerTest {
 				done = true;
 				IMarkerDelta[] deltas = event.findMarkerDeltas(IMarker.TASK, false);
 				listenerInMainThreadCallback.set(() -> {
-					assertEquals("1.0", 1, deltas.length);
-					assertEquals("1.1", marker.getId(), deltas[0].getId());
-					assertEquals("1.2", IResourceDelta.REMOVED, deltas[0].getKind());
+					assertThat(deltas).hasSize(1).allSatisfy(delta -> {
+						assertThat(delta.getId()).isEqualTo(marker.getId());
+						assertThat(delta.getKind()).isEqualTo(IResourceDelta.REMOVED);
+					});
 					synchronized (this) {
 						notifyAll();
 					}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
@@ -75,8 +76,7 @@ public class IWorkspaceRootTest {
 
 		//try to find the file using the upper case device
 		IFile[] files = getWorkspace().getRoot().findFilesForLocation(fileLocationUpper);
-		assertEquals("1.0", 1, files.length);
-		assertEquals("1.1", link, files[0]);
+		assertThat(files).containsExactly(link);
 	}
 
 	/**
@@ -114,8 +114,7 @@ public class IWorkspaceRootTest {
 		//should find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IContainer[] result = root.findContainersForLocation(root.getLocation());
-		assertEquals("1.0", 1, result.length);
-		assertEquals("1.1", root, result[0]);
+		assertThat(result).containsExactly(root);
 
 		//deep linked resource
 		IFolder parent = p2.getFolder("parent");
@@ -189,7 +188,7 @@ public class IWorkspaceRootTest {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IFile[] result = root.findFilesForLocation(root.getLocation());
-		assertEquals("1.0", 0, result.length);
+		assertThat(result).isEmpty();
 
 		IFile existing = project.getFile("file1");
 		createInWorkspace(existing);
@@ -239,22 +238,14 @@ public class IWorkspaceRootTest {
 	 * Asserts that the given result array contains only the given resource.
 	 */
 	private void assertResources(String message, IResource expected, IResource[] actual) {
-		assertEquals(message, 1, actual.length);
-		assertEquals(message, expected, actual[0]);
+		assertThat(actual).describedAs(message).containsExactly(expected);
 	}
 
 	/**
 	 * Asserts that the given result array contains only the two given resources
 	 */
 	private void assertResources(String message, IResource expected0, IResource expected1, IResource[] actual) {
-		assertEquals(message, 2, actual.length);
-		if (actual[0].equals(expected0)) {
-			assertEquals(message, expected1, actual[1]);
-		} else if (actual[0].equals(expected1)) {
-			assertEquals(message, expected0, actual[1]);
-		} else {
-			assertEquals(message, expected0, actual[0]);
-		}
+		assertThat(actual).describedAs(message).containsExactlyInAnyOrder(expected0, expected1);
 	}
 
 	/**
@@ -346,10 +337,10 @@ public class IWorkspaceRootTest {
 		folder.create(true, true, createTestMonitor());
 
 		IContainer[] containers = root.findContainersForLocationURI(folder.getLocationURI());
-		assertEquals("2.0", 0, containers.length);
+		assertThat(containers).isEmpty();
 
 		containers = root.findContainersForLocationURI(folder.getLocationURI(), IContainer.INCLUDE_HIDDEN);
-		assertEquals("3.0", 1, containers.length);
+		assertThat(containers).hasSize(1);
 	}
 
 	@Test
@@ -364,16 +355,16 @@ public class IWorkspaceRootTest {
 		file.create(new ByteArrayInputStream("foo".getBytes()), true, createTestMonitor());
 
 		IFile[] files = root.findFilesForLocationURI(file.getLocationURI());
-		assertEquals("3.0", 0, files.length);
+		assertThat(files).isEmpty();
 
 		files = root.findFilesForLocationURI(file.getLocationURI(), IContainer.INCLUDE_HIDDEN);
-		assertEquals("4.0", 1, files.length);
+		assertThat(files).hasSize(1);
 
 		IContainer[] containers = root.findContainersForLocationURI(file.getLocationURI());
-		assertEquals("5.0", 0, containers.length);
+		assertThat(containers).isEmpty();
 
 		containers = root.findContainersForLocationURI(file.getLocationURI(), IContainer.INCLUDE_HIDDEN);
-		assertEquals("6.0", 1, containers.length);
+		assertThat(containers).hasSize(1);
 	}
 
 	/**
@@ -483,12 +474,12 @@ public class IWorkspaceRootTest {
 
 	private void checkFindFiles(URI location, int memberFlags, int foundResources) {
 		IFile[] files = getWorkspace().getRoot().findFilesForLocationURI(location, memberFlags);
-		assertEquals(foundResources, files.length);
+		assertThat(files).hasSize(foundResources);
 	}
 
 	private void checkFindContainers(URI location, int memberFlags, int foundResources) {
 		IContainer[] containers = getWorkspace().getRoot().findContainersForLocationURI(location, memberFlags);
-		assertEquals(foundResources, containers.length);
+		assertThat(containers).hasSize(foundResources);
 	}
 
 	private IFile createFile(IContainer parent, int updateFlags, boolean linked) throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
@@ -227,7 +228,7 @@ public class IWorkspaceTest {
 		//copy a folder
 		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, createTestMonitor());
 		assertTrue("3.7", folderCopy.exists());
-		assertTrue("3.8", folderCopy.members().length > 0);
+		assertThat(folderCopy.members()).hasSizeGreaterThan(0);
 		removeFromWorkspace(folderCopy);
 		removeFromFileSystem(folderCopy);
 	}
@@ -309,95 +310,81 @@ public class IWorkspaceTest {
 		assertNotNull("2.0", current);
 		assertEquals("2.1", NATURE_SIMPLE, current.getNatureId());
 		assertEquals("2.2", "Simple", current.getLabel());
-		assertEquals("2.3", 0, current.getRequiredNatureIds().length);
-		assertEquals("2.4", 0, current.getNatureSetIds().length);
+		assertThat(current.getRequiredNatureIds()).isEmpty();
+		assertThat(current.getNatureSetIds()).isEmpty();
 
 		current = findNature(descriptors, NATURE_SNOW);
 		assertNotNull("3.0", current);
 		assertEquals("3.1", NATURE_SNOW, current.getNatureId());
 		assertEquals("3.2", "Snow", current.getLabel());
 		String[] required = current.getRequiredNatureIds();
-		assertEquals("3.3", 1, required.length);
-		assertEquals("3.4", NATURE_WATER, required[0]);
+		assertThat(required).containsExactly(NATURE_WATER);
 		String[] sets = current.getNatureSetIds();
-		assertEquals("3.5", 1, sets.length);
-		assertEquals("3.6", SET_OTHER, sets[0]);
+		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = findNature(descriptors, NATURE_WATER);
 		assertNotNull("4.0", current);
 		assertEquals("4.1", NATURE_WATER, current.getNatureId());
 		assertEquals("4.2", "Water", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("4.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("4.4", 1, sets.length);
-		assertEquals("4.5", SET_STATE, sets[0]);
+		assertThat(sets).containsExactly(SET_STATE);
 
 		current = findNature(descriptors, NATURE_EARTH);
 		assertNotNull("5.0", current);
 		assertEquals("5.1", NATURE_EARTH, current.getNatureId());
 		assertEquals("5.2", "Earth", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("5.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("5.4", 1, sets.length);
-		assertEquals("5.5", SET_STATE, sets[0]);
+		assertThat(sets).containsExactly(SET_STATE);
 
 		current = findNature(descriptors, NATURE_MUD);
 		assertNotNull("6.0", current);
 		assertEquals("6.1", NATURE_MUD, current.getNatureId());
 		assertEquals("6.2", "Mud", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("6.3", 2, required.length);
 		//water and earth are required for mud
-		if (required[0].equals(NATURE_WATER)) {
-			assertEquals("6.4", NATURE_EARTH, required[1]);
-		} else {
-			assertEquals("6.5", NATURE_EARTH, required[0]);
-			assertEquals("6.6", NATURE_WATER, required[0]);
-		}
+		assertThat(required).containsExactlyInAnyOrder(NATURE_WATER, NATURE_EARTH);
 		sets = current.getNatureSetIds();
-		assertEquals("6.7", 1, sets.length);
-		assertEquals("6.8", SET_OTHER, sets[0]);
+		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = findNature(descriptors, NATURE_INVALID);
 		assertNotNull("7.0", current);
 		assertEquals("7.1", NATURE_INVALID, current.getNatureId());
 		assertEquals("7.2", "", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("7.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("7.4", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE1);
 		assertNotNull("8.0", current);
 		assertEquals("8.1", NATURE_CYCLE1, current.getNatureId());
 		assertEquals("8.2", "Cycle1", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("8.3", 1, required.length);
-		assertEquals("8.4", NATURE_CYCLE2, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE2);
 		sets = current.getNatureSetIds();
-		assertEquals("8.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE2);
 		assertNotNull("5.0", current);
 		assertEquals("9.1", NATURE_CYCLE2, current.getNatureId());
 		assertEquals("9.2", "Cycle2", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("9.3", 1, required.length);
-		assertEquals("9.4", NATURE_CYCLE3, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE3);
 		sets = current.getNatureSetIds();
-		assertEquals("9.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE3);
 		assertNotNull("10.0", current);
 		assertEquals("10.1", NATURE_CYCLE3, current.getNatureId());
 		assertEquals("10.2", "Cycle3", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("10.3", 1, required.length);
-		assertEquals("10.4", NATURE_CYCLE1, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE1);
 		sets = current.getNatureSetIds();
-		assertEquals("10.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 	}
 
 	/**
@@ -413,95 +400,80 @@ public class IWorkspaceTest {
 		assertNotNull("2.0", current);
 		assertEquals("2.1", NATURE_SIMPLE, current.getNatureId());
 		assertEquals("2.2", "Simple", current.getLabel());
-		assertEquals("2.3", 0, current.getRequiredNatureIds().length);
-		assertEquals("2.4", 0, current.getNatureSetIds().length);
+		assertThat(current.getRequiredNatureIds()).isEmpty();
+		assertThat(current.getNatureSetIds()).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_SNOW);
 		assertNotNull("3.0", current);
 		assertEquals("3.1", NATURE_SNOW, current.getNatureId());
 		assertEquals("3.2", "Snow", current.getLabel());
 		String[] required = current.getRequiredNatureIds();
-		assertEquals("3.3", 1, required.length);
-		assertEquals("3.4", NATURE_WATER, required[0]);
+		assertThat(required).containsExactly(NATURE_WATER);
 		String[] sets = current.getNatureSetIds();
-		assertEquals("3.5", 1, sets.length);
-		assertEquals("3.6", SET_OTHER, sets[0]);
+		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = ws.getNatureDescriptor(NATURE_WATER);
 		assertNotNull("4.0", current);
 		assertEquals("4.1", NATURE_WATER, current.getNatureId());
 		assertEquals("4.2", "Water", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("4.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("4.4", 1, sets.length);
-		assertEquals("4.5", SET_STATE, sets[0]);
+		assertThat(sets).containsExactly(SET_STATE);
 
 		current = ws.getNatureDescriptor(NATURE_EARTH);
 		assertNotNull("5.0", current);
 		assertEquals("5.1", NATURE_EARTH, current.getNatureId());
 		assertEquals("5.2", "Earth", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("5.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("5.4", 1, sets.length);
-		assertEquals("5.5", SET_STATE, sets[0]);
+		assertThat(sets).containsExactly(SET_STATE);
 
 		current = ws.getNatureDescriptor(NATURE_MUD);
 		assertNotNull("6.0", current);
 		assertEquals("6.1", NATURE_MUD, current.getNatureId());
 		assertEquals("6.2", "Mud", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("6.3", 2, required.length);
-		//water and earth are required for mud
-		if (required[0].equals(NATURE_WATER)) {
-			assertEquals("6.4", NATURE_EARTH, required[1]);
-		} else {
-			assertEquals("6.5", NATURE_EARTH, required[0]);
-			assertEquals("6.6", NATURE_WATER, required[0]);
-		}
+		assertThat(required).containsExactlyInAnyOrder(NATURE_WATER, NATURE_EARTH);
 		sets = current.getNatureSetIds();
-		assertEquals("6.7", 1, sets.length);
-		assertEquals("6.8", SET_OTHER, sets[0]);
+		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = ws.getNatureDescriptor(NATURE_INVALID);
 		assertNotNull("7.0", current);
 		assertEquals("7.1", NATURE_INVALID, current.getNatureId());
 		assertEquals("7.2", "", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("7.3", 0, required.length);
+		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
-		assertEquals("7.4", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE1);
 		assertNotNull("8.0", current);
 		assertEquals("8.1", NATURE_CYCLE1, current.getNatureId());
 		assertEquals("8.2", "Cycle1", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("8.3", 1, required.length);
-		assertEquals("8.4", NATURE_CYCLE2, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE2);
 		sets = current.getNatureSetIds();
-		assertEquals("8.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE2);
 		assertNotNull("5.0", current);
 		assertEquals("9.1", NATURE_CYCLE2, current.getNatureId());
 		assertEquals("9.2", "Cycle2", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("9.3", 1, required.length);
-		assertEquals("9.4", NATURE_CYCLE3, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE3);
 		sets = current.getNatureSetIds();
-		assertEquals("9.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE3);
 		assertNotNull("10.0", current);
 		assertEquals("10.1", NATURE_CYCLE3, current.getNatureId());
 		assertEquals("10.2", "Cycle3", current.getLabel());
 		required = current.getRequiredNatureIds();
-		assertEquals("10.3", 1, required.length);
-		assertEquals("10.4", NATURE_CYCLE1, required[0]);
+		assertThat(required).containsExactly(NATURE_CYCLE1);
 		sets = current.getNatureSetIds();
-		assertEquals("10.5", 0, sets.length);
+		assertThat(sets).isEmpty();
 	}
 
 	/**
@@ -544,7 +516,7 @@ public class IWorkspaceTest {
 		CoreException ex = assertThrows(CoreException.class,
 				() -> getWorkspace().move(resources2, folder.getFullPath(), true, createTestMonitor()));
 		assertFalse("3.1", ex.getStatus().isOK());
-		assertEquals("3.2", 1, ex.getStatus().getChildren().length);
+		assertThat(ex.getStatus().getChildren()).hasSize(1);
 		assertFalse("3.3", file.exists());
 		assertFalse("3.4", anotherFile.exists());
 		assertFalse("3.5", oneMoreFile.exists());
@@ -628,7 +600,7 @@ public class IWorkspaceTest {
 				() -> getWorkspace().copy(resources2, folder.getFullPath(), true, createTestMonitor()));
 		IStatus status = e.getStatus();
 		assertFalse("3.1", status.isOK());
-		assertEquals("3.2", 1, status.getChildren().length);
+		assertThat(status.getChildren()).hasSize(1);
 		assertTrue("3.3", file1.exists());
 		assertTrue("3.4", anotherFile.exists());
 		assertTrue("3.5", oneMoreFile.exists());
@@ -661,7 +633,7 @@ public class IWorkspaceTest {
 				() -> getWorkspace().copy(new IResource[] { project }, destination.getFullPath(), true, createTestMonitor()));
 		status = ex2.getStatus();
 		assertFalse("5.1", status.isOK());
-		assertEquals("5.2", 1, status.getChildren().length);
+		assertThat(status.getChildren()).hasSize(1);
 	}
 
 	@Test
@@ -773,29 +745,22 @@ public class IWorkspaceTest {
 		String[][] invalid = getInvalidNatureSets();
 		for (String[] element : invalid) {
 			String[] sorted = ws.sortNatureSet(element);
-			assertNotNull("0.0", sorted);
 			//set may grow if it contained duplicates
-			assertTrue("0.1", sorted.length <= element.length);
+			assertThat(sorted).hasSizeLessThanOrEqualTo(element.length);
 		}
 		String[] sorted = ws.sortNatureSet(new String[] {});
-		assertEquals("1.0", 0, sorted.length);
+		assertThat(sorted).isEmpty();
 
 		sorted = ws.sortNatureSet(new String[] {NATURE_SIMPLE});
-		assertEquals("2.0", 1, sorted.length);
-		assertEquals("2.1", NATURE_SIMPLE, sorted[0]);
+		assertThat(sorted).containsExactly(NATURE_SIMPLE);
 
 		sorted = ws.sortNatureSet(new String[] {NATURE_SNOW, NATURE_WATER});
-		assertEquals("3.0", 2, sorted.length);
-		assertEquals("3.1", NATURE_WATER, sorted[0]);
-		assertEquals("3.2", NATURE_SNOW, sorted[1]);
+		assertThat(sorted).containsExactly(NATURE_WATER, NATURE_SNOW);
 
 		sorted = ws.sortNatureSet(new String[] {NATURE_WATER, NATURE_SIMPLE, NATURE_SNOW});
-		assertEquals("4.0", 3, sorted.length);
-		//three valid sorts: water, snow, simple; water, simple, snow; simple, water, snow
-		boolean first = sorted[0].equals(NATURE_WATER) && sorted[1].equals(NATURE_SNOW) && sorted[2].equals(NATURE_SIMPLE);
-		boolean second = sorted[0].equals(NATURE_WATER) && sorted[1].equals(NATURE_SIMPLE) && sorted[2].equals(NATURE_SNOW);
-		boolean third = sorted[0].equals(NATURE_SIMPLE) && sorted[1].equals(NATURE_WATER) && sorted[2].equals(NATURE_SNOW);
-		assertTrue("4.1", first || second || third);
+		assertThat(sorted).satisfiesAnyOf(order -> assertThat(order).containsExactly(NATURE_WATER, NATURE_SNOW, NATURE_SIMPLE),
+				order -> assertThat(order).containsExactly(NATURE_WATER, NATURE_SIMPLE, NATURE_SNOW),
+				order -> assertThat(order).containsExactly(NATURE_SIMPLE, NATURE_WATER, NATURE_SNOW));
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.canCreateSymLinks;
 import static org.eclipse.core.tests.harness.FileSystemHelper.createSymLink;
@@ -213,7 +214,7 @@ public class LinkedResourceTest {
 		assertEquals("1.2", resolve(location), folder.getLocation());
 		assertTrue("1.3", !resolve(location).toFile().exists());
 		//getting children should succeed (and be empty)
-		assertEquals("1.4", 0, folder.members().length);
+		assertThat(folder.members()).isEmpty();
 
 		//delete should succeed
 		folder.delete(IResource.NONE, createTestMonitor());
@@ -898,7 +899,7 @@ public class LinkedResourceTest {
 		link.createLink(upperCase, IResource.NONE, createTestMonitor());
 		IPath lowerCaseFilePath = lowerCase.append("file.txt");
 		IFile[] files = getWorkspace().getRoot().findFilesForLocation(lowerCaseFilePath);
-		assertEquals("1.0", 1, files.length);
+		assertThat(files).hasSize(1);
 	}
 
 	/**
@@ -968,28 +969,24 @@ public class LinkedResourceTest {
 		nonExistingFolderInOtherExistingProject.createLink(childLoc, IResource.NONE, createTestMonitor());
 		createInWorkspace(nonExistingFolderInOtherExistingProject.getFile("foo"));
 
-		assertTrue("2.0", existingFolderInExistingFolder.members().length == 1);
-		assertTrue("3.0", existingFolderInExistingFolder.members()[0].getName().equals("foo"));
-		assertTrue("2.0", nonExistingFolderInOtherExistingProject.members().length == 1);
-		assertTrue("3.0", nonExistingFolderInOtherExistingProject.members()[0].getName().equals("foo"));
-
-		assertTrue("4.0", nonExistingFolderInExistingProject.members().length == 1);
-		assertTrue("5.0", nonExistingFolderInExistingProject.members()[0].getName()
-				.equals(existingFolderInExistingFolder.getName()));
+		assertThat(existingFolderInExistingFolder.members()).hasSize(1)
+				.satisfiesExactly(member -> assertThat(member.getName()).as("name").isEqualTo("foo"));
+		assertThat(nonExistingFolderInOtherExistingProject.members()).hasSize(1)
+				.satisfiesExactly(member -> assertThat(member.getName()).as("name").isEqualTo("foo"));
+		assertThat(nonExistingFolderInExistingProject.members()).hasSize(1).satisfiesExactly(
+				member -> assertThat(member.getName()).as("name").isEqualTo(existingFolderInExistingFolder.getName()));
 
 		// Swap links around
 		nonExistingFolderInExistingProject.createLink(childLoc, IResource.REPLACE, createTestMonitor());
 		nonExistingFolderInOtherExistingProject.createLink(parentLoc, IResource.REPLACE, createTestMonitor());
 
-		assertTrue("2.0", existingFolderInExistingFolder.members().length == 1);
-		assertTrue("3.0", existingFolderInExistingFolder.members()[0].getName().equals("foo"));
-		assertTrue(nonExistingFolderInExistingProject.getLocation().equals(childLoc));
-		assertTrue("2.0", nonExistingFolderInExistingProject.members().length == 1);
-		assertTrue("3.0", nonExistingFolderInExistingProject.members()[0].getName().equals("foo"));
-
-		assertTrue("4.0", nonExistingFolderInOtherExistingProject.members().length == 1);
-		assertTrue("5.0", nonExistingFolderInOtherExistingProject.members()[0].getName()
-				.equals(existingFolderInExistingFolder.getName()));
+		assertThat(existingFolderInExistingFolder.members()).hasSize(1)
+				.satisfiesExactly(member -> assertThat(member.getName()).as("name").isEqualTo("foo"));
+		assertThat(nonExistingFolderInOtherExistingProject.members()).hasSize(1).satisfiesExactly(
+				member -> assertThat(member.getName()).as("name").isEqualTo(existingFolderInExistingFolder.getName()));
+		assertThat(nonExistingFolderInExistingProject.members()).hasSize(1)
+				.satisfiesExactly(member -> assertThat(member.getName()).as("name").isEqualTo("foo"));
+		assertThat(nonExistingFolderInExistingProject.getLocation()).isEqualTo(childLoc);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,10 +38,10 @@ public class MarkerSetTest {
 	@Rule
 	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
-	private void assertMarkerElementsEqual(String message, IMarkerSetElement[] array1, IMarkerSetElement[] array2) {
-		assertNotNull(message, array1);
-		assertNotNull(message, array2);
-		assertEquals(message, array1.length, array2.length);
+	private void assertMarkerElementsEqual(IMarkerSetElement[] array1, IMarkerSetElement[] array2) {
+		assertNotNull(array1);
+		assertNotNull(array2);
+		assertThat(array1).hasSameSizeAs(array2);
 		IMarkerSetElement[] m1 = new IMarkerSetElement[array1.length];
 		System.arraycopy(array1, 0, m1, 0, array1.length);
 		IMarkerSetElement[] m2 = new IMarkerSetElement[array2.length];
@@ -56,7 +57,7 @@ public class MarkerSetTest {
 		Arrays.sort(m1, compare);
 		Arrays.sort(m2, compare);
 		for (int i = 0; i < m1.length; i++) {
-			assertEquals(message, m1[i].getId(), m2[i].getId());
+			assertEquals(m1[i].getId(), m2[i].getId());
 		}
 	}
 
@@ -106,7 +107,7 @@ public class MarkerSetTest {
 		assertEquals("1.0", max, set.size());
 
 		// remove each element
-		assertMarkerElementsEqual("2.0", set.elements(), infos);
+		assertMarkerElementsEqual(set.elements(), infos);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.internal.resources.PreferenceInitializer;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
@@ -182,7 +182,7 @@ public class ProjectEncodingTest {
 
 	private void thenProjectHasNoEncodingMarker() throws Exception {
 		IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
-		assertEquals("Expected to find no marker for project specific file encoding", 0, markers.length);
+		assertThat(markers).describedAs("Expected to find no marker for project specific file encoding").isEmpty();
 	}
 
 	private void thenProjectHasEncodingMarkerOfSeverity(int expectedSeverity) throws Exception {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
@@ -14,8 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -94,26 +94,27 @@ public class ProjectOrderTest {
 
 		IProject[] projects = new IProject[] { p4, p3, p2, p5, p1, p0 };
 		IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
-		assertTrue("0.1", oldOrder[1].length == 0);
+		assertThat(oldOrder[1]).isEmpty();
 		List<IProject> x = Arrays.asList(oldOrder[0]);
-		assertTrue("0.2", x.size() == 6);
-		assertTrue("0.3", x.indexOf(p0) >= 0);
-		assertTrue("0.4", x.indexOf(p1) >= 0);
-		assertTrue("0.5", x.indexOf(p5) >= 0);
-		assertTrue("0.6", x.indexOf(p2) > x.indexOf(p1));
-		assertTrue("0.7", x.indexOf(p3) > x.indexOf(p2));
-		assertTrue("0.8", x.indexOf(p4) > x.indexOf(p3));
+		assertThat(x).hasSize(6);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p2)).as("index p2").isGreaterThan(x.indexOf(p1));
+		assertThat(x.indexOf(p3)).as("index p3").isGreaterThan(x.indexOf(p2));
+		assertThat(x.indexOf(p4)).as("index p4").isGreaterThan(x.indexOf(p3));
+		assertThat(x.indexOf(p5)).as("index p5").isGreaterThanOrEqualTo(0);
 
 		IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("0.9", !order.hasCycles);
-		assertTrue("0.10", order.knots.length == 0);
-		assertTrue("0.11", x.size() == 6);
-		assertTrue("0.12", x.indexOf(p0) < x.indexOf(p1)); // alpha
-		assertTrue("0.13", x.indexOf(p2) > x.indexOf(p1)); // ref
-		assertTrue("0.14", x.indexOf(p3) > x.indexOf(p2)); // ref
-		assertTrue("0.15", x.indexOf(p4) > x.indexOf(p3)); // ref
-		assertTrue("0.16", x.indexOf(p5) > x.indexOf(p4)); // alpha
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(6);
+		assertThat(x.indexOf(p0)).as("index p0").isLessThan(x.indexOf(p1)); // alpha
+		assertThat(x.indexOf(p2)).as("index p2").isGreaterThan(x.indexOf(p1)); // ref
+		assertThat(x.indexOf(p3)).as("index p3").isGreaterThan(x.indexOf(p2)); // ref
+		assertThat(x.indexOf(p4)).as("index p4").isGreaterThan(x.indexOf(p3)); // ref
+		assertThat(x.indexOf(p5)).as("index p5").isGreaterThan(x.indexOf(p4)); // alpha
+		assertThat(x.indexOf(p5)).as("index p5").isGreaterThanOrEqualTo(0);
 	}
 
 	@Test
@@ -126,15 +127,15 @@ public class ProjectOrderTest {
 		IProject[] projects = new IProject[] {};
 		IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
 		List<IProject> x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.1", oldOrder[1].length == 0);
-		assertTrue("1.2", x.isEmpty());
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).isEmpty();
 
 		// no projects
 		IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.3", !order.hasCycles);
-		assertTrue("1.4", order.knots.length == 0);
-		assertTrue("1.5", x.isEmpty());
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).isEmpty();
 
 		// 1 project
 		// open projects show up
@@ -143,43 +144,43 @@ public class ProjectOrderTest {
 		projects = new IProject[] { p0 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.6.1", oldOrder[1].length == 0);
-		assertTrue("1.6.2", x.size() == 1);
-		assertTrue("1.6.3", x.indexOf(p0) >= 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.6.4", !order.hasCycles);
-		assertTrue("1.6.5", order.knots.length == 0);
-		assertTrue("1.6.6", x.size() == 1);
-		assertTrue("1.6.7", x.indexOf(p0) >= 0);
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
 
 		// closed projects do not show up
 		p0.close(null);
 		projects = new IProject[] { p0 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.6,8", oldOrder[1].length == 0);
-		assertTrue("1.6.9", x.isEmpty());
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).isEmpty();
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.6.10", !order.hasCycles);
-		assertTrue("1.6.11", order.knots.length == 0);
-		assertTrue("1.6.12", x.isEmpty());
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).isEmpty();
 
 		// non-existent projects do not show up either
 		projects = new IProject[] { p0, p1 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.6.13", oldOrder[1].length == 0);
-		assertTrue("1.6.14", x.isEmpty());
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).isEmpty();
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.6.15", !order.hasCycles);
-		assertTrue("1.6.16", order.knots.length == 0);
-		assertTrue("1.6.17", x.isEmpty());
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).isEmpty();
 
 		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 
@@ -193,54 +194,54 @@ public class ProjectOrderTest {
 		projects = new IProject[] { p1, p0 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.7.1", oldOrder[1].length == 0);
-		assertTrue("1.7.2", x.size() == 2);
-		assertTrue("1.7.3", x.indexOf(p0) >= 0);
-		assertTrue("1.7.4", x.indexOf(p1) >= 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.7.5", x.size() == 2);
-		assertTrue("1.7.6", x.indexOf(p0) >= 0);
-		assertTrue("1.7.7", x.indexOf(p1) >= 0);
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 		// alpha order
-		assertTrue("1.7.8", x.indexOf(p0) < x.indexOf(p1));
-		assertTrue("1.7.9", !order.hasCycles);
-		assertTrue("1.7.10", order.knots.length == 0);
+		assertThat(x.indexOf(p0)).as("index p0").isLessThan(x.indexOf(p1));
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
 
 		// closed projects do not show up
 		p0.close(null);
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.7.11", oldOrder[1].length == 0);
-		assertTrue("1.7.12", x.size() == 1);
-		assertTrue("1.7.13", x.indexOf(p0) < 0);
-		assertTrue("1.7.14", x.indexOf(p1) >= 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isLessThan(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.7.15", !order.hasCycles);
-		assertTrue("1.7.16", order.knots.length == 0);
-		assertTrue("1.7.17", x.size() == 1);
-		assertTrue("1.7.18", x.indexOf(p0) < 0);
-		assertTrue("1.7.19", x.indexOf(p1) >= 0);
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isLessThan(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		p0.open(null);
 		p1.close(null);
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.7.20", oldOrder[1].length == 0);
-		assertTrue("1.7.21", x.size() == 1);
-		assertTrue("1.7.22", x.indexOf(p0) >= 0);
-		assertTrue("1.7.23", x.indexOf(p1) < 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isLessThan(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.7.24", !order.hasCycles);
-		assertTrue("1.7.25", order.knots.length == 0);
-		assertTrue("1.7.26", x.size() == 1);
-		assertTrue("1.7.27", x.indexOf(p0) >= 0);
-		assertTrue("1.7.28", x.indexOf(p1) < 0);
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isLessThan(0);
 
 		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
@@ -255,20 +256,20 @@ public class ProjectOrderTest {
 		projects = new IProject[] { p1, p0 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.8.1", oldOrder[1].length == 0);
-		assertTrue("1.8.2", x.size() == 2);
-		assertTrue("1.8.3", x.indexOf(p0) >= 0);
-		assertTrue("1.8.4", x.indexOf(p1) >= 0);
-		assertTrue("1.8.5", x.indexOf(p0) > x.indexOf(p1));
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThan(x.indexOf(p1));
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.8.6", x.size() == 2);
-		assertTrue("1.8.7", x.indexOf(p0) >= 0);
-		assertTrue("1.8.8", x.indexOf(p1) >= 0);
-		assertTrue("1.8.9", x.indexOf(p0) > x.indexOf(p1));
-		assertTrue("1.8.10", !order.hasCycles);
-		assertTrue("1.8.11", order.knots.length == 0);
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThan(x.indexOf(p1));
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
 
 		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
@@ -283,20 +284,20 @@ public class ProjectOrderTest {
 		projects = new IProject[] { p1, p0 };
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.9.1", oldOrder[1].length == 0);
-		assertTrue("1.9.2", x.size() == 2);
-		assertTrue("1.9.3", x.indexOf(p0) >= 0);
-		assertTrue("1.9.4", x.indexOf(p1) >= 0);
-		assertTrue("1.9.5", x.indexOf(p1) > x.indexOf(p0));
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThan(x.indexOf(p0));
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.9.6", !order.hasCycles);
-		assertTrue("1.9.7", order.knots.length == 0);
-		assertTrue("1.9.8", x.size() == 2);
-		assertTrue("1.9.9", x.indexOf(p0) >= 0);
-		assertTrue("1.9.10", x.indexOf(p1) >= 0);
-		assertTrue("1.9.11", x.indexOf(p1) > x.indexOf(p0));
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThan(x.indexOf(p0));
 
 		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
@@ -314,77 +315,77 @@ public class ProjectOrderTest {
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
 		List<IProject> unordered = Arrays.asList(oldOrder[1]);
-		assertTrue("1.10.1", oldOrder[1].length == 2);
-		assertTrue("1.10.2", x.isEmpty());
-		assertTrue("1.10.3", unordered.size() == 2);
-		assertTrue("1.10.4", unordered.indexOf(p0) >= 0);
-		assertTrue("1.10.5", unordered.indexOf(p1) >= 0);
+		assertThat(oldOrder[1]).hasSize(2);
+		assertThat(x).isEmpty();
+		assertThat(unordered).hasSize(2);
+		assertThat(unordered.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.10.6", order.hasCycles);
-		assertTrue("1.10.7", order.knots.length == 1);
-		assertTrue("1.10.8", x.size() == 2);
-		assertTrue("1.10.9", x.indexOf(p0) >= 0);
-		assertTrue("1.10.10", x.indexOf(p1) >= 0);
+		assertThat(order).matches(it -> it.hasCycles, "has cycles");
+		assertThat(order.knots).hasNumberOfRows(1);
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 		List<IProject> knot = Arrays.asList(order.knots[0]);
-		assertTrue("1.10.11", knot.size() == 2);
-		assertTrue("1.10.12", knot.indexOf(p0) >= 0);
-		assertTrue("1.10.13", knot.indexOf(p1) >= 0);
+		assertThat(knot).hasSize(2);
+		assertThat(knot.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(knot.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		// closing one breaks the cycle
 		p0.close(null);
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.10.14", oldOrder[1].length == 0);
-		assertTrue("1.10.15", x.size() == 1);
-		assertTrue("1.10.16", x.indexOf(p1) >= 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.10.17", !order.hasCycles);
-		assertTrue("1.10.18", order.knots.length == 0);
-		assertTrue("1.10.19", x.size() == 1);
-		assertTrue("1.10.20", x.indexOf(p1) >= 0);
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		// closing other instead breaks the cycle
 		p0.open(null);
 		p1.close(null);
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
-		assertTrue("1.10.21", oldOrder[1].length == 0);
-		assertTrue("1.10.22", x.size() == 1);
-		assertTrue("1.10.23", x.indexOf(p0) >= 0);
+		assertThat(oldOrder[1]).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.10.24", !order.hasCycles);
-		assertTrue("1.10.25", order.knots.length == 0);
-		assertTrue("1.10.26", x.size() == 1);
-		assertTrue("1.10.27", x.indexOf(p0) >= 0);
+		assertThat(order).matches(it -> !it.hasCycles, "has no cycles");
+		assertThat(order.knots).isEmpty();
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
 
 		// reopening both brings back the cycle
 		p1.open(null);
 		oldOrder = ws.computePrerequisiteOrder(projects);
 		x = Arrays.asList(oldOrder[0]);
 		unordered = Arrays.asList(oldOrder[1]);
-		assertTrue("1.10.28", oldOrder[1].length == 2);
-		assertTrue("1.10.29", x.isEmpty());
-		assertTrue("1.10.30", unordered.size() == 2);
-		assertTrue("1.10.31", unordered.indexOf(p0) >= 0);
-		assertTrue("1.10.32", unordered.indexOf(p1) >= 0);
+		assertThat(oldOrder[1]).hasSize(2);
+		assertThat(x).isEmpty();
+		assertThat(unordered).hasSize(2);
+		assertThat(unordered.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("1.10.33", order.hasCycles);
-		assertTrue("1.10.34", order.knots.length == 1);
-		assertTrue("1.10.35", x.size() == 2);
-		assertTrue("1.10.36", x.indexOf(p0) >= 0);
-		assertTrue("1.10.37", x.indexOf(p1) >= 0);
+		assertThat(order).matches(it -> it.hasCycles, "has cycles");
+		assertThat(order.knots).hasNumberOfRows(1);
+		assertThat(x).hasSize(2);
+		assertThat(x.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 		knot = Arrays.asList(order.knots[0]);
-		assertTrue("1.10.38", knot.size() == 2);
-		assertTrue("1.10.39", knot.indexOf(p0) >= 0);
-		assertTrue("1.10.40", knot.indexOf(p1) >= 0);
+		assertThat(x).hasSize(2);
+		assertThat(knot.indexOf(p0)).as("index p0").isGreaterThanOrEqualTo(0);
+		assertThat(knot.indexOf(p1)).as("index p1").isGreaterThanOrEqualTo(0);
 
 		p0.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
 		p1.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
@@ -452,43 +453,43 @@ public class ProjectOrderTest {
 		IProject[][] oldOrder = ws.computePrerequisiteOrder(projects);
 		List<IProject> x = Arrays.asList(oldOrder[0]);
 		List<IProject> unordered = Arrays.asList(oldOrder[1]);
-		assertTrue("2.1", x.size() == 1);
-		assertTrue("2.2", x.indexOf(h) >= 0);
-		assertTrue("2.3", unordered.size() == 7);
-		assertTrue("2.4", unordered.indexOf(a) >= 0);
-		assertTrue("2.5", unordered.indexOf(b) >= 0);
-		assertTrue("2.6", unordered.indexOf(c) >= 0);
-		assertTrue("2.7", unordered.indexOf(d) >= 0);
-		assertTrue("2.8", unordered.indexOf(e) >= 0);
-		assertTrue("2.9", unordered.indexOf(f) >= 0);
-		assertTrue("2.10", unordered.indexOf(g) >= 0);
+		assertThat(x).hasSize(1);
+		assertThat(x.indexOf(h)).as("index h").isGreaterThanOrEqualTo(0);
+		assertThat(unordered).hasSize(7);
+		assertThat(unordered.indexOf(a)).as("index a").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(b)).as("index b").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(c)).as("index c").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(d)).as("index d").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(e)).as("index e").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(f)).as("index f").isGreaterThanOrEqualTo(0);
+		assertThat(unordered.indexOf(g)).as("index g").isGreaterThanOrEqualTo(0);
 
 		IWorkspace.ProjectOrder order = ws.computeProjectOrder(projects);
 		x = Arrays.asList(order.projects);
-		assertTrue("2.11", x.size() == 8);
-		assertTrue("2.12", x.indexOf(a) >= 0);
-		assertTrue("2.13", x.indexOf(b) >= 0);
-		assertTrue("2.14", x.indexOf(c) >= 0);
-		assertTrue("2.15", x.indexOf(d) >= 0);
-		assertTrue("2.16", x.indexOf(e) >= 0);
-		assertTrue("2.17", x.indexOf(f) >= 0);
-		assertTrue("2.18", x.indexOf(g) >= 0);
-		assertTrue("2.19", x.indexOf(h) >= 0);
+		assertThat(x).hasSize(8);
+		assertThat(x.indexOf(a)).as("index a").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(b)).as("index b").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(c)).as("index c").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(d)).as("index d").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(e)).as("index e").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(f)).as("index f").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(g)).as("index g").isGreaterThanOrEqualTo(0);
+		assertThat(x.indexOf(h)).as("index h").isGreaterThanOrEqualTo(0);
 		// {a, b, e} < {c,d} < {f, g} < {h}
-		assertTrue("2.20", x.indexOf(b) < x.indexOf(c));
-		assertTrue("2.21", x.indexOf(b) < x.indexOf(d));
-		assertTrue("2.22", x.indexOf(a) < x.indexOf(c));
-		assertTrue("2.23", x.indexOf(a) < x.indexOf(d));
-		assertTrue("2.24", x.indexOf(e) < x.indexOf(c));
-		assertTrue("2.25", x.indexOf(e) < x.indexOf(d));
-		assertTrue("2.26", x.indexOf(c) < x.indexOf(f));
-		assertTrue("2.27", x.indexOf(c) < x.indexOf(g));
-		assertTrue("2.28", x.indexOf(d) < x.indexOf(f));
-		assertTrue("2.29", x.indexOf(d) < x.indexOf(g));
-		assertTrue("2.30", x.indexOf(f) < x.indexOf(h));
-		assertTrue("2.31", x.indexOf(g) < x.indexOf(h));
-		assertTrue("2.32", order.hasCycles);
-		assertTrue("2.33", order.knots.length == 3);
+		assertThat(x.indexOf(b)).as("index b").isLessThan(x.indexOf(c));
+		assertThat(x.indexOf(b)).as("index b").isLessThan(x.indexOf(d));
+		assertThat(x.indexOf(a)).as("index a").isLessThan(x.indexOf(c));
+		assertThat(x.indexOf(a)).as("index a").isLessThan(x.indexOf(d));
+		assertThat(x.indexOf(e)).as("index e").isLessThan(x.indexOf(c));
+		assertThat(x.indexOf(e)).as("index e").isLessThan(x.indexOf(d));
+		assertThat(x.indexOf(c)).as("index c").isLessThan(x.indexOf(f));
+		assertThat(x.indexOf(c)).as("index c").isLessThan(x.indexOf(g));
+		assertThat(x.indexOf(d)).as("index d").isLessThan(x.indexOf(f));
+		assertThat(x.indexOf(d)).as("index d").isLessThan(x.indexOf(g));
+		assertThat(x.indexOf(f)).as("index f").isLessThan(x.indexOf(h));
+		assertThat(x.indexOf(g)).as("index g").isLessThan(x.indexOf(h));
+		assertThat(order).matches(it -> it.hasCycles, "has cycles");
+		assertThat(order.knots).hasNumberOfRows(3);
 		List<IProject> k1 = Arrays.asList(order.knots[0]);
 		List<IProject> k2 = Arrays.asList(order.knots[1]);
 		List<IProject> k3 = Arrays.asList(order.knots[2]);
@@ -508,18 +509,18 @@ public class ProjectOrderTest {
 			k3 = temp;
 		}
 		// knot 1
-		assertTrue("2.34", k1.size() == 3);
-		assertTrue("2.35", k1.indexOf(a) >= 0);
-		assertTrue("2.36", k1.indexOf(b) >= 0);
-		assertTrue("2.37", k1.indexOf(e) >= 0);
+		assertThat(k1).hasSize(3);
+		assertThat(k1.indexOf(a)).as("index a").isGreaterThanOrEqualTo(0);
+		assertThat(k1.indexOf(b)).as("index b").isGreaterThanOrEqualTo(0);
+		assertThat(k1.indexOf(e)).as("index e").isGreaterThanOrEqualTo(0);
 		// knot 2
-		assertTrue("2.38", k2.size() == 2);
-		assertTrue("2.39", k2.indexOf(c) >= 0);
-		assertTrue("2.40", k2.indexOf(d) >= 0);
+		assertThat(k2).hasSize(2);
+		assertThat(k2.indexOf(c)).as("index c").isGreaterThanOrEqualTo(0);
+		assertThat(k2.indexOf(d)).as("index d").isGreaterThanOrEqualTo(0);
 		// knot 3
-		assertTrue("2.41", k3.size() == 2);
-		assertTrue("2.42", k3.indexOf(f) >= 0);
-		assertTrue("2.43", k3.indexOf(g) >= 0);
+		assertThat(k3).hasSize(2);
+		assertThat(k3.indexOf(f)).as("index f").isGreaterThanOrEqualTo(0);
+		assertThat(k3.indexOf(g)).as("index g").isGreaterThanOrEqualTo(0);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.resources;
 
 import static java.io.InputStream.nullInputStream;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
@@ -130,7 +131,7 @@ public class VirtualFolderTest {
 		assertTrue("4.0", !location.toFile().exists());
 
 		// getting children should succeed (and be empty)
-		assertEquals("5.0", 0, linkedFolder.members().length);
+		assertThat(linkedFolder.members()).isEmpty();
 
 		// delete should succeed
 		linkedFolder.delete(IResource.NONE, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.canCreateSymLinks;
 import static org.eclipse.core.tests.harness.FileSystemHelper.createSymLink;
@@ -372,7 +373,7 @@ public class WorkspaceTest {
 		monitor.prepare();
 		project.setDescription(description, monitor);
 		monitor.assertUsedUp();
-		assertTrue(target.getReferencingProjects().length == 1);
+		assertThat(target.getReferencingProjects()).hasSize(1);
 
 		monitor.prepare();
 		target.delete(true, true, monitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/LazyInputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/LazyInputStreamTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.content;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -91,7 +92,7 @@ public class LazyInputStreamTest {
 		stream.skip(4);
 		byte[] buffer = new byte[7];
 		int read = stream.read(buffer);
-		assertEquals("1.0", buffer.length, read);
+		assertThat(buffer).hasSize(read);
 		assertEquals("1.1", DATA.substring(4, 4 + buffer.length), new String(buffer));
 		assertEquals("1.2", 11, stream.getOffset());
 		read = stream.read(buffer, 3, 4);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/LazyReaderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/LazyReaderTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.content;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -90,7 +91,7 @@ public class LazyReaderTest {
 		stream.skip(4);
 		char[] buffer = new char[7];
 		int read = stream.read(buffer);
-		assertEquals("1.0", buffer.length, read);
+		assertThat(buffer).hasSize(read);
 		assertEquals("1.1", DATA.substring(4, 4 + buffer.length), new String(buffer));
 		assertEquals("1.2", 11, stream.getOffset());
 		read = stream.read(buffer, 3, 4);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/SpecificContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/SpecificContextTest.java
@@ -13,14 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.content;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.internal.content.ContentTypeManager;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.content.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.core.runtime.content.IContentTypeMatcher;
+import org.eclipse.core.runtime.content.IContentTypeSettings;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.junit.Rule;
@@ -104,8 +110,7 @@ public class SpecificContextTest extends ContentTypeTest {
 		localSettings = textContentType.getSettings(scope);
 		// scope-specific settings should contain the filespec we just added
 		String[] fileSpecs = localSettings.getFileSpecs(IContentType.FILE_EXTENSION_SPEC);
-		assertEquals("2.2", 1, fileSpecs.length);
-		assertEquals("2.3", "foo", fileSpecs[0]);
+		assertThat(fileSpecs).containsExactly("foo");
 		// now it is associated at the scope level...
 		assertTrue("2.5", textContentType.isAssociatedWith("hello.foo", scope));
 		// ...but not at the global level

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/TestBug94498.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/TestBug94498.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.content;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 
 import junit.framework.Test;
@@ -33,18 +34,16 @@ public class TestBug94498 extends TestCase {
 
 	public void test1() throws CoreException {
 		IContentType text = Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
-		assertNotNull("1.0", text);
+		assertThat(text).isNotNull();
 		text.addFileSpec(FILE_NAME, IContentType.FILE_NAME_SPEC);
 		String[] fileSpecs = text.getFileSpecs(IContentType.FILE_NAME_SPEC | IContentType.IGNORE_PRE_DEFINED);
-		assertEquals("2.0", 1, fileSpecs.length);
-		assertEquals("2.1", FILE_NAME, fileSpecs[0]);
+		assertThat(fileSpecs).containsExactly(FILE_NAME);
 	}
 
 	public void test2() {
 		IContentType text = Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
-		assertNotNull("1.0", text);
+		assertThat(text).isNotNull();
 		String[] fileSpecs = text.getFileSpecs(IContentType.FILE_NAME_SPEC | IContentType.IGNORE_PRE_DEFINED);
-		assertEquals("2.0", 1, fileSpecs.length);
-		assertEquals("2.1", FILE_NAME, fileSpecs[0]);
+		assertThat(fileSpecs).containsExactly(FILE_NAME);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/RefreshProviderTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -89,16 +88,16 @@ public class RefreshProviderTest {
 		IFile link = project.getFile("Link");
 		// ensure we currently have just the project being monitored
 		TestRefreshProvider provider = TestRefreshProvider.getInstance();
-		assertEquals("1.0", 1, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).hasSize(1);
 		link.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		joinAutoRefreshJobs();
-		assertEquals("1.1", 2, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).hasSize(2);
 		link.delete(IResource.FORCE, createTestMonitor());
 		joinAutoRefreshJobs();
-		assertEquals("1.2", 1, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).hasSize(1);
 		removeFromWorkspace(project);
 		joinAutoRefreshJobs();
-		assertEquals("1.3", 0, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).isEmpty();
 		// check provider for other errors
 		AssertionFailedError[] failures = provider.getFailures();
 		assertThat(failures).isEmpty();
@@ -116,16 +115,16 @@ public class RefreshProviderTest {
 		joinAutoRefreshJobs();
 		// ensure we currently have just the project being monitored
 		TestRefreshProvider provider = TestRefreshProvider.getInstance();
-		assertEquals("1.0", 1, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).hasSize(1);
 		project.close(createTestMonitor());
 		joinAutoRefreshJobs();
-		assertEquals("1.1", 0, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).isEmpty();
 		project.open(createTestMonitor());
 		joinAutoRefreshJobs();
-		assertEquals("1.2", 1, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).hasSize(1);
 		removeFromWorkspace(project);
 		joinAutoRefreshJobs();
-		assertEquals("1.3", 0, provider.getMonitoredResources().length);
+		assertThat(provider.getMonitoredResources()).isEmpty();
 		// check provider for other errors
 		AssertionFailedError[] failures = provider.getFailures();
 		assertThat(failures).isEmpty();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -69,23 +69,20 @@ public class Bug_027271 {
 		IPathVariableManager pvm = getWorkspace().getPathVariableManager();
 		Preferences prefs = ResourcesPlugin.getPlugin().getPluginPreferences();
 
-		assertEquals("1.0", 0, pvm.getPathVariableNames().length);
+		assertThat(pvm.getPathVariableNames()).isEmpty();
 		prefs.setValue(VARIABLE_PREFIX + "VALID_VAR", IPath.fromOSString("c:/temp").toPortableString());
-		assertEquals("1.1", 1, pvm.getPathVariableNames().length);
-		assertEquals("1.2", "VALID_VAR", pvm.getPathVariableNames()[0]);
+		assertThat(pvm.getPathVariableNames()).containsExactly("VALID_VAR");
 
 		//sets invalid value (relative path)
 		IPath relativePath = IPath.fromOSString("temp");
 		prefs.setValue(VARIABLE_PREFIX + "INVALID_VAR", relativePath.toPortableString());
-		assertEquals("2.0", 1, pvm.getPathVariableNames().length);
-		assertEquals("2.1", "VALID_VAR", pvm.getPathVariableNames()[0]);
+		assertThat(pvm.getPathVariableNames()).containsExactly("VALID_VAR");
 
 		//sets invalid value (invalid path)
 		IPath invalidPath = IPath.fromOSString("c:\\a\\:\\b");
 		prefs.setValue(VARIABLE_PREFIX + "ANOTHER_INVALID_VAR", invalidPath.toPortableString());
 		assertTrue("3.0", !IPath.EMPTY.isValidPath(invalidPath.toPortableString()));
-		assertEquals("3.1", 1, pvm.getPathVariableNames().length);
-		assertEquals("3.2", "VALID_VAR", pvm.getPathVariableNames()[0]);
+		assertThat(pvm.getPathVariableNames()).containsExactly("VALID_VAR");
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_079398.java
@@ -13,14 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.internal.localstore.IHistoryStore;
 import org.eclipse.core.internal.resources.Workspace;
@@ -62,7 +61,7 @@ public class Bug_079398 {
 
 		IFileState[] sourceStates = file1.getHistory(createTestMonitor());
 		// just make sure our assumptions are valid
-		assertEquals("0.4", 10, sourceStates.length);
+		assertThat(sourceStates).hasSize(10);
 
 		// copy the file - the history should be shared, but the destination
 		// will conform to the policy
@@ -71,10 +70,10 @@ public class Bug_079398 {
 		assertExistsInWorkspace(file2);
 		sourceStates = file1.getHistory(createTestMonitor());
 		// the source is unaffected so far
-		assertEquals("1.2", 10, sourceStates.length);
+		assertThat(sourceStates).hasSize(10);
 		IFileState[] destinationStates = file2.getHistory(createTestMonitor());
 		// but the destination conforms to the policy
-		assertEquals("1.4", description.getMaxFileStates(), destinationStates.length);
+		assertThat(destinationStates).hasSize(description.getMaxFileStates());
 
 		// now cause the destination to have many more states
 		for (int i = 0; i <= description.getMaxFileStates(); i++) {
@@ -87,15 +86,12 @@ public class Bug_079398 {
 		destinationStates = file2.getHistory(createTestMonitor());
 		// cleaning will remove any states the destination had in common
 		// with the source since they don't fit into the policy
-		assertEquals("1.7", description.getMaxFileStates(), destinationStates.length);
+		assertThat(destinationStates).hasSize(description.getMaxFileStates());
 
 		sourceStates = file1.getHistory(createTestMonitor());
 		// the source should have any extra states removed as well,
 		// but the ones left should still exist
-		assertEquals("1.7", description.getMaxFileStates(), sourceStates.length);
-		for (int i = 0; i < sourceStates.length; i++) {
-			assertTrue("1.8." + i, sourceStates[i].exists());
-		}
+		assertThat(sourceStates).hasSize(description.getMaxFileStates()).allMatch(IFileState::exists);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -86,21 +87,21 @@ public class Bug_165892 {
 		// modify the source file so it has some history
 		sourceFile.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 		// check that the source file has the expected history
-		assertEquals("1.0", 1, sourceFile.getHistory(createTestMonitor()).length);
+		assertThat(sourceFile.getHistory(createTestMonitor())).hasSize(1);
 
 		//copy the file
 		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the history was copied
-		assertEquals("2.0", 1, sourceFile.getHistory(createTestMonitor()).length);
-		assertEquals("2.1", 1, destinationFile.getHistory(createTestMonitor()).length);
+		assertThat(sourceFile.getHistory(createTestMonitor())).hasSize(1);
+		assertThat(destinationFile.getHistory(createTestMonitor())).hasSize(1);
 
 		//modify the destination to change its history
 		destinationFile.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 
 		//make sure the history is correct
-		assertEquals("2.0", 1, sourceFile.getHistory(createTestMonitor()).length);
-		assertEquals("2.1", 2, destinationFile.getHistory(createTestMonitor()).length);
+		assertThat(sourceFile.getHistory(createTestMonitor())).hasSize(1);
+		assertThat(destinationFile.getHistory(createTestMonitor())).hasSize(2);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.canCreateSymLinks;
 import static org.eclipse.core.tests.harness.FileSystemHelper.createSymLink;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -21,7 +22,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -63,7 +63,7 @@ public class Bug_233939 {
 		container.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		IResource theLink = container.findMember(linkName);
 		assertExistsInWorkspace(theLink);
-		assertTrue("2.2", theLink.getResourceAttributes().isSymbolicLink());
+		assertTrue(theLink.getResourceAttributes().isSymbolicLink());
 	}
 
 	/**
@@ -96,8 +96,7 @@ public class Bug_233939 {
 		symLinkAndRefresh(project, fileName, fileInTempDirPath);
 
 		IFile[] files = root.findFilesForLocationURI(file.getLocationURI());
-		assertEquals("7.0", 1, files.length);
-		assertEquals("7.1", file, files[0]);
+		assertThat(files).containsExactly(file);
 
 		// Bug 198291: We do not track canonical symlink locations below project level
 		//		IFile[] files = root.findFilesForLocation(fileInTempDirPath);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
@@ -392,7 +393,7 @@ public class IResourceTest {
 		IStatus status = exception.getStatus();
 		if (status.isMultiStatus()) {
 			IStatus[] children = status.getChildren();
-			assertEquals("1.1", 1, children.length);
+			assertThat(children).hasSize(1);
 			status = children[0];
 		}
 		assertEquals("1.2", IResourceStatus.OUT_OF_SYNC_LOCAL, status.getCode());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IWorkspaceTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -59,7 +60,7 @@ public class IWorkspaceTest {
 		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), true, createTestMonitor());
 		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		IFileState[] states = file1.getHistory(createTestMonitor());
-		assertEquals("1.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(allResources, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 
@@ -71,7 +72,7 @@ public class IWorkspaceTest {
 		getWorkspace().move(new IFile[] { file1 }, folder.getFullPath(), false, createTestMonitor());
 		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file1.getHistory(createTestMonitor());
-		assertEquals("2.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(allResources, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 	}
@@ -94,7 +95,7 @@ public class IWorkspaceTest {
 		getWorkspace().delete(new IFile[] { file1 }, true, createTestMonitor());
 		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		IFileState[] states = file1.getHistory(createTestMonitor());
-		assertEquals("1.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 
@@ -105,7 +106,7 @@ public class IWorkspaceTest {
 		getWorkspace().delete(new IFile[] { file1 }, false, createTestMonitor());
 		file1.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file1.getHistory(createTestMonitor());
-		assertEquals("2.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(new IResource[] { file1 }, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 
@@ -120,7 +121,7 @@ public class IWorkspaceTest {
 		folder.create(true, true, createTestMonitor());
 		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("3.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 
@@ -133,7 +134,7 @@ public class IWorkspaceTest {
 		folder.create(true, true, createTestMonitor());
 		file2.create(createRandomContentsStream(), true, createTestMonitor());
 		states = file2.getHistory(createTestMonitor());
-		assertEquals("4.0", 3, states.length);
+		assertThat(states).hasSize(3);
 		getWorkspace().delete(new IResource[] { folder, file1, file2 }, true, createTestMonitor());
 		project.clearHistory(createTestMonitor());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
@@ -85,10 +86,10 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		//Only builder1 should have been built
 		SortBuilder[] builders = SortBuilder.allInstances();
-		assertEquals("1.0", 2, builders.length);
-		assertTrue("1.1", builders[0].wasBuilt());
-		assertTrue("1.2", builders[0].wasIncrementalBuild());
-		assertTrue("1.3", !builders[1].wasBuilt());
+		assertThat(builders).hasSize(2).satisfiesExactly(first -> {
+			assertThat(first.wasBuilt()).isTrue();
+			assertThat(first.wasIncrementalBuild()).isTrue();
+		}, second -> assertThat(second.wasAutoBuild()).isFalse());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -14,13 +14,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import java.util.Arrays;
-import java.util.List;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -71,8 +70,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.1", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test that a deleted file can be found
 		// create and delete a file
@@ -84,27 +82,17 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	public void test2() throws Exception {
 		// the deleted file should show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.1", 1, df.length);
-		assertEquals("0.2", pfile, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.3", 1, df.length);
-		assertEquals("0.4", pfile, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.5", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// the deleted file should show up as a deleted member of workspace root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.5.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.5.2", 1, df.length);
-		assertEquals("0.5.3", pfile, df[0]);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.5.4", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(pfile);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// recreate the file
 		pfile.create(createRandomContentsStream(), true, createTestMonitor());
@@ -114,32 +102,21 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	public void test3() throws Exception {
 		// the deleted file should no longer show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.6", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.7", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.8", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// the deleted file should no longer show up as a deleted member of ws root
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.8.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("0.8.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("0.8.3", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// scrub the project
 		project.delete(true, createTestMonitor());
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("0.9", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test folder
 		// create and delete a file in a folder
@@ -152,28 +129,18 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	public void test4() throws Exception {
 		// the deleted file should show up as a deleted member
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.1", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.2", 1, df.length);
-		assertEquals("1.3", file, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.4", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(file);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// recreate the file
 		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// the recreated file should no longer show up as a deleted member
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.6", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.7", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// deleting the folder should bring it back into history
 		folder.delete(true, true, createTestMonitor());
@@ -183,15 +150,10 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	public void test5() throws Exception {
 		// the deleted file should show up as a deleted member of project
-		IFile[] df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.8", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.9", 1, df.length);
-		assertEquals("1.10", file, df[0]);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.11", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactly(file);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
 
 		// create and delete a file where the folder was
 		folderAsFile.create(createRandomContentsStream(), true, createTestMonitor());
@@ -199,29 +161,19 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		folder.create(true, true, createTestMonitor());
 
 		// the deleted file should show up as a deleted member of folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("1.12", 1, df.length);
-		assertEquals("1.13", folderAsFile, df[0]);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.14", 2, df.length);
-		List<IFile> dfList = Arrays.asList(df);
-		assertTrue("1.15", dfList.contains(file));
-		assertTrue("1.16", dfList.contains(folderAsFile));
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("1.17", 2, df.length);
-		dfList = Arrays.asList(df);
-		assertTrue("1.18", dfList.contains(file));
-		assertTrue("1.19", dfList.contains(folderAsFile));
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor()))
+				.containsExactly(folderAsFile);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file, folderAsFile);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file, folderAsFile);
 
 		// scrub the project
 		project.delete(true, createTestMonitor());
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
 
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("1.50", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
 
 		// test a bunch of deletes
 		// create and delete a file in a folder
@@ -237,52 +189,26 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	public void test6() throws Exception {
 		// under root
-		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.3", 3, df.length);
-		List<IFile> dfList = Arrays.asList(df);
-		assertTrue("3.3.1", dfList.contains(file1));
-		assertTrue("3.3.2", dfList.contains(file2));
-		assertTrue("3.3.3", dfList.contains(file3));
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file1, file2, file3);
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.4", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.6", 3, df.length);
-		dfList = Arrays.asList(df);
-		assertTrue("3.6.1", dfList.contains(file1));
-		assertTrue("3.6.2", dfList.contains(file2));
-		assertTrue("3.6.3", dfList.contains(file3));
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor()))
+				.containsExactlyInAnyOrder(file1, file2, file3);
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.7", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.8", 2, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.9", 3, df.length);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).hasSize(2);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).hasSize(3);
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("3.10", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("3.11", 1, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("3.12", 1, df.length);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).hasSize(1);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).hasSize(1);
 
 		project.delete(true, createTestMonitor());
 
@@ -292,44 +218,24 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 	public void test7() throws Exception {
 		// once the project is gone, so is all the history for that project
 		// under root
-		IFile[] df = root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.1", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.2", 0, df.length);
-
-		df = root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.3", 0, df.length);
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under project
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.4", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.5", 0, df.length);
-
-		df = project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.6", 0, df.length);
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under folder
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.7", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.8", 0, df.length);
-
-		df = folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.9", 0, df.length);
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(folder.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		// under folder2
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor());
-		assertEquals("4.10", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor());
-		assertEquals("4.11", 0, df.length);
-
-		df = folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.12", 0, df.length);
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
+		assertThat(folder2.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor())).isEmpty();
 
 		saveWorkspace();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBuilderDeltaSerialization.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
@@ -95,10 +96,10 @@ public class TestBuilderDeltaSerialization extends WorkspaceSerializationTest {
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		//Only builder1 should have been built
 		SortBuilder[] builders = SortBuilder.allInstances();
-		assertEquals("1.0", 2, builders.length);
-		assertTrue("1.1", builders[0].wasBuilt());
-		assertTrue("1.2", builders[0].wasIncrementalBuild());
-		assertTrue("1.3", !builders[1].wasBuilt());
+		assertThat(builders).hasSize(2).satisfiesExactly(first -> {
+			assertThat(first.wasBuilt()).isTrue();
+			assertThat(first.wasIncrementalBuild()).isTrue();
+		}, second -> assertThat(second.wasAutoBuild()).isFalse());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
@@ -44,8 +45,7 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 		// projects should exist immediately due to snapshot - files may or
 		// may not exist due to snapshot timing. All resources should exist after refresh.
 		IResource[] members = workspace.getRoot().members();
-		assertEquals("1.0", 1, members.length);
-		assertTrue("1.1", members[0].getType() == IResource.PROJECT);
+		assertThat(members).hasSize(1).allSatisfy(member -> assertThat(member.getType()).isEqualTo(IResource.PROJECT));
 		IProject project = (IProject) members[0];
 		assertTrue("1.2", project.exists());
 		IFolder folder = project.getFolder(FOLDER);
@@ -56,7 +56,7 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 			project.open(null);
 		}
 
-		assertEquals("2.0", 3, project.members().length);
+		assertThat(project.members()).hasSize(3);
 		assertTrue("2.1", folder.exists());
 		assertTrue("2.2", file.exists());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -66,8 +67,7 @@ public class TestMultiSnap extends WorkspaceSerializationTest {
 
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
-		assertEquals("1.0", 1, children.length);
-		assertEquals("1.1", children[0], project);
+		assertThat(children).containsExactly(project);
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSave.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -40,13 +42,14 @@ public class TestSave extends WorkspaceSerializationTest {
 
 	public void test2() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		assertTrue("1.0", root.exists());
+		assertThat(root.exists()).isTrue();
 		IResource[] children = root.members();
-		assertEquals("1.2", 1, children.length);
-		IProject project = (IProject) children[0];
-		assertTrue("1.3", project.exists());
-		assertTrue("1.4", project.isOpen());
-		assertEquals("1.5", PROJECT, project.getName());
+		assertThat(children).singleElement().asInstanceOf(InstanceOfAssertFactories.type(IProject.class))
+				.satisfies(project -> {
+					assertThat(project.exists()).isTrue();
+					assertThat(project.isOpen()).isTrue();
+					assertThat(project.getName()).isEqualTo(PROJECT);
+				});
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveCreateProject.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import junit.framework.Test;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -39,12 +41,13 @@ public class TestSaveCreateProject extends WorkspaceSerializationTest {
 
 	public void test2() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		assertTrue("1.0", root.exists());
+		assertThat(root.exists()).isTrue();
 		IResource[] children = root.members();
-		assertEquals("1.2", 1, children.length);
-		IProject project = (IProject) children[0];
-		assertTrue("1.3", project.exists());
-		assertEquals("1.4", PROJECT, project.getName());
+		assertThat(children).singleElement().asInstanceOf(InstanceOfAssertFactories.type(IProject.class))
+				.satisfies(project -> {
+					assertThat(project.exists()).isTrue();
+					assertThat(project.getName()).isEqualTo(PROJECT);
+				});
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -71,8 +72,7 @@ public class TestSaveSnap extends WorkspaceSerializationTest {
 
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
-		assertEquals("1.0", 1, children.length);
-		assertEquals("1.1", children[0], project);
+		assertThat(children).containsExactly(project);
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -67,8 +68,7 @@ public class TestSnapSaveSnap extends WorkspaceSerializationTest {
 
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
-		assertEquals("1.0", 1, children.length);
-		assertEquals("1.1", children[0], project);
+		assertThat(children).containsExactly(project);
 		assertTrue("1.2", project.exists());
 		assertTrue("1.3", project.isOpen());
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
@@ -57,7 +58,7 @@ public class Snapshot3Test extends SnapshotTest {
 		assertTrue("3.0", project.exists());
 		assertTrue("3.1", project.isOpen());
 
-		assertEquals("4.0", 4, project.members().length);
+		assertThat(project.members()).hasSize(4);
 		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
@@ -114,7 +115,7 @@ public class Snapshot4Test extends SnapshotTest {
 		assertTrue("3.0", project.exists());
 		assertTrue("3.1", project.isOpen());
 
-		assertEquals("4.0", 4, project.members().length);
+		assertThat(project.members()).hasSize(4);
 		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children


### PR DESCRIPTION
In order to reduce/avoid usage of ambiguous `assertEquals` (hard to distinguish expected/actual) and prepare for a migration to JUnit 5 with swapped expected/actual parameters in the `assertEquals` signature, this change replaces certain `assertEquals` calls with AssertJ assertions:
* Replace `assertEquals(MESSAGE, EXPECTED, ACTUAL.length)` with
`assertThat(ACTUAL).describedAs(MESSAGE).hasSize(EXPECTED))` and remove obsolete message where possible
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL).hasSize(EXPECTED))`
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL.length, is(EXPECTED))` if `ACTUAL` is a primitive type array
* Replace `hasSize(0)` with `isEmpty()` to improve failure messages
* Combine array size comparison with array contents comparison where possible

### What I Did

Initial changes are the result of two regex replacements:
#### Length assertions with message
Find: `assertEquals\((.*), (.*), (.*)\.length\);`
Insert: `assertThat\($3\)\.as\($1\)\.hasSize\($2)\);`

#### Length assertions without message
Find: `assertEquals\((.*), (.*)\.length\);`
Insert: `assertThat\($2\)\.hasSize\($1)\);`

Further improvements, in particular the combination of size and content assertions, is manual work.

### Benefits
* Improved failure messages:
  * When an empty array is asserted, the non-empty array will be reported in case of a failure
  * When size and content of an array are validated, the test will not fail reporting an improper size but reporting the mismatching elements
* Improved comprehensibility due to matchers giving more semantics to the validations than plain assertEquals
* Eased migration to JUnit 5: `assertEquals` statements would need to adapted during a migration from JUnit 4 to 5 because expected/actual parameters are swapped