### PR TITLE
Improve array length assertions in UA tests

### DIFF
--- a/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org
 Import-Package: javax.servlet;version="3.1.0",
  javax.servlet.http;version="3.1.0",
+ org.assertj.core.api,
  org.junit.jupiter.api,
  org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestCompositeParser.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestCompositeParser.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.composite;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -131,12 +132,10 @@ public class TestCompositeParser {
 		assertTrue(parser.getStatus().isOK());
 		AbstractTask task1 = model.getDependencies().getTask("task1");
 		AbstractTask task2 = model.getDependencies().getTask("task2");
-		assertTrue(task1.getRequiredTasks().length == 0);
-		assertTrue(task1.getSuccessorTasks().length == 1);
-		assertEquals(task2, task1.getSuccessorTasks()[0]);
-		assertTrue(task2.getSuccessorTasks().length == 0);
-		assertTrue(task2.getRequiredTasks().length == 1);
-		assertEquals(task1, task2.getRequiredTasks()[0]);
+		assertThat(task1.getRequiredTasks()).isEmpty();
+		assertThat(task1.getSuccessorTasks()).containsExactly(task2);
+		assertThat(task2.getSuccessorTasks()).isEmpty();
+		assertThat(task2.getRequiredTasks()).containsExactly(task1);
 		assertTrue(task1.isSkippable());
 		assertFalse(task2.isSkippable());
 	}
