### PR TITLE
Properly initialize session tests and test name before logging it

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceSessionTest.java
@@ -61,8 +61,8 @@ public class WorkspaceSessionTest extends TestCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		workspaceRule.before();
 		workspaceRule.setTestName(getName());
+		workspaceRule.before();
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/TestMultipleBuildersOfSameType.java
@@ -47,6 +47,7 @@ public class TestMultipleBuildersOfSameType extends WorkspaceSessionTest {
 
 	@Override
 	protected void setUp() throws Exception {
+		super.setUp();
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		project1 = root.getProject("Project1");
 		unsorted1 = project1.getFolder(SortBuilder.UNSORTED_FOLDER);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -50,6 +50,7 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 
 	@Override
 	protected void setUp() throws Exception {
+		super.setUp();
 		root = getWorkspace().getRoot();
 		project = root.getProject("MyProject");
 		pfile = project.getFile("file.txt");
@@ -60,7 +61,6 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		file2 = folder.getFile("file2.txt");
 		folder2 = folder.getFolder("folder2");
 		file3 = folder2.getFile("file3.txt");
-
 	}
 
 	private void saveWorkspace() throws CoreException {


### PR DESCRIPTION
Currently, WorkspaceSessionTests log their name in their setup logic
before actually setting the name, such that "[null] setUp" is always
logged. In addition, two WorkspaceSessionTest implementations overwrite
the general setup logic without a `super` call to the general
initialization. This change corrects the setup statements order and
ensures that all session tests call the general initialization logic.