### PR TITLE
Improve array length assertions in runtime and team tests

### DIFF
--- a/runtime/tests/org.eclipse.core.contenttype.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.contenttype.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle:
  org.eclipse.core.contenttype;bundle-version="3.6",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.junit;bundle-version="4.7"
+Import-Package: org.assertj.core.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.core.contenttype.tests

--- a/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle:
  org.eclipse.core.expressions;bundle-version="[3.4.100,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.junit;bundle-version="3.8.2"
+Import-Package: org.assertj.core.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionInfoTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionInfoTests.java
@@ -13,14 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -156,7 +150,7 @@ public class ExpressionInfoTests {
 		info.addAccessedPropertyName("prop1");
 		other.addAccessedPropertyName("prop2");
 		info.merge(other);
-		assertPropertyAccess(info, new String[] { "prop1", "prop2" }, false);
+		assertPropertyAccess(info, new String[] { "prop1", "prop2" });
 	}
 
 	@Test
@@ -260,82 +254,70 @@ public class ExpressionInfoTests {
 	}
 
 	private void assertDefaultAccessOnly(ExpressionInfo info) {
-		assertTrue("Accesses default variable", info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		assertTrue("No variable accesses", info.getAccessedVariableNames().length == 0);
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
+		assertThat(info).matches(ExpressionInfo::hasDefaultVariableAccess, "accesses default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedVariableNames()).as("no variable accessed").isEmpty();
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
 	}
 
 	private void assertSystemPropertyOnly(ExpressionInfo info) {
-		assertFalse("Doesn't accesses default variable", info.hasDefaultVariableAccess());
-		assertTrue("Accesses system property", info.hasSystemPropertyAccess());
-		assertTrue("No variable accesses", info.getAccessedVariableNames().length == 0);
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(ExpressionInfo::hasSystemPropertyAccess, "accesses system property");
+		assertThat(info.getAccessedVariableNames()).as("no variable accessed").isEmpty();
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
 	}
 
 	private void assertNoAccess(ExpressionInfo info) {
-		assertFalse("Doesn't accesses default variable", info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		assertTrue("No variable accesses", info.getAccessedVariableNames().length == 0);
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedVariableNames()).as("no variable accessed").isEmpty();
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
 	}
 
 	private void assertVariableAccess(ExpressionInfo info, String variable) {
-		assertFalse("Doesn't accesses default variable", info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		String[] accessedVariableNames= info.getAccessedVariableNames();
-		assertEquals("One variable accessed", 1, accessedVariableNames.length);
-		assertEquals("Variable accessed", variable, accessedVariableNames[0]);
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedVariableNames()).as("one variable accessed").containsExactly(variable);
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
 	}
 
 	private void assertVariableAccess(ExpressionInfo info, String[] variables) {
-		assertFalse("Doesn't accesses default variable", info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		Set<String> accessedVariableNames= new HashSet<>(Arrays.asList(info.getAccessedVariableNames()));
-		assertEquals("All variable accessed", variables.length, accessedVariableNames.size());
-		for (String variable : variables) {
-			assertTrue("Variable accessed", accessedVariableNames.contains(variable));
-		}
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedVariableNames()).as("all variables accessed").containsExactlyInAnyOrder(variables);
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
 	}
 
 	private void assertPropertyAccess(ExpressionInfo info, String property, boolean defaultVariable) {
-		assertEquals("Accesses default variable", defaultVariable, info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		String[] accessedPropertyNames= info.getAccessedPropertyNames();
-		assertEquals("One property accessed", 1, accessedPropertyNames.length);
-		assertEquals("Property accessed", property, accessedPropertyNames[0]);
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No variable accesses", 0, info.getAccessedVariableNames().length);
+		if (defaultVariable) {
+			assertThat(info).matches(ExpressionInfo::hasDefaultVariableAccess, "accesses default variable");
+		} else {
+			assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		}
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedPropertyNames()).as("one property accessed").containsExactly(property);
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedVariableNames()).as("no variable accessed").isEmpty();
 	}
 
-	private void assertPropertyAccess(ExpressionInfo info, String[] properties, boolean defaultVariable) {
-		assertEquals("Accesses default variable", defaultVariable, info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		Set<String> accessedPropertyNames= new HashSet<>(Arrays.asList(info.getAccessedPropertyNames()));
-		assertEquals("All properties accessed", properties.length, accessedPropertyNames.size());
-		for (String property : properties) {
-			assertTrue("Property accessed", accessedPropertyNames.contains(property));
-		}
-		assertNull("No misbehaving expression types", info.getMisbehavingExpressionTypes());
-		assertEquals("No variable accesses", 0, info.getAccessedVariableNames().length);
+	private void assertPropertyAccess(ExpressionInfo info, String[] properties) {
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedPropertyNames()).as("all properties accessed").containsExactlyInAnyOrder(properties);
+		assertThat(info.getMisbehavingExpressionTypes()).as("no misbehaving expression types").isNull();
+		assertThat(info.getAccessedVariableNames()).as("one variable accessed").isEmpty();
 	}
 
 	private void assertMisbehavedExpressionTypes(ExpressionInfo info, Class<?>[] types) {
-		assertFalse("Doesn't accesses default variable", info.hasDefaultVariableAccess());
-		assertFalse("Doesn't accesses system property", info.hasSystemPropertyAccess());
-		assertTrue("No variable accesses", info.getAccessedVariableNames().length == 0);
-		assertEquals("No properties accessed", 0, info.getAccessedPropertyNames().length);
-		Set<?> misbehavedTypes = new HashSet<>(Arrays.asList(info.getMisbehavingExpressionTypes()));
-		assertEquals("All types accessed", types.length, misbehavedTypes.size());
-		for (Class<?> type : types) {
-			assertTrue("Type collected", misbehavedTypes.contains(type));
-		}
+		assertThat(info).matches(not(ExpressionInfo::hasDefaultVariableAccess), "doesn't access default variable");
+		assertThat(info).matches(not(ExpressionInfo::hasSystemPropertyAccess), "doesn't access system property");
+		assertThat(info.getAccessedVariableNames()).as("no variable accessed").isEmpty();
+		assertThat(info.getAccessedPropertyNames()).as("no properties accessed").isEmpty();
+		assertThat(info.getMisbehavingExpressionTypes()).as("all types accessed").containsExactlyInAnyOrder(types);
 	}
 }

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.internal.expressions.tests;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -981,13 +983,10 @@ public class ExpressionTests {
 		IConfigurationElement enable= findExtension(ces, "test2").getChildren("enablement")[0]; //$NON-NLS-1$ //$NON-NLS-2$
 		EnablementExpression exp= (EnablementExpression) ExpressionConverter.getDefault().perform(enable);
 		Expression[] children= exp.getChildren();
-		assertTrue(children.length == 3);
-		TestExpression test= (TestExpression) children[0];
-		assertTrue(test.testGetForcePluginActivation());
-		test= (TestExpression) children[1];
-		assertTrue(!test.testGetForcePluginActivation());
-		test= (TestExpression) children[2];
-		assertTrue(!test.testGetForcePluginActivation());
+		assertThat(children).hasSize(3).allSatisfy(child -> assertThat(child).isInstanceOf(TestExpression.class));
+		assertThat((TestExpression) children[0]).matches(TestExpression::testGetForcePluginActivation);
+		assertThat((TestExpression) children[1]).matches(not(TestExpression::testGetForcePluginActivation));
+		assertThat((TestExpression) children[2]).matches(not(TestExpression::testGetForcePluginActivation));
 	}
 
 	@Test

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
@@ -615,7 +615,7 @@ public class EclipsePreferencesTest {
 
 		// no children to start
 		result = node.childrenNames();
-		assertEquals("1.1", 0, result.length);
+		assertThat(result).isEmpty();
 
 		// add children
 		for (String childrenName : childrenNames) {
@@ -681,18 +681,17 @@ public class EclipsePreferencesTest {
 		String[] values = new String[] {getUniqueString(), getUniqueString(), getUniqueString()};
 
 		// none to start with
-		assertEquals("1.0", 0, node.keys().length);
+		assertThat(node.keys()).isEmpty();
 
 		// fill the node up with values
 		for (int i = 0; i < keys.length; i++) {
 			node.put(keys[i], values[i]);
 		}
-		assertEquals("2.0", keys.length, node.keys().length);
 		assertThat(keys).containsExactlyInAnyOrder(node.keys());
 
 		// clear the values and check
 		node.clear();
-		assertEquals("3.0", 0, node.keys().length);
+		assertThat(node.keys()).isEmpty();
 		for (int i = 0; i < keys.length; i++) {
 			assertNull("3.1." + i, node.get(keys[i], null));
 		}
@@ -1086,10 +1085,7 @@ public class EclipsePreferencesTest {
 		IScopeContext defaultScope = DefaultScope.INSTANCE;
 		defaultScope.getNode(TEST_NODE_PATH).putByteArray(TEST_PREF_KEY, testArray);
 		final byte[] returnArray = Platform.getPreferencesService().getByteArray(TEST_NODE_PATH, TEST_PREF_KEY, new byte[] {}, null);
-		assertEquals("1.0 Wrong size", testArray.length, returnArray.length);
-		for (int i = 0; i < testArray.length; i++) {
-			assertEquals("2.0 Wrong value at: " + i, testArray[i], returnArray[i]);
-		}
+		assertThat(returnArray).isEqualTo(testArray);
 	}
 
 	/*
@@ -1111,7 +1107,7 @@ public class EclipsePreferencesTest {
 
 		// check the child has the expected values
 		Preferences child = node.node("foo");
-		assertEquals("2.0", 2, child.keys().length);
+		assertThat(child.keys()).hasSize(2);
 		assertEquals("2.1", "value1", child.get("key1", null));
 		assertEquals("2.2", "value2", child.get("key2", null));
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
@@ -748,7 +748,7 @@ public class PreferencesServiceTest {
 
 		// an empty transfer list matches nothing
 		matching = service.matches(service.getRootNode(), new IPreferenceFilter[0]);
-		assertEquals("1.1", 0, matching.length);
+		assertThat(matching).isEmpty();
 
 		// don't match this filter
 		IPreferenceFilter filter = new IPreferenceFilter() {
@@ -765,24 +765,24 @@ public class PreferencesServiceTest {
 			}
 		};
 		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
-		assertEquals("2.1", 0, matching.length);
+		assertThat(matching).isEmpty();
 
 		// shouldn't match since there are no key/value pairs in the node
 		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
-		assertEquals("3.0", 0, matching.length);
+		assertThat(matching).isEmpty();
 
 		// add some values so it does match
 		InstanceScope.INSTANCE.getNode(QUALIFIER).put("key", "value");
 		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { filter });
-		assertEquals("3.1", 1, matching.length);
+		assertThat(matching).hasSize(1);
 
 		// should match on the exact node too
 		matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
-		assertEquals("4.1", 1, matching.length);
+		assertThat(matching).hasSize(1);
 
 		// shouldn't match a different scope
 		matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
-		assertEquals("5.1", 0, matching.length);
+		assertThat(matching).isEmpty();
 
 		// try matching on the root node for a filter which matches all nodes in the scope
 		filter = new IPreferenceFilter() {
@@ -797,11 +797,11 @@ public class PreferencesServiceTest {
 			}
 		};
 		matching = service.matches(InstanceScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
-		assertEquals("6.1", 1, matching.length);
+		assertThat(matching).hasSize(1);
 
 		// shouldn't match
 		matching = service.matches(ConfigurationScope.INSTANCE.getNode(QUALIFIER), new IPreferenceFilter[] { filter });
-		assertEquals("7.1", 0, matching.length);
+		assertThat(matching).isEmpty();
 	}
 
 	/*
@@ -828,7 +828,7 @@ public class PreferencesServiceTest {
 				return new String[] {InstanceScope.SCOPE};
 			}
 		}};
-		assertEquals("1.0", 1, service.matches(service.getRootNode(), filters).length);
+		assertThat(service.matches(service.getRootNode(), filters)).hasSize(1);
 	}
 
 	@Test
@@ -1000,7 +1000,7 @@ public class PreferencesServiceTest {
 		node.put(VALID_KEY_4, "value4");
 
 		matching = service.matches(service.getRootNode(), new IPreferenceFilter[] { transfer });
-		assertEquals("2.00", 1, matching.length);
+		assertThat(matching).hasSize(1);
 
 		ExportVerifier verifier = new ExportVerifier(service.getRootNode(), new IPreferenceFilter[] {transfer});
 		verifier.addVersion();
@@ -1062,17 +1062,17 @@ public class PreferencesServiceTest {
 		}
 		String debugString = ((EclipsePreferences) node).toDeepDebugString();
 		String[] children = node.childrenNames();
-		assertEquals(debugString, 1, children.length);
+		assertThat(children).as(debugString).hasSize(1);
 
 		assertEquals(InstanceScope.SCOPE, children[0]);
 		node = node.node(children[0]);
 		children = node.childrenNames();
-		assertEquals(debugString, 1, children.length);
+		assertThat(children).as(debugString).hasSize(1);
 
 		assertEquals("bug418046", children[0]);
 		node = node.node(children[0]);
 		children = node.childrenNames();
-		assertEquals(debugString, 0, children.length);
+		assertThat(children).as(debugString).isEmpty();
 
 		assertEquals(debugString, "someValue", node.get("someKey", null));
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -50,7 +51,7 @@ public class LogSerializationTest {
 		if (actual == null) {
 			assertNull(msg + " expected " + Arrays.toString(expected) + " but got null", expected);
 		}
-		assertEquals(msg + " different number of statuses", expected.length, actual.length);
+		assertThat(actual).as(msg + " number of statuses").hasSameSizeAs(expected);
 		for (int i = 0, imax = expected.length; i < imax; i++) {
 			assertStatusEquals(msg + " differ at status " + i, expected[i], actual[i]);
 		}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.runtime;
 
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -153,12 +154,7 @@ public class PlatformTest {
 		final List<IStatus> collected = new ArrayList<>();
 
 		// add a log listener to ensure that we report using the right plug-in id
-		ILogListener logListener = new ILogListener() {
-			@Override
-			public void logging(IStatus status, String plugin) {
-				collected.add(status);
-			}
-		};
+		ILogListener logListener = (status, plugin) -> collected.add(status);
 		Platform.addLogListener(logListener);
 
 		final Exception exception = new Exception("PlatformTest.testRunnable: this exception is thrown on purpose as part of the test.");
@@ -331,17 +327,17 @@ public class PlatformTest {
 
 		Bundle[] result = Platform.getBundles(bundleName, null); // no version constraint => get all 3
 		assertNotNull(bundleName + " bundle not available", bundles);
-		assertEquals(3, result.length);
+		assertThat(result).hasSize(3);
 		assertEquals(3, result[0].getVersion().getMajor()); // 3.0.0 version first
 		assertEquals(1, result[2].getVersion().getMajor()); // 1.0.0 version last
 
 		result = Platform.getBundles(bundleName, "2.0.0");
-		assertEquals(2, result.length);
+		assertThat(result).hasSize(2);
 		assertEquals(3, result[0].getVersion().getMajor()); // 3.0.0 version first
 		assertEquals(2, result[1].getVersion().getMajor()); // 2.0.0 version last
 
 		result = Platform.getBundles(bundleName, "[1.0.0,2.0.0)");
-		assertEquals(1, result.length);
+		assertThat(result).hasSize(1);
 		assertEquals(1, result[0].getVersion().getMajor()); // 1.0.0 version
 
 		result = Platform.getBundles(bundleName, "[1.1.0,2.0.0)");
@@ -352,11 +348,10 @@ public class PlatformTest {
 	public void testGetSystemBundle() {
 		Bundle expectedSystem = RuntimeTestsPlugin.getContext().getBundle(Constants.SYSTEM_BUNDLE_LOCATION);
 		Bundle actualSystem = Platform.getBundle(Constants.SYSTEM_BUNDLE_SYMBOLICNAME);
-		assertEquals("Wrong system bundle.", expectedSystem, actualSystem);
+		assertThat(actualSystem).as("check system bundle").isEqualTo(expectedSystem);
 
 		Bundle[] actualSystems = Platform.getBundles(Constants.SYSTEM_BUNDLE_SYMBOLICNAME, null);
-		assertEquals("Wrong number of system bundles.", 1, actualSystems.length);
-		assertEquals("Wrong system bundle.", expectedSystem, actualSystems[0]);
+		assertThat(actualSystems).as("check system bundles").containsExactly(expectedSystem);
 	}
 
 	/**

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceForwarderTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceForwarderTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -33,7 +34,6 @@ import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Preferences;
 import org.eclipse.core.runtime.Preferences.IPropertyChangeListener;
-import org.eclipse.core.runtime.Preferences.PropertyChangeEvent;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.junit.Test;
@@ -314,7 +314,7 @@ public class PreferenceForwarderTest {
 		Preferences ps = new PreferenceForwarder(getUniqueString());
 
 		// there are no properties initially
-		assertEquals("1.0", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 
 		String[] keys = {"a", "b", "c", "d"};
 
@@ -322,13 +322,13 @@ public class PreferenceForwarderTest {
 		for (String key : keys) {
 			ps.setDefault(key, "default");
 		}
-		assertEquals("1.1", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 
 		// setting real values does add name to set
 		for (String key : keys) {
 			ps.setValue(key, "actual");
 		}
-		assertEquals("1.2", keys.length, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).hasSameSizeAs(keys);
 
 		Set<String> s1 = new HashSet<>(Arrays.asList(keys));
 		Set<String> s2 = new HashSet<>(Arrays.asList(ps.propertyNames()));
@@ -340,7 +340,7 @@ public class PreferenceForwarderTest {
 			Set<String> s = new HashSet<>(Arrays.asList(ps.propertyNames()));
 			assertTrue("1.4", !s.contains(key));
 		}
-		assertEquals("1.5", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 	}
 
 	@Test
@@ -382,7 +382,7 @@ public class PreferenceForwarderTest {
 		Preferences ps = new PreferenceForwarder(getUniqueString());
 
 		// there are no default properties initially
-		assertEquals("1.0", 0, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).isEmpty();
 
 		String[] keys = {"a", "b", "c", "d"};
 
@@ -390,13 +390,13 @@ public class PreferenceForwarderTest {
 		for (String key : keys) {
 			ps.setValue(key, "actual");
 		}
-		assertEquals("1.1", 0, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).isEmpty();
 
 		// setting defaults does add name to set
 		for (String key : keys) {
 			ps.setDefault(key, "default");
 		}
-		assertEquals("1.2", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 
 		Set<String> s1 = new HashSet<>(Arrays.asList(keys));
 		Set<String> s2 = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
@@ -408,7 +408,7 @@ public class PreferenceForwarderTest {
 			Set<String> s = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
 			assertTrue("1.4", s.contains(key));
 		}
-		assertEquals("1.5", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 
 		// setting to default-default does not remove name from set either
 		for (String key : keys) {
@@ -436,7 +436,7 @@ public class PreferenceForwarderTest {
 			s = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
 			assertTrue("1.6.6", s.contains(key));
 		}
-		assertEquals("1.7", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 	}
 
 	@Test
@@ -820,12 +820,7 @@ public class PreferenceForwarderTest {
 	public void testListenerOnRemove() throws BackingStoreException {
 		AtomicReference<IStatus> logStatus = new AtomicReference<>();
 		// create a new log listener that will fail if anything is written
-		ILogListener logListener = new ILogListener() {
-			@Override
-			public void logging(IStatus status, String plugin) {
-				logStatus.set(status);
-			}
-		};
+		ILogListener logListener = (status, plugin) -> logStatus.set(status);
 
 		// set a preference value to get everything initialized
 		String id = getUniqueString();
@@ -834,10 +829,7 @@ public class PreferenceForwarderTest {
 
 		// add a property change listener which will cause one to be
 		// added at the preference node level
-		IPropertyChangeListener listener = new Preferences.IPropertyChangeListener() {
-			@Override
-			public void propertyChange(PropertyChangeEvent event) {
-			}
+		IPropertyChangeListener listener = event -> {
 		};
 		ps.addPropertyChangeListener(listener);
 		ps.setValue("key2", "value2");

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferencesTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferencesTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -128,7 +129,7 @@ public class PreferencesTest {
 		assertTrue("2.5", ps.getDefaultString(k1).equals(Preferences.STRING_DEFAULT_DEFAULT));
 		// change to same value as default
 		ps.setValue(k1, ps.getDefaultString(k1));
-		assertTrue("2.6", ps.isDefault(k1) == true);
+		assertTrue("2.6", ps.isDefault(k1));
 		assertTrue("2.7", ps.getString(k1).equals(ps.getDefaultString(k1)));
 		assertTrue("2.8", ps.getDefaultString(k1).equals(Preferences.STRING_DEFAULT_DEFAULT));
 		// reset to default
@@ -294,7 +295,7 @@ public class PreferencesTest {
 		Preferences ps = new Preferences();
 
 		// there are no properties initially
-		assertEquals("1.0", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 
 		String[] keys = {"a", "b", "c", "d"};
 
@@ -302,13 +303,13 @@ public class PreferencesTest {
 		for (String key : keys) {
 			ps.setDefault(key, "default");
 		}
-		assertEquals("1.1", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 
 		// setting real values does add name to set
 		for (String key : keys) {
 			ps.setValue(key, "actual");
 		}
-		assertEquals("1.2", keys.length, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).hasSameSizeAs(keys);
 
 		Set<String> s1 = new HashSet<>(Arrays.asList(keys));
 		Set<String> s2 = new HashSet<>(Arrays.asList(ps.propertyNames()));
@@ -320,7 +321,7 @@ public class PreferencesTest {
 			Set<String> s = new HashSet<>(Arrays.asList(ps.propertyNames()));
 			assertTrue("1.4", !s.contains(key));
 		}
-		assertEquals("1.5", 0, ps.propertyNames().length);
+		assertThat(ps.propertyNames()).isEmpty();
 	}
 
 	@Test
@@ -364,7 +365,7 @@ public class PreferencesTest {
 		Preferences ps = new Preferences();
 
 		// there are no default properties initially
-		assertEquals("1.0", 0, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).isEmpty();
 
 		String[] keys = {"a", "b", "c", "d"};
 
@@ -372,13 +373,13 @@ public class PreferencesTest {
 		for (String key : keys) {
 			ps.setValue(key, "actual");
 		}
-		assertEquals("1.1", 0, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).isEmpty();
 
 		// setting defaults does add name to set
 		for (String key : keys) {
 			ps.setDefault(key, "default");
 		}
-		assertEquals("1.2", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 
 		Set<String> s1 = new HashSet<>(Arrays.asList(keys));
 		Set<String> s2 = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
@@ -390,7 +391,7 @@ public class PreferencesTest {
 			Set<String> s = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
 			assertTrue("1.4", s.contains(key));
 		}
-		assertEquals("1.5", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 
 		// setting to default-default does not remove name from set either
 		for (String key : keys) {
@@ -418,7 +419,7 @@ public class PreferencesTest {
 			s = new HashSet<>(Arrays.asList(ps.defaultPropertyNames()));
 			assertTrue("1.6.6", s.contains(key));
 		}
-		assertEquals("1.7", keys.length, ps.defaultPropertyNames().length);
+		assertThat(ps.defaultPropertyNames()).hasSameSizeAs(keys);
 	}
 
 	@Test

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -314,55 +315,32 @@ public class JobGroupTest extends AbstractJobTest {
 		// Try finding all jobs by supplying the NULL parameter.
 		// Note: Running the test framework may cause other system jobs to run,
 		// so check that the jobs started by this test are a subset of all running jobs.
-		HashSet<Job> testJobs = new HashSet<>();
-		testJobs.addAll(Arrays.asList(jobs));
-		Job[] allJobs = manager.find(null);
-		assertTrue("1.0", allJobs.length >= NUM_JOBS);
-		for (int i = 0; i < allJobs.length; i++) {
-			// Only test jobs that we know about.
-			if (testJobs.remove(allJobs[i])) {
-				JobGroup group = allJobs[i].getJobGroup();
-				assertTrue("1." + i, (group == firstJobGroup || group == secondJobGroup || group == thirdJobGroup || group == fourthJobGroup || group == fifthJobGroup));
-			}
-		}
-		assertTrue("1.2", testJobs.isEmpty());
-
-		List<Job> activeJobs;
+		HashSet<Job> testJobs = new HashSet<>(Arrays.asList(jobs));
+		assertThat(manager.find(null)).hasSizeGreaterThanOrEqualTo(NUM_JOBS) //
+				.filteredOn(job -> testJobs.remove(job)) // only test jobs that we know about
+				.allSatisfy(job -> assertThat(job.getJobGroup()).isIn(firstJobGroup, secondJobGroup, thirdJobGroup,
+						fourthJobGroup, fifthJobGroup));
+		assertThat(testJobs).isEmpty();
 
 		// Try finding all jobs from the first job group.
-		activeJobs = firstJobGroup.getActiveJobs();
-		assertEquals("2.0", 4, activeJobs.size());
-		for (int i = 0; i < activeJobs.size(); i++) {
-			assertEquals("2." + (i + 1), firstJobGroup, activeJobs.get(i).getJobGroup());
-		}
+		assertThat(firstJobGroup.getActiveJobs()).hasSize(4)
+				.allSatisfy(it -> assertThat(it.getJobGroup()).isEqualTo(firstJobGroup));
 
 		// Try finding all jobs from the second job group.
-		activeJobs = secondJobGroup.getActiveJobs();
-		assertEquals("3.0", 4, activeJobs.size());
-		for (int i = 0; i < activeJobs.size(); i++) {
-			assertEquals("3." + (i + 1), secondJobGroup, activeJobs.get(i).getJobGroup());
-		}
+		assertThat(secondJobGroup.getActiveJobs()).hasSize(4)
+				.allSatisfy(it -> assertThat(it.getJobGroup()).isEqualTo(secondJobGroup));
 
 		// Try finding all jobs from the third job group.
-		activeJobs = thirdJobGroup.getActiveJobs();
-		assertEquals("4.0", 4, activeJobs.size());
-		for (int i = 0; i < activeJobs.size(); i++) {
-			assertEquals("4." + (i + 1), thirdJobGroup, activeJobs.get(i).getJobGroup());
-		}
+		assertThat(thirdJobGroup.getActiveJobs()).hasSize(4)
+				.allSatisfy(it -> assertThat(it.getJobGroup()).isEqualTo(thirdJobGroup));
 
 		// Try finding all jobs from the fourth job group.
-		activeJobs = fourthJobGroup.getActiveJobs();
-		assertEquals("5.0", 4, activeJobs.size());
-		for (int i = 0; i < activeJobs.size(); i++) {
-			assertEquals("5." + (i + 1), fourthJobGroup, activeJobs.get(i).getJobGroup());
-		}
+		assertThat(fourthJobGroup.getActiveJobs()).hasSize(4)
+				.allSatisfy(it -> assertThat(it.getJobGroup()).isEqualTo(fourthJobGroup));
 
 		// Try finding all jobs from the fifth job group.
-		activeJobs = fifthJobGroup.getActiveJobs();
-		assertEquals("6.0", 4, activeJobs.size());
-		for (int i = 0; i < activeJobs.size(); i++) {
-			assertEquals("6." + (i + 1), fifthJobGroup, activeJobs.get(i).getJobGroup());
-		}
+		assertThat(fifthJobGroup.getActiveJobs()).hasSize(4)
+				.allSatisfy(it -> assertThat(it.getJobGroup()).isEqualTo(fifthJobGroup));
 
 		// The first job should still be running.
 		for (int i = 0; i < 5; i++) {
@@ -374,39 +352,29 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForCompletion(firstJobGroup);
 
 		// First job group should not contain any active jobs.
-		activeJobs = firstJobGroup.getActiveJobs();
-		assertTrue("7.2", activeJobs.isEmpty());
+		assertThat(firstJobGroup.getActiveJobs()).isEmpty();
 
 		// Cancel the second job group.
 		secondJobGroup.cancel();
 		waitForCompletion(secondJobGroup);
 		// Second job group should not contain any active jobs.
-		activeJobs = secondJobGroup.getActiveJobs();
-		assertTrue("9.0", activeJobs.isEmpty());
+		assertThat(secondJobGroup.getActiveJobs()).isEmpty();
 
 		// Cancel the fourth job group.
 		fourthJobGroup.cancel();
 		waitForCompletion(fourthJobGroup);
 		// Fourth job group should not contain any active jobs.
-		activeJobs = fourthJobGroup.getActiveJobs();
-		assertTrue("9.1", activeJobs.isEmpty());
+		assertThat(fourthJobGroup.getActiveJobs()).isEmpty();
 
 		// Finding all jobs by supplying the NULL parameter should return at least 8 jobs
 		// (4 from the 3rd family, and 4 from the 5th family)
 		// Note: Running the test framework may cause other system jobs to run,
 		// so check that the expected jobs started by this test are a subset of all running jobs.
 		testJobs.addAll(Arrays.asList(jobs));
-		allJobs = manager.find(null);
-		assertTrue("11.0", allJobs.length >= 8);
-		for (int i = 0; i < allJobs.length; i++) {
-			// Only test jobs that we know about.
-			if (testJobs.remove(allJobs[i])) {
-				JobGroup group = allJobs[i].getJobGroup();
-				assertTrue("11." + (i + 1), (group == thirdJobGroup || group == fifthJobGroup));
-			}
-		}
-
-		assertEquals("11.2", 12, testJobs.size());
+		assertThat(manager.find(null)).hasSizeGreaterThanOrEqualTo(8) //
+				.filteredOn(job -> testJobs.remove(job)) // only test jobs that we know about
+				.allSatisfy(job -> assertThat(job.getJobGroup()).isIn(thirdJobGroup, fifthJobGroup));
+		assertThat(testJobs).hasSize(12);
 		testJobs.clear();
 
 		// Cancel the fifth and third job groups.
@@ -424,12 +392,10 @@ public class JobGroupTest extends AbstractJobTest {
 		// Note: Running the test framework may cause other system jobs to run,
 		// so check that there no jobs started by this test are present in all running jobs.
 		testJobs.addAll(Arrays.asList(jobs));
-		allJobs = manager.find(null);
-		for (Job job : allJobs) {
-			// Verify that no jobs that we know about are found (they should have all been removed)
-			assertFalse(job.toString(), testJobs.remove(job));
-		}
-		assertEquals("15.0", NUM_JOBS, testJobs.size());
+		// Verify that no jobs that we know about are found (they should have all been
+		// removed)
+		assertThat(manager.find(null)).allMatch(job -> !testJobs.remove(job), "job is none of the ones we started");
+		assertThat(testJobs).hasSize(NUM_JOBS);
 		testJobs.clear();
 	}
 
@@ -823,7 +789,7 @@ public class JobGroupTest extends AbstractJobTest {
 		jobGroup.join(0, null);
 
 		IStatus[] children = jobGroup.getResult().getChildren();
-		assertEquals(SEED_JOBS, children.length);
+		assertThat(children).hasSize(SEED_JOBS);
 		Integer[] results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
 			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
@@ -845,7 +811,7 @@ public class JobGroupTest extends AbstractJobTest {
 		jobGroup.join(0, monitor);
 
 		children = jobGroup.getResult().getChildren();
-		assertEquals(SEED_JOBS + 1, children.length);
+		assertThat(children).hasSize(SEED_JOBS + 1);
 		results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
 			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
@@ -863,7 +829,7 @@ public class JobGroupTest extends AbstractJobTest {
 		jobGroup.join(0, monitor);
 
 		children = jobGroup.getResult().getChildren();
-		assertEquals(SEED_JOBS + 2, children.length);
+		assertThat(children).hasSize(SEED_JOBS + 2);
 		results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
 			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
@@ -1408,7 +1374,7 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForCompletion(jobGroup);
 		IStatus[] jobResults = jobGroup.getResult().getChildren();
 		// Verify that the group result contains all the job results except the OK statuses.
-		assertEquals("1.0", status.length - 1, jobResults.length);
+		assertThat(jobResults).hasSize(status.length - 1);
 		for (int i = 1; i < status.length; i++) {
 			assertEquals("2." + i, status[i], jobResults[i - 1].getSeverity());
 		}
@@ -1448,7 +1414,7 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 		waitForCompletion(jobGroup);
 		// Verify that the compute group result is called with all the completed job results.
-		assertEquals("2.0", status.length, originalJobResults[0].length);
+		assertThat(originalJobResults[0]).hasSameSizeAs(status);
 		for (int i = 0; i < status.length; i++) {
 			assertEquals("3." + i, status[i], originalJobResults[0][i].getSeverity());
 		}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -1380,10 +1379,8 @@ public class JobTest extends AbstractJobTest {
 			}
 		}
 		try {
-			Job[] found = Job.getJobManager().find(job);
-			assertEquals("Job should still run", 1, found.length);
-			assertSame("Job should still run", job, found[0]);
-			assertThat(runCount.get()).as("number of job executions").isEqualTo(1L);
+			assertThat(Job.getJobManager().find(job)).as("check job still runs").contains(job);
+			assertThat(runCount.get()).as("expected to see exact one job execution").isEqualTo(1);
 		} finally {
 			keepRunning.set(false);
 		}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/WorkerPoolTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/WorkerPoolTest.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -102,7 +102,7 @@ public class WorkerPoolTest {
 	private int getWorkerThreadCount() {
 		Thread[] threads = new Thread[Thread.activeCount() * 2];
 		int enumeratedThreadCount = Thread.enumerate(threads);
-		assertTrue("Too many active threads: " + enumeratedThreadCount, enumeratedThreadCount < threads.length);
+		assertThat(enumeratedThreadCount).as("check not too many active threads").isLessThan(threads.length);
 
 		int workerThreadCount = 0;
 		for (int i = 0; i < enumeratedThreadCount; i++) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.perf;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.clear;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
@@ -290,8 +291,8 @@ public class ContentTypePerformanceTest extends TestCase {
 					} catch (IOException e) {
 						throw new IllegalStateException("unexpected exception occurred", e);
 					}
-					assertEquals("1.0." + i, 1, result.length);
-					assertEquals("1.1." + i, id, result[0].getId());
+					assertThat(result).as("content types for element " + i).singleElement()
+							.satisfies(it -> assertThat(it.getId()).as("id").isEqualTo(id));
 				}
 			}
 		}.run(this, 10, 2);

--- a/runtime/tests/org.eclipse.e4.core.javax.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  javax.inject;version="[1.0.0,2.0.0)",
  junit.framework;version="[4.13.0,5.0.0)",
+ org.assertj.core.api,
  org.eclipse.osgi.service.datalocation,
  org.eclipse.osgi.service.debug,
  org.junit;version="[4.13.0,5.0.0)",

--- a/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/contexts/inject/ServiceContextTest.java
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/contexts/inject/ServiceContextTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.e4.core.internal.tests.contexts.inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -248,7 +249,7 @@ public class ServiceContextTest {
 			PrintService service = (PrintService) otherServiceContext
 					.get(PrintService.SERVICE_NAME);
 			assertEquals("1.0", stringPrint1, service);
-			assertEquals("1.1", 1, ref.getUsingBundles().length);
+			assertThat(ref.getUsingBundles()).hasSize(1);
 			service = null;
 			otherServiceContext.dispose();
 			assertNull("2.0", ref.getUsingBundles());

--- a/runtime/tests/org.eclipse.e4.core.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.e4.core.tests/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",
  junit.framework;version="[4.13.0,5.0.0)",
+ org.assertj.core.api,
  org.eclipse.osgi.service.datalocation,
  org.eclipse.osgi.service.debug,
  org.junit;version="[4.13.0,5.0.0)",

--- a/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/contexts/inject/ServiceContextTest.java
+++ b/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/contexts/inject/ServiceContextTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.e4.core.internal.tests.contexts.inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -248,7 +249,7 @@ public class ServiceContextTest {
 			PrintService service = (PrintService) otherServiceContext
 					.get(PrintService.SERVICE_NAME);
 			assertEquals("1.0", stringPrint1, service);
-			assertEquals("1.1", 1, ref.getUsingBundles().length);
+			assertThat(ref.getUsingBundles()).hasSize(1);
 			service = null;
 			otherServiceContext.dispose();
 			assertNull("2.0", ref.getUsingBundles());

--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Require-Bundle: org.junit,
  org.eclipse.core.tests.harness,
  org.eclipse.core.filesystem,
  org.eclipse.team.ui
-Import-Package: org.junit.jupiter.api,
+Import-Package: org.assertj.core.api,
+ org.assertj.core.api.iterable,
+ org.junit.jupiter.api,
  org.junit.platform.suite.api
 Bundle-Activator: org.eclipse.compare.tests.CompareTestPlugin
 Bundle-ActivationPolicy: lazy

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareUIPluginTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareUIPluginTest.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-import org.eclipse.compare.*;
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.IStreamContentAccessor;
+import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.internal.CompareUIPlugin;
 import org.eclipse.compare.internal.ViewerDescriptor;
 import org.eclipse.compare.structuremergeviewer.DiffNode;
@@ -99,7 +99,7 @@ public class CompareUIPluginTest {
 
 		// API Compatibility : "no descriptor found" should return a null array instead
 		// of a 0-lengthed one.
-		assertNull(result);
+		assertThat(result).isNull();
 	}
 
 	@Test
@@ -112,8 +112,7 @@ public class CompareUIPluginTest {
 		 * "TextTypedElement" is "text" typed : it thus has a Content Viewer attached.
 		 * However, this content viewer is currently NOT returned because of bug 293926
 		 */
-		assertNotNull(result);
-		assertEquals(1, result.length);
+		assertThat(result).hasSize(1);
 	}
 
 	@Test
@@ -127,7 +126,6 @@ public class CompareUIPluginTest {
 		 * However, the content viewer will only be returned because we made our
 		 * "ITypedElement" be an IStreamContentAccessor.
 		 */
-		assertNotNull(result);
-		assertEquals(1, result.length);
+		assertThat(result).hasSize(1);
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
@@ -13,12 +13,13 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.compare.internal.DocLineComparator;
 import org.eclipse.compare.internal.core.TextLineLCS;
-import org.eclipse.compare.rangedifferencer.*;
+import org.eclipse.compare.rangedifferencer.IRangeComparator;
+import org.eclipse.compare.rangedifferencer.RangeDifference;
+import org.eclipse.compare.rangedifferencer.RangeDifferencer;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -45,17 +46,17 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
-		assertTrue(result[0].length == 3);
+		assertThat(result[0]).hasSameSizeAs(result[1]).hasSize(3);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 0);
-		assertTrue(result[1][0].lineNumber() == 0);
-		assertTrue(result[0][1].lineNumber() == 1);
-		assertTrue(result[1][1].lineNumber() == 1);
-		assertTrue(result[0][2].lineNumber() == 2);
-		assertTrue(result[1][2].lineNumber() == 3);
+		assertThat(result[0][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][0].lineNumber()).isEqualTo(0);
+		assertThat(result[0][1].lineNumber()).isEqualTo(1);
+		assertThat(result[1][1].lineNumber()).isEqualTo(1);
+		assertThat(result[0][2].lineNumber()).isEqualTo(2);
+		assertThat(result[1][2].lineNumber()).isEqualTo(3);
 	}
 
 	@Test
@@ -67,16 +68,17 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
+		assertThat(result[0]).hasSameSizeAs(result[1]);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 0);
-		assertTrue(result[0][1].lineNumber() == 1);
-		assertTrue(result[0][2].lineNumber() == 3);
-		assertTrue(result[1][0].lineNumber() == 0);
-		assertTrue(result[1][1].lineNumber() == 1);
-		assertTrue(result[1][2].lineNumber() == 2);
+		assertThat(result[0][0].lineNumber()).isEqualTo(0);
+		assertThat(result[0][1].lineNumber()).isEqualTo(1);
+		assertThat(result[0][2].lineNumber()).isEqualTo(3);
+		assertThat(result[1][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][1].lineNumber()).isEqualTo(1);
+		assertThat(result[1][2].lineNumber()).isEqualTo(2);
 	}
 
 	@Test
