### PR TITLE
Improve array length assertions in ant and debug tests

### DIFF
--- a/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.ant.core,
  org.eclipse.core.runtime,
  org.eclipse.pde.core
+Import-Package: org.assertj.core.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
@@ -7,13 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Ericsson AB, Julian Enoch - Bug 465594
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -265,7 +266,7 @@ public class FrameworkTests extends AbstractAntTest {
 			runner.setBuildFileLocation(buildFile.getLocation().toFile().toString());
 		}
 		TargetInfo[] infos = runner.getAvailableTargets();
-		assertTrue("incorrect number of targets retrieved", infos != null && infos.length == 3); //$NON-NLS-1$
+		assertThat(infos).as("number of retrieved targets").hasSize(3); //$NON-NLS-1$
 	}
 
 	/**

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
@@ -7,14 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +35,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testDefaultTarget() throws CoreException {
 		TargetInfo[] targets = getTargets("TestForEcho.xml"); //$NON-NLS-1$
-		assertEquals("Should be two targets in TestForEcho.xml", 2, targets.length); //$NON-NLS-1$
+		assertThat(targets).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
 		assertTrue("Test for Echo should be the default target", targets[1].isDefault()); //$NON-NLS-1$
 	}
 
@@ -45,7 +45,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testGetTargetsWithDataTypes() throws CoreException {
 		TargetInfo[] targets = getTargets("Bug32551.xml"); //$NON-NLS-1$
-		assertEquals("Should be one targets in Bug32551.xml", 1, targets.length); //$NON-NLS-1$
+		assertThat(targets).as("number of targets in Bug32551.xml").hasSize(1); //$NON-NLS-1$
 	}
 
 	/**
@@ -70,7 +70,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testTargetNames() throws CoreException {
 		String[] targetNames = getTargetNames("TestForEcho.xml"); //$NON-NLS-1$
-		assertEquals("Should be two targets in TestForEcho.xml", 2, targetNames.length); //$NON-NLS-1$
+		assertThat(targetNames).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
 		assertEquals("First name should be init", "init", targetNames[0]); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("Second name should be Test for Echo", "Test for Echo", targetNames[1]); //$NON-NLS-1$ //$NON-NLS-2$
 	}
@@ -81,7 +81,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testTargetDescription() throws CoreException {
 		String[] targetDescriptions = getTargetDescriptions("TestForEcho.xml"); //$NON-NLS-1$
-		assertEquals("Should be two targets in TestForEcho.xml", 2, targetDescriptions.length); //$NON-NLS-1$
+		assertThat(targetDescriptions).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
 		assertNull("First description should be null", targetDescriptions[0]); //$NON-NLS-1$
 		assertEquals("Second description should be Calls other targets", "Calls other echos", targetDescriptions[1]); //$NON-NLS-1$ //$NON-NLS-2$
 	}
@@ -101,8 +101,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testTargetDependencies() throws CoreException {
 		String[] dependencies = getDependencies("TestForEcho.xml", "Test for Echo"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNotNull("Dependencies should not be null", dependencies); //$NON-NLS-1$
-		assertEquals("Should be one dependency in Test for Echo", 1, dependencies.length); //$NON-NLS-1$
+		assertThat(dependencies).as("number of dependencies in Test for Echo").hasSize(1); //$NON-NLS-1$
 		assertEquals("First dependency should be init", "init", dependencies[0]); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/PropertyTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +68,7 @@ public class PropertyTests extends AbstractAntDebugTest {
 
 			AntStackFrame frame = (AntStackFrame) thread.getTopStackFrame();
 			IVariable[] vars = frame.getVariables();
-			assertTrue("Should be a bunch of properties", 0 < vars.length); //$NON-NLS-1$
+			assertThat(vars).hasSizeGreaterThan(0);
 			AntProperty property = frame.findProperty("ant.library.dir"); //$NON-NLS-1$
 			assertNotNull(property);
 
@@ -103,7 +104,7 @@ public class PropertyTests extends AbstractAntDebugTest {
 
 			AntStackFrame frame = (AntStackFrame) thread.getTopStackFrame();
 			IVariable[] vars = frame.getVariables();
-			assertTrue("Should be a bunch of properties", 0 < vars.length); //$NON-NLS-1$
+			assertThat(vars).hasSizeGreaterThan(0);
 			AntProperty property = frame.findProperty("ant.home"); //$NON-NLS-1$
 			assertNotNull(property);
 
@@ -135,7 +136,7 @@ public class PropertyTests extends AbstractAntDebugTest {
 
 			AntStackFrame frame = (AntStackFrame) thread.getTopStackFrame();
 			IVariable[] vars = frame.getVariables();
-			assertTrue("Should be a bunch of properties", 0 < vars.length); //$NON-NLS-1$
+			assertThat(vars).hasSizeGreaterThan(0);
 			AntProperty property = frame.findProperty("ant.home"); //$NON-NLS-1$
 			assertNotNull(property);
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
 import org.eclipse.core.resources.IFile;
@@ -47,7 +47,7 @@ public class StackTests extends AbstractAntDebugTest {
 
 			IStackFrame[] frames = thread.getStackFrames();
 
-			assertTrue(frames.length == 3);
+			assertThat(frames).hasSize(3);
 			IStackFrame frame = frames[0];
 			frame.getName().equals(""); //$NON-NLS-1$
 		}

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -67,11 +69,11 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor();
 
 		ICompletionProposal[] proposals = processor.getAttributeProposals("contains", "ca"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
-		assertEquals("casesensitive - (true | false | on | off | yes | no)", proposals[0].getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1).satisfiesExactly(it -> assertThat(it.getDisplayString())
+				.isEqualTo("casesensitive - (true | false | on | off | yes | no)")); //$NON-NLS-1$
 
 		proposals = processor.getAttributeProposals("move", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(17, proposals.length);
+		assertThat(proposals).hasSize(17);
 		ICompletionProposal proposal = proposals[0];
 		String displayString = proposal.getDisplayString();
 		assertTrue(displayString.equals("id") //$NON-NLS-1$
@@ -92,25 +94,24 @@ public class CodeCompletionTest extends AbstractAntUITest {
 				|| displayString.equals("granularity")); //$NON-NLS-1$
 
 		proposals = processor.getAttributeProposals("move", "to"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(2, proposals.length);
+		assertThat(proposals).hasSize(2);
 
 		proposals = processor.getAttributeProposals("reference", "idl"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(0, proposals.length);
+		assertThat(proposals).isEmpty();
 
 		proposals = processor.getAttributeProposals("reference", "id"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
-		assertEquals("id", proposals[0].getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1).satisfiesExactly(it -> assertThat(it.getDisplayString()).isEqualTo("id")); //$NON-NLS-1$
 
 		proposals = processor.getAttributeProposals("reference", "i"); //$NON-NLS-1$ //$NON-NLS-2$
 		// id includesfile includes
-		assertEquals(3, proposals.length);
+		assertThat(proposals).hasSize(3);
 		displayString = proposals[0].getDisplayString();
 		assertTrue(displayString.equals("id") //$NON-NLS-1$
 				|| displayString.equals("includesfile") //$NON-NLS-1$
 				|| displayString.equals("includes")); //$NON-NLS-1$
 
 		proposals = processor.getAttributeProposals("project", "de"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 	}
 
 	/**
@@ -127,7 +128,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getPropertyProposals(getCurrentDocument(), "", lineOffset + columnNumber); //$NON-NLS-1$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("prop1", proposals); //$NON-NLS-1$
 
 		lineNumber = 18;
@@ -137,7 +138,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getPropertyProposals(getCurrentDocument(), "", lineOffset + columnNumber); //$NON-NLS-1$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("prop2", proposals); //$NON-NLS-1$
 	}
 
@@ -158,7 +159,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 			processor.setCursorPosition(lineOffset + columnNumber);
 
 			ICompletionProposal[] proposals = processor.determineTemplateProposals();
-			assertTrue("No templates are relevant at the current position. Found: " + proposals.length, proposals.length == 0); //$NON-NLS-1$
+			assertThat(proposals).isEmpty();
 		}
 		finally {
 			EditorTestHelper.closeAllEditors();
@@ -179,7 +180,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getPropertyProposals(getCurrentDocument(), "", lineOffset + columnNumber); //$NON-NLS-1$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("java.home", proposals); //$NON-NLS-1$
 	}
 
@@ -197,7 +198,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getPropertyProposals(getCurrentDocument(), "", lineOffset + columnNumber); //$NON-NLS-1$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("ant.file", proposals); //$NON-NLS-1$
 		assertContains("ant.version", proposals); //$NON-NLS-1$
 		assertContains("ant.project.name", proposals); //$NON-NLS-1$
@@ -227,7 +228,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 			processor.setColumnNumber(columnNumber);
 			processor.setCursorPosition(lineOffset + columnNumber);
 			ICompletionProposal[] proposals = processor.getPropertyProposals(getCurrentDocument(), "", lineOffset + columnNumber); //$NON-NLS-1$
-			assertTrue(proposals.length >= 3);
+			assertThat(proposals).hasSizeGreaterThanOrEqualTo(3);
 			assertContains("eclipse.home", proposals); // contributed //$NON-NLS-1$
 			assertContains("property.ui.testing2", proposals); // contributed //$NON-NLS-1$
 			assertContains("test", proposals); //$NON-NLS-1$
@@ -253,7 +254,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getTargetAttributeValueProposals(getCurrentDocument(), getCurrentDocument().get(0, lineOffset
 				+ columnNumber), "", "depends"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(proposals.length == 7);
+		assertThat(proposals).hasSize(7);
 		assertContains("pretest", proposals); //$NON-NLS-1$
 		assertContains("testMoreDepends", proposals); //$NON-NLS-1$
 		// comma separated depends
@@ -265,7 +266,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getTargetAttributeValueProposals(getCurrentDocument(), getCurrentDocument().get(0, lineOffset
 				+ columnNumber), "", "depends"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(proposals.length == 7);
+		assertThat(proposals).hasSize(7);
 		assertContains("main", proposals); //$NON-NLS-1$
 		// XXX why do we not want a valid proposal?
 		/* assertDoesNotContain("pretest", proposals); */
