### PR TITLE
Remove not needed target-platform-configuration

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem.linux.aarch64/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.linux.aarch64/pom.xml
@@ -25,22 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>aarch64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/resources/bundles/org.eclipse.core.filesystem.linux.ppc64le/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.linux.ppc64le/pom.xml
@@ -25,22 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>ppc64le</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/resources/bundles/org.eclipse.core.filesystem.linux.x86_64/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.linux.x86_64/pom.xml
@@ -21,25 +21,6 @@
   <version>1.2.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>build-natives</id>

--- a/resources/bundles/org.eclipse.core.filesystem.macosx/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.macosx/pom.xml
@@ -25,22 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>macosx</os>
-              <ws>cocoa</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/resources/bundles/org.eclipse.core.filesystem.win32.x86_64/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.win32.x86_64/pom.xml
@@ -21,22 +21,4 @@
   <version>1.4.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/resources/bundles/org.eclipse.core.resources.win32.x86_64/pom.xml
+++ b/resources/bundles/org.eclipse.core.resources.win32.x86_64/pom.xml
@@ -18,22 +18,4 @@
   <version>3.5.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/team/bundles/org.eclipse.compare.win32/pom.xml
+++ b/team/bundles/org.eclipse.compare.win32/pom.xml
@@ -25,22 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <!-- tycho is not able to automatically determine os/ws/arch of this bundle -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/team/bundles/org.eclipse.core.net.linux/pom.xml
+++ b/team/bundles/org.eclipse.core.net.linux/pom.xml
@@ -26,20 +26,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/team/bundles/org.eclipse.core.net.win32.x86_64/pom.xml
+++ b/team/bundles/org.eclipse.core.net.win32.x86_64/pom.xml
@@ -25,21 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/team/bundles/org.eclipse.core.net.win32/pom.xml
+++ b/team/bundles/org.eclipse.core.net.win32/pom.xml
@@ -25,20 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Tycho derives it from Eclipse-PlatformFilter in manifest file.