@@ -88,15 +90,15 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
-		assertTrue(result[0].length == 2);
+		assertThat(result[0]).hasSameSizeAs(result[1]).hasSize(2);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 0);
-		assertTrue(result[1][0].lineNumber() == 0);
-		assertTrue(result[0][1].lineNumber() == 1);
-		assertTrue(result[1][1].lineNumber() == 1);
+		assertThat(result[0][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][0].lineNumber()).isEqualTo(0);
+		assertThat(result[0][1].lineNumber()).isEqualTo(1);
+		assertThat(result[1][1].lineNumber()).isEqualTo(1);
 	}
 
 	@Test
@@ -108,15 +110,15 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
-		assertTrue(result[0].length == 2);
+		assertThat(result[0]).hasSameSizeAs(result[1]).hasSize(2);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 0);
-		assertTrue(result[1][0].lineNumber() == 0);
-		assertTrue(result[0][1].lineNumber() == 1);
-		assertTrue(result[1][1].lineNumber() == 1);
+		assertThat(result[0][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][0].lineNumber()).isEqualTo(0);
+		assertThat(result[0][1].lineNumber()).isEqualTo(1);
+		assertThat(result[1][1].lineNumber()).isEqualTo(1);
 	}
 
 	@Test
@@ -128,15 +130,15 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
-		assertTrue(result[0].length == 2);
+		assertThat(result[0]).hasSameSizeAs(result[1]).hasSize(2);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 0);
-		assertTrue(result[1][0].lineNumber() == 1);
-		assertTrue(result[0][1].lineNumber() == 1);
-		assertTrue(result[1][1].lineNumber() == 2);
+		assertThat(result[0][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][0].lineNumber()).isEqualTo(1);
+		assertThat(result[0][1].lineNumber()).isEqualTo(1);
+		assertThat(result[1][1].lineNumber()).isEqualTo(2);
 	}
 
 	@Test