@@ -285,7 +286,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals(3, proposals.length);
+		assertThat(proposals).hasSize(3);
 		assertContains("main", proposals); //$NON-NLS-1$
 		assertContains("pretest", proposals); //$NON-NLS-1$
 		assertContains("test2", proposals); //$NON-NLS-1$
@@ -318,7 +319,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals(3, proposals.length);
+		assertThat(proposals).hasSize(3);
 		assertContains("task", proposals); //$NON-NLS-1$
 		assertContains("task2", proposals); //$NON-NLS-1$
 		assertContains("task3", proposals); //$NON-NLS-1$
@@ -350,7 +351,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals(2, proposals.length);
+		assertThat(proposals).hasSize(2);
 		assertContains("task", proposals); //$NON-NLS-1$
 		assertContains("task3", proposals); //$NON-NLS-1$
 
@@ -381,7 +382,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getTargetAttributeValueProposals(getCurrentDocument(), getCurrentDocument().get(0, lineOffset
 				+ columnNumber), "", "if"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("prop1", proposals); //$NON-NLS-1$
 	}
 
@@ -400,7 +401,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getTargetAttributeValueProposals(getCurrentDocument(), getCurrentDocument().get(0, lineOffset
 				+ columnNumber), "prop", "unless"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(proposals.length >= 1);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(1);
 		assertContains("prop1", proposals); //$NON-NLS-1$
 
 	}
@@ -418,7 +419,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getAntCallAttributeValueProposals(getCurrentDocument(), "", "target"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(proposals.length == 2);
+		assertThat(proposals).hasSize(2);
 		assertContains("call", proposals); //$NON-NLS-1$
 		assertContains("pre-call", proposals); //$NON-NLS-1$
 	}
@@ -486,9 +487,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("taskdef.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getTaskProposals(getCurrentDocument(), "target", "min"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
-		ICompletionProposal proposal = proposals[0];
-		assertEquals("mine", proposal.getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1).satisfiesExactly(it -> assertThat(it.getDisplayString()).isEqualTo("mine")); //$NON-NLS-1$
 		processor.dispose();
 	}
 
@@ -512,9 +511,8 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("macrodef.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getTaskProposals(getCurrentDocument(), "target", "eclipsema"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
-		ICompletionProposal proposal = proposals[0];
-		assertEquals("eclipseMacro", proposal.getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1)
+				.satisfiesExactly(it -> assertThat(it.getDisplayString()).isEqualTo("eclipseMacro")); //$NON-NLS-1$
 
 	}
 
@@ -526,9 +524,9 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("98853.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getTaskProposals(getCurrentDocument(), "target", "xyz"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(2, proposals.length);
-		ICompletionProposal proposal = proposals[0];
-		assertEquals("xyz:echo-macro", proposal.getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(2).satisfiesExactly(
+				first -> assertThat(first.getDisplayString()).isEqualTo("xyz:echo-macro"), //$NON-NLS-1$
+				identity()::apply);
 		processor.dispose();
 	}
 
@@ -545,7 +543,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals(proposals.length, 5);
+		assertThat(proposals).hasSize(5);
 		assertContains(IAntCoreConstants.DESCRIPTION, proposals);
 		assertContains("implicit - (true | false | on | off | yes | no)", proposals); //$NON-NLS-1$
 		assertContains(IAntCoreConstants.NAME, proposals);
@@ -565,7 +563,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 2);
+		assertThat(proposals).hasSize(2);
 		assertContains("v", proposals); //$NON-NLS-1$
 		assertContains("eclipse", proposals); //$NON-NLS-1$
 		assertTrue("Additional proposal information not correct", proposals[1].getAdditionalProposalInfo().startsWith("Testing Eclipse")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -585,7 +583,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals("There should be one completion proposal", proposals.length, 1); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1);
 		assertContains("str", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -603,7 +601,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals("There should be 1 completion proposal", proposals.length, 1); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1);
 		assertTrue("Proposal not correct", proposals[0].getDisplayString().equals("some-tasks")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("Additional proposal information not correct", proposals[0].getAdditionalProposalInfo().endsWith("Not required")); //$NON-NLS-1$ //$NON-NLS-2$
 		processor.dispose();
@@ -617,21 +615,21 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getTaskProposals("         <", "rename", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertEquals(0, proposals.length);
+		assertThat(proposals).isEmpty();
 
 		proposals = processor.getTaskProposals("       <cl", "property", "cl"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 		ICompletionProposal proposal = proposals[0];
 		assertEquals("classpath", proposal.getDisplayString()); //$NON-NLS-1$
 
 		proposals = processor.getTaskProposals("       <pr", "property", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 		proposal = proposals[0];
 		assertEquals("classpath", proposal.getDisplayString()); //$NON-NLS-1$
 
 		// "<project><target><mk"
 		proposals = processor.getTaskProposals("<project><target><mk", "target", "mk"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 		proposal = proposals[0];
 		assertEquals("mkdir", proposal.getDisplayString()); //$NON-NLS-1$
 		processor.dispose();
@@ -682,7 +680,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("buildtest1.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getAttributeProposals("fail", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(6, proposals.length);
+		assertThat(proposals).hasSize(6);
 
 		assertContains("message", proposals); //$NON-NLS-1$
 		assertContains("if", proposals); //$NON-NLS-1$
@@ -698,13 +696,13 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("mixed.xml")); //$NON-NLS-1$
 		// String string = "<project><target><sql driver=\"\" password=\"\" url=\"\" userid=\"\"></sql><concat></concat>";
 		ICompletionProposal[] proposals = processor.getTaskProposals(getCurrentDocument(), processor.getParentName(getCurrentDocument(), 0, 62), "t"); //$NON-NLS-1$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 		ICompletionProposal proposal = proposals[0];
 		assertEquals("transaction", proposal.getDisplayString()); //$NON-NLS-1$
 
 		proposals = processor.getTaskProposals(getCurrentDocument(), processor.getParentName(getCurrentDocument(), 0, 76), ""); //$NON-NLS-1$
 		// filelist fileset filterchain footer header path
-		assertEquals(6, proposals.length);
+		assertThat(proposals).hasSize(6);
 		proposal = proposals[0];
 		assertEquals("filelist", proposal.getDisplayString()); //$NON-NLS-1$
 		processor.dispose();
@@ -892,14 +890,13 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("empty.xml")); //$NON-NLS-1$
 
 		ICompletionProposal[] proposals = processor.getBuildFileProposals("", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
-		assertEquals("project", proposals[0].getDisplayString()); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1).satisfiesExactly(it -> assertThat(it.getDisplayString()).isEqualTo("project")); //$NON-NLS-1$
 
 		proposals = processor.getBuildFileProposals("            jl", "jl"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(0, proposals.length);
+		assertThat(proposals).isEmpty();
 
 		proposals = processor.getBuildFileProposals("    \n<project></project>", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals(1, proposals.length);
+		assertThat(proposals).hasSize(1);
 		processor.dispose();
 	}
 
@@ -919,7 +916,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// for sure should have project.class.path and project.class.path2 but project.class.path2
 		// should not present itself as a possible reference
-		assertTrue(proposals.length >= 2);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(2);
 		assertContains("project.class.path", proposals); //$NON-NLS-1$
 		assertDoesNotContain("project.class.path2", proposals); //$NON-NLS-1$
 		processor.dispose();
@@ -940,8 +937,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// true false yes no on off
-		System.out.println("Proposals length:" + proposals.length); //$NON-NLS-1$
-		assertTrue(proposals.length == 6);
+		assertThat(proposals).hasSize(6);
 		assertContains("true", proposals); //$NON-NLS-1$
 		assertContains("no", proposals); //$NON-NLS-1$
 		processor.dispose();
@@ -960,7 +956,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), "c"); //$NON-NLS-1$
-		assertEquals("Incorrect number of proposals", 2, proposals.length); //$NON-NLS-1$
+		assertThat(proposals).hasSize(2);
 		assertContains("cool", proposals); //$NON-NLS-1$
 		assertContains("chillin", proposals); //$NON-NLS-1$
 		assertDoesNotContain("awesome", proposals); //$NON-NLS-1$
@@ -980,7 +976,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), "e"); //$NON-NLS-1$
-		assertEquals("Incorrect number of proposals", 1, proposals.length); //$NON-NLS-1$
+		assertThat(proposals).hasSize(1);
 		// the reference to the project by name
 		assertContains("Extension Point Task", proposals); //$NON-NLS-1$
 		processor.dispose();
@@ -999,7 +995,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 1);
+		assertThat(proposals).hasSize(1);
 		assertContains("works", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -1017,7 +1013,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 1);