@@ -148,12 +147,10 @@ public class TestCompositeParser {
 		assertTrue(parser.getStatus().isOK());
 		AbstractTask task1 = model.getDependencies().getTask("task1");
 		AbstractTask task2 = model.getDependencies().getTask("task2");
-		assertTrue(task1.getRequiredTasks().length == 0);
-		assertTrue(task1.getSuccessorTasks().length == 1);
-		assertEquals(task2, task1.getSuccessorTasks()[0]);
-		assertTrue(task2.getSuccessorTasks().length == 0);
-		assertTrue(task2.getRequiredTasks().length == 1);
-		assertEquals(task1, task2.getRequiredTasks()[0]);
+		assertThat(task1.getRequiredTasks()).isEmpty();
+		assertThat(task1.getSuccessorTasks()).containsExactly(task2);
+		assertThat(task2.getSuccessorTasks()).isEmpty();
+		assertThat(task2.getRequiredTasks()).containsExactly(task1);
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestState.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestState.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.composite;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -152,14 +153,12 @@ public class TestState {
 		task1.setState(ICompositeCheatSheetTask.IN_PROGRESS);
 		task2.setState(ICompositeCheatSheetTask.COMPLETED);
 		task4.setState(ICompositeCheatSheetTask.SKIPPED);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(task1).length);
-		assertEquals(task1, TaskStateUtilities.getRestartTasks(task1)[0]);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(task2).length);
-		assertEquals(0, TaskStateUtilities.getRestartTasks(task3).length);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(task4).length);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(group).length);
-		assertEquals(task4, TaskStateUtilities.getRestartTasks(group)[0]);
-		assertEquals(3, TaskStateUtilities.getRestartTasks(root).length);
+		assertThat(TaskStateUtilities.getRestartTasks(task1)).containsExactly(task1);
+		assertThat(TaskStateUtilities.getRestartTasks(task2)).hasSize(1);
+		assertThat(TaskStateUtilities.getRestartTasks(task3)).isEmpty();
+		assertThat(TaskStateUtilities.getRestartTasks(task4)).hasSize(1);
+		assertThat(TaskStateUtilities.getRestartTasks(group)).containsExactly(task4);
+		assertThat(TaskStateUtilities.getRestartTasks(root)).hasSize(3);
 	}
 
 	/**
@@ -190,11 +189,11 @@ public class TestState {
 		task2.complete();
 		task3.complete();
 		task5.setStarted();
-		assertEquals(4, TaskStateUtilities.getRestartTasks(root).length);
-		assertEquals(4, TaskStateUtilities.getRestartTasks(task1).length);
-		assertEquals(3, TaskStateUtilities.getRestartTasks(task2).length);
-		assertEquals(2, TaskStateUtilities.getRestartTasks(task3).length);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(subGroup).length);
+		assertThat(TaskStateUtilities.getRestartTasks(root)).hasSize(4);
+		assertThat(TaskStateUtilities.getRestartTasks(task1)).hasSize(4);
+		assertThat(TaskStateUtilities.getRestartTasks(task2)).hasSize(3);
+		assertThat(TaskStateUtilities.getRestartTasks(task3)).hasSize(2);
+		assertThat(TaskStateUtilities.getRestartTasks(subGroup)).hasSize(1);
 		// Reset task5 and  start task 1 and 3 and skip task 2.
 		// Resetting task1 will not require task2 or task3 to be reset
 		task5.setState(ICompositeCheatSheetTask.NOT_STARTED);
@@ -202,9 +201,9 @@ public class TestState {
 		task2.setState(ICompositeCheatSheetTask.NOT_STARTED);
 		task2.setState(ICompositeCheatSheetTask.SKIPPED);
 		task3.setStarted();
-		assertEquals(3, TaskStateUtilities.getRestartTasks(root).length);
-		assertEquals(1, TaskStateUtilities.getRestartTasks(task1).length);
-		assertEquals(2, TaskStateUtilities.getRestartTasks(task2).length);
+		assertThat(TaskStateUtilities.getRestartTasks(root)).hasSize(3);
+		assertThat(TaskStateUtilities.getRestartTasks(task1)).hasSize(1);
+		assertThat(TaskStateUtilities.getRestartTasks(task2)).hasSize(2);
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestSuccessors.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/composite/TestSuccessors.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.composite;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.ui.internal.cheatsheets.composite.model.CompositeCheatSheetModel;
@@ -70,14 +71,13 @@ public class TestSuccessors {
 	private void assertSingleSuccessor(ICompositeCheatSheetTask task, ICompositeCheatSheetTask expectedSuccessor) {
 		SuccesorTaskFinder finder = new SuccesorTaskFinder(task);
 		ICompositeCheatSheetTask[] successors = finder.getRecommendedSuccessors();
-		assertEquals(1, successors.length);
-		assertEquals(expectedSuccessor, successors[0]);
+		assertThat(successors).containsExactly(expectedSuccessor);
 	}
 
 	private void assertNoSuccessors(ICompositeCheatSheetTask task) {
 		SuccesorTaskFinder finder = new SuccesorTaskFinder(task);
 		ICompositeCheatSheetTask[] successors = finder.getRecommendedSuccessors();
-		assertEquals(0, successors.length);
+		assertThat(successors).isEmpty();
 	}
 
 	@Test
@@ -155,11 +155,8 @@ public class TestSuccessors {
 		setupModel(true);
 		SuccesorTaskFinder finder = new SuccesorTaskFinder(subGroup);
 		ICompositeCheatSheetTask[] successors = finder.getRecommendedSuccessors();
-		assertEquals(3, successors.length);
 		// The successors should be in task order
-		assertEquals(task1, successors[0]);
-		assertEquals(task2, successors[1]);
-		assertEquals(task3, successors[2]);
+		assertThat(successors).containsExactly(task1, task2, task3);
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/execution/TestActionExecution.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/execution/TestActionExecution.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.execution;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -103,9 +104,7 @@ public class TestActionExecution {
 		assertTrue(status.isOK());
 		assertEquals(1, ActionEnvironment.getTimesCompleted());
 		String[] actuals = ActionEnvironment.getParams();
-		assertEquals(2, actuals.length);
-		assertEquals(value0, actuals[0]);
-		assertEquals(value1, actuals[1]);
+		assertThat(actuals).containsExactly(value0, value1);
 	}
 
 	private String getPluginId() {

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/other/TestCheatSheetCollection.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/other/TestCheatSheetCollection.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -63,8 +64,8 @@ public class TestCheatSheetCollection {
 
 	@Test
 	public void testRoot() {
-		assertEquals(2, root.getChildren().length);
-		assertEquals(2, root.getCheatSheets().length);
+		assertThat(root.getChildren()).hasSize(2);
+		assertThat(root.getCheatSheets()).hasSize(2);
 		assertFalse(root.isEmpty());
 		assertEquals("rootName", root.getLabel(null));
 		assertEquals("rootId", root.getId());
@@ -76,11 +77,11 @@ public class TestCheatSheetCollection {
 		Object[] children = root.getChildren();
 		assertEquals(c1, children[0]);
 		assertEquals(c2, children[1]);
-		assertEquals(2, c1.getChildren().length);
-		assertEquals(0, c1.getCheatSheets().length);
+		assertThat(c1.getChildren()).hasSize(2);
+		assertThat(c1.getCheatSheets()).isEmpty();
 		assertFalse(c1.isEmpty());
-		assertEquals(0, c2.getChildren().length);
-		assertEquals(1, c2.getCheatSheets().length);
+		assertThat(c2.getChildren()).isEmpty();
+		assertThat(c2.getCheatSheets()).hasSize(1);
 		assertFalse(c2.isEmpty());
 	}
 
@@ -96,11 +97,11 @@ public class TestCheatSheetCollection {
 		Object[] children = c1.getChildren();
 		assertEquals(c11, children[0]);
 		assertEquals(c12, children[1]);
-		assertEquals(0, c11.getChildren().length);
-		assertEquals(0, c11.getCheatSheets().length);
+		assertThat(c11.getChildren()).isEmpty();
+		assertThat(c11.getCheatSheets()).isEmpty();
 		assertTrue(c11.isEmpty());
-		assertEquals(0, c12.getChildren().length);
-		assertEquals(1, c12.getCheatSheets().length);
+		assertThat(c12.getChildren()).isEmpty();
+		assertThat(c12.getCheatSheets()).hasSize(1);
 		assertFalse(c12.isEmpty());
 	}
 

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/CheatSheetModelSerializerTest.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/CheatSheetModelSerializerTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.cheatsheet.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -48,7 +50,7 @@ public class CheatSheetModelSerializerTest {
 	public void testRunSerializer() throws IOException {
 		URL[] urls = ResourceFinder.findFiles(FrameworkUtil.getBundle(getClass()), "data/cheatsheet/valid", ".xml",
 				true);
-		Assert.assertTrue("Unable to find sample cheat sheets to test parser", urls.length > 0);
+		assertThat(urls).as("check sample cheat sheets to test parser").hasSizeGreaterThan(0);
 		for (URL url : urls) {
 			CheatSheetParser parser = new CheatSheetParser();
 			CheatSheet sheet = (CheatSheet) parser.parse(url, FrameworkUtil.getBundle(getClass()).getSymbolicName(),

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/CriteriaDefinitionTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/CriteriaDefinitionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.criteria;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -43,7 +44,7 @@ public class CriteriaDefinitionTest {
 		UserCriterionValueDefinition valueDefinition = new UserCriterionValueDefinition(VALUEID1, VALUENAME1);
 		assertEquals(VALUEID1, valueDefinition.getId());
 		assertEquals(VALUENAME1, valueDefinition.getName());
-		assertEquals(0, valueDefinition.getChildren().length);
+		assertThat(valueDefinition.getChildren()).isEmpty();
 	}
 
 	@Test
@@ -52,7 +53,7 @@ public class CriteriaDefinitionTest {
 		ICriterionValueDefinition copy = new CriterionValueDefinition(valueDefinition);
 		assertEquals(VALUEID1, copy.getId());
 		assertEquals(VALUENAME1, copy.getName());
-		assertEquals(0, copy.getChildren().length);
+		assertThat(copy.getChildren()).isEmpty();
 	}
 
 	@Test
@@ -64,7 +65,7 @@ public class CriteriaDefinitionTest {
 		ICriterionValueDefinition copy = (ICriterionValueDefinition) element;
 		assertEquals(VALUEID1, copy.getId());
 		assertEquals(VALUENAME1, copy.getName());
-		assertEquals(0, copy.getChildren().length);
+		assertThat(copy.getChildren()).isEmpty();
 	}
 
 	// Criterion - no children
@@ -73,7 +74,7 @@ public class CriteriaDefinitionTest {
 		UserCriterionDefinition definition = new UserCriterionDefinition(CRITERIONID1, CRITERIONNAME1);
 		assertEquals(CRITERIONID1, definition.getId());
 		assertEquals(CRITERIONNAME1, definition.getName());
-		assertEquals(0, definition.getChildren().length);
+		assertThat(definition.getChildren()).isEmpty();
 	}
 
 	@Test
@@ -82,7 +83,7 @@ public class CriteriaDefinitionTest {
 		ICriterionDefinition copy = new CriterionDefinition(definition);
 		assertEquals(CRITERIONID1, copy.getId());
 		assertEquals(CRITERIONNAME1, copy.getName());
-		assertEquals(0, copy.getChildren().length);
+		assertThat(copy.getChildren()).isEmpty();
 	}
 
 	@Test
@@ -94,7 +95,7 @@ public class CriteriaDefinitionTest {
 		ICriterionDefinition copy = (ICriterionDefinition) element;
 		assertEquals(CRITERIONID1, copy.getId());
 		assertEquals(CRITERIONNAME1, copy.getName());
-		assertEquals(0, copy.getChildren().length);
+		assertThat(copy.getChildren()).isEmpty();
 	}
 
 	@Test
@@ -139,7 +140,7 @@ public class CriteriaDefinitionTest {
 		assertEquals(CRITERIONID1, copy.getId());
 		assertEquals(CRITERIONNAME1, copy.getName());
 		ICriterionValueDefinition[] values = copy.getCriterionValueDefinitions();
-		assertEquals(2, values.length);
+		assertThat(values).hasSize(2);
 		assertEquals(VALUEID1, values[0].getId());
 		assertEquals(VALUENAME1, values[0].getName());
 		assertEquals(VALUEID2, values[1].getId());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/ParseTocWithCriteria.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/ParseTocWithCriteria.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.criteria;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -101,7 +102,7 @@ public class ParseTocWithCriteria {
 	public void testTopicWithCriteria() throws Exception {
 		IToc toc = parseToc("data/help/criteria/c1.xml");
 		ITopic[] topics = toc.getTopics();
-		assertEquals(topics.length, 2);
+		assertThat(topics).hasSize(2);
 		// First topic
 		Map<String, Set<String>> criteria = new HashMap<>();
 		assertTrue(topics[0] instanceof ITopic2);
@@ -129,7 +130,7 @@ public class ParseTocWithCriteria {
 	public void testCriteriaScoping1() throws Exception {
 		IToc toc = parseToc("data/help/criteria/c1.xml");
 		ITopic[] topics = toc.getTopics();
-		assertEquals(topics.length, 2);
+		assertThat(topics).hasSize(2);
 		CriterionResource[] resource = new CriterionResource[1];
 		resource[0] = new CriterionResource("version");
 		resource[0].addCriterionValue("1.0");
@@ -143,7 +144,7 @@ public class ParseTocWithCriteria {
 	public void testCriteriaScoping2() throws Exception {
 		IToc toc = parseToc("data/help/criteria/c1.xml");
 		ITopic[] topics = toc.getTopics();
-		assertEquals(topics.length, 2);
+		assertThat(topics).hasSize(2);
 		CriterionResource[] resource = new CriterionResource[1];
 		resource[0] = new CriterionResource("platform");
 		resource[0].addCriterionValue("linux");
@@ -157,7 +158,7 @@ public class ParseTocWithCriteria {
 	public void testMultipleCriteriaScoping() throws Exception {
 		IToc toc = parseToc("data/help/criteria/c1.xml");
 		ITopic[] topics = toc.getTopics();
-		assertEquals(topics.length, 2);
+		assertThat(topics).hasSize(2);
 		CriterionResource[] resource = new CriterionResource[2];
 		resource[0] = new CriterionResource("platform");
 		resource[0].addCriterionValue("linux");
@@ -178,7 +179,7 @@ public class ParseTocWithCriteria {
 		resource[0].addCriterionValue("linux");
 		resource[1] = new CriterionResource("version");
 		resource[1].addCriterionValue("2.0");
-		assertEquals(topics.length, 2);
+		assertThat(topics).hasSize(2);
 		CriteriaHelpScope scope = new CriteriaHelpScope(resource);
 		assertTrue(scope.inScope(toc));
 		assertFalse(scope.inScope(topics[0]));
@@ -194,7 +195,7 @@ public class ParseTocWithCriteria {
 		toc.addCriterion(criterion2);
 
 		ICriteria[] criteria = toc.getCriteria();
-		assertEquals(2, criteria.length);
+		assertThat(criteria).hasSize(2);
 		assertEquals("version", criteria[0].getName());
 		assertEquals("1.0", criteria[0].getValue());
 		assertEquals("version", criteria[1].getName());
@@ -212,7 +213,7 @@ public class ParseTocWithCriteria {
 		Toc copy = new Toc(toc);
 
 		ICriteria[] criteria = copy.getCriteria();
-		assertEquals(2, criteria.length);
+		assertThat(criteria).hasSize(2);
 		assertEquals("version", criteria[0].getName());
 		assertEquals("1.0", criteria[0].getValue());
 		assertEquals("version", criteria[1].getName());
@@ -230,7 +231,7 @@ public class ParseTocWithCriteria {
 		Topic copy = new Topic(topic);
 
 		ICriteria[] criteria = copy.getCriteria();
-		assertEquals(2, criteria.length);
+		assertThat(criteria).hasSize(2);
 		assertEquals("version", criteria[0].getName());
 		assertEquals("1.0", criteria[0].getValue());
 		assertEquals("version", criteria[1].getName());
@@ -245,7 +246,7 @@ public class ParseTocWithCriteria {
 		topic.addCriterion(criterion1);
 		topic.addCriterion(criterion2);
 		ICriteria[] criteria = topic.getCriteria();
-		assertEquals(2, criteria.length);
+		assertThat(criteria).hasSize(2);
 		assertEquals("version", criteria[0].getName());
 		assertEquals("1.0", criteria[0].getValue());
 		assertEquals("version", criteria[1].getName());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/TestCriteriaProvider.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/criteria/TestCriteriaProvider.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.criteria;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +42,7 @@ public class TestCriteriaProvider {
 		Topic copy = new Topic(topic);
 
 		ICriteria[] nativeCriteria = copy.getCriteria();
-		assertEquals(2, nativeCriteria.length);
+		assertThat(nativeCriteria).hasSize(2);
 		assertEquals("version", nativeCriteria[0].getName());
 		assertEquals("1.0", nativeCriteria[0].getValue());
 		assertEquals("version", nativeCriteria[1].getName());
@@ -65,7 +66,7 @@ public class TestCriteriaProvider {
 		Toc copy = new Toc(toc);
 
 		ICriteria[] nativeCriteria = copy.getCriteria();
-		assertEquals(2, nativeCriteria.length);
+		assertThat(nativeCriteria).hasSize(2);
 		assertEquals("version", nativeCriteria[0].getName());
 		assertEquals("1.0", nativeCriteria[0].getValue());
 		assertEquals("version", nativeCriteria[1].getName());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/index/IndexAssemblerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/index/IndexAssemblerTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.index;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -69,23 +70,23 @@ public class IndexAssemblerTest {
 		List<IndexContribution> contributions = new ArrayList<>(Arrays.asList(contrib));
 		Index index = assembler.assemble(contributions, Platform.getNL());
 		IIndexEntry[] children = index.getEntries();
-		assertEquals(2,children.length);
+		assertThat(children).hasSize(2);
 		IIndexEntry eclipseEntry = children[0];
 		assertEquals("eclipse", eclipseEntry.getKeyword());
 		IUAElement[] eclipseChildren = eclipseEntry.getChildren();
-		assertEquals(4, eclipseChildren.length);
+		assertThat(eclipseChildren).hasSize(4);
 		assertTrue(eclipseChildren[0] instanceof Topic);
 		assertTrue(eclipseChildren[1] instanceof IndexEntry);
 		assertTrue(eclipseChildren[2] instanceof IndexSee);
 		assertTrue(eclipseChildren[3] instanceof IndexSee);
 		IndexSee seeHelios = (IndexSee) eclipseChildren[2];
 		IndexSee seeHeliosRelease = (IndexSee) eclipseChildren[3];
-		assertEquals(0, seeHelios.getSubpathElements().length);
-		assertEquals(1, seeHeliosRelease.getSubpathElements().length);
+		assertThat(seeHelios.getSubpathElements()).isEmpty();
+		assertThat(seeHeliosRelease.getSubpathElements()).hasSize(1);
 		IIndexEntry heliosEntry = children[1];
 		assertEquals("helios", heliosEntry.getKeyword());
 		IIndexSee[] heliosSees = ((IIndexEntry2)heliosEntry).getSees();
-		assertEquals(1, heliosSees.length);
+		assertThat(heliosSees).hasSize(1);
 		assertEquals("eclipse", heliosSees[0].getKeyword());
 	}
 
@@ -98,10 +99,10 @@ public class IndexAssemblerTest {
 		List<IndexContribution> contributions = new ArrayList<>(Arrays.asList(contrib));
 		Index index = assembler.assemble(contributions, Platform.getNL());
 		IIndexEntry[] children = index.getEntries();
-		assertEquals(1,children.length);
+		assertThat(children).hasSize(1);
 		assertEquals("keyword1", children[0].getKeyword());
 		ITopic[] topics = children[0].getTopics();
-		assertEquals(3, topics.length);
+		assertThat(topics).hasSize(3);
 		assertEquals("topic0", topics[0].getLabel());
 		assertEquals("topic1", topics[1].getLabel());
 		assertEquals("topic2", topics[2].getLabel());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextLinkSorter.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextLinkSorter.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.help.IContext2;
@@ -88,7 +89,7 @@ public class ContextLinkSorter {
 		ContextHelpSorter sorter = new ContextHelpSorter(new TestContext());
 		TestResource[] resources = new TestResource[0];
 		sorter.sort(null, resources);
-		assertEquals(0, resources.length);
+		assertThat(resources).isEmpty();
 	}
 
 	@Test
@@ -100,7 +101,7 @@ public class ContextLinkSorter {
 				new TestResource("a2", "c1", "http://www.a2.com")
 		};
 		sorter.sort(null, resources);
-		assertEquals(3, resources.length);
+		assertThat(resources).hasSize(3);
 		assertEquals("a1", resources[0].getLabel());
 		assertEquals("a3", resources[1].getLabel());
 		assertEquals("a2", resources[2].getLabel());
@@ -120,7 +121,7 @@ public class ContextLinkSorter {
 				new TestResource("a7", null, "http://www.a2.com")
 		};
 		sorter.sort(null, resources);
-		assertEquals(8, resources.length);
+		assertThat(resources).hasSize(8);
 		assertEquals("a1", resources[0].getLabel());
 		assertEquals("a2", resources[1].getLabel());
 		assertEquals("a9", resources[2].getLabel());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextMergeTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextMergeTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -73,14 +74,14 @@ public class ContextMergeTest {
 		assertEquals("Context Description", context1.getText());
 		assertEquals("viewer", context1.getId());
 		IHelpResource[] related = context1.getRelatedTopics();
-		assertEquals(3, related.length);
+		assertThat(related).hasSize(3);
 		assertEquals("eclipse", related[0].getLabel());
 		assertEquals("enabled", related[1].getLabel());
 		assertEquals("bugzilla", related[2].getLabel());
 		assertTrue(related[0] instanceof IUAElement);
 		IUAElement topic = (IUAElement)related[1];
 		IUAElement[] topicChildren = topic.getChildren();
-		assertEquals(1, topicChildren.length);
+		assertThat(topicChildren).hasSize(1);
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/ContextTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -86,7 +87,7 @@ public class ContextTest {
 		assertEquals("Sample View", context.getTitle());
 		assertEquals("Context Description", context.getText());
 		IHelpResource[] related = context.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		assertEquals("eclipse", related[0].getLabel());
 	}
 
@@ -102,12 +103,12 @@ public class ContextTest {
 		assertEquals("Context Description", context.getText());
 		assertEquals("viewer", context.getId());
 		IHelpResource[] related = context.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		assertEquals("enabled", related[0].getLabel());
 		assertTrue(related[0] instanceof IUAElement);
 		IUAElement topic = (IUAElement)related[0];
 		IUAElement[] topicChildren = topic.getChildren();
-		assertEquals(1, topicChildren.length);
+		assertThat(topicChildren).hasSize(1);
 	}
 
 	@Test
@@ -128,21 +129,21 @@ public class ContextTest {
 		assertEquals("new id2", context3.getId());
 
 		IHelpResource[] related = context.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		assertEquals("enabled", related[0].getLabel());
 		assertTrue(related[0] instanceof IUAElement);
 		Topic topic = (Topic)related[0];
 		assertEquals("http://www.eclipse.org", topic.getHref());
 
 		related = context2.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		assertEquals("enabled", related[0].getLabel());
 		assertTrue(related[0] instanceof IUAElement);
 		topic = (Topic)related[0];
 		assertEquals("http://www.eclipse.org", topic.getHref());
 
 		related = context3.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		assertEquals("enabled", related[0].getLabel());
 		assertTrue(related[0] instanceof IUAElement);
 		topic = (Topic)related[0];
@@ -159,7 +160,7 @@ public class ContextTest {
 			END_CONTEXT;
 		Context context  = createContext(contextSource);
 		IHelpResource[] related = context.getRelatedTopics();
-		assertEquals(3, related.length);
+		assertThat(related).hasSize(3);
 		assertTrue(((Topic)related[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related[1]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related[2]).isEnabled(HelpEvaluationContext.getContext()));
@@ -177,17 +178,17 @@ public class ContextTest {
 		Context context3 = new Context(context2, "id2");
 
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -204,17 +205,17 @@ public class ContextTest {
 		Context context3 = new Context(context1, "id2");
 
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -230,17 +231,17 @@ public class ContextTest {
 		Context context2 = new Context(context1, "id");
 		Context context3 = new Context(context2, "id2");
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -257,17 +258,17 @@ public class ContextTest {
 		Context context3 = new Context(context1, "id2");
 
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -283,17 +284,17 @@ public class ContextTest {
 		Context context2 = new Context(context1, "id");
 		Context context3 = new Context(context2, "id2");
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -310,17 +311,17 @@ public class ContextTest {
 		Context context3 = new Context(context1, "id2");
 
 		IHelpResource[] related1 = context1.getRelatedTopics();
-		assertEquals(2, related1.length);
+		assertThat(related1).hasSize(2);
 		assertTrue(((Topic)related1[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related1[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related2 = context2.getRelatedTopics();
-		assertEquals(2, related2.length);
+		assertThat(related2).hasSize(2);
 		assertTrue(((Topic)related2[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related2[1]).isEnabled(HelpEvaluationContext.getContext()));
 
 		IHelpResource[] related3 = context3.getRelatedTopics();
-		assertEquals(2, related3.length);
+		assertThat(related3).hasSize(2);
 		assertTrue(((Topic)related3[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related3[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}
@@ -343,16 +344,16 @@ public class ContextTest {
 
 	private void deleteAndInsert(Context context) {
 		IHelpResource[] related = context.getRelatedTopics();
-		assertEquals(2, related.length);
+		assertThat(related).hasSize(2);
 		IHelpResource enabled= related[0];
 		context.removeChild((UAElement) enabled);
 		related = context.getRelatedTopics();
-		assertEquals(1, related.length);
+		assertThat(related).hasSize(1);
 		Topic disabled = (Topic)related[0];
 		assertFalse(disabled.isEnabled(HelpEvaluationContext.getContext()));
 		context.insertBefore((UAElement) enabled, disabled);
 		related = context.getRelatedTopics();
-		assertEquals(2, related.length);
+		assertThat(related).hasSize(2);
 		assertTrue(((Topic)related[0]).isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(((Topic)related[1]).isEnabled(HelpEvaluationContext.getContext()));
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexEntryTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexEntryTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,9 +97,9 @@ public class IndexEntryTest {
 		IndexEntry entry;
 		entry = createEntry(ENTRY_ECLIPSE);
 		assertEquals(ECLIPSE, entry.getKeyword());
-		assertEquals(0, entry.getTopics().length);
-		assertEquals(0, entry.getSubentries().length);
-		assertEquals(0, entry.getSees().length);
+		assertThat(entry.getTopics()).isEmpty();
+		assertThat(entry.getSubentries()).isEmpty();
+		assertThat(entry.getSees()).isEmpty();
 	}
 
 	@Test
@@ -116,14 +117,14 @@ public class IndexEntryTest {
 		entry1 = createEntry(ENTRY_WITH_CHILD);
 		IndexEntry entry2 = new IndexEntry(entry1);
 
-		assertEquals(1, entry1.getSubentries().length);
+		assertThat(entry1.getSubentries()).hasSize(1);
 		IndexEntry child1 = (IndexEntry)entry1.getSubentries()[0];
 		assertEquals(BUGZILLA, child1.getKeyword());
 
-		assertEquals(1, entry2.getSubentries().length);
+		assertThat(entry2.getSubentries()).hasSize(1);
 		IndexEntry child2 = (IndexEntry)entry2.getSubentries()[0];
 		assertEquals(BUGZILLA, child2.getKeyword());
-		assertEquals(1, entry2.getSubentries().length);
+		assertThat(entry2.getSubentries()).hasSize(1);
 	}
 
 	@Test
@@ -132,14 +133,14 @@ public class IndexEntryTest {
 		entry1 = createEntry(ENTRY_WITH_TOPIC);
 		IndexEntry entry2 = new IndexEntry(entry1);
 
-		assertEquals(0, entry1.getSubentries().length);
-		assertEquals(1, entry1.getTopics().length);
+		assertThat(entry1.getSubentries()).isEmpty();
+		assertThat(entry1.getTopics()).hasSize(1);
 		Topic child1 = (Topic)entry1.getTopics()[0];
 		assertEquals(BUGZILLA, child1.getLabel());
 		assertEquals(BUGZILLA_HREF, child1.getHref());
 
-		assertEquals(0, entry2.getSubentries().length);
-		assertEquals(1, entry2.getTopics().length);
+		assertThat(entry2.getSubentries()).isEmpty();
+		assertThat(entry2.getTopics()).hasSize(1);
 		Topic child2 = (Topic)entry2.getTopics()[0];
 		assertEquals(BUGZILLA, child2.getLabel());
 		assertEquals(BUGZILLA_HREF, child2.getHref());
@@ -151,13 +152,13 @@ public class IndexEntryTest {
 		entry1 = createEntry(ENTRY_WITH_SEE);
 		IndexEntry entry2 = new IndexEntry(entry1);
 
-		assertEquals(0, entry1.getSubentries().length);
-		assertEquals(1, entry1.getSees().length);
+		assertThat(entry1.getSubentries()).isEmpty();
+		assertThat(entry1.getSees()).hasSize(1);
 		IndexSee child1 = (IndexSee)entry1.getSees()[0];
 		assertEquals("sdk", child1.getKeyword());
 
-		assertEquals(0, entry2.getSubentries().length);
-		assertEquals(1, entry2.getSees().length);
+		assertThat(entry2.getSubentries()).isEmpty();
+		assertThat(entry2.getSees()).hasSize(1);
 		IndexSee child2 = (IndexSee)entry2.getSees()[0];
 		assertEquals("sdk", child2.getKeyword());
 	}
@@ -311,9 +312,9 @@ public class IndexEntryTest {
 		IIndexEntry[] subentries = entry.getSubentries();
 		ITopic[] topics = entry.getTopics();
 		IIndexSee[] sees = entry.getSees();
-		assertEquals(2, subentries.length);
-		assertEquals(1, sees.length);
-		assertEquals(3,topics.length);
+		assertThat(subentries).hasSize(2);
+		assertThat(sees).hasSize(1);
+		assertThat(topics).hasSize(3);
 		assertEquals("jdt", subentries[0].getKeyword());
 		assertEquals("compiler", subentries[1].getKeyword());
 		assertEquals("label1", topics[0].getLabel());
@@ -329,9 +330,9 @@ public class IndexEntryTest {
 		IIndexEntry[] subentries = entry.getSubentries();
 		ITopic[] topics = entry.getTopics();
 		IIndexSee[] sees = entry.getSees();
-		assertEquals(2, subentries.length);
-		assertEquals(1, sees.length);
-		assertEquals(3,topics.length);
+		assertThat(subentries).hasSize(2);
+		assertThat(sees).hasSize(1);
+		assertThat(topics).hasSize(3);
 		assertTrue(subentries[0].isEnabled(HelpEvaluationContext.getContext()));
 		assertFalse(subentries[1].isEnabled(HelpEvaluationContext.getContext()));
 		assertTrue(topics[0].isEnabled(HelpEvaluationContext.getContext()));

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexSeeTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/IndexSeeTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,11 +97,11 @@ public class IndexSeeTest {
 		see1 = createSee(SEE_ECLIPSE);
 		IndexSee see2 = new IndexSee(see1);
 		assertEquals(ECLIPSE, see1.getKeyword());
-		assertEquals(0, see1.getSubpathElements().length);
+		assertThat(see1.getSubpathElements()).isEmpty();
 		assertEquals(ECLIPSE, see1.getKeyword());
 
 		assertEquals(ECLIPSE, see2.getKeyword());
-		assertEquals(0, see2.getSubpathElements().length);
+		assertThat(see2.getSubpathElements()).isEmpty();
 		assertEquals(ECLIPSE, see2.getKeyword());
 	}
 
@@ -110,11 +111,11 @@ public class IndexSeeTest {
 		see1 = createSee(SEE_ECLIPSE_SDK);
 		IndexSee see2 = new IndexSee(see1);
 
-		assertEquals(1, see1.getSubpathElements().length);
+		assertThat(see1.getSubpathElements()).hasSize(1);
 		assertEquals(ECLIPSE, see1.getKeyword());
 		assertEquals(SDK, see1.getSubpathElements()[0].getKeyword());
 
-		assertEquals(1, see2.getSubpathElements().length);
+		assertThat(see2.getSubpathElements()).hasSize(1);
 		assertEquals(ECLIPSE, see2.getKeyword());
 		assertEquals(SDK, see2.getSubpathElements()[0].getKeyword());
 
@@ -126,12 +127,12 @@ public class IndexSeeTest {
 		see1 = createSee(SEE_ECLIPSE_SDK_VIEWS);
 		IndexSee see2 = new IndexSee(see1);
 
-		assertEquals(2, see1.getSubpathElements().length);
+		assertThat(see1.getSubpathElements()).hasSize(2);
 		assertEquals(ECLIPSE, see1.getKeyword());
 		assertEquals(SDK, see1.getSubpathElements()[0].getKeyword());
 		assertEquals(VIEWS, see1.getSubpathElements()[1].getKeyword());
 
-		assertEquals(2, see2.getSubpathElements().length);
+		assertThat(see2.getSubpathElements()).hasSize(2);
 		assertEquals(ECLIPSE, see2.getKeyword());
 		assertEquals(SDK, see2.getSubpathElements()[0].getKeyword());
 		assertEquals(VIEWS, see2.getSubpathElements()[1].getKeyword());
@@ -309,7 +310,7 @@ public class IndexSeeTest {
 	private void checkCreatedSee(IndexSee see) {
 		assertEquals("eclipse", see.getKeyword());
 		IIndexSubpath[] subpath = see.getSubpathElements();
-		assertEquals(2, subpath.length);
+		assertThat(subpath).hasSize(2);
 		assertEquals("platform", subpath[0].getKeyword());
 		assertEquals("ui", subpath[1].getKeyword());
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/TocObjectTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/TocObjectTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.help.ITopic;
 import org.eclipse.help.internal.base.HelpEvaluationContext;
@@ -85,8 +85,8 @@ public class TocObjectTest {
 		UserToc	utoc = new UserToc(TITLE_1, null, true);
 		Toc toc = new Toc(utoc);
 		ITopic emptyTopic = toc.getTopic(null);
-		assertTrue(emptyTopic.getChildren().length == 0);
-		assertTrue(emptyTopic.isEnabled(HelpEvaluationContext.getContext()));
+		assertThat(emptyTopic.getChildren()).isEmpty();
+		assertThat(emptyTopic).matches(it -> it.isEnabled(HelpEvaluationContext.getContext()), "is enabed");
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/TopicTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/TopicTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -116,16 +117,16 @@ public class TopicTest {
 		Topic topic1 = createTopic(TOPIC_WITH_CHILD);
 		Topic topic2 = new Topic(topic1);
 
-		assertEquals(1, topic1.getSubtopics().length);
+		assertThat(topic1.getSubtopics()).hasSize(1);
 		Topic child1 = (Topic)topic1.getSubtopics()[0];
 		assertEquals(BUGZILLA, child1.getLabel());
 		assertEquals(BUGZILLA_HREF, child1.getHref());
 
-		assertEquals(1, topic2.getSubtopics().length);
+		assertThat(topic2.getSubtopics()).hasSize(1);
 		Topic child2 = (Topic)topic2.getSubtopics()[0];
 		assertEquals(BUGZILLA, child2.getLabel());
 		assertEquals(BUGZILLA_HREF, child2.getHref());
-		assertEquals(1, topic2.getSubtopics().length);
+		assertThat(topic2.getSubtopics()).hasSize(1);
 	}
 
 	/*
@@ -299,7 +300,7 @@ public class TopicTest {
 		assertEquals(ECLIPSE, t1.getLabel());
 		assertEquals(ECLIPSE_HREF, t1.getHref());
 		assertTrue(t1.isEnabled(HelpEvaluationContext.getContext()));
-		assertEquals(1, t1.getChildren().length);
+		assertThat(t1.getChildren()).hasSize(1);
 		ITopic t2 = t1.getSubtopics()[0];
 		assertEquals(BUGZILLA, t2.getLabel());
 		assertEquals(BUGZILLA_HREF, t2.getHref());
@@ -317,7 +318,7 @@ public class TopicTest {
 		assertEquals(ECLIPSE, t1.getLabel());
 		assertEquals(ECLIPSE_HREF, t1.getHref());
 		assertTrue(t1.isEnabled(HelpEvaluationContext.getContext()));
-		assertEquals(1, t1.getChildren().length);
+		assertThat(t1.getChildren()).hasSize(1);
 		ITopic t1s = t1.getSubtopics()[0];
 		assertEquals(BUGZILLA, t1s.getLabel());
 		assertEquals(BUGZILLA_HREF, t1s.getHref());
@@ -325,7 +326,7 @@ public class TopicTest {
 		assertEquals(ECLIPSE, t2.getLabel());
 		assertEquals(ECLIPSE_HREF, t2.getHref());
 		assertTrue(t2.isEnabled(HelpEvaluationContext.getContext()));
-		assertEquals(1, t2.getChildren().length);
+		assertThat(t2.getChildren()).hasSize(1);
 		ITopic t2s = t2.getSubtopics()[0];
 		assertEquals(BUGZILLA, t2s.getLabel());
 		assertEquals(BUGZILLA_HREF, t2s.getHref());

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/UAElementTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/UAElementTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -39,10 +40,10 @@ public class UAElementTest {
 	public void testSimpleUAElement() {
 		UAElement element = new UAElement("name1");
 		assertEquals("name1", element.getElementName());
-		assertEquals(0, element.getChildren().length);
+		assertThat(element.getChildren()).isEmpty();
 		Object topicChildren = element.getChildren(Topic.class);
 		assertTrue(topicChildren instanceof Topic[]);
-		assertTrue(((Topic[])topicChildren).length == 0);
+		assertThat(((Topic[]) topicChildren)).isEmpty();
 		assertNull(element.getParentElement());
 		assertNull(element.getAttribute("a1"));
 		assertTrue(element.equals(element));
@@ -70,25 +71,25 @@ public class UAElementTest {
 		initializeElements();
 		parent1.appendChild(child1);
 		IUAElement[] children = parent1.getChildren();
-		assertEquals(1, children.length);
+		assertThat(children).hasSize(1);
 		assertEquals("c1", ((UAElement)children[0]).getElementName());
 		assertEquals(parent1, ((UAElement)children[0]).getParentElement());
 		assertEquals("c1", ((UAElement)children[0]).getAttribute("id"));
 		parent1.appendChild(child2);
 		children = parent1.getChildren();
-		assertEquals(2, children.length);
+		assertThat(children).hasSize(2);
 		assertEquals("c2", ((UAElement)children[1]).getElementName());
 		parent1.insertBefore(child3, child2);
 		children = parent1.getChildren();
-		assertEquals(3, children.length);
+		assertThat(children).hasSize(3);
 		assertEquals("c3", ((UAElement)children[1]).getElementName());
 		parent1.removeChild(child1);
 		children = parent1.getChildren();
-		assertEquals(2, children.length);
+		assertThat(children).hasSize(2);
 		assertEquals("c3", ((UAElement)children[0]).getElementName());
 		parent1.appendChildren(new IUAElement[] {child1, child4});
 		children = parent1.getChildren();
-		assertEquals(4, children.length);
+		assertThat(children).hasSize(4);
 		assertEquals("c1", ((UAElement)children[2]).getElementName());
 		assertEquals("c4", ((UAElement)children[3]).getElementName());
 	}
@@ -101,7 +102,7 @@ public class UAElementTest {
 		parent1.appendChild(child2);
 		parent1.appendChild(child1);
 		IUAElement[] children = parent1.getChildren();
-		assertEquals(4, children.length);
+		assertThat(children).hasSize(4);
 		assertEquals("c1", ((UAElement)children[0]).getElementName());
 		assertEquals("c2", ((UAElement)children[1]).getElementName());
 		assertEquals("c2", ((UAElement)children[2]).getElementName());
@@ -114,7 +115,7 @@ public class UAElementTest {
 		child1.appendChild(grandchild1);
 		parent2.appendChild(child1);
 		UAElement firstChild = (UAElement) parent2.getChildren()[0];
-		assertEquals(1, firstChild.getChildren().length);
+		assertThat(firstChild.getChildren()).hasSize(1);
 		UAElement firstGrandchild = (UAElement) firstChild.getChildren()[0];
 		assertEquals("g1", firstGrandchild.getElementName());
 		assertEquals(firstGrandchild.getParentElement(), firstChild);

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/IndexAssemblePerformanceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/performance/IndexAssemblePerformanceTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.performance;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ public class IndexAssemblePerformanceTest extends PerformanceTestCaseJunit5 {
 		IndexAssembler assembler = new IndexAssembler();
 		List<IndexContribution> contributions = new ArrayList<>(Arrays.asList(a, b, c));
 		Index assembled = assembler.assemble(contributions, Platform.getNL());
-		assertEquals(100, assembled.getChildren().length);
+		assertThat(assembled.getChildren()).hasSize(100);
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/BookmarksTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/BookmarksTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.preferences;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -84,7 +85,7 @@ public class BookmarksTest {
 		assertEquals(BookmarkManager.REMOVE_ALL, observer.getEvent().getType());
 		assertNull(observer.getEvent().getBookmark());
 		IHelpResource[] bookmarks = manager.getBookmarks();
-		assertEquals(0, bookmarks.length);
+		assertThat(bookmarks).isEmpty();
 		assertEquals(1, observer.eventCount);
 	}
 
@@ -100,7 +101,7 @@ public class BookmarksTest {
 		manager.addBookmark(HTTP_BUGZILLA, BUGZILLA);
 		BookmarkManager manager2 = new BookmarkManager();
 		IHelpResource[] bookmarks = manager2.getBookmarks();
-		assertEquals(2, bookmarks.length);
+		assertThat(bookmarks).hasSize(2);
 		assertEquals(ECLIPSE, bookmarks[0].getLabel());
 		assertEquals(BUGZILLA, bookmarks[1].getLabel());
 		assertEquals(HTTP_ECLIPSE, bookmarks[0].getHref());
@@ -131,6 +132,6 @@ public class BookmarksTest {
 		assertEquals(event.getType(), BookmarkManager.REMOVE);
 		assertEquals(BUGZILLA, event.getBookmark().getLabel());
 		assertEquals(HTTP_BUGZILLA, event.getBookmark().getHref());
-		assertEquals(1, manager.getBookmarks().length);
+		assertThat(manager.getBookmarks()).hasSize(1);
 	}
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/CssPreferences.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/CssPreferences.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.preferences;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.webapp.data.CssUtil;
@@ -34,28 +34,25 @@ public class CssPreferences {
 	@Test
 	public void testNull() {
 		String[] options = CssUtil.getCssFilenames(null);
-		assertEquals(0, options.length);
+		assertThat(options).isEmpty();
 	}
 
 	@Test
 	public void testEmptyString() {
 		String[] options = CssUtil.getCssFilenames("");
-		assertEquals(0, options.length);
+		assertThat(options).isEmpty();
 	}
 
 	@Test
 	public void testSingleString() {
 		String[] options = CssUtil.getCssFilenames(ORG_ECLIPSE_TEST_FILE_CSS);
-		assertEquals(1, options.length);
-		assertEquals(ORG_ECLIPSE_TEST_FILE_CSS, options[0]);
+		assertThat(options).containsExactly(ORG_ECLIPSE_TEST_FILE_CSS);
 	}
 
 	@Test
 	public void testTwoStrings() {
 		String[] options = CssUtil.getCssFilenames(ORG_ECLIPSE_TEST_FILE_CSS + " , " + FILENAME_WITH_PARAM);
-		assertEquals(2, options.length);
-		assertEquals(ORG_ECLIPSE_TEST_FILE_CSS, options[0]);
-		assertEquals(FILENAME_WITH_OS, options[1]);
+		assertThat(options).containsExactly(ORG_ECLIPSE_TEST_FILE_CSS, FILENAME_WITH_OS);
 	}
 
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ua.tests.help.preferences;
 
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.List;
@@ -161,7 +162,7 @@ public class ProductPreferencesTest {
 					.loadPropertiesFile(FrameworkUtil.getBundle(getClass()).getSymbolicName(), path);
 
 			Assert.assertNotNull("The result of loading a properties file was unexpectedly null", properties);
-			Assert.assertEquals(data.length - 1, properties.size());
+			assertThat(data).hasSize(properties.size() + 1);
 
 			for (int j=1;j<data.length;++j) {
 				StringTokenizer tok = new StringTokenizer(data[j], "=");
@@ -203,7 +204,7 @@ public class ProductPreferencesTest {
 			List<String> output = ProductPreferences.tokenize(input);
 
 			Assert.assertNotNull("The tokenized output was unexpectedly null for: " + input, output);
-			Assert.assertEquals("The number of tokens did not match the expected result for: " + input, data.length - 1, output.size());
+			assertThat(output).as("check number of tokens").hasSize(data.length - 1);
 
 			for (int j=0;j<output.size();++j) {
 				Assert.assertEquals("One of the tokens did not match the expected result", data[j + 1], output.get(j));

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContextServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContextServletTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -59,7 +60,7 @@ public class ContextServletTest {
 	@Test
 	public void testRemoteContextFound() throws Exception {
 		Element[] topics = getContextsFromServlet("org.eclipse.ua.tests.test_cheatsheets");
-		assertEquals(1, topics.length);
+		assertThat(topics).hasSize(1);
 		assertEquals("abcdefg", topics[0].getAttribute("label"));
 	}
 
@@ -67,7 +68,7 @@ public class ContextServletTest {
 	public void testRemoteContextFoundDe() throws Exception {
 		Element[] topics = getContextsUsingLocale
 			("org.eclipse.ua.tests.test_cheatsheets", "de");
-		assertEquals(1, topics.length);
+			assertThat(topics).hasSize(1);
 		assertEquals("German Context", topics[0].getAttribute("label"));
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/GetContextUsingRemoteHelp.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/GetContextUsingRemoteHelp.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -50,7 +51,7 @@ public class GetContextUsingRemoteHelp {
 		IContext context = HelpPlugin.getContextManager().getContext("org.eclipse.ua.tests.test_one", "en");
 		assertNotNull(context);
 		IHelpResource[] relatedTopics = context.getRelatedTopics();
-		assertEquals(1, relatedTopics.length);
+		assertThat(relatedTopics).hasSize(1);
 		String topicLabel = relatedTopics[0].getLabel();
 		assertEquals("context_one_en", topicLabel);
 		String title = ((IContext3)context).getTitle();
@@ -65,7 +66,7 @@ public class GetContextUsingRemoteHelp {
 		IContext context = HelpPlugin.getContextManager().getContext("org.eclipse.ua.tests.test_cheatsheets", "en");
 		assertNotNull(context);
 		IHelpResource[] relatedTopics = context.getRelatedTopics();
-		assertEquals(1, relatedTopics.length);
+		assertThat(relatedTopics).hasSize(1);
 		String topicLabel = relatedTopics[0].getLabel();
 		assertEquals("abcdefg", topicLabel);
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/IndexServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/IndexServletTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -53,70 +54,70 @@ public class IndexServletTest {
 	public void testIndexServletContainsSimpleWord() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "xyz");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithAccent() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "\u00E1mbito");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithGt() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "character >");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithLt() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "character <");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithAmp() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "character &");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithQuot() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "character \"");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testIndexServletContainsWordWithApostrophe() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "character '");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testDeWordNotInEnIndex() throws Exception {
 		Node root = getIndexContributions("en");
 		Element[] UARoot = findEntryInAllContributions(root, "munich");
-		assertEquals(0, UARoot.length);
+		assertThat(UARoot).isEmpty();
 	}
 
 	@Test
 	public void testWordInDeIndex() throws Exception {
 		Node root = getIndexContributions("de");
 		Element[] UARoot = findEntryInAllContributions(root, "munich");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testWordNotInDeIndex() throws Exception {
 		Node root = getIndexContributions("de");
 		Element[] UARoot = findEntryInAllContributions(root, "xyz");
-		assertEquals(0, UARoot.length);
+		assertThat(UARoot).isEmpty();
 	}
 
 	private Element[] findEntryInAllContributions(Node parent, String keyword) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/LoadIndexUsingRemoteHelp.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/LoadIndexUsingRemoteHelp.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.remote;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,13 +49,13 @@ public class LoadIndexUsingRemoteHelp {
 		String locale = "en";
 		HelpPlugin.getIndexManager().clearCache();
 		IIndex index = HelpPlugin.getIndexManager().getIndex(locale);
-		assertEquals(0, matchingEntries(index, "entry1_" + locale).length);
-		assertEquals(0, matchingEntries(index, "entry2_" + locale).length);
+		assertThat(matchingEntries(index, "entry1_" + locale)).isEmpty();
+		assertThat(matchingEntries(index, "entry2_" + locale)).isEmpty();
 		RemotePreferenceStore.setMockRemoteServer();
 		HelpPlugin.getIndexManager().clearCache();
 		index = HelpPlugin.getIndexManager().getIndex(locale);
-		assertEquals(1, matchingEntries(index, "entry1_" + locale).length);
-		assertEquals(1, matchingEntries(index, "entry2_" + locale).length);
+		assertThat(matchingEntries(index, "entry1_" + locale)).hasSize(1);
+		assertThat(matchingEntries(index, "entry2_" + locale)).hasSize(1);
 	}
 
 	@Test
@@ -64,19 +64,19 @@ public class LoadIndexUsingRemoteHelp {
 		HelpPlugin.getIndexManager().clearCache();
 		IIndex index = HelpPlugin.getIndexManager().getIndex(locale);
 		IIndexEntry[] entry1 = matchingEntries(index, "entry1_" + locale);
-		assertEquals(0, entry1.length);
+		assertThat(entry1).isEmpty();
 		IIndexEntry[] entry2 = matchingEntries(index, "entry2_" + locale);
-		assertEquals(0, entry2.length);
+		assertThat(entry2).isEmpty();
 		RemotePreferenceStore.setTwoMockRemoteServers();
 		HelpPlugin.getIndexManager().clearCache();
 		index = HelpPlugin.getIndexManager().getIndex(locale);
 		// Entry 1 has the same child on each remote server, Entry 2 has different children
 		entry1 = matchingEntries(index, "entry1_" + locale);
 		entry2 = matchingEntries(index, "entry2_" + locale);
-		assertEquals(1, entry1.length);
-		assertEquals(1, entry1[0].getTopics().length);
-		assertEquals(1, entry2.length);
-		assertEquals(2, entry2[0].getTopics().length);
+		assertThat(entry1).hasSize(1);
+		assertThat(entry1[0].getTopics()).hasSize(1);
+		assertThat(entry2).hasSize(1);
+		assertThat(entry2[0].getTopics()).hasSize(2);
 	}
 
 	private IIndexEntry[] matchingEntries(IIndex index, String keyword) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/RemotePreferenceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/RemotePreferenceTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -59,7 +60,7 @@ public class RemotePreferenceTest {
 		setToDefault(IHelpBaseConstants.P_KEY_REMOTE_HELP_DEFAULT_PORT);
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(0, handler.getTotalRemoteInfocenters());
-		assertEquals(0, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).isEmpty();
 	}
 
 	/*
@@ -77,7 +78,7 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(0, handler.getTotalRemoteInfocenters());
-		assertEquals(0, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).isEmpty();
 	}
 
 	/*
@@ -95,7 +96,7 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(1, handler.getTotalRemoteInfocenters());
-		assertEquals(1, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(1);
 	}
 
 	@Test
@@ -110,10 +111,10 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(0, handler.getTotalRemoteInfocenters());
-		assertEquals(0, handler.getHostEntries().length);
-		assertEquals(0, handler.getPortEntries().length);
-		assertEquals(0, handler.getEnabledEntries().length);
-		assertEquals(0, handler.getPathEntries().length);
+		assertThat(handler.getHostEntries()).isEmpty();
+		assertThat(handler.getPortEntries()).isEmpty();
+		assertThat(handler.getEnabledEntries()).isEmpty();
+		assertThat(handler.getPathEntries()).isEmpty();
 	}
 
 	@Test
@@ -128,13 +129,13 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "false");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(1, handler.getTotalRemoteInfocenters());
-		assertEquals(1, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(1);
 		assertEquals("localhost", handler.getHostEntries()[0]);
-		assertEquals(1, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(1);
 		assertEquals("8081", handler.getPortEntries()[0]);
-		assertEquals(1, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(1);
 		assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
-		assertEquals(1, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(1);
 		assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 	}
 
@@ -149,16 +150,16 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "false,false");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(2, handler.getTotalRemoteInfocenters());
-		assertEquals(2, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(2);
 		assertEquals("localhost", handler.getHostEntries()[0]);
 		assertEquals("www.eclipse.org", handler.getHostEntries()[1]);
-		assertEquals(2, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(2);
 		assertEquals("8081", handler.getPortEntries()[0]);
 		assertEquals("8082", handler.getPortEntries()[1]);
-		assertEquals(2, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(2);
 		assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
 		assertEquals("false", handler.getEnabledEntries()[1].toLowerCase());
-		assertEquals(2, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(2);
 		assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 		assertEquals("/eclipse/help", handler.getPathEntries()[1].toLowerCase());
 	}
@@ -175,13 +176,13 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "false,true");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(1, handler.getTotalRemoteInfocenters());
-		assertEquals(1, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(1);
 		assertEquals("localhost", handler.getHostEntries()[0]);
-		assertEquals(1, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(1);
 		assertEquals("8081", handler.getPortEntries()[0]);
-		assertEquals(1, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(1);
 		assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
-		assertEquals(1, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(1);
 		assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 	}
 
@@ -197,13 +198,13 @@ public class RemotePreferenceTest {
 		setPreference("remoteHelpICContributed", "");
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(1, handler.getTotalRemoteInfocenters());
-		assertEquals(1, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(1);
 		assertEquals("localhost", handler.getHostEntries()[0]);
-		assertEquals(1, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(1);
 		//assertEquals("80", handler.getPortEntries()[0]);
-		assertEquals(1, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(1);
 		//assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
-		assertEquals(1, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(1);
 		//assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 	}
 
@@ -212,10 +213,10 @@ public class RemotePreferenceTest {
 		PreferenceFileHandler.commitRemoteICs(new RemoteIC[0]);
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(0, handler.getTotalRemoteInfocenters());
-		assertEquals(0, handler.getHostEntries().length);
-		assertEquals(0, handler.getPortEntries().length);
-		assertEquals(0, handler.getEnabledEntries().length);
-		assertEquals(0, handler.getPathEntries().length);
+		assertThat(handler.getHostEntries()).isEmpty();
+		assertThat(handler.getPortEntries()).isEmpty();
+		assertThat(handler.getEnabledEntries()).isEmpty();
+		assertThat(handler.getPathEntries()).isEmpty();
 	}
 
 	@Test
@@ -224,13 +225,13 @@ public class RemotePreferenceTest {
 		PreferenceFileHandler.commitRemoteICs(ic);
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(1, handler.getTotalRemoteInfocenters());
-		assertEquals(1, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(1);
 		assertEquals("host", handler.getHostEntries()[0]);
-		assertEquals(1, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(1);
 		assertEquals("8080", handler.getPortEntries()[0]);
-		assertEquals(1, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(1);
 		assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
-		assertEquals(1, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(1);
 		assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 	}
 
@@ -241,16 +242,16 @@ public class RemotePreferenceTest {
 		PreferenceFileHandler.commitRemoteICs(ic);
 		PreferenceFileHandler handler = new PreferenceFileHandler();
 		assertEquals(2, handler.getTotalRemoteInfocenters());
-		assertEquals(2, handler.getHostEntries().length);
+		assertThat(handler.getHostEntries()).hasSize(2);
 		assertEquals("host", handler.getHostEntries()[0]);
 		assertEquals("remotehost", handler.getHostEntries()[1]);
-		assertEquals(2, handler.getPortEntries().length);
+		assertThat(handler.getPortEntries()).hasSize(2);
 		assertEquals("8080", handler.getPortEntries()[0]);
 		assertEquals("8081", handler.getPortEntries()[1]);
-		assertEquals(2, handler.getEnabledEntries().length);
+		assertThat(handler.getEnabledEntries()).hasSize(2);
 		assertEquals("true", handler.getEnabledEntries()[0].toLowerCase());
 		assertEquals("false", handler.getEnabledEntries()[1].toLowerCase());
-		assertEquals(2, handler.getPathEntries().length);
+		assertThat(handler.getPathEntries()).hasSize(2);
 		assertEquals("/help", handler.getPathEntries()[0].toLowerCase());
 		assertEquals("/help2", handler.getPathEntries()[1].toLowerCase());
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/SearchServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/SearchServletTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -58,61 +59,61 @@ public class SearchServletTest {
 	@Test
 	public void testRemoteSearchNotFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("duernfryehd");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	@Test
 	public void testRemoteSearchFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("jehcyqpfjs");
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 	}
 
 	@Test
 	public void testRemoteSearchOrFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("jehcyqpfjs OR duernfryehd");
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 	}
 
 	@Test
 	public void testRemoteSearchAndFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("jehcyqpfjs AND vkrhjewiwh");
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 	}
 
 	@Test
 	public void testRemoteSearchAndNotFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("jehcyqpfjs AND duernfryehd");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	@Test
 	public void testRemoteSearchExactMatchFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("\"jehcyqpfjs vkrhjewiwh\"");
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 	}
 
 	@Test
 	public void testRemoteSearchExactMatchNotFound() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("\"vkrhjewiwh jehcyqpfjs\"");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	@Test
 	public void testRemoteSearchWordNotInDefaultLocale() throws Exception {
 		Node[] hits = getSearchHitsFromServlet("deuejwuid");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	@Test
 	public void testRemoteSearchUsingDeLocale() throws Exception {
 		Node[] hits = getSearchHitsUsingLocale("deuejwuid", "de");
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 	}
 
 	@Test
 	public void testRemoteSearchUsingEnLocale() throws Exception {
 		Node[] hits = getSearchHitsUsingLocale("deuejwuid", "en");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	protected Node[] getSearchHitsFromServlet(String phrase)

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/TocServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/TocServletTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -53,51 +54,51 @@ public class TocServletTest {
 	public void testTocServletContainsUAToc() throws Exception {
 		Node root = getTocContributions("en");
 		Element[] UARoot = findContributionById(root, "/org.eclipse.ua.tests/data/help/toc/root.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testTocServletContainsFilteredToc() throws Exception {
 		Node root = getTocContributions("en");
 		Element[] UARoot = findContributionById(root, "/org.eclipse.ua.tests/data/help/toc/filteredToc/toc.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testTocServletContainsUnlinkedToc() throws Exception {
 		Node root = getTocContributions("en");
 		Element[] UARoot = findContributionById(root, "/org.eclipse.ua.tests/data/help/toc/filteredToc/nonPrimaryToc.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
 	public void testReadEnToc() throws Exception {
 		Node root = getTocContributions("en");
 		Element[] uaRoot = findContributionById(root, "/org.eclipse.ua.tests/data/help/search/toc.xml");
-		assertEquals(1, uaRoot.length);
+		assertThat(uaRoot).hasSize(1);
 		Element[] toc = findChildren(uaRoot[0], "toc", "label", "search");
-		assertEquals(1, toc.length);
+		assertThat(toc).hasSize(1);
 		Element[] topicSearch = findChildren(toc[0], "topic", "label", "search");
-		assertEquals(1, topicSearch.length);
+		assertThat(topicSearch).hasSize(1);
 		Element[] topicEn = findChildren(topicSearch[0], "topic", "label", "testen.html");
-		assertEquals(1, topicEn.length);
+		assertThat(topicEn).hasSize(1);
 		Element[] topicDe = findChildren(topicSearch[0], "topic", "label", "testde.html");
-		assertEquals(0, topicDe.length);
+		assertThat(topicDe).isEmpty();
 	}
 
 	@Test
 	public void testReadDeToc() throws Exception {
 		Node root = getTocContributions("de");
 		Element[] uaRoot = findContributionById(root, "/org.eclipse.ua.tests/data/help/search/toc.xml");
-		assertEquals(1, uaRoot.length);
+		assertThat(uaRoot).hasSize(1);
 		Element[] toc = findChildren(uaRoot[0], "toc", "label", "search");
-		assertEquals(1, toc.length);
+		assertThat(toc).hasSize(1);
 		Element[] topicSearch = findChildren(toc[0], "topic", "label", "search");
-		assertEquals(1, topicSearch.length);
+		assertThat(topicSearch).hasSize(1);
 		Element[] topicEn = findChildren(topicSearch[0], "topic", "label", "testen.html");
-		assertEquals(0, topicEn.length);
+		assertThat(topicEn).isEmpty();
 		Element[] topicDe = findChildren(topicSearch[0], "topic", "label", "testde.html");
-		assertEquals(1, topicDe.length);
+		assertThat(topicDe).hasSize(1);
 	}
 
 	private Element[] findContributionById(Node root, String id) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/InfocenterWorkingSetManagerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/InfocenterWorkingSetManagerTest.java
@@ -14,14 +14,13 @@
 
 package org.eclipse.ua.tests.help.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
@@ -46,10 +45,9 @@ public class InfocenterWorkingSetManagerTest {
 		wset.setElements(new AdaptableHelpResource[] { toc });
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		assertTrue(resources[0].equals(toc));
+		assertThat(resources).containsExactly(toc);
 	}
 
 	@Test
@@ -66,10 +64,9 @@ public class InfocenterWorkingSetManagerTest {
 		req2.setCookies(resp.getCookies());
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		assertTrue(resources[0].equals(toc));
+		assertThat(resources).containsExactly(toc);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -85,12 +82,9 @@ public class InfocenterWorkingSetManagerTest {
 		wset.setElements(new AdaptableHelpResource[] { topic1 });
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		assertTrue(topics.contains(resources[0]));
+		assertThat(resources).containsExactly(topic1);
 		checkCookies(resp);
 	}
 
@@ -107,14 +101,9 @@ public class InfocenterWorkingSetManagerTest {
 		wset.setElements(new AdaptableHelpResource[] { topic1, topic3 });
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(2, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		topics.add(topic3);
-		assertTrue(topics.contains(resources[0]));
-		assertTrue(topics.contains(resources[1]));
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3);
 		checkCookies(resp);
 	}
 
@@ -134,16 +123,9 @@ public class InfocenterWorkingSetManagerTest {
 		mgr.addWorkingSet(wset);
 
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(3, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		topics.add(topic3);
-		topics.add(topic5);
-		assertTrue(topics.contains(resources[0]));
-		assertTrue(topics.contains(resources[1]));
-		assertTrue(topics.contains(resources[2]));
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3, topic5);
 		checkCookies(resp);
 	}
 
@@ -163,13 +145,10 @@ public class InfocenterWorkingSetManagerTest {
 		req2.setCookies(resp.getCookies());
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		assertTrue(topics.contains(resources[0]));
+		assertThat(resources).containsExactly(topic1);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -192,14 +171,9 @@ public class InfocenterWorkingSetManagerTest {
 		req2.setCookies(resp.getCookies());
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(2, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		topics.add(topic3);
-		assertTrue(topics.contains(resources[0]));
-		assertTrue(topics.contains(resources[1]));
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -224,16 +198,9 @@ public class InfocenterWorkingSetManagerTest {
 		req2.setCookies(resp.getCookies());
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(3, resources.length);
-		Set<AdaptableTopic> topics = new HashSet<>();
-		topics.add(topic1);
-		topics.add(topic3);
-		topics.add(topic5);
-		assertTrue(topics.contains(resources[0]));
-		assertTrue(topics.contains(resources[1]));
-		assertTrue(topics.contains(resources[2]));
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3, topic5);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -254,13 +221,11 @@ public class InfocenterWorkingSetManagerTest {
 		mgr.addWorkingSet(wset1);
 		mgr.addWorkingSet(wset2);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(2, readWsets.length);
+		assertThat(readWsets).hasSize(2);
 		AdaptableHelpResource[] resourcesT3 = mgr.getWorkingSet("test3").getElements();
-		assertEquals(1, resourcesT3.length);
-		assertEquals(topic1, resourcesT3[0]);
+		assertThat(resourcesT3).containsExactly(topic1);
 		AdaptableHelpResource[] resourcesT4 = mgr.getWorkingSet("test4").getElements();
-		assertEquals(1, resourcesT4.length);
-		assertEquals(topic3, resourcesT4[0]);
+		assertThat(resourcesT4).containsExactly(topic3);
 		checkCookies(resp);
 	}
 
@@ -321,13 +286,12 @@ public class InfocenterWorkingSetManagerTest {
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(2, readWsets.length);
+		assertThat(readWsets).hasSize(2);
 		AdaptableHelpResource[] resourcesT3 = mgr2.getWorkingSet("test3").getElements();
-		assertEquals(1, resourcesT3.length);
+		assertThat(resourcesT3).containsExactly(topic1);
 		assertEquals(topic1, resourcesT3[0]);
 		AdaptableHelpResource[] resourcesT4 = mgr2.getWorkingSet("test4").getElements();
-		assertEquals(1, resourcesT4.length);
-		assertEquals(topic3, resourcesT4[0]);
+		assertThat(resourcesT4).containsExactly(topic3);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -346,9 +310,9 @@ public class InfocenterWorkingSetManagerTest {
 		wset.setCriteria(criteria);
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
-		assertEquals(1, readResources.length);
+		assertThat(readResources).hasSize(1);
 		checkCookies(resp);
 	}
 
@@ -372,9 +336,9 @@ public class InfocenterWorkingSetManagerTest {
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
-		assertEquals(1, readResources.length);
+		assertThat(readResources).hasSize(1);
 		checkCookies(resp);
 		checkCookies(resp2);
 	}
@@ -395,7 +359,7 @@ public class InfocenterWorkingSetManagerTest {
 		wset.setCriteria(criteria);
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
 		checkResourceWithTwoChildren(readResources);
 		checkCookies(resp);
@@ -419,7 +383,7 @@ public class InfocenterWorkingSetManagerTest {
 		InfocenterWorkingSetManager mgr2 = new InfocenterWorkingSetManager(req2, resp2, "en");
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
 		checkResourceWithTwoChildren(readResources);
 		checkCookies(resp);
@@ -427,7 +391,7 @@ public class InfocenterWorkingSetManagerTest {
 	}
 
 	private void checkResourceWithTwoChildren(CriterionResource[] readResources) {
-		assertEquals(2, readResources.length);
+		assertThat(readResources).hasSize(2);
 		CriterionResource readVersion;
 		CriterionResource readPlatform;
 		if (readResources[0].getCriterionName().equals("version")) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/MetaKeywords.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/MetaKeywords.java
@@ -14,6 +14,7 @@
 package org.eclipse.ua.tests.help.search;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -41,14 +42,14 @@ public class MetaKeywords {
 	@Test
 	public void testDescriptionInHtml() {
 		SearchHit[] hits = getResultDescriptions("ydhaedrsc", "en");
-		assertEquals(hits.length, 1);
+		assertThat(hits).hasSize(1);
 		assertEquals("HTML Meta description", hits[0].getDescription());
 	}
 
 	@Test
 	public void testDescriptionInXhtml() {
 		SearchHit[] hits = getResultDescriptions("olfrgkjrifjd", "en");
-		assertEquals(hits.length, 1);
+		assertThat(hits).hasSize(1);
 		assertEquals("XHTML Meta description", hits[0].getDescription());
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchCheatsheet.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchCheatsheet.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -85,7 +86,7 @@ public class SearchCheatsheet {
 		checkForCompositeMatch(hits);
 		// Matches in task ids should not be hits
 		hits = findHits("TaskId_AhB4U8");
-		assertEquals(0, hits.length);
+		assertThat(hits).isEmpty();
 	}
 
 	@Test
@@ -102,7 +103,7 @@ public class SearchCheatsheet {
 	 * Chech that there was one match, the
 	 */
 	private void checkForCheatSheetMatch(SearchHit[] hits) {
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 		assertEquals("/org.eclipse.ua.tests/data/cheatsheet/search/CSSearchTest.xml",
 				ignoreQuery(hits[0].getHref()));
 		assertTrue(hits[0].getDescription().startsWith("CSIntro_AhB4U8 This cheat sheet is used to test search."));
@@ -110,7 +111,7 @@ public class SearchCheatsheet {
 		}
 
 	private void checkForCompositeMatch(SearchHit[] hits) {
-		assertEquals(1, hits.length);
+		assertThat(hits).hasSize(1);
 		assertEquals("/org.eclipse.ua.tests/data/cheatsheet/search/CompositeSearchTest.xml",
 				ignoreQuery(hits[0].getHref()));
 		assertTrue(hits[0].getDescription().startsWith("Intro text TaskGroupIntro_AhB4U8"));

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchIntro.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchIntro.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.search;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 
@@ -38,26 +38,22 @@ public class SearchIntro {
 
 	@Test
 	public void testSearchIntroGroupLabel() {
-		SearchHit[] hits = SearchTestUtils.getSearchHits("ifirifjrnfj", "en");
-		assertEquals(1, hits.length);
+		assertThat(SearchTestUtils.getSearchHits("ifirifjrnfj", "en")).hasSize(1);
 	}
 
 	@Test
 	public void testSearchIntroGroupText() {
-		SearchHit[] hits = SearchTestUtils.getSearchHits("nenfhhdhhed", "en");
-		assertEquals(1, hits.length);
+		assertThat(SearchTestUtils.getSearchHits("nenfhhdhhed", "en")).hasSize(1);
 	}
 
 	@Test
 	public void testSearchIntroLinkLabel() {
-		SearchHit[] hits = SearchTestUtils.getSearchHits("hydefefed", "en");
-		assertEquals(1, hits.length);
+		assertThat(SearchTestUtils.getSearchHits("hydefefed", "en")).hasSize(1);
 	}
 
 	@Test
 	public void testSearchIntroLinkText() {
-		SearchHit[] hits = SearchTestUtils.getSearchHits("hfuejfujduj", "en");
-		assertEquals(1, hits.length);
+		assertThat(SearchTestUtils.getSearchHits("hfuejfujduj", "en")).hasSize(1);
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchParticipantTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchParticipantTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ua.tests.help.search;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.help.internal.search.SearchHit;
@@ -59,14 +60,14 @@ public class SearchParticipantTest {
 	@Test
 	public void testReturnedTitle() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("jkijkijkk", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Title1", hits[0].getLabel());
 	}
 
 	@Test
 	public void testReturnedSummary() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("jkijkijkk", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Summary1", hits[0].getSummary());
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchParticipantXMLTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchParticipantXMLTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ua.tests.help.search;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.help.internal.search.SearchHit;
@@ -44,28 +45,28 @@ public class SearchParticipantXMLTest {
 	@Test
 	public void testReturnedTitle() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("jfplepdl", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Participant XML 1", hits[0].getLabel());
 	}
 
 	@Test
 	public void testReturnedSummary() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("jfplepdl", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Summary for file Participant XML1", hits[0].getSummary());
 	}
 
 	@Test
 	public void testReturnedTitleNestedCase() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("odoeofoedo", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Participant XML 2 - tests nesting", hits[0].getLabel());
 	}
 
 	@Test
 	public void testReturnedSummaryNestedCase() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("odoeofoedo", "en");
-		assertEquals(hits.length,1);
+		assertThat(hits).hasSize(1);
 		assertEquals("Summary for file Participant XML2", hits[0].getSummary());
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchRanking.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchRanking.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class SearchRanking {
 	public void testTitleBoost1() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("mjuhgt", "en");
 		Arrays.sort(hits);
-		assertEquals(2, hits.length);
+		assertThat(hits).hasSize(2);
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest1b.htm", getPath(hits[0]));
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest1a.htm", getPath(hits[1]));
 	}
@@ -53,7 +54,7 @@ public class SearchRanking {
 	public void testTitleBoost2() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("odrgtb", "en");
 		Arrays.sort(hits);
-		assertEquals(2, hits.length);
+		assertThat(hits).hasSize(2);
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest1a.htm", getPath(hits[0]));
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest1b.htm", getPath(hits[1]));
 	}
@@ -65,7 +66,7 @@ public class SearchRanking {
 	public void testConsecutiveWords1() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("iduhnf xaqsdab", "en");
 		Arrays.sort(hits);
-		assertEquals(2, hits.length);
+		assertThat(hits).hasSize(2);
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest2b.htm",
 				getPath(hits[0]));
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest2a.htm",
@@ -76,7 +77,7 @@ public class SearchRanking {
 	public void testConsecutiveWords2() {
 		SearchHit[] hits = SearchTestUtils.getSearchHits("xaqsdab iduhnf", "en");
 		Arrays.sort(hits);
-		assertEquals(2, hits.length);
+		assertThat(hits).hasSize(2);
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest2a.htm",
 				getPath(hits[0]));
 		assertEquals("/org.eclipse.ua.tests/data/help/search/extraDir/ranking/ranktest2b.htm",

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/WorkingSetManagerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/WorkingSetManagerTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.ua.tests.help.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public class WorkingSetManagerTest {
 	@Test
 	public void testNewWSM() {
 		WorkingSetManager mgr = new WorkingSetManager();
-		assertEquals(0, mgr.getWorkingSets().length);
+		assertThat(mgr.getWorkingSets()).isEmpty();
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		assertEquals(mgr, mgr2);
 		assertEquals(mgr.hashCode(), mgr2.hashCode());
@@ -84,10 +84,9 @@ public class WorkingSetManagerTest {
 		wset.setElements(new AdaptableHelpResource[] { toc });
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		assertTrue(resources[0].equals(toc));
+		assertThat(resources).containsExactly(toc);
 	}
 
 	@Test
@@ -163,10 +162,9 @@ public class WorkingSetManagerTest {
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		mgr2.restoreState();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(1, resources.length);
-		assertTrue(resources[0].equals(toc));
+		assertThat(resources).containsExactly(toc);
 	}
 
 	@Test
@@ -176,10 +174,10 @@ public class WorkingSetManagerTest {
 		mgr.saveState();
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
 		Toc[] tocs = HelpPlugin.getTocManager().getTocs(Platform.getNL());
-		assertEquals(tocs.length, resources.length);
+		assertThat(resources).hasSize(tocs.length);
 	}
 
 	@Test
@@ -247,17 +245,9 @@ public class WorkingSetManagerTest {
 		wset.setElements(new AdaptableHelpResource[] { topic1, topic3 });
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(2, resources.length);
-		if (resources[0].equals(topic1)) {
-			assertEquals(topic3, resources[1]);
-			assertNotSame(topic3, resources[0]);
-		} else {
-			assertEquals(topic3, resources[0]);
-			assertEquals(topic1, resources[1]);
-			assertNotSame(topic3, resources[1]);
-		}
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3);
 	}
 
 	@Test
@@ -273,17 +263,9 @@ public class WorkingSetManagerTest {
 		mgr.saveState();
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		AdaptableHelpResource[] resources = readWsets[0].getElements();
-		assertEquals(2, resources.length);
-		if (resources[0].equals(topic1)) {
-			assertEquals(topic3, resources[1]);
-			assertNotSame(topic3, resources[0]);
-		} else {
-			assertEquals(topic3, resources[0]);
-			assertEquals(topic1, resources[1]);
-			assertNotSame(topic3, resources[1]);
-		}
+		assertThat(resources).containsExactlyInAnyOrder(topic1, topic3);
 	}
 
 	@Test
@@ -300,13 +282,11 @@ public class WorkingSetManagerTest {
 		mgr.addWorkingSet(wset1);
 		mgr.addWorkingSet(wset2);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(2, readWsets.length);
+		assertThat(readWsets).hasSize(2);
 		AdaptableHelpResource[] resourcesT3 = mgr.getWorkingSet("test3").getElements();
-		assertEquals(1, resourcesT3.length);
-		assertEquals(topic1, resourcesT3[0]);
+		assertThat(resourcesT3).containsExactly(topic1);
 		AdaptableHelpResource[] resourcesT4 = mgr.getWorkingSet("test4").getElements();
-		assertEquals(1, resourcesT4.length);
-		assertEquals(topic3, resourcesT4[0]);
+		assertThat(resourcesT4).containsExactly(topic3);
 	}
 
 	@Test
@@ -326,13 +306,11 @@ public class WorkingSetManagerTest {
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(2, readWsets.length);
+		assertThat(readWsets).hasSize(2);
 		AdaptableHelpResource[] resourcesT3 = mgr2.getWorkingSet("test3").getElements();
-		assertEquals(1, resourcesT3.length);
-		assertEquals(topic1, resourcesT3[0]);
+		assertThat(resourcesT3).containsExactly(topic1);
 		AdaptableHelpResource[] resourcesT4 = mgr2.getWorkingSet("test4").getElements();
-		assertEquals(1, resourcesT4.length);
-		assertEquals(topic3, resourcesT4[0]);
+		assertThat(resourcesT4).containsExactly(topic3);
 	}
 
 	@Test
@@ -347,9 +325,9 @@ public class WorkingSetManagerTest {
 		wset.setCriteria(criteria);
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
-		assertEquals(1, readResources.length);
+		assertThat(readResources).hasSize(1);
 	}
 
 	@Test
@@ -368,9 +346,9 @@ public class WorkingSetManagerTest {
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
-		assertEquals(1, readResources.length);
+		assertThat(readResources).hasSize(1);
 	}
 
 	@Test
@@ -387,7 +365,7 @@ public class WorkingSetManagerTest {
 		wset.setCriteria(criteria);
 		mgr.addWorkingSet(wset);
 		WorkingSet[] readWsets = mgr.getWorkingSets();
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
 		checkResourceWithTwoChildren(readResources);
 	}
@@ -407,13 +385,13 @@ public class WorkingSetManagerTest {
 		WorkingSetManager mgr2 = new WorkingSetManager();
 		WorkingSet[] readWsets = mgr2.getWorkingSets();
 
-		assertEquals(1, readWsets.length);
+		assertThat(readWsets).hasSize(1);
 		CriterionResource[] readResources = readWsets[0].getCriteria();
 		checkResourceWithTwoChildren(readResources);
 	}
 
 	private void checkResourceWithTwoChildren(CriterionResource[] readResources) {
-		assertEquals(2, readResources.length);
+		assertThat(readResources).hasSize(2);
 		CriterionResource readVersion;
 		CriterionResource readPlatform;
 		if (readResources[0].getCriterionName().equals("version")) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/EnabledTopicTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/EnabledTopicTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.toc;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -137,7 +137,7 @@ public class EnabledTopicTest {
 	@Test
 	public void testEnabledTopicsEmptyArray() throws Exception {
 		ITopic[] enabled = EnabledTopicUtils.getEnabled(new ITopic[0]);
-		assertTrue(enabled.length == 0);
+		assertThat(enabled).isEmpty();
 	}
 
 	@Test
@@ -146,9 +146,9 @@ public class EnabledTopicTest {
 		topics[0] = new ETopic("T1", true);
 		topics[1] = new ETopic("T2", true);
 		ITopic[] enabled = EnabledTopicUtils.getEnabled(topics);
-		assertTrue(enabled.length == 2);
-		assertTrue(topics[0].getLabel().equals("T1"));
-		assertTrue(topics[1].getLabel().equals("T2"));
+		assertThat(enabled).hasSize(2).satisfiesExactly( //
+				first -> assertThat(first.getLabel()).isEqualTo("T1"),
+				second -> assertThat(second.getLabel()).isEqualTo("T2"));
 	}
 
 	@Test
@@ -157,7 +157,7 @@ public class EnabledTopicTest {
 		topics[0] = new ETopic("T1", false);
 		topics[1] = new ETopic("T2", false);
 		ITopic[] enabled = EnabledTopicUtils.getEnabled(topics);
-		assertTrue(enabled.length == 0);
+		assertThat(enabled).isEmpty();
 	}
 
 	@Test
@@ -168,9 +168,9 @@ public class EnabledTopicTest {
 		topics[2] = new ETopic("T3", true);
 		topics[3] = new ETopic("T4", false);
 		ITopic[] enabled = EnabledTopicUtils.getEnabled(topics);
-		assertEquals(2, enabled.length);
-		assertEquals("T1", enabled[0].getLabel());
-		assertEquals("T3", enabled[1].getLabel());
+		assertThat(enabled).hasSize(2).satisfiesExactly( //
+				first -> assertThat(first.getLabel()).isEqualTo("T1"),
+				second -> assertThat(second.getLabel()).isEqualTo("T3"));
 	}
 
 	@Test
@@ -292,7 +292,7 @@ public class EnabledTopicTest {
 	public void testEnabledIndexArrayEmpty() {
 		IIndexEntry[] entries = new EIndexEntry[0];
 		IIndexEntry[] filtered =EnabledTopicUtils.getEnabled(entries);
-		assertEquals(0, filtered.length);
+		assertThat(filtered).isEmpty();
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class EnabledTopicTest {
 		EIndexEntry entry2 = new EIndexEntry("def");
 		IIndexEntry[] entries = new EIndexEntry[]{entry1, entry2};
 		IIndexEntry[] filtered =EnabledTopicUtils.getEnabled(entries);
-		assertEquals(0, filtered.length);
+		assertThat(filtered).isEmpty();
 	}
 
 	@Test
@@ -312,9 +312,9 @@ public class EnabledTopicTest {
 		entry2.addTopic(new ETopic("T2", true));
 		IIndexEntry[] entries = new EIndexEntry[]{entry1, entry2};
 		IIndexEntry[] filtered =EnabledTopicUtils.getEnabled(entries);
-		assertEquals(2, filtered.length);
-		assertEquals(filtered[0].getKeyword(), "abc");
-		assertEquals(filtered[1].getKeyword(), "def");
+		assertThat(filtered).hasSize(2).satisfiesExactly( //
+				first -> assertThat(first.getKeyword()).isEqualTo("abc"),
+				second -> assertThat(second.getKeyword()).isEqualTo("def"));
 	}
 
 	@Test
@@ -327,9 +327,9 @@ public class EnabledTopicTest {
 		entry4.addTopic(new ETopic("T2", true));
 		IIndexEntry[] entries = new EIndexEntry[]{entry1, entry2, entry3, entry4};
 		IIndexEntry[] filtered =EnabledTopicUtils.getEnabled(entries);
-		assertEquals(2, filtered.length);
-		assertEquals(filtered[0].getKeyword(), "def");
-		assertEquals(filtered[1].getKeyword(), "jkl");
+		assertThat(filtered).hasSize(2).satisfiesExactly( //
+				first -> assertThat(first.getKeyword()).isEqualTo("def"),
+				second -> assertThat(second.getKeyword()).isEqualTo("jkl"));
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocProviderTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocProviderTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.toc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -41,7 +42,7 @@ public class TocProviderTest {
 		for (ITopic child : children) {
 			if ("Generated Parent".equals(child.getLabel())) {
 				generatedParentTopics++;
-				assertEquals(4, child.getSubtopics().length);
+				assertThat(child.getSubtopics()).hasSize(4);
 			}
 		}
 		assertEquals(1, generatedParentTopics);

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocSortingTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocSortingTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.toc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -181,7 +182,7 @@ public class TocSortingTest {
 	public void testNoTocs() {
 		TocSorter sorter = new TocSorter();
 		ITocContribution[] result = sorter.orderTocContributions(new TC[0]);
-		assertEquals(result.length, 0);
+		assertThat(result).isEmpty();
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TopicFinderTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TopicFinderTest.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.ua.tests.help.toc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.help.IToc;
 import org.eclipse.help.ITopic;
@@ -38,7 +38,7 @@ public class TopicFinderTest {
 
 	@Test
 	public void testTocsFound() {
-		assertTrue(getTocs().length != 0);
+		assertThat(getTocs()).isNotEmpty();
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class TopicFinderTest {
 		assertNotNull(path);
 		String tocHref = getTocs()[selectedToc].getHref();
 		assertEquals("/org.eclipse.ua.tests/data/help/toc/root.xml", tocHref);
-		assertEquals(2, path.length);
+		assertThat(path).hasSize(2);
 		assertEquals("manual", path[0].getLabel());
 		assertEquals("filter", path[1].getLabel());
 	}
@@ -80,7 +80,7 @@ public class TopicFinderTest {
 		assertNotNull(path);
 		String tocHref = getTocs()[selectedToc].getHref();
 		assertEquals("/org.eclipse.ua.tests/data/help/toc/root.xml", tocHref);
-		assertEquals(2, path.length);
+		assertThat(path).hasSize(2);
 		assertEquals("manual", path[0].getLabel());
 		assertEquals("filter", path[1].getLabel());
 	}
@@ -95,7 +95,7 @@ public class TopicFinderTest {
 		assertNotNull(path);
 		String tocHref = getTocs()[selectedToc].getHref();
 		assertEquals("/org.eclipse.ua.tests/data/help/toc/root.xml", tocHref);
-		assertEquals(2, path.length);
+		assertThat(path).hasSize(2);
 		assertEquals("filter", path[0].getLabel());
 		assertEquals("The plugin org.eclipse.help is installed", path[1].getLabel());
 		assertEquals("/org.eclipse.ua.tests/data/help/toc/filteredToc/helpInstalled.html", path[1].getHref());
@@ -119,7 +119,7 @@ public class TopicFinderTest {
 		String fullPath = "" + tocIndex + "_" + numericPath;
 		int[] intPath = UrlUtil.splitPath(fullPath);
 		ITopic[] topics = TocData.decodePath(intPath, tocs[tocIndex], new FilterScope());
-		assertEquals(2, topics.length);
+		assertThat(topics).hasSize(2);
 		assertEquals("filter", topics[0].getLabel());
 		assertEquals("The plugin org.eclipse.help is installed", topics[1].getLabel());
 		assertEquals("/org.eclipse.ua.tests/data/help/toc/filteredToc/helpInstalled.html", topics[1].getHref());
@@ -134,7 +134,7 @@ public class TopicFinderTest {
 		String navPath = "http://127.0.0.1:1936/help/nav/" + selectedToc;
 		TopicFinder finder2 = new TopicFinder(navPath, tocs, new UniversalScope());
 		assertEquals(selectedToc, finder2.getSelectedToc());
-		assertEquals(0, finder2.getTopicPath().length);
+		assertThat(finder2.getTopicPath()).isEmpty();
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class TopicFinderTest {
 		TopicFinder finder2 = new TopicFinder(navPath, tocs, new UniversalScope());
 		assertEquals(selectedToc, finder2.getSelectedToc());
 		ITopic[] topicPath = finder2.getTopicPath();
-		assertEquals(2, topicPath.length);
+		assertThat(topicPath).hasSize(2);
 		ITopic[] topLevelTopics = tocs[selectedToc].getTopics();
 		assertEquals(topLevelTopics[index1], topicPath[0]);
 		ITopic[] secondLevelTopics = topLevelTopics[index1].getSubtopics();

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/TopicPathTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/TopicPathTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.webapp;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 
 import org.eclipse.help.internal.webapp.data.UrlUtil;
@@ -28,16 +28,13 @@ public class TopicPathTest {
 	@Test
 	public void testTocOnly() {
 		int[] topics = UrlUtil.splitPath("25");
-		assertEquals(1, topics.length);
-		assertEquals(25, topics[0]);
+		assertThat(topics).containsExactly(25);
 	}
 
 	@Test
 	public void testTopic() {
 		int[] topics = UrlUtil.splitPath("2_5");
-		assertEquals(2, topics.length);
-		assertEquals(2, topics[0]);
-		assertEquals(5, topics[1]);
+		assertThat(topics).containsExactly(2, 5);
 	}
 
 	@Test
@@ -55,9 +52,7 @@ public class TopicPathTest {
 	@Test
 	public void testDoubleUnderscore() {
 		int[] topics = UrlUtil.splitPath("1__2");
-		assertEquals(2, topics.length);
-		assertEquals(1, topics[0]);
-		assertEquals(2, topics[1]);
+		assertThat(topics).containsExactly(1, 2);
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/UrlUtilsTests.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/UrlUtilsTests.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.webapp;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -54,10 +55,7 @@ public class UrlUtilsTests {
 	@Test
 	public void testNavTopicPath() {
 		int[] path = UrlUtil.getTopicPath("/nav/23_4_5", "en_us");
-		assertEquals(3, path.length);
-		assertEquals(23, path[0]);
-		assertEquals(4, path[1]);
-		assertEquals(5, path[2]);
+		assertThat(path).containsExactly(23, 4, 5);
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/ExtensionServiceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/ExtensionServiceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ua.tests.help.webapp.service;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -54,7 +55,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findContributionByContent(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc2.xml#element.1");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
@@ -62,7 +63,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findContributionByContent(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc2.xml#element.3");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
@@ -70,7 +71,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findContributionByContent(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc2.xml#element.4");
-		assertEquals(0, UARoot.length);
+		assertThat(UARoot).isEmpty();
 	}
 
 	@Test
@@ -78,7 +79,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findContributionByPath(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/extension.xml#anchor.invalidcontribution");
-		assertEquals(2, UARoot.length);
+		assertThat(UARoot).hasSize(2);
 	}
 
 	@Test
@@ -86,7 +87,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findReplacementByContent(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc2.xml#element.1");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
@@ -94,7 +95,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findReplacementByContent(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc2.xml#element.3");
-		assertEquals(0, UARoot.length);
+		assertThat(UARoot).isEmpty();
 	}
 
 	@Test
@@ -102,7 +103,7 @@ public class ExtensionServiceTest {
 		Node root = getContentExtensions("en");
 		Element[] UARoot = findReplacementByPath(root,
 				"/org.eclipse.ua.tests/data/help/dynamic/shared/doc1.xml#element.2");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	private Element[] findContributionByContent(Node root, String content) {

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/TocFragmentServiceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/TocFragmentServiceTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.webapp.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -60,7 +61,7 @@ public class TocFragmentServiceTest {
 		Node root = getTreeData(url);
 		Element[] UARoot = findNodeById(root,
 				"/org.eclipse.ua.tests/data/help/toc/root.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 	}
 
 	@Test
@@ -71,16 +72,16 @@ public class TocFragmentServiceTest {
 		Node root = getTreeData(url);
 		Element[] UARoot = findNodeById(root,
 				"/org.eclipse.ua.tests/data/help/toc/root.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 		Element[] filterNode = findNodeById(UARoot[0], "2");
-		assertEquals(1, filterNode.length);
+		assertThat(filterNode).hasSize(1);
 		Element[] results = findHref(filterNode[0], "node",
 				"../topic/org.eclipse.ua.tests/data/help/toc/filteredToc/simple_page.html");
-		assertEquals(24, results.length);
+		assertThat(results).hasSize(24);
 
 		results = findHref(filterNode[0], "node",
 		"../topic/org.eclipse.ua.tests/data/help/toc/filteredToc/helpInstalled.html");
-		assertEquals(1, results.length);
+		assertThat(results).hasSize(1);
 	}
 
 	@Test
@@ -93,15 +94,15 @@ public class TocFragmentServiceTest {
 		Node root = getTreeData(url);
 		Element[] UARoot = findNodeById(root,
 				"/org.eclipse.ua.tests/data/help/toc/root.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 		Element[] searchNode = findChildren(UARoot[0], "node", "title", "search");
-		assertEquals(1, searchNode.length);
+		assertThat(searchNode).hasSize(1);
 		Element[] topicEn = findHref(searchNode[0], "node",
 				"../topic/org.eclipse.ua.tests/data/help/search/test_en.html");
-		assertEquals(1, topicEn.length);
+		assertThat(topicEn).hasSize(1);
 		Element[] topicDe = findHref(searchNode[0], "node",
 				"../topic/org.eclipse.ua.tests/data/help/search/test_de.html");
-		assertEquals(0, topicDe.length);
+		assertThat(topicDe).isEmpty();
 	}
 
 	private int findUATopicIndex(String title, String locale) {
@@ -132,14 +133,14 @@ public class TocFragmentServiceTest {
 		Node root = getTreeData(url);
 		Element[] UARoot = findNodeById(root,
 				"/org.eclipse.ua.tests/data/help/toc/root.xml");
-		assertEquals(1, UARoot.length);
+		assertThat(UARoot).hasSize(1);
 		Element[] searchNode = findChildren(UARoot[0], "node", "title", "search");
 		Element[] topicEn = findHref(searchNode[0], "node",
 				"../topic/org.eclipse.ua.tests/data/help/search/test_en.html");
-		assertEquals(0, topicEn.length);
+		assertThat(topicEn).isEmpty();
 		Element[] topicDe = findHref(searchNode[0], "node",
 				"../topic/org.eclipse.ua.tests/data/help/search/test_de.html");
-		assertEquals(1, topicDe.length);
+		assertThat(topicDe).hasSize(1);
 		BaseHelpSystem.setMode(helpMode);
 	}
 

--- a/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/anchors/ExtensionReorderingTest.java
+++ b/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/anchors/ExtensionReorderingTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.intro.anchors;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -192,7 +192,7 @@ public class ExtensionReorderingTest {
 	public void testOrder123456() {
 		readIntroConfig();
 		assertNotNull(config);
-		assertEquals(6, introConfigExtensions.length);
+		assertThat(introConfigExtensions).hasSize(6);
 		IntroModelRoot model = new IntroModelRoot(config, introConfigExtensions);
 		model.loadModel();
 		checkModel(model, 6);
@@ -202,7 +202,7 @@ public class ExtensionReorderingTest {
 		assertTrue(model.hasValidConfig());
 		Object[] pages = model.getChildrenOfType(AbstractIntroElement.ABSTRACT_PAGE);
 		AbstractIntroPage root = (AbstractIntroPage) model.findChild("root");
-		assertEquals(elements + 2, pages.length);
+		assertThat(pages).hasSize(elements + 2);
 		IntroPage extn1 = (IntroPage) model.findChild("page1");
 		assertNotNull(extn1);
 		AbstractIntroElement p1link = root.findChild("page1link");


### PR DESCRIPTION
In order to reduce/avoid usage of ambiguous `assertEquals` (hard to distinguish expected/actual) and prepare for a migration to JUnit 5 with swapped expected/actual parameters in the `assertEquals` signature, this change replaces certain `assertEquals` calls with AssertJ assertions:
* Replace `assertEquals(MESSAGE, EXPECTED, ACTUAL.length)` with
`assertThat(ACTUAL).describedAs(MESSAGE).hasSize(EXPECTED))` and remove obsolete message where possible
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL).hasSize(EXPECTED))`
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL.length, is(EXPECTED))` if `ACTUAL` is a primitive type array
* Replace `hasSize(0)` with `isEmpty()` to improve failure messages
* Combine array size comparison with array contents comparison where possible

### What I Did

Initial changes are the result of two regex replacements:
#### Length assertions with message
Find: `assertEquals\((.*), (.*), (.*)\.length\);`
Insert: `assertThat\($3\)\.as\($1\)\.hasSize\($2)\);`

#### Length assertions without message
Find: `assertEquals\((.*), (.*)\.length\);`
Insert: `assertThat\($2\)\.hasSize\($1)\);`

Further improvements, in particular the combination of size and content assertions, is manual work.

### Benefits
* Improved failure messages:
  * When an empty array is asserted, the non-empty array will be reported in case of a failure
  * When size and content of an array are validated, the test will not fail reporting an improper size but reporting the mismatching elements
* Improved comprehensibility due to matchers giving more semantics to the validations than plain assertEquals
* Eased migration to JUnit 5: `assertEquals` statements would need to adapted during a migration from JUnit 4 to 5 because expected/actual parameters are swapped