@@ -148,15 +150,15 @@ public class DiffTest {
 		TextLineLCS lcs = new TextLineLCS(l1, l2);
 		lcs.longestCommonSubsequence(SubMonitor.convert(null, 100));
 		TextLineLCS.TextLine[][] result = lcs.getResult();
-		assertTrue(result[0].length == result[1].length);
-		assertTrue(result[0].length == 2);
+		assertThat(result[0]).hasSameSizeAs(result[1]).hasSize(2);
 		for (int i = 0; i < result[0].length; i++) {
-			assertTrue(result[0][i].sameText(result[1][i]));
+			int index = i;
+			assertThat(result[0][i]).matches(it -> it.sameText(result[1][index]), "same text at index " + index);
 		}
-		assertTrue(result[0][0].lineNumber() == 1);
-		assertTrue(result[0][1].lineNumber() == 2);
-		assertTrue(result[1][0].lineNumber() == 0);
-		assertTrue(result[1][1].lineNumber() == 1);
+		assertThat(result[0][0].lineNumber()).isEqualTo(1);
+		assertThat(result[0][1].lineNumber()).isEqualTo(2);
+		assertThat(result[1][0].lineNumber()).isEqualTo(0);
+		assertThat(result[1][1].lineNumber()).isEqualTo(1);
 	}
 
 	private IRangeComparator toRangeComparator(String s) {
@@ -170,7 +172,7 @@ public class DiffTest {
 		IRangeComparator comp2 = toRangeComparator(s2);
 		RangeDifference[] differences = RangeDifferencer.findDifferences(comp1, comp2);
 		RangeDifference[] oldDifferences = RangeDifferencer.findDifferences(comp1, comp2);
-		assertArrayEquals(differences, oldDifferences);
+		assertThat(differences).containsExactly(oldDifferences);
 		return differences;
 	}
 
@@ -181,11 +183,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 2);
-		assertTrue(result[0].leftLength() == 0);
-		assertTrue(result[0].rightStart() == 2);
-		assertTrue(result[0].rightLength() == 1);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(2);
+		assertThat(result[0].leftLength()).isEqualTo(0);
+		assertThat(result[0].rightStart()).isEqualTo(2);
+		assertThat(result[0].rightLength()).isEqualTo(1);
 	}
 
 	@Test