+		assertThat(proposals).hasSize(1);
 		assertContains("nestedelement", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -1038,7 +1034,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 
 			ICompletionProposal[] proposals = processor.computeCompletionProposals(lineOffset);
 
-			assertTrue("No templates are relevant at the current position. Found: " + proposals.length, proposals.length == 1); //$NON-NLS-1$
+			assertThat(proposals).hasSize(1);
 		}
 		finally {
 			EditorTestHelper.closeAllEditors();
@@ -1058,7 +1054,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertEquals("There should be 6 completion proposals", proposals.length, 6); //$NON-NLS-1$
+		assertThat(proposals).hasSize(6);
 		assertContains("true", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -1076,7 +1072,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), "n"); //$NON-NLS-1$
-		assertTrue(proposals.length == 1);
+		assertThat(proposals).hasSize(1);
 		assertContains(IAntCoreConstants.NAME, proposals);
 		processor.dispose();
 	}
@@ -1094,7 +1090,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 6); // boolean proposals
+		assertThat(proposals).hasSize(6);
 		assertContains("false", proposals); //$NON-NLS-1$
 
 		lineNumber = 3;
@@ -1104,7 +1100,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 6); // boolean proposals
+		assertThat(proposals).hasSize(6);
 		assertContains("true", proposals); //$NON-NLS-1$
 
 		lineNumber = 4;
@@ -1114,7 +1110,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 6); // boolean proposals
+		assertThat(proposals).hasSize(6);
 		assertContains("no", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -1132,7 +1128,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 			editor.getSelectionProvider().setSelection(TextSelection.emptySelection());
 
 			ICompletionProposal[] proposals = processor.computeCompletionProposals(0);
-			assertTrue("Four proposals are relevant at the current position. Found: " + proposals.length, proposals.length == 4); //$NON-NLS-1$
+			assertThat(proposals).hasSize(4);
 			assertContains("project", proposals); //$NON-NLS-1$
 			assertContains("Buildfile template - simple buildfile with two targets", proposals); //$NON-NLS-1$
 			processor.dispose();
@@ -1157,7 +1153,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// for sure should have project.class.path and project.class.path2
-		assertTrue(proposals.length >= 2);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(2);
 		assertContains("project.class.path", proposals); //$NON-NLS-1$
 		assertContains("project.class.path2", proposals); //$NON-NLS-1$
 
@@ -1169,7 +1165,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// for sure should have project.class.path and project.class.path2
-		assertTrue(proposals.length >= 2);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(2);
 		assertContains("project.class.path", proposals); //$NON-NLS-1$
 		assertContains("project.class.path2", proposals); //$NON-NLS-1$
 
@@ -1181,7 +1177,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// for sure should have project.class.path and project.class.path2
-		assertTrue(proposals.length >= 2);
+		assertThat(proposals).hasSizeGreaterThanOrEqualTo(2);
 		assertContains("project.class.path", proposals); //$NON-NLS-1$
 		assertContains("project.class.path2", proposals); //$NON-NLS-1$
 		processor.dispose();
@@ -1202,7 +1198,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// includes all the public targets
-		assertTrue(proposals.length == 8);
+		assertThat(proposals).hasSize(8);
 		assertContains("main", proposals); //$NON-NLS-1$
 		assertContains("testUnless", proposals); //$NON-NLS-1$
 		processor.dispose();
@@ -1223,7 +1219,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
 		// includes all the project attributes
-		assertTrue(proposals.length == 3);
+		assertThat(proposals).hasSize(3);
 		assertContains(IAntCoreConstants.NAME, proposals);
 		assertContains("default", proposals); //$NON-NLS-1$
 		assertContains("basedir", proposals); //$NON-NLS-1$
@@ -1234,7 +1230,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		proposals = processor.getProposalsFromDocument(getCurrentDocument(), "n"); //$NON-NLS-1$
-		assertTrue(proposals.length == 1);
+		assertThat(proposals).hasSize(1);
 		assertContains(IAntCoreConstants.NAME, proposals);
 		processor.dispose();
 	}
@@ -1250,7 +1246,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), "ext"); //$NON-NLS-1$
-		assertTrue(proposals.length == 3);
+		assertThat(proposals).hasSize(3);
 		assertContains("extension-point", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}
@@ -1266,7 +1262,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setColumnNumber(columnNumber);
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(getCurrentDocument(), ""); //$NON-NLS-1$
-		assertTrue(proposals.length == 1);
+		assertThat(proposals).hasSize(1);
 		assertContains("ep-B", proposals); //$NON-NLS-1$
 		processor.dispose();
 	}

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -53,8 +54,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		Map<String, String> properties = null;
 		String propertyFiles = null;
 		AntTargetNode[] targets = AntUtil.getTargets(buildFile.getAbsolutePath(), getLaunchConfiguration(buildFileName, arguments, properties, propertyFiles));
-		assertTrue(targets != null);
-		assertTrue("Incorrect number of targets retrieved; should be 4 was: " + targets.length, targets.length == 4); //$NON-NLS-1$
+		assertThat(targets).hasSize(4);
 		assertContains("echo3", targets); //$NON-NLS-1$
 	}
 
@@ -66,8 +66,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		Map<String, String> properties = null;
 		String propertyFiles = null;
 		AntTargetNode[] targets = AntUtil.getTargets(buildFile.getAbsolutePath(), getLaunchConfiguration(buildFileName, arguments, properties, propertyFiles));
-		assertTrue(targets != null);
-		assertTrue("Incorrect number of targets retrieved; should be 3 was: " + targets.length, targets.length == 3); //$NON-NLS-1$
+		assertThat(targets).hasSize(3);
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
@@ -81,8 +80,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		properties.put("importFileName", "notToBeImported.xml"); //$NON-NLS-1$ //$NON-NLS-2$
 		String propertyFiles = null;
 		AntTargetNode[] targets = AntUtil.getTargets(buildFile.getAbsolutePath(), getLaunchConfiguration(buildFileName, arguments, properties, propertyFiles));
-		assertTrue(targets != null);
-		assertTrue("Incorrect number of targets retrieved; should be 3 was: " + targets.length, targets.length == 3); //$NON-NLS-1$
+		assertThat(targets).hasSize(3);
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
@@ -95,8 +93,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		properties.put("importFileName", "toBeImported.xml"); //$NON-NLS-1$ //$NON-NLS-2$
 		String propertyFiles = null;
 		AntTargetNode[] targets = AntUtil.getTargets(buildFile.getAbsolutePath(), getLaunchConfiguration(buildFileName, arguments, properties, propertyFiles));
-		assertTrue(targets != null);
-		assertTrue("Incorrect number of targets retrieved; should be 3 was: " + targets.length, targets.length == 3); //$NON-NLS-1$
+		assertThat(targets).hasSize(3);
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
@@ -108,8 +105,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		Map<String, String> properties = null;
 		String propertyFiles = "buildtest1.properties"; //$NON-NLS-1$
 		AntTargetNode[] targets = AntUtil.getTargets(buildFile.getAbsolutePath(), getLaunchConfiguration(buildFileName, arguments, properties, propertyFiles));
-		assertTrue(targets != null);
-		assertTrue("Incorrect number of targets retrieved; should be 3 was: " + targets.length, targets.length == 3); //$NON-NLS-1$
+		assertThat(targets).hasSize(3);
 		assertContains("import-default", targets); //$NON-NLS-1$
 	}
 
@@ -242,7 +238,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		String[] expectedTargets = { "deploy", "commonLv1.deploy", "commonLv1.commonLv2.deploySuper", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				"commonLv1.commonLv2.commonLv3.deployLv3", "commonLv1.commonLv2.commonLv3.commonLv4.deployLv4" }; //$NON-NLS-1$ //$NON-NLS-2$
 		// Expected targets