@@ -195,11 +197,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 2);
-		assertTrue(result[0].leftLength() == 1);
-		assertTrue(result[0].rightStart() == 2);
-		assertTrue(result[0].rightLength() == 0);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(2);
+		assertThat(result[0].leftLength()).isEqualTo(1);
+		assertThat(result[0].rightStart()).isEqualTo(2);
+		assertThat(result[0].rightLength()).isEqualTo(0);
 	}
 
 	@Test
@@ -209,11 +211,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 0);
-		assertTrue(result[0].leftLength() == 0);
-		assertTrue(result[0].rightStart() == 0);
-		assertTrue(result[0].rightLength() == 1);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(0);
+		assertThat(result[0].leftLength()).isEqualTo(0);
+		assertThat(result[0].rightStart()).isEqualTo(0);
+		assertThat(result[0].rightLength()).isEqualTo(1);
 	}
 
 	@Test
@@ -223,11 +225,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 0);
-		assertTrue(result[0].leftLength() == 1);
-		assertTrue(result[0].rightStart() == 0);
-		assertTrue(result[0].rightLength() == 0);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(0);
+		assertThat(result[0].leftLength()).isEqualTo(1);
+		assertThat(result[0].rightStart()).isEqualTo(0);
+		assertThat(result[0].rightLength()).isEqualTo(0);
 	}
 
 	@Test