-		Assert.assertEquals(3380, targets.length);
+		assertThat(targets).hasSize(3380);
 		// Just test if the mentioned targets are contained
 		for (String expectedTarget : expectedTargets) {
 			assertContains(expectedTarget, targets);

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
@@ -7,12 +7,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.externaltools;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -50,9 +51,7 @@ public class MigrationTests extends AbstractExternalToolTest {
 		assertEquals("refresh scope", config.getAttribute(RefreshTab.ATTR_REFRESH_SCOPE, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		String[] targets = AntLaunchingUtil.getTargetNames(config);
 		assertNotNull("No targets found", targets); //$NON-NLS-1$
-		assertEquals("Wrong number of targets", 2, targets.length); //$NON-NLS-1$
-		assertEquals("target1", targets[0]); //$NON-NLS-1$
-		assertEquals("target2", targets[1]); //$NON-NLS-1$
+		assertThat(targets).containsExactly("target1", "target2"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals(true, config.getAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, false));
 		assertEquals(true, config.getAttribute(IDebugUIConstants.ATTR_LAUNCH_IN_BACKGROUND, false));
 		assertEquals("build kinds", config.getAttribute(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, "")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -100,9 +99,7 @@ public class MigrationTests extends AbstractExternalToolTest {
 		assertEquals("build kinds", config.getAttribute(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("arg1 arg2", config.getAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		String[] targets = AntLaunchingUtil.getTargetNames(config);
-		assertEquals("Wrong number of targets", 2, targets.length); //$NON-NLS-1$
-		assertEquals("target1", targets[0]); //$NON-NLS-1$
-		assertEquals("target2", targets[1]); //$NON-NLS-1$
+		assertThat(targets).containsExactly("target1", "target2"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**

--- a/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
@@ -39,7 +39,9 @@ Require-Bundle: org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.ant.launching,
  org.eclipse.core.externaltools,
  org.eclipse.pde.core
-Import-Package: org.junit.jupiter.api,
+Import-Package: org.assertj.core.api,
+ org.assertj.core.api.iterable,
+ org.junit.jupiter.api,
  org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -29,6 +29,7 @@ Export-Package: org.eclipse.debug.tests,
  org.eclipse.debug.tests.ui,
  org.eclipse.debug.tests.view.memory,
  org.eclipse.debug.tests.viewer.model
-Import-Package: org.assertj.core.api;version="3.24.2"
+Import-Package: org.assertj.core.api;version="3.24.2",
+ org.assertj.core.api.iterable
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.debug.tests

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.breakpoint;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -83,7 +84,7 @@ public class SerialExecutorTest extends AbstractDebugTest {
 		}
 		Job.getJobManager().join(this, null);
 		Job[] jobs = Job.getJobManager().find(this);
-		assertEquals(0, jobs.length);
+		assertThat(jobs).isEmpty();
 		long stop = System.nanoTime();
 		long millis = (stop - start) / 1000_000;
 		assertEquals(RUNS, executions.get());
@@ -112,7 +113,7 @@ public class SerialExecutorTest extends AbstractDebugTest {
 		}
 		Job.getJobManager().join(this, null);
 		Job[] jobs = Job.getJobManager().find(this);
-		assertEquals(0, jobs.length);
+		assertThat(jobs).isEmpty();
 		assertEquals(RUNS, executions.get());
 	}
 
@@ -128,7 +129,7 @@ public class SerialExecutorTest extends AbstractDebugTest {
 		}
 		Job.getJobManager().join(this, null);
 		Job[] jobs = Job.getJobManager().find(this);
-		assertEquals(0, jobs.length);
+		assertThat(jobs).isEmpty();
 		assertEquals(RUNS, executions.get());
 	}
 
@@ -152,7 +153,7 @@ public class SerialExecutorTest extends AbstractDebugTest {
 			}
 			Job.getJobManager().join(this, null);
 			Job[] jobs = Job.getJobManager().find(this);
-			assertEquals(0, jobs.length);
+			assertThat(jobs).isEmpty();
 			assertEquals("failed on run " + run, RUNS, executions.get());
 			// does fail on run ~ 40 if the final job.join() is removed.
 		}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.debug.tests.console;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -50,7 +51,7 @@ public class ConsoleTests extends AbstractDebugTest {
 		// abcdef need 1 byte in UTF-8 each
 		// Ã¤Ã¶Ã¼ (\u00e4\u00f6\u00fc) need 2 bytes each
 		byte[] testStringBuffer = testString.getBytes(StandardCharsets.UTF_8);
-		assertEquals("Test string \"" + testString + "\" should consist of 12 UTF-8 bytes", 12, testStringBuffer.length); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(testStringBuffer).as("Test string \"" + testString + "\" should consist of 12 UTF-8 bytes").hasSize(12);
 		MessageConsole console = new MessageConsole("Test Console", //$NON-NLS-1$
 				IConsoleConstants.MESSAGE_CONSOLE_TYPE, null, StandardCharsets.UTF_8.name(), true);
 		IDocument document = console.getDocument();
@@ -78,7 +79,7 @@ public class ConsoleTests extends AbstractDebugTest {
 	public void testConsoleOutputStreamLastR() throws IOException {
 		String testString = "a\r"; //$NON-NLS-1$
 		byte[] testStringBuffer = testString.getBytes(StandardCharsets.UTF_8);
-		assertEquals("Test string \"" + testString + "\" should consist of 2 UTF-8 bytes", 2, testStringBuffer.length); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(testStringBuffer).as("Test string \"" + testString + "\" should consist of 2 UTF-8 bytes").hasSize(2);
 		MessageConsole console = new MessageConsole("Test Console 2", //$NON-NLS-1$
 				IConsoleConstants.MESSAGE_CONSOLE_TYPE, null, StandardCharsets.UTF_8.name(), true);
 		IDocument document = console.getDocument();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.console;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -634,8 +635,7 @@ public final class IOConsoleTestUtil {
 	public IOConsoleTestUtil verifyPartitions(final int offset, final int length, final String expectedType, final boolean allowMixedTypes, final boolean allowGaps, int minPartitionNumber) {
 		{
 			final ITypedRegion[] partitions = getPartitioner().computePartitioning(offset, length);
-			assertNotNull("Got no partitions.", partitions);
-			assertTrue("Got less partitions than expected.", partitions.length >= minPartitionNumber);
+			assertThat(partitions).as("number of partitions").hasSizeGreaterThanOrEqualTo(minPartitionNumber);
 
 			// points to offset after last partition range aka. expected start
 			// of next partition

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.console;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -744,7 +745,8 @@ public class IOConsoleTests extends AbstractDebugTest {
 		final IOConsoleTestUtil c = getTestUtil("Test IConsoleDocumentPartitioner");
 		try (IOConsoleOutputStream otherOut = c.getConsole().newOutputStream()) {
 			StyleRange[] styles = c.getPartitioner().getStyleRanges(0, 1);
-			assertEquals("Got fake styles.", 0, (styles == null ? 0 : styles.length));
+			assertThat(styles).satisfiesAnyOf(it -> assertThat(it).isNull(),
+					it -> assertThat(it).hasSize(0));
 
 			c.insertAndVerify("#\n");
 			c.insertTyping("L");
@@ -762,32 +764,32 @@ public class IOConsoleTests extends AbstractDebugTest {
 			styles = c.getPartitioner().getStyleRanges(0, c.getContentLength());
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertTrue("Expected more styles.", styles.length >= 3);
+			assertThat(styles).hasSizeGreaterThanOrEqualTo(3);
 
 			styles = c.getPartitioner().getStyleRanges(5, 20);
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertEquals("Number of styles:", 1, styles.length);
+			assertThat(styles).hasSize(1);
 
 			styles = c.getPartitioner().getStyleRanges(loremEnd + 1, 1);
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertEquals("Number of styles:", 1, styles.length);
+			assertThat(styles).hasSize(1);
 
 			styles = c.getPartitioner().getStyleRanges(loremEnd, c.getContentLength() - loremEnd);
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertEquals("Number of styles:", 2, styles.length);
+			assertThat(styles).hasSize(2);
 
 			styles = c.getPartitioner().getStyleRanges(loremEnd - 3, 5);
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertEquals("Number of styles:", 2, styles.length);
+			assertThat(styles).hasSize(2);
 
 			styles = c.getPartitioner().getStyleRanges(loremEnd - 3, 8);
 			checkOverlapping(styles);
 			assertNotNull("Partitioner provided no styles.", styles);
-			assertEquals("Number of styles:", 3, styles.length);
+			assertThat(styles).hasSize(3);
 
 
 			assertTrue("Offset should be read-only.", c.getPartitioner().isReadOnly(0));
@@ -814,14 +816,14 @@ public class IOConsoleTests extends AbstractDebugTest {
 				assertTrue("Area should be read-only.", extension.isReadOnly(6, 105));
 				assertTrue("Area should be read-only.", extension.containsReadOnly(8, 111));
 
-				assertTrue("Read-only parts not found.", extension.computeReadOnlyPartitions().length > 0);
-				assertTrue("Writable parts not found.", extension.computeWritablePartitions().length > 0);
-				assertTrue("Read-only parts not found.", extension.computeReadOnlyPartitions(loremEnd - 5, 7).length > 0);
-				assertTrue("Writable parts not found.", extension.computeWritablePartitions(loremEnd - 5, 7).length > 0);
-				assertTrue("Area should be read-only.", extension.computeReadOnlyPartitions(5, 100).length > 0);
-				assertEquals("Area should be read-only.", 0, extension.computeWritablePartitions(5, 100).length);
-				assertEquals("Area should be writable.", 0, extension.computeReadOnlyPartitions(loremEnd, 2).length);
-				assertTrue("Area should be writable.", extension.computeWritablePartitions(loremEnd, 2).length > 0);
+				assertThat(extension.computeReadOnlyPartitions()).as("has read-only parts").hasSizeGreaterThan(0);
+				assertThat(extension.computeWritablePartitions()).as("has writable parts").hasSizeGreaterThan(0);
+				assertThat(extension.computeReadOnlyPartitions(loremEnd - 5, 7)).as("has read-only parts").hasSizeGreaterThan(0);
+				assertThat(extension.computeWritablePartitions(loremEnd - 5, 7)).as("has writable parts").hasSizeGreaterThan(0);
+				assertThat(extension.computeReadOnlyPartitions(5, 100)).as("area is readable").hasSizeGreaterThan(0);
+				assertThat(extension.computeWritablePartitions(5, 100)).as("area is read-only").isEmpty();
+				assertThat(extension.computeReadOnlyPartitions(loremEnd, 2)).as("area is not read-only").isEmpty();
+				assertThat(extension.computeWritablePartitions(loremEnd, 2)).as("area is writable").hasSizeGreaterThan(0);
 
 				assertEquals("Got wrong offset.", 0, extension.getNextOffsetByState(0, false));
 				assertEquals("Got wrong offset.", 2, extension.getNextOffsetByState(0, true));

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
@@ -15,7 +15,6 @@ package org.eclipse.debug.tests.console;
 
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -75,7 +74,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 			launchManager.addLaunch(launch);
 			// do not wait on input read job
 			TestUtil.waitForJobs(name.getMethodName(), 0, 10000, ProcessConsole.class);
-			assertEquals("No console was added.", 1, consoleManager.getConsoles().length);
+			assertThat(consoleManager.getConsoles()).as("console has been added").hasSize(1);
 		} finally {
 			mockProcess.destroy();
 		}
@@ -83,7 +82,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 		if (launch != null) {
 			launchManager.removeLaunch(launch);
 			TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
-			assertEquals("Console is not removed.", 0, consoleManager.getConsoles().length);
+			assertThat(consoleManager.getConsoles()).as("console has been removed").isEmpty();
 		}
 	}
 
@@ -132,7 +131,9 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 		assertThat(openConsoles).as(failureMessage).hasSameSizeAs(launches);
 
 		final ConsoleRemoveAllTerminatedAction removeAction = new ConsoleRemoveAllTerminatedAction();
-		assertTrue("Remove terminated action should be enabled.", removeAction.isEnabled() || launchManager.getLaunches().length == 0);
+		if (launchManager.getLaunches().length != 0) {
+			assertThat(removeAction).matches(ConsoleRemoveAllTerminatedAction::isEnabled, "is enabled");
+		}
 		removeAction.run();
 		TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
 		assertNull("First console not removed.", processConsoleManager.getConsole(process1));

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -214,10 +214,10 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				console.initialize();
 				@SuppressWarnings("restriction")
 				final Class<?> jobFamily = org.eclipse.debug.internal.ui.views.console.ProcessConsole.class;
-				assertTrue("Input read job not started.", Job.getJobManager().find(jobFamily).length > 0);
+				assertThat(Job.getJobManager().find(jobFamily)).as("check input read job started").hasSizeGreaterThan(0);
 				Job.getJobManager().cancel(jobFamily);
 				TestUtil.waitForJobs(name.getMethodName(), 0, 1000);
-				assertEquals("Input read job not canceled.", 0, Job.getJobManager().find(jobFamily).length);
+				assertThat(Job.getJobManager().find(jobFamily)).as("check input read job is canceled").isEmpty();
 			} finally {
 				console.destroy();
 			}
@@ -398,7 +398,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				String expectedPathMsg = MessageFormat.format(org.eclipse.debug.internal.ui.views.console.ConsoleMessages.ProcessConsole_1, new Object[] {
 						outFile.getAbsolutePath() });
 				assertEquals("No or wrong output of redirect file path in console.", expectedPathMsg, doc.get(doc.getLineOffset(0), doc.getLineLength(0)));
-				assertEquals("Expected redirect file path to be linked.", 1, console.getHyperlinks().length);
+				assertThat(console.getHyperlinks()).as("check redirect file path is linked").hasSize(1);
 			}
 			if (checkOutput) {
 				assertEquals("Output not found in console.", new String(testContent), doc.get(doc.getLineOffset(1), doc.getLineLength(1)));

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/expressions/ExpressionManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/expressions/ExpressionManagerTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.expressions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -137,22 +138,6 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 	}
 
 	/**
-	 * Returns the index of the given expression in the given list or -1 if not present.
-	 *
-	 * @param expression candidate
-	 * @param list list to search
-	 * @return index or -1
-	 */
-	private int indexOf(IExpression expression, IExpression[] list) {
-		for (int i = 0; i < list.length; i++) {
-			if (expression.equals(list[i])) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	/**
 	 * Add expressions and ensure proper call backs are received.
 	 */
 	@Test
@@ -168,7 +153,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			IWatchExpression exp3 = manager.newWatchExpression("exp3"); //$NON-NLS-1$
 			manager.addExpressions(new IExpression[]{exp1, exp2, exp3});
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 3, expressions.length); //$NON-NLS-1$
+			assertThat(expressions).containsExactly(exp1, exp2, exp3);
 			assertEquals(single.addedCallbacks, 3);
 			assertEquals(3, single.added.size());
 			assertEquals(0, single.added.indexOf(exp1));
@@ -179,9 +164,6 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(1, multi.addedCallbacks);
 			assertEquals(0, multi.removedCallbacks);
 			assertEquals(0, multi.changedCallbacks);
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp2, expressions));
-			assertEquals(2, indexOf(exp3, expressions));
 		} finally {
 			manager.removeExpressionListener(single);
 			manager.removeExpressionListener(multi);
@@ -205,7 +187,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			manager.addExpressions(new IExpression[]{exp1, exp2, exp3});
 			manager.removeExpressions(new IExpression[]{exp1, exp3});
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 1, expressions.length); //$NON-NLS-1$
+			assertThat(expressions).containsExactly(exp2);
 			assertEquals(single.addedCallbacks, 3);
 			assertEquals(3, single.added.size());
 			assertEquals(0, single.added.indexOf(exp1));
@@ -220,9 +202,6 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(0, multi.removed.indexOf(exp1));
 			assertEquals(1, multi.removed.indexOf(exp3));
 			assertEquals(0, multi.changedCallbacks);
-			assertEquals(-1, indexOf(exp1, expressions));
-			assertEquals(0, indexOf(exp2, expressions));
-			assertEquals(-1, indexOf(exp3, expressions));
 		} finally {
 			manager.removeExpressionListener(single);
 			manager.removeExpressionListener(multi);
@@ -247,7 +226,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			IExpression[] expressions = manager.getExpressions();
 			exp1.setEnabled(false);
 			exp2.setExpressionText("exp2changed"); //$NON-NLS-1$
-			assertEquals("Wrong number of expressions", 3, expressions.length); //$NON-NLS-1$
+			assertThat(expressions).containsExactly(exp1, exp2, exp3);
 			assertEquals(single.addedCallbacks, 3);
 			assertEquals(3, single.added.size());
 			assertEquals(0, single.added.indexOf(exp1));
@@ -262,9 +241,6 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(2, multi.changedCallbacks);
 			assertEquals(0, multi.changed.indexOf(exp1));
 			assertEquals(1, multi.changed.indexOf(exp2));
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp2, expressions));
-			assertEquals(2, indexOf(exp3, expressions));
 		} finally {
 			manager.removeExpressionListener(single);
 			manager.removeExpressionListener(multi);
@@ -288,10 +264,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			IWatchExpression exp5 = manager.newWatchExpression("exp5"); //$NON-NLS-1$
 			manager.addExpressions(new IExpression[]{exp1, exp2, exp3});
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 3, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp2, expressions));
-			assertEquals(2, indexOf(exp3, expressions));
+			assertThat(expressions).containsExactly(exp1, exp2, exp3);
 			// add listeners
 			manager.addExpressionListener(single);
 			manager.addExpressionListener(multi);
@@ -315,12 +288,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(1, insert.inserted.indexOf(exp5));
 
 			expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 5, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp4, expressions));
-			assertEquals(2, indexOf(exp5, expressions));
-			assertEquals(3, indexOf(exp2, expressions));
-			assertEquals(4, indexOf(exp3, expressions));
+			assertThat(expressions).containsExactly(exp1, exp4, exp5, exp2, exp3);
 
 		} finally {
 			manager.removeExpressionListener(single);
@@ -346,10 +314,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			IWatchExpression exp5 = manager.newWatchExpression("exp5"); //$NON-NLS-1$
 			manager.addExpressions(new IExpression[]{exp1, exp2, exp3});
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 3, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp2, expressions));
-			assertEquals(2, indexOf(exp3, expressions));
+			assertThat(expressions).containsExactly(exp1, exp2, exp3);
 			// add listeners
 			manager.addExpressionListener(single);
 			manager.addExpressionListener(multi);
@@ -373,12 +338,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(1, insert.inserted.indexOf(exp5));
 
 			expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 5, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp1, expressions));
-			assertEquals(1, indexOf(exp2, expressions));
-			assertEquals(2, indexOf(exp4, expressions));
-			assertEquals(3, indexOf(exp5, expressions));
-			assertEquals(4, indexOf(exp3, expressions));
+			assertThat(expressions).containsExactly(exp1, exp2, exp4, exp5, exp3);
 
 		} finally {
 			manager.removeExpressionListener(single);
@@ -424,12 +384,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(2, insert.insertIndex);
 
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 5, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp3, expressions));
-			assertEquals(1, indexOf(exp4, expressions));
-			assertEquals(2, indexOf(exp1, expressions));
-			assertEquals(3, indexOf(exp2, expressions));
-			assertEquals(4, indexOf(exp5, expressions));
+			assertThat(expressions).containsExactly(exp3, exp4, exp1, exp2, exp5);
 
 		} finally {
 			manager.removeExpressionListener(single);
@@ -475,12 +430,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 			assertEquals(1, insert.insertIndex);
 
 			IExpression[] expressions = manager.getExpressions();
-			assertEquals("Wrong number of expressions", 5, expressions.length); //$NON-NLS-1$
-			assertEquals(0, indexOf(exp3, expressions));
-			assertEquals(1, indexOf(exp1, expressions));
-			assertEquals(2, indexOf(exp2, expressions));
-			assertEquals(3, indexOf(exp4, expressions));
-			assertEquals(4, indexOf(exp5, expressions));
+			assertThat(expressions).containsExactly(exp3, exp1, exp2, exp4, exp5);
 
 		} finally {
 			manager.removeExpressionListener(single);
@@ -506,12 +456,8 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 		// create a new manager that will restore the expressions
 		ExpressionManager manager2 = new ExpressionManager();
 		IExpression[] expressions = manager2.getExpressions();
-		assertEquals("Wrong number of expressions", 5, expressions.length); //$NON-NLS-1$
-		assertEquals("exp1", expressions[0].getExpressionText()); //$NON-NLS-1$
-		assertEquals("exp2", expressions[1].getExpressionText()); //$NON-NLS-1$
-		assertEquals("exp3", expressions[2].getExpressionText()); //$NON-NLS-1$
-		assertEquals("exp4", expressions[3].getExpressionText()); //$NON-NLS-1$
-		assertEquals("exp5", expressions[4].getExpressionText()); //$NON-NLS-1$
+		assertThat(expressions).hasSize(5) //
+				.extracting(IExpression::getExpressionText).containsExactly("exp1", "exp2", "exp3", "exp4", "exp5");
 	}
 
 	/**
@@ -546,7 +492,7 @@ public class ExpressionManagerTests extends AbstractDebugTest {
 		t2.start();
 		t1.join();
 		t2.join();
-		assertEquals(0, getManager().getExpressions().length);
+		assertThat(getManager().getExpressions()).isEmpty();
 		assertNull(ex[0]);
 	}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
@@ -75,7 +76,7 @@ public class ArgumentParsingTests extends AbstractDebugTest {
 		}
 
 		String[] splitArguments = DebugPlugin.splitArguments(commandLine);
-		assertEquals(expectedArgs.length, splitArguments.length);
+		assertThat(splitArguments).hasSameSizeAs(expectedArgs);
 		String sb = String.join(" ", splitArguments); //$NON-NLS-1$
 		assertEquals(commandLine, sb);
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -505,7 +506,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		wc.doSave();
 
 		ILaunchConfiguration[] newConfigs = getLaunchManager().getLaunchConfigurations();
-		assertTrue("Should be the same number of configs", newConfigs.length == configs.length); //$NON-NLS-1$
+		assertThat(newConfigs).as("compare number of configs").hasSameSizeAs(configs);
 
 		// cleanup
 		handle.delete();
@@ -935,7 +936,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		project.open(null);
 		assertTrue("Should only be local configs when closed", local); //$NON-NLS-1$
 		ILaunchConfiguration[] after = getLaunchManager().getLaunchConfigurations();
-		assertTrue("Should be same number of configs after openning", after.length == before.length); //$NON-NLS-1$
+		assertThat(after).as("compare number of configs").hasSameSizeAs(before);
 		for (ILaunchConfiguration b : before) {
 			assertTrue("Config should exist after openning", existsIn(after, b)); //$NON-NLS-1$
 		}
@@ -1473,11 +1474,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 			chars1 = getInputStreamAsCharArray(in1);
 			chars2 = getInputStreamAsCharArray(in2);
 		}
-		assertEquals("Should be the same characters", chars1.length, chars2.length); //$NON-NLS-1$
-		for (int i = 0; i < chars2.length; i++) {
-			assertEquals("Should be the same character", chars1[i], chars2[i]); //$NON-NLS-1$
-		}
-
+		assertThat(chars1).isEqualTo(chars2);
 	}
 
 	/**
@@ -1554,11 +1551,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 			chars1 = getInputStreamAsCharArray(in1);
 			chars2 = getInputStreamAsCharArray(in2);
 		}
-		assertEquals("Should be the same characters", chars1.length, chars2.length); //$NON-NLS-1$
-		for (int i = 0; i < chars2.length; i++) {
-			assertEquals("Should be the same character", chars1[i], chars2[i]); //$NON-NLS-1$
-		}
-
+		assertThat(chars1).isEqualTo(chars2);
 	}
 
 	/**
@@ -1667,7 +1660,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 			setResourceMappings(wc, new ResourceItem[] { new ResourceItem("test.project", Integer.valueOf(IResource.PROJECT)) }); //$NON-NLS-1$
 			IResource[] res = wc.getMappedResources();
 			assertNotNull("There should be mapped resources", res); //$NON-NLS-1$
-			assertTrue("There should be one project", res.length == 1); //$NON-NLS-1$
+			assertThat(res).hasSize(1);
 		}
 		finally {
 			lc.delete();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchFavoriteTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchFavoriteTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -150,7 +150,7 @@ public class LaunchFavoriteTests extends AbstractLaunchTest {
 		ILaunchConfiguration[] favorites = history.getFavorites();
 		assertNotNull("No favorites", favorites); //$NON-NLS-1$
 		if (size != -1) {
-			assertEquals("Favorites wrong size", size, favorites.length); //$NON-NLS-1$
+			assertThat(favorites).hasSize(size);
 		}
 		for (ILaunchConfiguration favorite : favorites) {
 			if (configuration.equals(favorite)) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchGroupTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchGroupTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -152,10 +153,10 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		grp.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
 
 		ILaunchConfiguration[] history = runHistory.getHistory();
-		assertEquals(3, history.length);
-		assertTrue("history[0] should be Test Group", history[0].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[1] should be Test2", history[1].contentsEqual(t2)); //$NON-NLS-1$
-		assertTrue("history[2] should be Test1", history[2].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(3).satisfiesExactly(//
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp), "is Test Group"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(t2), "is Test2"), //
+				third -> assertThat(third).matches(it -> it.contentsEqual(t1), "is Test1"));
 	}
 
 	@Test
@@ -172,10 +173,10 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		assertTrue("delay was not awaited", (System.currentTimeMillis() - start) >= 2000); //$NON-NLS-1$
 
 		ILaunchConfiguration[] history = runHistory.getHistory();
-		assertEquals(3, history.length);
-		assertTrue("history[0] should be Test Group", history[0].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[1] should be Test2", history[1].contentsEqual(t2)); //$NON-NLS-1$
-		assertTrue("history[2] should be Test1", history[2].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(3).satisfiesExactly(//
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp), "is Test Group"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(t2), "is Test2"), //
+				third -> assertThat(third).matches(it -> it.contentsEqual(t1), "is Test1"));
 	}
 
 	@Test
@@ -218,10 +219,10 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		// terminate? don't think so - at least run the code path to have it
 		// covered.
 		ILaunchConfiguration[] history = runHistory.getHistory();
-		assertEquals(3, history.length);
-		assertTrue("history[0] should be Test Group", history[0].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[1] should be Test2", history[1].contentsEqual(t2)); //$NON-NLS-1$
-		assertTrue("history[2] should be Test1", history[2].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(3).satisfiesExactly(//
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp), "is Test Group"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(t2), "is Test2"), //
+				third -> assertThat(third).matches(it -> it.contentsEqual(t1), "is Test1"));
 	}
 
 	@Test
@@ -237,9 +238,9 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		grp.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
 
 		ILaunchConfiguration[] history = runHistory.getHistory();
-		assertEquals(2, history.length);
-		assertTrue("history[0] should be Test Group", history[0].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[1] should be Test1", history[1].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(2).satisfiesExactly(//
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp), "is Test Group"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(t1), "is Test1"));
 		assertEquals("Test1 should be launched only once", 1, launchCount.get()); //$NON-NLS-1$
 	}
 
@@ -266,11 +267,11 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 
 		ILaunchConfiguration[] history = runHistory.getHistory();
 		assertTrue("post launch should not be run", (System.currentTimeMillis() - startTime) < 9_000); //$NON-NLS-1$
-		assertEquals(4, history.length);
-		assertTrue("history[0] should be Group 3", history[0].contentsEqual(grp3)); //$NON-NLS-1$
-		assertTrue("history[1] should be Group 2", history[1].contentsEqual(grp2)); //$NON-NLS-1$
-		assertTrue("history[2] should be Group 1", history[2].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[3] should be Test1", history[3].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(4).satisfiesExactly( //
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp3), "is Test Group 3"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(grp2), "is Test Group 2"), //
+				third -> assertThat(third).matches(it -> it.contentsEqual(grp), "is Test Group 1"), //
+				fourth -> assertThat(fourth).matches(it -> it.contentsEqual(t1), "is Test1"));
 		assertEquals("Test1 should be launched only once", 1, launchCount.get()); //$NON-NLS-1$
 	}
 
@@ -322,10 +323,10 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 		assertTrue("output was not awaited", (System.currentTimeMillis() - start) >= 2000); //$NON-NLS-1$
 
 		ILaunchConfiguration[] history = runHistory.getHistory();
-		assertEquals(3, history.length);
-		assertTrue("history[0] should be Test Group", history[0].contentsEqual(grp)); //$NON-NLS-1$
-		assertTrue("history[1] should be Test2", history[1].contentsEqual(t2)); //$NON-NLS-1$
-		assertTrue("history[2] should be Test1", history[2].contentsEqual(t1)); //$NON-NLS-1$
+		assertThat(history).hasSize(3).satisfiesExactly(//
+				first -> assertThat(first).matches(it -> it.contentsEqual(grp), "is Test Group"), //
+				second -> assertThat(second).matches(it -> it.contentsEqual(t2), "is Test2"), //
+				third -> assertThat(third).matches(it -> it.contentsEqual(t1), "is Test1"));
 	}
 
 	@Test
@@ -393,15 +394,12 @@ public class LaunchGroupTests extends AbstractLaunchTest {
 
 	private static DummyStream attachDummyProcess(final ILaunch l) {
 		final DummyStream dummy = new DummyStream();
-		final InvocationHandler streamProxyHandler = new InvocationHandler() {
-			@Override
-			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-				String name = method.getName();
-				if (name.equals("getOutputStreamMonitor")) { //$NON-NLS-1$
-					return dummy;
-				}
-				return null;
+		final InvocationHandler streamProxyHandler = (proxy, method, args) -> {
+			String name = method.getName();
+			if (name.equals("getOutputStreamMonitor")) { //$NON-NLS-1$
+				return dummy;
 			}
+			return null;
 		};
 
 		final InvocationHandler handler = new InvocationHandler() {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchHistoryTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchHistoryTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -193,7 +194,7 @@ public class LaunchHistoryTests extends AbstractLaunchTest {
 		config = getLaunchConfiguration("LaunchHistoryTest2"); //$NON-NLS-1$
 		assertNotNull("LaunchHistoryTest2 launch config should not be null", config); //$NON-NLS-1$
 		config.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
-		assertTrue("there should only be two items in the history", runhistory.getHistory().length == getMaxHistorySize()); //$NON-NLS-1$
-		assertTrue("the complete launch history should be greater than or equal to the history size", runhistory.getCompleteLaunchHistory().length >= runhistory.getHistory().length); //$NON-NLS-1$
+		assertThat(runhistory.getHistory()).hasSize(getMaxHistorySize());
+		assertThat(runhistory.getCompleteLaunchHistory()).hasSizeGreaterThanOrEqualTo(runhistory.getHistory().length);
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/RefreshTabTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/RefreshTabTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.launching;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -75,9 +76,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		IResource resource = getProject().getFolder("src"); //$NON-NLS-1$
 		setSelection(resource);
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(resource, result[0]);
+		assertThat(result).containsExactly(resource);
 	}
 
 	/**
@@ -89,9 +88,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		IResource resource = getProject().getFolder("src"); //$NON-NLS-1$
 		setSelection(resource);
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(resource.getParent(), result[0]);
+		assertThat(result).containsExactly(resource.getParent());
 	}
 
 	/**
@@ -103,9 +100,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		IResource resource = getProject().getFolder("src"); //$NON-NLS-1$
 		setSelection(resource);
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(resource.getProject(), result[0]);
+		assertThat(result).containsExactly(resource.getProject());
 	}
 
 	/**
@@ -115,9 +110,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 	public void testWorkspaceScope() throws CoreException {
 		String scope = "${workspace}"; //$NON-NLS-1$
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(ResourcesPlugin.getWorkspace().getRoot(), result[0]);
+		assertThat(result).containsExactly(ResourcesPlugin.getWorkspace().getRoot());
 	}
 
 	/**
@@ -128,9 +121,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		String scope = "${resource:/RefreshTabTests/some.file}"; //$NON-NLS-1$
 		IResource resource = getProject().getFile("some.file"); //$NON-NLS-1$
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(resource, result[0]);
+		assertThat(result).containsExactly(resource);
 	}
 
 	/**
@@ -141,9 +132,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		String scope= "${working_set:<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<launchConfigurationWorkingSet factoryID=\"org.eclipse.ui.internal.WorkingSetFactory\" name=\"workingSet\" editPageId=\"org.eclipse.ui.resourceWorkingSetPage\">\n<item factoryID=\"org.eclipse.ui.internal.model.ResourceFactory\" path=\"/RefreshTabTests/some.file\" type=\"1\"/>\n</launchConfigurationWorkingSet>}"; //$NON-NLS-1$
 		IResource resource = getProject().getFile("some.file"); //$NON-NLS-1$
 		IResource[] result = RefreshTab.getRefreshResources(scope);
-		assertNotNull(result);
-		assertEquals(1, result.length);
-		assertEquals(resource, result[0]);
+		assertThat(result).containsExactly(resource);
 	}
 
 	/**
@@ -199,11 +188,7 @@ public class RefreshTabTests extends AbstractLaunchTest {
 		IResource[] resources = new IResource[] { getProject(), getProject().getFile("not.exist"), getProject().getFile("some.file") }; //$NON-NLS-1$ //$NON-NLS-2$
 		String memento = RefreshUtil.toMemento(resources);
 		IResource[] restore = RefreshUtil.toResources(memento);
-		assertNotNull(resources);
-		assertEquals(resources.length, restore.length);
-		assertEquals(resources[0], restore[0]);
-		assertEquals(resources[1], restore[1]);
-		assertEquals(resources[2], restore[2]);
+		assertThat(restore).containsExactly(resources);
 	}
 
 	/**
@@ -213,7 +198,6 @@ public class RefreshTabTests extends AbstractLaunchTest {
 	public void testEmptyResourceSet() throws CoreException {
 		String memento = RefreshUtil.toMemento(new IResource[]{});
 		IResource[] resources = RefreshUtil.toResources(memento);
-		assertNotNull(resources);
-		assertEquals("Should be empty", 0, resources.length); //$NON-NLS-1$
+		assertThat(resources).isEmpty();
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/stepfilters/StepFiltersTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/stepfilters/StepFiltersTests.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.stepfilters;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -28,14 +28,14 @@ public class StepFiltersTests extends AbstractDebugTest {
 	public void testStepFitlersExtension_01() {
 		IStepFilter[] stepFilters = DebugPlugin.getStepFilters("com.example.lalala.model"); //$NON-NLS-1$
 		assertNotNull(stepFilters);
-		assertEquals(0, stepFilters.length);
+		assertThat(stepFilters).isEmpty();
 	}
 
 	@Test
 	public void testStepFitlersExtension_02() {
 		IStepFilter[] stepFilters = DebugPlugin.getStepFilters("com.example.debug.model"); //$NON-NLS-1$
 		assertNotNull(stepFilters);
-		assertEquals(1, stepFilters.length);
+		assertThat(stepFilters).hasSize(1);
 
 		assertTrue(stepFilters[0].isFiltered(Boolean.TRUE));
 		assertFalse(stepFilters[0].isFiltered(Boolean.FALSE));

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/MemoryRenderingTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/MemoryRenderingTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.view.memory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -35,7 +36,7 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 	public void testRenderingTypes() {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryRenderingType[] types = manager.getRenderingTypes();
-		assertTrue("Wrong number of rendering types contributed", types.length > 6); //$NON-NLS-1$
+		assertThat(types).as("number of contributed rendering types").hasSizeGreaterThan(6);
 		assertTrue("Missing type 1", indexOf(manager.getRenderingType("rendering_type_1"), types) >= 0); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("Missing type 2", indexOf(manager.getRenderingType("rendering_type_2"), types) >= 0); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("Missing type 3", indexOf(manager.getRenderingType("rendering_type_3"), types) >= 0); //$NON-NLS-1$ //$NON-NLS-2$
@@ -59,8 +60,8 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockOne();
 		IMemoryRenderingType[] types = manager.getRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-		assertEquals("Wrong binding", "rendering_type_1", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+				binding -> assertThat(binding.getId()).isEqualTo("rendering_type_1"));
 	}
 
 	@Test
@@ -68,9 +69,9 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockTwo();
 		IMemoryRenderingType[] types = manager.getRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 2, types.length); //$NON-NLS-1$
-		assertTrue("Missing binding", indexOf(manager.getRenderingType("rendering_type_1"), types) >= 0); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Missing binding", indexOf(manager.getRenderingType("rendering_type_2"), types) >= 0); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(2).satisfiesExactly( //
+				firstBinding -> assertThat(firstBinding.getId()).isEqualTo("rendering_type_1"), //
+				secondBinding -> assertThat(secondBinding.getId()).isEqualTo("rendering_type_2"));
 	}
 
 	@Test
@@ -78,8 +79,8 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockOne();
 		IMemoryRenderingType[] types = manager.getDefaultRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-		assertEquals("Wrong binding", "rendering_type_1", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+				binding -> assertThat(binding.getId()).isEqualTo("rendering_type_1"));
 	}
 
 	@Test
@@ -87,7 +88,7 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockTwo();
 		IMemoryRenderingType[] types = manager.getDefaultRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 0, types.length); //$NON-NLS-1$
+		assertThat(types).as("number of bindings").isEmpty();
 	}
 
 	@Test
@@ -111,8 +112,8 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockThree();
 		IMemoryRenderingType[] types = manager.getDefaultRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-		assertEquals("Wrong binding", "rendering_type_3", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+				binding -> assertThat(binding.getId()).isEqualTo("rendering_type_3"));
 	}
 
 	@Test
@@ -120,13 +121,13 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 		IMemoryRenderingManager manager = DebugUITools.getMemoryRenderingManager();
 		IMemoryBlock block = new MemoryBlockDynamic();
 		IMemoryRenderingType[] types = manager.getRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-		assertEquals("Wrong binding", "rendering_type_1", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+				binding -> assertThat(binding.getId()).isEqualTo("rendering_type_1"));
 		types = manager.getDefaultRenderingTypes(block);
-		assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-		assertEquals("Wrong binding", "rendering_type_1", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+				binding -> assertThat(binding.getId()).isEqualTo("rendering_type_1"));
 		IMemoryRenderingType type = manager.getPrimaryRenderingType(block);
-		assertEquals("Wrong bindings", manager.getRenderingType("rendering_type_1"), type); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(type).as("has correct binding").isEqualTo(manager.getRenderingType("rendering_type_1"));
 	}
 
 	@Test
@@ -146,8 +147,8 @@ public class MemoryRenderingTests extends AbstractDebugTest {
 			DynamicRenderingBindings.setBinding("rendering_type_2"); //$NON-NLS-1$
 			assertTrue("Renderings should have changed", changed[0]); //$NON-NLS-1$
 			types = manager.getRenderingTypes(block);
-			assertEquals("Wrong number of bindings", 1, types.length); //$NON-NLS-1$
-			assertEquals("Wrong binding", "rendering_type_2", types[0].getId()); //$NON-NLS-1$ //$NON-NLS-2$
+			assertThat(types).as("number of bindings").hasSize(1).satisfiesExactly( //
+					binding -> assertThat(binding.getId()).isEqualTo("rendering_type_2"));
 		} finally {
 			// restore original bindings
 			DynamicRenderingBindings.setBinding("rendering_type_1"); //$NON-NLS-1$

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;
@@ -232,7 +233,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		// Verify that the replaced element is in viewer now (i.e. it's not filtered out.
 		TreePath[] replacedElementPaths = fViewer.getElementPaths(replacedElement);
-		assertTrue(replacedElementPaths.length != 0);
+		assertThat(replacedElementPaths).hasSizeGreaterThan(0);
 	}
 
 	@Test
@@ -281,7 +282,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		// Verify that the replaced element is in viewer now (i.e. it's not filtered out.
 		TreePath[] replacedElementPaths = fViewer.getElementPaths(replacedElement);
-		assertTrue(replacedElementPaths.length != 0);
+		assertThat(replacedElementPaths).hasSizeGreaterThan(0);
 	}
 
 	@Test
@@ -371,13 +372,13 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true, filters);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
 		assertTrue( StateTests.areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
 
 		// Note: in past it was observed sub-optimal coalescing in this test due
@@ -396,13 +397,13 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true, filters);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertTrue(!getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
 		assertTrue( StateTests.areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
 
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModel.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TestModel.java
@@ -14,13 +14,14 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.eclipse.core.runtime.PlatformObject;
-
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ICheckUpdate;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IChildrenCountUpdate;
@@ -42,13 +43,10 @@ import org.eclipse.debug.internal.ui.viewers.model.provisional.ITreeModelViewer;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IViewerUpdate;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ModelDelta;
 import org.eclipse.debug.internal.ui.viewers.provisional.AbstractModelProxy;
-
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
-
 import org.eclipse.swt.widgets.Display;
-
 import org.junit.Assert;
 
 /**
@@ -164,8 +162,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 			} else {
 				TestElement[] children = element.getChildren();
 
-				for (int i = 0; i < children.length; i++) {
-					installSubModelProxies(path.createChildPath(children[i]), delta.addNode(children[i], IModelDelta.NO_CHANGE));
+				for (TestElement child : children) {
+					installSubModelProxies(path.createChildPath(child), delta.addNode(child, IModelDelta.NO_CHANGE));
 				}
 			}
 		}
@@ -221,8 +219,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 			return atDepth;
 		}
 		int depth = atDepth + 1;
-		for (int i = 0; i < children.length; i++) {
-			depth = Math.max(depth, getDepth(children[i], atDepth + 1));
+		for (TestElement child : children) {
+			depth = Math.max(depth, getDepth(child, atDepth + 1));
 		}
 
 		return depth;
@@ -246,8 +244,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 	public void processQueuedUpdates() {
 		List<IViewerUpdate> updates = new ArrayList<>(fQueuedUpdates);
 		fQueuedUpdates.clear();
-		for (int i = 0; i < updates.size(); i++) {
-			processUpdate(updates.get(i));
+		for (IViewerUpdate update : updates) {
+			processUpdate(update);
 		}
 	}
 
@@ -268,8 +266,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 	}
 
 	private void processUpdates(IViewerUpdate[] updates) {
-		for (int i = 0; i < updates.length; i++) {
-			processUpdate(updates[i]);
+		for (IViewerUpdate update : updates) {
+			processUpdate(update);
 		}
 	}
 
@@ -401,8 +399,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 
 	private void doSetExpanded(TestElement element) {
 		element.fExpanded = true;
-		for (int i = 0; i < element.fChildren.length; i++) {
-			doSetExpanded(element.fChildren[i]);
+		for (TestElement fChild : element.fChildren) {
+			doSetExpanded(fChild);
 		}
 	}
 
@@ -412,8 +410,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 
 	private void doSetAllAppendix(TestElement element, String appendix) {
 		element.setLabelAppendix(appendix);
-		for (int i = 0; i < element.fChildren.length; i++) {
-			doSetAllAppendix(element.fChildren[i], appendix);
+		for (TestElement fChild : element.fChildren) {
+			doSetAllAppendix(fChild, appendix);
 		}
 	}
 
@@ -437,18 +435,22 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 			TestElement[] children = element.getChildren();
 
 			int viewerIndex = 0;
-			for (int i = 0; i < children.length; i++) {
-				if (TestModelUpdatesListener.isFiltered(children[i], filters)) {
+			for (TestElement child : children) {
+				if (TestModelUpdatesListener.isFiltered(child, filters)) {
 					continue;
 				}
-				Assert.assertEquals(children[i], viewer.getChildElement(path, viewerIndex));
-				validateData(viewer, path.createChildPath(children[i]), expandedElementsOnly, filters);
+				Assert.assertEquals(child, viewer.getChildElement(path, viewerIndex));
+				validateData(viewer, path.createChildPath(child), expandedElementsOnly, filters);
 				viewerIndex++;
 			}
 			Assert.assertEquals(viewerIndex, viewer.getChildCount(path));
 		} else if (!viewer.getExpandedState(path)) {
 			// If element not expanded, verify the plus sign.
-			Assert.assertTrue(viewer.getHasChildren(path) == element.getChildren().length > 0);
+			if (viewer.getHasChildren(path)) {
+				assertThat(element.getChildren()).hasSizeGreaterThan(0);
+			} else {
+				assertThat(element.getChildren()).isEmpty();
+			}
 		}
 	}
 
@@ -683,8 +685,8 @@ public class TestModel implements IElementContentProvider, IElementLabelProvider
 		builder.append(element.toString());
 		builder.append('\n');
 		TestElement[] children = element.getChildren();
-		for (int i = 0; i < children.length; i++) {
-			builder.append(getElementString(children[i], indent + "  ")); //$NON-NLS-1$
+		for (TestElement child : children) {
+			builder.append(getElementString(child, indent + "  ")); //$NON-NLS-1$
 		}
 		return builder.toString();
 	}


### PR DESCRIPTION
In order to reduce/avoid usage of ambiguous `assertEquals` (hard to distinguish expected/actual) and prepare for a migration to JUnit 5 with swapped expected/actual parameters in the `assertEquals` signature, this change replaces certain `assertEquals` calls with AssertJ assertions:
* Replace `assertEquals(MESSAGE, EXPECTED, ACTUAL.length)` with
`assertThat(ACTUAL).describedAs(MESSAGE).hasSize(EXPECTED))` and remove obsolete message where possible
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL).hasSize(EXPECTED))`
* Replace `assertEquals(EXPECTED, ACTUAL.length)` with `assertThat(ACTUAL.length, is(EXPECTED))` if `ACTUAL` is a primitive type array
* Replace `hasSize(0)` with `isEmpty()` to improve failure messages
* Combine array size comparison with array contents comparison where possible

### What I Did

Initial changes are the result of two regex replacements:
#### Length assertions with message
Find: `assertEquals\((.*), (.*), (.*)\.length\);`
Insert: `assertThat\($3\)\.as\($1\)\.hasSize\($2)\);`

#### Length assertions without message
Find: `assertEquals\((.*), (.*)\.length\);`
Insert: `assertThat\($2\)\.hasSize\($1)\);`

Further improvements, in particular the combination of size and content assertions, is manual work.

### Benefits
* Improved failure messages:
  * When an empty array is asserted, the non-empty array will be reported in case of a failure
  * When size and content of an array are validated, the test will not fail reporting an improper size but reporting the mismatching elements
* Improved comprehensibility due to matchers giving more semantics to the validations than plain assertEquals
* Eased migration to JUnit 5: `assertEquals` statements would need to adapted during a migration from JUnit 4 to 5 because expected/actual parameters are swapped