@@ -237,11 +239,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 2);
-		assertTrue(result[0].leftLength() == 0);
-		assertTrue(result[0].rightStart() == 2);
-		assertTrue(result[0].rightLength() == 1);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(2);
+		assertThat(result[0].leftLength()).isEqualTo(0);
+		assertThat(result[0].rightStart()).isEqualTo(2);
+		assertThat(result[0].rightLength()).isEqualTo(1);
 	}
 
 	@Test
@@ -251,11 +253,11 @@ public class DiffTest {
 
 		RangeDifference[] result = getDifferences(s1, s2);
 
-		assertTrue(result.length == 1);
-		assertTrue(result[0].leftStart() == 2);
-		assertTrue(result[0].leftLength() == 1);
-		assertTrue(result[0].rightStart() == 2);
-		assertTrue(result[0].rightLength() == 0);
+		assertThat(result).hasSize(1);
+		assertThat(result[0].leftStart()).isEqualTo(2);
+		assertThat(result[0].leftLength()).isEqualTo(1);
+		assertThat(result[0].rightStart()).isEqualTo(2);
+		assertThat(result[0].rightLength()).isEqualTo(0);
 	}
 
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
@@ -81,12 +82,11 @@ public class FileDiffResultTest {
 		assertFalse(project.getFile(NEW_FILENAME).exists());
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
-		assertNotNull(filePatch);
-		assertEquals(1, filePatch.length);
+		assertThat(filePatch).hasSize(1);
 
 		IFilePatchResult filePatchResult = filePatch[0].apply((IStorage) null, patchConfiguration, createTestMonitor());
 		assertTrue(filePatchResult.hasMatches());
-		assertEquals(0, filePatchResult.getRejects().length);
+		assertThat(filePatchResult.getRejects()).isEmpty();
 		assertEquals("", getStringFromStream(filePatchResult.getOriginalContents()));
 		assertEquals(NEW_FILE_CONTENT, getStringFromStream(filePatchResult.getPatchedContents()));
 	}
@@ -109,14 +109,13 @@ public class FileDiffResultTest {
 		assertTrue(project.getFile(NEW_FILENAME).exists());
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
-		assertNotNull(filePatch);
-		assertEquals(1, filePatch.length);
+		assertThat(filePatch).hasSize(1);
 
 		IFilePatchResult filePatchResult = filePatch[0].apply(project.getFile(NEW_FILENAME), patchConfiguration,
 				createTestMonitor());
 
 		assertFalse(filePatchResult.hasMatches());
-		assertEquals(1, filePatchResult.getRejects().length);
+		assertThat(filePatchResult.getRejects()).hasSize(1);
 
 		assertNotNull(filePatchResult.getOriginalContents());
 		assertNotNull(filePatchResult.getPatchedContents());
@@ -145,13 +144,12 @@ public class FileDiffResultTest {
 		assertTrue(project.getFile(NEW_FILENAME).exists());
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
-		assertNotNull(filePatch);
-		assertEquals(1, filePatch.length);
+		assertThat(filePatch).hasSize(1);
 
 		IFilePatchResult filePatchResult = filePatch[0].apply(project.getFile(NEW_FILENAME), patchConfiguration,
 				createTestMonitor());
 		assertFalse(filePatchResult.hasMatches());
-		assertEquals(1, filePatchResult.getRejects().length);
+		assertThat(filePatchResult.getRejects()).hasSize(1);
 
 		assertNotNull(filePatchResult.getOriginalContents());
 		assertNotNull(filePatchResult.getPatchedContents());

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -45,9 +45,9 @@ public class PatchBuilderTest {
 		IStorage patchStorage = new StringStorage("patch_modifyHunks.txt");
 		IStorage contextStorage = new StringStorage("context.txt");
 		IFilePatch[] patches = ApplyPatchOperation.parsePatch(patchStorage);
-		assertEquals(1, patches.length);
+		assertThat(patches).hasSize(1);
 		IHunk[] hunksBefore = patches[0].getHunks();
-		assertEquals(5, hunksBefore.length);
+		assertThat(hunksBefore).hasSize(5);
 
 		String[] lines = new String[] { " [d]", "+[d1]", "+[d2]", "+[d3]", "+[d4]", " [e]" };
 		String lineDelimiter = getLineDelimiter(patchStorage);
@@ -59,7 +59,7 @@ public class PatchBuilderTest {
 		filePatch = PatchBuilder.removeHunks(filePatch, toRemove);
 
 		IHunk[] hunksAfter = filePatch.getHunks();
-		assertEquals(4, hunksAfter.length);
+		assertThat(hunksAfter).hasSize(4);
 		assertEquals(3, ((Hunk) hunksAfter[0]).getStart(false));
 		assertEquals(3, ((Hunk) hunksAfter[0]).getStart(true));
 		assertEquals(7, ((Hunk) hunksAfter[1]).getStart(false));
@@ -73,7 +73,7 @@ public class PatchBuilderTest {
 				new NullProgressMonitor());
 
 		IHunk[] rejects = result.getRejects();
-		assertEquals(1, rejects.length);
+		assertThat(rejects).hasSize(1);
 
 		InputStream actual = result.getPatchedContents();
 
@@ -89,9 +89,9 @@ public class PatchBuilderTest {
 		IStorage patchStorage = new StringStorage("patch_addHunks.txt");
 		IStorage contextStorage = new StringStorage("context_full.txt");
 		IFilePatch[] patches = ApplyPatchOperation.parsePatch(patchStorage);
-		assertEquals(1, patches.length);
+		assertThat(patches).hasSize(1);
 		IHunk[] hunksBefore = patches[0].getHunks();
-		assertEquals(3, hunksBefore.length);
+		assertThat(hunksBefore).hasSize(3);
 
 		String[] lines0 = new String[] { " [d]", "+[d1]", "+[d2]", "+[d3]", "+[d4]", " [e]" };
 		String lineDelimiter = getLineDelimiter(patchStorage);
@@ -106,7 +106,7 @@ public class PatchBuilderTest {
 		IFilePatch2 filePatch = PatchBuilder.addHunks(patches[0], toAdd);
 
 		IHunk[] hunksAfter = filePatch.getHunks();
-		assertEquals(5, hunksAfter.length);
+		assertThat(hunksAfter).hasSize(5);
 		assertEquals(0, ((Hunk) hunksAfter[0]).getStart(false));
 		assertEquals(0, ((Hunk) hunksAfter[0]).getStart(true));
 		assertEquals(3, ((Hunk) hunksAfter[1]).getStart(false));
@@ -122,7 +122,7 @@ public class PatchBuilderTest {
 				new NullProgressMonitor());
 
 		IHunk[] rejects = result.getRejects();
-		assertEquals(0, rejects.length);
+		assertThat(rejects).isEmpty();
 
 		InputStream actual = result.getPatchedContents();
 
@@ -138,15 +138,15 @@ public class PatchBuilderTest {
 		IStorage patchStorage = new StringStorage("patch_removeHunks.txt");
 		IStorage contextStorage = new StringStorage("context_full.txt");
 		IFilePatch[] patches = ApplyPatchOperation.parsePatch(patchStorage);
-		assertEquals(1, patches.length);
+		assertThat(patches).hasSize(1);
 		IHunk[] hunksBefore = patches[0].getHunks();
-		assertEquals(5, hunksBefore.length);
+		assertThat(hunksBefore).hasSize(5);
 
 		IHunk[] toRemove = new IHunk[] { hunksBefore[0], hunksBefore[1] };
 		IFilePatch2 filePatch = PatchBuilder.removeHunks(patches[0], toRemove);
 
 		IHunk[] hunksAfter = filePatch.getHunks();
-		assertEquals(3, hunksAfter.length);
+		assertThat(hunksAfter).hasSize(3);
 		assertEquals(19, ((Hunk) hunksAfter[0]).getStart(false));
 		assertEquals(19, ((Hunk) hunksAfter[0]).getStart(true));
 		assertEquals(29, ((Hunk) hunksAfter[1]).getStart(false));
@@ -158,7 +158,7 @@ public class PatchBuilderTest {
 				new NullProgressMonitor());
 
 		IHunk[] rejects = result.getRejects();
-		assertEquals(0, rejects.length);
+		assertThat(rejects).isEmpty();
 
 		InputStream actual = result.getPatchedContents();
 
@@ -188,9 +188,7 @@ public class PatchBuilderTest {
 		IFilePatch2 filePatch = PatchBuilder.createFilePatch(IPath.fromOSString(""), IFilePatch2.DATE_UNKNOWN, IPath.fromOSString(""),
 				IFilePatch2.DATE_UNKNOWN, hunks);
 
-		assertEquals(2, filePatch.getHunks().length);
-		assertEquals(hunk0, filePatch.getHunks()[0]);
-		assertEquals(hunk1, filePatch.getHunks()[1]);
+		assertThat(filePatch.getHunks()).containsExactly(hunk0, hunk1);
 
 		IFilePatchResult result = filePatch.apply(Utilities.getReaderCreator(contextStorage), new PatchConfiguration(),
 				new NullProgressMonitor());
@@ -208,8 +206,8 @@ public class PatchBuilderTest {
 	public void testCreateHunk0() throws CoreException, IOException {
 		IStorage patch = new StringStorage("patch_createHunk0.txt");
 		IFilePatch[] filePatches = ApplyPatchOperation.parsePatch(patch);
-		assertEquals(1, filePatches.length);
-		assertEquals(1, filePatches[0].getHunks().length);
+		assertThat(filePatches).hasSize(1);
+		assertThat(filePatches[0].getHunks()).hasSize(1);
 
 		String[] lines = new String[] { "+[a1]", "+[a2]", "+[a3]", " [a]", " [b]", "-[c]", " [d]", " [e]", " [f]" };
 		String lineDelimiter = getLineDelimiter(patch);
@@ -226,8 +224,8 @@ public class PatchBuilderTest {
 	public void testCreateHunk1() throws CoreException, IOException {
 		IStorage patch = new StringStorage("patch_createHunk1.txt");
 		IFilePatch[] filePatches = ApplyPatchOperation.parsePatch(patch);
-		assertEquals(1, filePatches.length);
-		assertEquals(1, filePatches[0].getHunks().length);
+		assertThat(filePatches).hasSize(1);
+		assertThat(filePatches[0].getHunks()).hasSize(1);
 
 		String[] lines = new String[] { " [a]", " [b]", "-[c]", " [d]", "-[e]", " [f]", " [g]", " [h]", "+[h1]", " [i]",
 				" [j]", "+[j1]", "+[j2]", " [k]", " [l]", " [m]" };
@@ -245,8 +243,8 @@ public class PatchBuilderTest {
 	public void testCreateHunk2() throws CoreException, IOException {
 		IStorage patch = new StringStorage("patch_createHunk2.txt");
 		IFilePatch[] filePatches = ApplyPatchOperation.parsePatch(patch);
-		assertEquals(1, filePatches.length);
-		assertEquals(1, filePatches[0].getHunks().length);
+		assertThat(filePatches).hasSize(1);
+		assertThat(filePatches[0].getHunks()).hasSize(1);
 
 		String[] lines = new String[] { "+[aa]", "+[bb]", "+[cc]" };
 		String lineDelimiter = getLineDelimiter(patch);
@@ -263,8 +261,8 @@ public class PatchBuilderTest {
 	public void testCreateHunk3() throws CoreException, IOException {
 		IStorage patch = new StringStorage("patch_createHunk3.txt");
 		IFilePatch[] filePatches = ApplyPatchOperation.parsePatch(patch);
-		assertEquals(1, filePatches.length);
-		assertEquals(1, filePatches[0].getHunks().length);
+		assertThat(filePatches).hasSize(1);
+		assertThat(filePatches[0].getHunks()).hasSize(1);
 
 		String[] lines = new String[] { "-[aa]", "-[bb]", "-[cc]", "-[dd]" };
 		String lineDelimiter = getLineDelimiter(patch);
@@ -280,11 +278,7 @@ public class PatchBuilderTest {
 	private void assertHunkEquals(Hunk h1, Hunk h2) {
 		String[] l1 = h1.getLines();
 		String[] l2 = h2.getLines();
-		assertEquals(l1.length, l2.length);
-		for (int i = 0; i < l1.length; i++) {
-			assertFalse(l1[i] == null && l2[i] != null);
-			assertEquals(l1[i], (l2[i]));
-		}
+		assertThat(l1).containsExactly(l2);
 		assertEquals(h1.getStart(false), h2.getStart(false));
 		assertEquals(h1.getStart(true), h2.getStart(true));
 		assertEquals(h1.getLength(false), h2.getLength(false));

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -111,15 +112,15 @@ public class PatchTest {
 		IStorage patchStorage = new StringStorage("patch_hunkFilter.txt");
 		IStorage expStorage = new StringStorage("context.txt");
 		IFilePatch[] patches = ApplyPatchOperation.parsePatch(patchStorage);
-		assertEquals(1, patches.length);
+		assertThat(patches).hasSize(1);
 		IHunk[] hunks = patches[0].getHunks();
-		assertEquals(5, hunks.length);
+		assertThat(hunks).hasSize(5);
 		PatchConfiguration pc = new PatchConfiguration();
 		final IHunk toFilterOut = hunks[3];
 		pc.addHunkFilter(hunk -> hunk != toFilterOut);
 		IFilePatchResult result = patches[0].apply(expStorage, pc, new NullProgressMonitor());
 		IHunk[] rejects = result.getRejects();
-		assertEquals(2, rejects.length);
+		assertThat(rejects).hasSize(2);
 		boolean aFiltered = pc.getHunkFilters()[0].select(rejects[0]);
 		boolean bFiltered = pc.getHunkFilters()[0].select(rejects[1]);
 		assertTrue((aFiltered && !bFiltered) || (!aFiltered && bFiltered));
@@ -465,7 +466,7 @@ public class PatchTest {
 		IStorage oldStorage = new StringStorage(old);
 		IStorage patchStorage = new StringStorage(patch);
 		IFilePatch[] patches = ApplyPatchOperation.parsePatch(patchStorage);
-		assertTrue(patches.length == 1);
+		assertThat(patches).hasSize(1);
 		IFilePatchResult result = patches[0].apply(oldStorage, new PatchConfiguration(), null);
 		assertTrue(result.hasMatches());
 		assertFalse(result.hasRejects());
@@ -486,7 +487,7 @@ public class PatchTest {
 		}
 
 		FilePatch2[] diffs = patcher.getDiffs();
-		Assert.assertEquals(diffs.length, 1);
+		assertThat(diffs).hasSize(1);
 
 		FileDiffResult diffResult = patcher.getDiffResult(diffs[0]);
 		diffResult.patch(inLines, null);
@@ -517,7 +518,7 @@ public class PatchTest {
 			PatchConfiguration patchConfiguration) {
 
 		// ensure that we have the same number of input files as we have expected files
-		Assert.assertEquals(originalFiles.length, expectedOutcomeFiles.length);
+		assertThat(expectedOutcomeFiles).hasSameSizeAs(originalFiles);
 
 		// Parse the passed in patch and extract all the Diffs
 		WorkspacePatcher patcher = new WorkspacePatcher();

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerThreeWayDiffTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerThreeWayDiffTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.compare.contentmergeviewer.ITokenComparator;
 import org.eclipse.compare.internal.DocLineComparator;
@@ -35,10 +35,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(3, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.CONFLICT, diffs[1].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[2].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.CONFLICT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -49,10 +47,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(3, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.CONFLICT, diffs[1].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[2].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.CONFLICT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -63,10 +59,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(3, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.CONFLICT, diffs[1].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[2].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.CONFLICT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -77,10 +71,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(3, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.CONFLICT, diffs[1].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[2].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.CONFLICT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -91,11 +83,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(4, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.LEFT, diffs[1].kind());
-		assertEquals(RangeDifference.RIGHT, diffs[2].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[3].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.LEFT, RangeDifference.RIGHT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -106,11 +95,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(4, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.LEFT, diffs[1].kind());
-		assertEquals(RangeDifference.RIGHT, diffs[2].kind());
-		assertEquals(RangeDifference.NOCHANGE, diffs[3].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.LEFT, RangeDifference.RIGHT, RangeDifference.NOCHANGE);
 	}
 
 	@Test
@@ -121,10 +107,8 @@ public class RangeDifferencerThreeWayDiffTest {
 
 		RangeDifference[] diffs = findRange(a, l, r);
 
-		assertEquals(3, diffs.length);
-		assertEquals(RangeDifference.NOCHANGE, diffs[0].kind());
-		assertEquals(RangeDifference.LEFT, diffs[1].kind());
-		assertEquals(RangeDifference.RIGHT, diffs[2].kind());
+		assertThat(diffs).extracting(RangeDifference::kind).containsExactly(RangeDifference.NOCHANGE,
+				RangeDifference.LEFT, RangeDifference.RIGHT);
 	}
 
 	private RangeDifference[] findRange(String a, String l, String r) {

--- a/team/tests/org.eclipse.core.tests.net/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.core.tests.net/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.net;bundle-version="[1.0.0,2.0.0)",
  org.junit
+Import-Package: org.assertj.core.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
@@ -13,21 +13,28 @@
  *******************************************************************************/
 package org.eclipse.core.tests.net;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 import org.eclipse.core.internal.net.ProxyData;
 import org.eclipse.core.internal.net.ProxyType;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class NetTest {
 
@@ -284,17 +291,11 @@ public class NetTest {
 		setDataTest(IProxyData.HTTPS_PROXY_TYPE);
 		setDataTest(IProxyData.SOCKS_PROXY_TYPE);
 
-		IProxyData[] allData = this.getProxyManager().getProxyDataForHost("www.randomhot.com");
-		assertEquals(3, allData.length);
-
-		IProxyData data = this.getProxyManager().getProxyDataForHost("www.randomhot.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNotNull(data);
-
-		allData = this.getProxyManager().getProxyDataForHost("localhost");
-		assertEquals(0, allData.length);
-
-		data = this.getProxyManager().getProxyDataForHost("localhost", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
+		assertThat(this.getProxyManager().getProxyDataForHost("www.randomhot.com")).hasSize(3);
+		assertThat(this.getProxyManager().getProxyDataForHost("www.randomhot.com", IProxyData.HTTP_PROXY_TYPE))
+				.isNotNull();
+		assertThat(this.getProxyManager().getProxyDataForHost("localhost")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("localhost", IProxyData.HTTP_PROXY_TYPE)).isNull();
 	}
 
 	@Test
@@ -306,23 +307,13 @@ public class NetTest {
 		String[] oldHosts = this.getProxyManager().getNonProxiedHosts();
 		this.getProxyManager().setNonProxiedHosts(new String[] { "*ignore.com" });
 
-		IProxyData[] allData = this.getProxyManager().getProxyDataForHost("www.randomhot.com");
-		assertEquals(3, allData.length);
-
-		IProxyData data = this.getProxyManager().getProxyDataForHost("www.randomhot.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNotNull(data);
-
-		allData = this.getProxyManager().getProxyDataForHost("www.ignore.com");
-		assertEquals(0, allData.length);
-
-		data = this.getProxyManager().getProxyDataForHost("www.ignore.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
-
-		allData = this.getProxyManager().getProxyDataForHost("ignore.com");
-		assertEquals(0, allData.length);
-
-		data = this.getProxyManager().getProxyDataForHost("ignore.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
+		assertThat(this.getProxyManager().getProxyDataForHost("www.randomhot.com")).hasSize(3);
+		assertThat(this.getProxyManager().getProxyDataForHost("www.randomhot.com", IProxyData.HTTP_PROXY_TYPE))
+				.isNotNull();
+		assertThat(this.getProxyManager().getProxyDataForHost("www.ignore.com")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("www.ignore.com", IProxyData.HTTP_PROXY_TYPE)).isNull();
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com", IProxyData.HTTP_PROXY_TYPE)).isNull();
 
 		this.getProxyManager().setNonProxiedHosts(oldHosts);
 	}
@@ -336,24 +327,13 @@ public class NetTest {
 		String[] oldHosts = this.getProxyManager().getNonProxiedHosts();
 		this.getProxyManager().setNonProxiedHosts(new String[] { "ignore.com" });
 
-		IProxyData[] allData = this.getProxyManager().getProxyDataForHost("ignore.com.randomhot.com");
-		assertEquals(3, allData.length);
-
-		IProxyData data = this.getProxyManager().getProxyDataForHost("ignore.com.randomhot.com",
-				IProxyData.HTTP_PROXY_TYPE);
-		assertNotNull(data);
-
-		allData = this.getProxyManager().getProxyDataForHost("www.ignore.com");
-		assertEquals(0, allData.length);
-
-		data = this.getProxyManager().getProxyDataForHost("www.ignore.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
-
-		allData = this.getProxyManager().getProxyDataForHost("ignore.com");
-		assertEquals(0, allData.length);
-
-		data = this.getProxyManager().getProxyDataForHost("ignore.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com.randomhot.com")).hasSize(3);
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com.randomhot.com", IProxyData.HTTP_PROXY_TYPE))
+				.isNotNull();
+		assertThat(this.getProxyManager().getProxyDataForHost("www.ignore.com")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("www.ignore.com", IProxyData.HTTP_PROXY_TYPE)).isNull();
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("ignore.com", IProxyData.HTTP_PROXY_TYPE)).isNull();
 
 		this.getProxyManager().setNonProxiedHosts(oldHosts);
 	}
@@ -368,10 +348,8 @@ public class NetTest {
 
 		this.getProxyManager().setNonProxiedHosts(new String[] { "nonexisting.com" });
 
-		IProxyData[] allData = this.getProxyManager().getProxyDataForHost("NONEXISTING.COM");
-		assertEquals(0, allData.length);
-		IProxyData data = this.getProxyManager().getProxyDataForHost("NONEXISTING.COM", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
+		assertThat(this.getProxyManager().getProxyDataForHost("NONEXISTING.COM")).isEmpty();
+		assertThat(this.getProxyManager().getProxyDataForHost("NONEXISTING.COM", IProxyData.HTTP_PROXY_TYPE)).isNull();
 
 		this.getProxyManager().setNonProxiedHosts(oldHosts);
 	}
@@ -384,13 +362,12 @@ public class NetTest {
 
 		IProxyData data1 = this.getProxyManager().getProxyDataForHost("randomhost.com", IProxyData.HTTP_PROXY_TYPE);
 		IProxyData[] data2 = this.getProxyManager().select(new URI("http://randomhost.com"));
-		assertEquals(data2.length, 1);
-		assertEquals(data1, data2[0]);
+		assertThat(data2).singleElement().isEqualTo(data1);
 
 		IProxyData data3 = this.getProxyManager().getProxyDataForHost("randomhost.com", null);
 		IProxyData[] data4 = this.getProxyManager().select(new URI(null, "randomhost.com", null, null));
-		assertNull(data3);
-		assertEquals(data4.length, 0);
+		assertThat(data3).isNull();
+		assertThat(data4).isEmpty();
 	}
 
 	@Test
@@ -402,13 +379,13 @@ public class NetTest {
 		this.getProxyManager().setProxiesEnabled(false);
 
 		IProxyData data = this.getProxyManager().getProxyDataForHost("randomhost.com", IProxyData.HTTP_PROXY_TYPE);
-		assertNull(data);
+		assertThat(data).isNull();
 
 		IProxyData[] data2 = this.getProxyManager().select(new URI("http://randomhost.com"));
-		assertEquals(data2.length, 0);
+		assertThat(data2).isEmpty();
 
 		IProxyData data3[] = this.getProxyManager().getProxyDataForHost("http://randomhost.com");
-		assertEquals(data3.length, 0);
+		assertThat(data3).isEmpty();
 	}
 
 	@Test

--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.net;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +27,9 @@ import org.eclipse.core.internal.net.ProxyData;
 import org.eclipse.core.internal.net.ProxySelector;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SystemProxyTest {
 
@@ -193,23 +196,12 @@ public class SystemProxyTest {
 	 */
 	@Test
 	public void testNonProxiedHosts_WindowsIEManualSettings() throws URISyntaxException {
-		IProxyData[] proxiesData = getProxyManager().select(new URI("http://eclipse"));
-		assertEquals(1, proxiesData.length);
-
-		proxiesData = getProxyManager().select(new URI("http://eclipse.org/bugs"));
-		assertEquals(0, proxiesData.length);
-
-		proxiesData = getProxyManager().select(new URI("http://nonexisting.com"));
-		assertEquals(0, proxiesData.length);
-
-		proxiesData = getProxyManager().select(new URI("http://www.eclipse.org"));
-		assertEquals(0, proxiesData.length);
-
-		proxiesData = getProxyManager().select(new URI("http://www.myDomain.com"));
-		assertEquals(0, proxiesData.length);
-
-		proxiesData = getProxyManager().select(new URI("http://www.test.edu"));
-		assertEquals(0, proxiesData.length);
+		assertThat(getProxyManager().select(new URI("http://eclipse"))).hasSize(1);
+		assertThat(getProxyManager().select(new URI("http://eclipse.org/bugs"))).isEmpty();
+		assertThat(getProxyManager().select(new URI("http://nonexisting.com"))).isEmpty();
+		assertThat(getProxyManager().select(new URI("http://www.eclipse.org"))).isEmpty();
+		assertThat(getProxyManager().select(new URI("http://www.myDomain.com"))).isEmpty();
+		assertThat(getProxyManager().select(new URI("http://www.test.edu"))).isEmpty();
 	}
 
 	void initializeTestProxyData(String proxyDataSource) {


### PR DESCRIPTION
In order to reduce/avoid usage of ambiguous `assertEquals` (hard to distinguish expected/actual) and prepare for a migration to JUnit 5 with swapped expected/actual parameters in the `assertEquals` signature, this change replaces certain `assertEquals` calls with AssertJ assertions:
* Replace `assertEquals(MESSAGE, EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL).as(MESSAGE).hasSize(EXPECTED))` and remove obsolete message where possible
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL).hasSize(EXPECTED))`
* Replace `hasSize(0)` with `isEmpty()` to improve failure messages
* Combine array size comparison with array contents comparison where possible

### What I Did

Initial changes are the result of two regex replacements:
#### Length assertions with message
Find: `assertEquals\((.*), (.*), (.*)\.length\);`
Insert: `assertThat\($3\)\.as\($1\)\.hasSize\($2)\);`

#### Length assertions without message
Find: `assertEquals\((.*), (.*)\.length\);`
Insert: `assertThat\($2\)\.hasSize\($1)\);`

Further improvements, in particular the combination of size and content assertions, is manual work.

### Benefits
* Improved failure messages:
  * When an empty array is asserted, the non-empty array will be reported in case of a failure
  * When size and content of an array are validated, the test will not fail reporting an improper size but reporting the mismatching elements
* Improved comprehensibility due to matchers giving more semantics to the validations than plain assertEquals
* Eased migration to JUnit 5: `assertEquals` statements would need to adapted during a migration from JUnit 4 to 5 because expected/actual parameters are swapped