### PR TITLE
Improve assertions in org.eclipse.ua.tests

### DIFF
--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/execution/ActionWithParameters.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/execution/ActionWithParameters.java
@@ -14,11 +14,9 @@
 
 package org.eclipse.ua.tests.cheatsheet.execution;
 
-
-import org.junit.Assert;
+import static org.junit.Assert.fail;
 
 import org.eclipse.jface.action.Action;
-
 import org.eclipse.ui.cheatsheets.ICheatSheetAction;
 import org.eclipse.ui.cheatsheets.ICheatSheetManager;
 
@@ -33,7 +31,7 @@ public class ActionWithParameters extends Action implements ICheatSheetAction {
 	 */
 	@Override
 	public void run() {
-		Assert.fail("Should not call this version of run");
+		fail("Should not call this version of run");
 	}
 
 	@Override

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/other/TestCheatSheetCategories.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/other/TestCheatSheetCategories.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.cheatsheet.other;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -41,8 +42,7 @@ public class TestCheatSheetCategories {
 		CheatSheetCollectionElement cheatSheets =
 			CheatSheetRegistryReader.getInstance().getCheatSheets();
 		CheatSheetCollectionElement testCat = findChildCategory(cheatSheets, TEST_CATEGORY);
-		assertNotNull("Cannot find category org.eclipse.ua.tests.cheatsheet.cheatSheetsTestCat",
-							testCat);
+		assertThat(testCat).as("cannot find category org.eclipse.ua.tests.cheatsheet.cheatSheetsTestCat").isNotNull();
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/TolerateTest.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/TolerateTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.cheatsheet.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
@@ -20,7 +22,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheetParser;
 import org.eclipse.ui.internal.cheatsheets.data.ICheatSheet;
-import org.junit.Assert;
 import org.junit.Test;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,8 +37,9 @@ public class TolerateTest {
 		CheatSheetParser parser = new CheatSheetParser();
 		ICheatSheet sheet = parser.parse(url, FrameworkUtil.getBundle(getClass()).getSymbolicName(),
 				CheatSheetParser.SIMPLE_ONLY);
-		Assert.assertEquals("Warning not generated: " + url, IStatus.WARNING, parser.getStatus().getSeverity());
-		Assert.assertNotNull("Tried parsing a tolerable cheat sheet but parser returned null: " + url, sheet);
+		assertThat(parser.getStatus().getSeverity()).as("warning not generated: " + url).isEqualTo(IStatus.WARNING);
+		assertThat(sheet).withFailMessage("tried parsing a tolerable cheat sheet but parser returned null: " + url)
+				.isNotNull();
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/ValidTest.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/ValidTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.cheatsheet.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -23,7 +25,6 @@ import org.eclipse.ua.tests.cheatsheet.util.CheatSheetModelSerializer;
 import org.eclipse.ua.tests.util.FileUtil;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheet;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheetParser;
-import org.junit.Assert;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -39,11 +40,13 @@ public class ValidTest {
 		URL url = FileLocator.find(bundle, path, null);
 		CheatSheetParser parser = new CheatSheetParser();
 		CheatSheet sheet = (CheatSheet) parser.parse(url, bundle.getSymbolicName(), CheatSheetParser.ANY);
-		Assert.assertNotNull("Tried parsing a valid cheat sheet but parser returned null: " + url, sheet);
+		assertThat(sheet).as("tried parsing a valid cheat sheet but parser returned null: " + url).isNotNull();
 		String expectedPath = "data/cheatsheet/valid/" + getExpected(file);
 		String expected = FileUtil.getContents(bundle, expectedPath);
 		String actual = CheatSheetModelSerializer.serialize(sheet);
-		Assert.assertEquals("The model serialization generated for the cheatsheet did not match the expected result for: " + path, expected, actual);
+		assertThat(actual).as(
+				"the model serialization generated for the cheatsheet did not match the expected result for: " + path)
+				.isEqualTo(expected);
 	}
 
 	private String getExpected(String file) {

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/CheatSheetModelSerializerTest.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/CheatSheetModelSerializerTest.java
@@ -24,7 +24,6 @@ import org.eclipse.ua.tests.util.FileUtil;
 import org.eclipse.ua.tests.util.ResourceFinder;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheet;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheetParser;
-import org.junit.Assert;
 import org.junit.Test;
 import org.osgi.framework.FrameworkUtil;
 
@@ -55,7 +54,7 @@ public class CheatSheetModelSerializerTest {
 			CheatSheetParser parser = new CheatSheetParser();
 			CheatSheet sheet = (CheatSheet) parser.parse(url, FrameworkUtil.getBundle(getClass()).getSymbolicName(),
 					CheatSheetParser.ANY);
-			Assert.assertNotNull("Tried parsing a valid cheat sheet but parser returned null: " + url, sheet);
+			assertThat(sheet).as("tried parsing a valid cheat sheet but parser returned null: " + url).isNotNull();
 
 			try (PrintWriter out = new PrintWriter(
 					new FileOutputStream(FileUtil.getResultFile(url.toString().substring("file:/".length()))))) {

--- a/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/StatusCheck.java
+++ b/ua/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/util/StatusCheck.java
@@ -14,11 +14,10 @@
 
 package org.eclipse.ua.tests.cheatsheet.util;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
-
 
 /**
  * Utilities for checking status
@@ -26,23 +25,17 @@ import org.eclipse.core.runtime.MultiStatus;
 public class StatusCheck {
 
 	public static void assertStatusContains(IStatus status, String text) {
-		if (!status.getMessage().contains(text)) {
-			Assert.fail("Expected status message to contain '" + text + "' actual message is '"
-					+ status.getMessage() + "'");
-		}
+		assertThat(status.getMessage()).contains(text);
 	}
 
 	public static void assertMultiStatusContains(IStatus status, String text) {
-		Assert.assertTrue(status instanceof MultiStatus);
+		assertThat(status).isInstanceOf(MultiStatus.class);
 		IStatus[] children = status.getChildren();
 		for (IStatus element : children) {
 			if (element.getMessage().contains(text)) {
 				return;
 			}
 		}
-		if (!status.getMessage().contains(text)) {
-			Assert.fail("Expected status message to contain '" + text + "' status.toString = '"
-					+ status.toString() + "'");
-		}
+		assertThat(status.getMessage()).contains(text);
 	}
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/dynamic/DynamicXHTMLProcessorTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/dynamic/DynamicXHTMLProcessorTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.dynamic;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,37 +80,37 @@ public class DynamicXHTMLProcessorTest {
 	@Test
 	public void testXhtmlNoCollapseAnchor() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyAnchor.xhtml");
-		assertTrue("Anchor collapsed in " + processed, processed.indexOf("</a>") > 0);
+		assertThat(processed.indexOf("</a>")).as("anchor collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test
 	public void testXhtmlNoCollapseParagraph() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyAnchor.xhtml");
-		assertTrue("Paragraph collapsed in " + processed, processed.indexOf("</p>") > 0);
+		assertThat(processed.indexOf("</p>")).as("paragraph collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test
 	public void testXhtmlNoCollapseAnchorIC() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyAnchorWithComment.xhtml");
-		assertTrue("Anchor collapsed in " + processed, processed.indexOf("</a>") > 0);
+		assertThat(processed.indexOf("</a>")).as("anchor collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test
 	public void testXhtmlNoCollapseParagraphIC() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyAnchorWithComment.xhtml");
-		assertTrue("Paragraph collapsed in " + processed, processed.indexOf("</p>") > 0);
+		assertThat(processed.indexOf("</p>")).as("paragraph collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test
 	public void testXhtmlNoCollapseDiv() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyDiv.xhtml");
-		assertTrue("Div collapsed in " + processed, processed.indexOf("</div>") > 0);
+		assertThat(processed.indexOf("</div>")).as("div collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test
 	public void testXhtmlNoCollapseScript() throws Exception {
 		String processed = process("data/help/dynamic/xhtml/emptyAnchor.xhtml");
-		assertTrue("Div collapsed in " + processed, processed.indexOf("</script>") > 0);
+		assertThat(processed.indexOf("</div>")).as("div collapsed in " + processed).isGreaterThan(0);
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/index/IndexAssemblerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/index/IndexAssemblerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ua.tests.help.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -108,15 +109,17 @@ public class IndexAssemblerTest {
 		assertEquals("topic2", topics[2].getLabel());
 	}
 
-	@Test(expected = SAXParseException.class)
+	@Test
 	public void testInvalid() throws Exception {
 		IndexFileParser parser = new IndexFileParser();
-		IndexContribution contrib = parser.parse(
-				new IndexFile(FrameworkUtil.getBundle(getClass()).getSymbolicName(),
-						"data/help/index/assembler/invalid.xml", "en"));
-		IndexAssembler assembler = new IndexAssembler();
-		List<IndexContribution> contributions = new ArrayList<>(Arrays.asList(contrib));
-		assembler.assemble(contributions, Platform.getNL());
+		assertThrows(SAXParseException.class, () -> {
+			IndexContribution contrib = parser
+					.parse(new IndexFile(FrameworkUtil.getBundle(getClass()).getSymbolicName(),
+							"data/help/index/assembler/invalid.xml", "en"));
+			IndexAssembler assembler = new IndexAssembler();
+			List<IndexContribution> contributions = new ArrayList<>(Arrays.asList(contrib));
+			assembler.assemble(contributions, Platform.getNL());
+		});
 	}
 
 	// Replaces white space between ">" and "<" by a single newline

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/EntityResolutionTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/other/EntityResolutionTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.other;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.io.Reader;
@@ -39,9 +39,9 @@ public class EntityResolutionTest {
 				read = stream.read(buf);
 			}
 			if (isSupportedDtd) {
-				assertTrue("Entity not found", read > 0);
+				assertThat(read).as("entity not found").isGreaterThan(0);
 			} else {
-				assertTrue("Unsupported Entity did not return empty stream", read == -1);
+				assertThat(read).as("unsupported Entity did not return empty stream").isEqualTo(-1);
 			}
 		}
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/HelpDataTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/HelpDataTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.preferences;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -28,7 +29,6 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.help.internal.HelpData;
 import org.eclipse.help.internal.HelpPlugin;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.FrameworkUtil;
@@ -93,9 +93,12 @@ public class HelpDataTest {
 			Set<String> expectedHiddenIndexes = new HashSet<>(Arrays.asList(entry[3]));
 			URL url = FrameworkUtil.getBundle(HelpDataTest.class).getEntry(file);
 			HelpData data = new HelpData(url);
-			Assert.assertEquals("Did not get the expected toc order from help data file " + file, expectedTocOrder, data.getTocOrder());
-			Assert.assertEquals("Did not get the expected hidden tocs from help data file " + file, expectedHiddenTocs, data.getHiddenTocs());
-			Assert.assertEquals("Did not get the expected hidden indexes from help data file " + file, expectedHiddenIndexes, data.getHiddenIndexes());
+			assertThat(data.getTocOrder()).as("toc order from help data file " + file)
+					.containsExactlyElementsOf(expectedTocOrder);
+			assertThat(data.getHiddenTocs()).as("hidden tocs from help data file " + file)
+					.containsExactlyElementsOf(expectedHiddenTocs);
+			assertThat(data.getHiddenIndexes()).as("hidden indexes from help data file " + file)
+					.containsExactlyElementsOf(expectedHiddenIndexes);
 		}
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/preferences/ProductPreferencesTest.java
@@ -24,7 +24,6 @@ import java.util.StringTokenizer;
 import java.util.stream.IntStream;
 
 import org.eclipse.help.internal.util.ProductPreferences;
-import org.junit.Assert;
 import org.junit.Test;
 import org.osgi.framework.FrameworkUtil;
 
@@ -150,7 +149,7 @@ public class ProductPreferencesTest {
 					.mapToObj(i -> ProductPreferences.tokenize(data[i + 3])).collect(toList());
 
 			List<String> actualOrder = ProductPreferences.getOrderedList(items, primaryOrdering, secondaryOrderings, null);
-			Assert.assertEquals("Items in list were not ordered as expected", expectedOrder, actualOrder);
+			assertThat(actualOrder).containsExactlyElementsOf(expectedOrder);
 		}
 	}
 
@@ -161,7 +160,7 @@ public class ProductPreferencesTest {
 			Properties properties = ProductPreferences
 					.loadPropertiesFile(FrameworkUtil.getBundle(getClass()).getSymbolicName(), path);
 
-			Assert.assertNotNull("The result of loading a properties file was unexpectedly null", properties);
+			assertThat(properties).as("result of loading a properties file").isNotNull();
 			assertThat(data).hasSize(properties.size() + 1);
 
 			for (int j=1;j<data.length;++j) {
@@ -169,7 +168,8 @@ public class ProductPreferencesTest {
 				String key = tok.nextToken();
 				String expectedValue = tok.nextToken();
 				String actualValue = properties.getProperty(key);
-				Assert.assertEquals("One of the properties files' keys did not match the expected value: file=" + path + ", key=" + key, expectedValue, actualValue);
+				assertThat(actualValue).as("one of the properties files' keys did not match the expected value: file="
+						+ path + ", key=" + key).isEqualTo(expectedValue);
 			}
 		}
 	}
@@ -189,10 +189,10 @@ public class ProductPreferencesTest {
 
 			String value = ProductPreferences.getValue(key, primary, secondary);
 			if (allowableValues.isEmpty()) {
-				Assert.assertNull("Value should have been null, but was not: " + key, value);
+				assertThat(value).as("value for key: " + key).isNull();
 			}
 			else {
-				Assert.assertTrue("Value returned was not one of the allowable values", allowableValues.contains(value));
+				assertThat(allowableValues).contains(value);
 			}
 		}
 	}
@@ -203,11 +203,11 @@ public class ProductPreferencesTest {
 			String input = data[0];
 			List<String> output = ProductPreferences.tokenize(input);
 
-			Assert.assertNotNull("The tokenized output was unexpectedly null for: " + input, output);
-			assertThat(output).as("check number of tokens").hasSize(data.length - 1);
-
+			assertThat(output).as("tokenized output for: " + input).isNotNull() //
+					.as("check number of tokens").hasSize(data.length - 1);
 			for (int j=0;j<output.size();++j) {
-				Assert.assertEquals("One of the tokens did not match the expected result", data[j + 1], output.get(j));
+				assertThat(output.get(j)).as("one of the tokens did not match the expected result")
+						.isEqualTo(data[j + 1]);
 			}
 		}
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContentServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContentServletTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ua.tests.help.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 
@@ -74,9 +75,9 @@ public class ContentServletTest {
 		assertFalse(remoteContent.equals(enLocalContent));
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testRemoteContentNotFound() throws Exception {
-		RemoteTestUtils.getRemoteContent(UA_TESTS, "/no/such/path.html", "en");
+		assertThrows(IOException.class, () -> RemoteTestUtils.getRemoteContent(UA_TESTS, "/no/such/path.html", "en"));
 	}
 
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContextServletTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/ContextServletTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ua.tests.help.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,9 +73,9 @@ public class ContextServletTest {
 		assertEquals("German Context", topics[0].getAttribute("label"));
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testRemoteContextNotFound() throws Exception {
-		getContextsFromServlet("org.eclipse.ua.tests.no_such_context");
+		assertThrows(IOException.class, () -> getContextsFromServlet("org.eclipse.ua.tests.no_such_context"));
 	}
 
 	protected Element[] getContextsFromServlet(String phrase)

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/SearchIndexCreation.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/SearchIndexCreation.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ua.tests.help.remote;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
@@ -63,7 +63,7 @@ public class SearchIndexCreation {
 		addHrefToIndex(index, "/org.eclipse.ua.tests/data/help/search/test77.htm", false); // Does not exist
 		index.endAddBatch(false, true);
 		int finalCallCount = MockContentServlet.getCallcount();
-		assertEquals("Remote server called", 0, finalCallCount - initialCallCount);
+		assertThat(finalCallCount - initialCallCount).as("Remote server called").isZero();
 	}
 
 	@Test
@@ -77,7 +77,7 @@ public class SearchIndexCreation {
 		addHrefToIndex(index, "/org.eclipse.ua.tests/data/help/search/test77.htm", false); // Does not exist
 		index.endAddBatch(false, true);
 		int finalCallCount = MockContentServlet.getCallcount();
-		assertEquals("Remote server called", 0, finalCallCount - initialCallCount);
+		assertThat(finalCallCount - initialCallCount).as("Remote server called").isZero();
 	}
 
 	@Test
@@ -92,7 +92,7 @@ public class SearchIndexCreation {
 		addHrefToIndex(index, "/org.eclipse.ua.tests/data/help/search/test77.htm", false); // Does not exist
 		index.endAddBatch(false, true);
 		int finalCallCount = MockContentServlet.getCallcount();
-		assertEquals("Remote server called", 0, finalCallCount - initialCallCount);
+		assertThat(finalCallCount - initialCallCount).as("Remote server called").isZero();
 	}
 
 	private void addHrefToIndex(SearchIndexWithIndexingProgress index,

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/AnalyzerTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/AnalyzerTest.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.search;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.help.internal.search.AnalyzerDescriptor;
 import org.junit.Test;
@@ -108,19 +107,17 @@ public class AnalyzerTest {
 	}
 
 	private void checkAnalyzer(String language, String analyzerKind) {
-		AnalyzerDescriptor an = new AnalyzerDescriptor(language);
-
+		String actualLanguageAnalyzerClassName = new AnalyzerDescriptor(language).getAnalyzerClassName();
 		for (String nextLocale : supportedLanguages) {
-			AnalyzerDescriptor expected = new AnalyzerDescriptor(nextLocale);
-			String analyzerClassName = expected.getAnalyzerClassName();
+			String otherLanguageAnalyzerClassName = new AnalyzerDescriptor(nextLocale).getAnalyzerClassName();
 			if (nextLocale.equals(analyzerKind)) {
-				assertEquals("Comparing " + nextLocale + " to " + language, analyzerClassName, an.getAnalyzerClassName());
+				assertThat(otherLanguageAnalyzerClassName).as("comparing analyzer for local: " + nextLocale)
+						.isEqualTo(actualLanguageAnalyzerClassName);
 			} else {
-				assertFalse("Both " + nextLocale + " and " + language + " have value of " + analyzerClassName, analyzerClassName.equals(an.getAnalyzerClassName()));
-
+				assertThat(otherLanguageAnalyzerClassName).as("comparing analyzer for local: " + nextLocale)
+						.isNotEqualTo(actualLanguageAnalyzerClassName);
 			}
 		}
-
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/ExtraDirTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/ExtraDirTest.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.help.search;
 
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -31,7 +32,6 @@ import org.eclipse.help.internal.workingset.AdaptableHelpResource;
 import org.eclipse.help.internal.workingset.AdaptableToc;
 import org.eclipse.help.internal.workingset.WorkingSet;
 import org.eclipse.help.internal.workingset.WorkingSetManager;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ExtraDirTest {
@@ -175,9 +175,7 @@ public class ExtraDirTest {
 			buf.append("While searching for: " + searchWord + ",\n");
 			if (!hrefsToFind.isEmpty()) {
 				buf.append("Some of the expected results were not found:\n");
-				Iterator<String> iter = hrefsToFind.iterator();
-				while (iter.hasNext()) {
-					String missedHref = iter.next();
+				for (String missedHref : hrefsToFind) {
 					buf.append(missedHref + "\n");
 				}
 			}
@@ -186,13 +184,11 @@ public class ExtraDirTest {
 					buf.append("\nAlso,\n");
 				}
 				buf.append("Found some unexpected search results:\n");
-				Iterator<String> iter = unexpectedHrefs.iterator();
-				while (iter.hasNext()) {
-			 		String unexpectedHref = iter.next();
-					buf.append(unexpectedHref + "\n");
+				for (String unexpectedHref : unexpectedHrefs) {
+			 		buf.append(unexpectedHref + "\n");
 				}
 			}
-			Assert.fail(buf.toString());
+			fail(buf.toString());
 		}
 	}
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/PrebuiltIndexCompatibility.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/PrebuiltIndexCompatibility.java
@@ -17,6 +17,7 @@ package org.eclipse.ua.tests.help.search;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,9 +54,9 @@ public class PrebuiltIndexCompatibility {
 	/**
 	 * Test index built with Lucene 8.4.1
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void test8_4_1_IndexUnreadable() throws Exception {
-		checkReadable("data/help/searchindex/index841");
+		assertThrows(IllegalArgumentException.class, () -> checkReadable("data/help/searchindex/index841"));
 	}
 
 	@Test

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchTestUtils.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchTestUtils.java
@@ -14,10 +14,11 @@
 
 package org.eclipse.ua.tests.help.search;
 
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -26,7 +27,6 @@ import org.eclipse.help.internal.search.ISearchQuery;
 import org.eclipse.help.internal.search.SearchHit;
 import org.eclipse.help.internal.search.SearchQuery;
 import org.eclipse.help.internal.search.SearchResults;
-import org.junit.Assert;
 
 public class SearchTestUtils {
 
@@ -38,7 +38,7 @@ public class SearchTestUtils {
 	public static void searchOneLocale(String searchWord, String[] hrefs, String nl) {
 		String unexpected = searchForExpectedResults(searchWord, hrefs, nl);
 		if (unexpected != null) {
-			Assert.fail(unexpected);
+			fail(unexpected);
 		}
 	}
 
@@ -74,9 +74,7 @@ public class SearchTestUtils {
 			buf.append("While searching for: " + searchWord + ",\n");
 			if (!hrefsToFind.isEmpty()) {
 				buf.append("Some of the expected results were not found:\n");
-				Iterator<String> iter = hrefsToFind.iterator();
-				while (iter.hasNext()) {
-					String missedHref = iter.next();
+				for (String missedHref : hrefsToFind) {
 					buf.append(missedHref + "\n");
 				}
 			}
@@ -85,9 +83,7 @@ public class SearchTestUtils {
 					buf.append("\nAlso,\n");
 				}
 				buf.append("Found some unexpected search results:\n");
-				Iterator<String> iter = unexpectedHrefs.iterator();
-				while (iter.hasNext()) {
-					String unexpectedHref = iter.next();
+				for (String unexpectedHref : unexpectedHrefs) {
 					buf.append(unexpectedHref + "\n");
 				}
 			}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocProviderTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/toc/TocProviderTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ua.tests.help.toc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.help.IToc;
 import org.eclipse.help.ITopic;
@@ -36,7 +35,7 @@ public class TocProviderTest {
 				uaToc = toc;
 			}
 		}
-		assertNotNull("User Assistance Tests not found", uaToc);
+		assertThat(uaToc).withFailMessage("User Assistance Tests not found").isNotNull();
 		ITopic[] children = uaToc.getTopics();
 		int generatedParentTopics = 0;
 		for (ITopic child : children) {
@@ -46,7 +45,6 @@ public class TocProviderTest {
 			}
 		}
 		assertEquals(1, generatedParentTopics);
-
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/util/LoadServletUtil.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/util/LoadServletUtil.java
@@ -14,13 +14,15 @@
 
 package org.eclipse.ua.tests.help.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.help.internal.server.WebappManager;
-import org.junit.Assert;
 
 public class LoadServletUtil {
 
@@ -37,7 +39,7 @@ public class LoadServletUtil {
 		setTimeout(connection, 5000);
 		try (InputStream input = url.openStream()) {
 			int firstbyte = input.read();
-			Assert.assertTrue(firstbyte > 0);
+			assertThat(firstbyte).isGreaterThan(0);
 		}
 	}
 
@@ -75,7 +77,7 @@ public class LoadServletUtil {
 					}
 				}
 			} while (nextChar != '$');
-			Assert.assertEquals(uniqueParam, value);
+			assertEquals(uniqueParam, value);
 		}
 	}
 

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/util/ParallelTestSupport.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/util/ParallelTestSupport.java
@@ -14,8 +14,7 @@
 
 package org.eclipse.ua.tests.help.util;
 
-import org.junit.Assert;
-
+import static org.junit.Assert.fail;
 
 public class ParallelTestSupport {
 
@@ -37,7 +36,7 @@ public class ParallelTestSupport {
 				result = e.getMessage();
 			}
 			if (result != null) {
-				Assert.fail(result);
+				fail(result);
 			}
 		}
 	}
@@ -59,14 +58,14 @@ public class ParallelTestSupport {
 					try {
 						Thread.sleep(100);
 					} catch (InterruptedException e) {
-						Assert.fail("Interrupted Exception");
+						fail("Interrupted Exception");
 					}
 				}
 			}
 		} while (!complete);
 		for (int i = 0; i < numberOfThreads; i++) {
 			if (testThreads[i].failureReason != null) {
-				Assert.fail(testThreads[i].failureReason);
+				fail(testThreads[i].failureReason);
 			}
 		}
 	}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/HelpServerInterrupt.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/HelpServerInterrupt.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ua.tests.help.webapp;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
@@ -21,7 +22,6 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import org.eclipse.help.internal.server.WebappManager;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -113,7 +113,7 @@ public class HelpServerInterrupt {
 			setTimeout(connection, 5000);
 			try (InputStream input = connection.getInputStream()) {
 				int firstbyte = input.read();
-				Assert.assertTrue(firstbyte > 0);
+				assertThat(firstbyte).isGreaterThan(0);
 			}
 		} catch (Exception e) {
 			long elapsed = System.currentTimeMillis() - start;

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/ContentServiceTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/webapp/service/ContentServiceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ua.tests.help.webapp.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 
@@ -64,9 +65,9 @@ public class ContentServiceTest extends ContentServletTest {
 	}
 
 	@Override
-	@Test(expected = IOException.class)
+	@Test
 	public void testRemoteContentNotFound() throws Exception {
-		ServicesTestUtils.getRemoteContent(UA_TESTS, "/no/such/path.html", "en");
+		assertThrows(IOException.class, () -> ServicesTestUtils.getRemoteContent(UA_TESTS, "/no/such/path.html", "en"));
 	}
 
 }

--- a/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/anchors/ExtensionReorderingTest.java
+++ b/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/anchors/ExtensionReorderingTest.java
@@ -116,7 +116,7 @@ public class ExtensionReorderingTest {
 
 			try {
 				model.loadModel();
-				assertTrue("Order = " + toString(order), model.hasValidConfig());
+				assertThat(model).matches(IntroModelRoot::hasValidConfig, "Order = " + toString(order));
 				checkModel(model, numContributions);
 			} catch (RuntimeException e) {
 				e.printStackTrace();

--- a/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/parser/ValidTest.java
+++ b/ua/org.eclipse.ua.tests/intro/org/eclipse/ua/tests/intro/parser/ValidTest.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ua.tests.intro.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -28,7 +28,6 @@ import org.eclipse.ua.tests.intro.util.IntroModelSerializerTest;
 import org.eclipse.ua.tests.util.FileUtil;
 import org.eclipse.ui.internal.intro.impl.model.IntroModelRoot;
 import org.eclipse.ui.internal.intro.impl.model.loader.ExtensionPointManager;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
@@ -97,17 +96,19 @@ public class ValidTest {
 
 						String expected = FileUtil.getContents(bundle, FileUtil.getResultFile(content));
 						String actual = serializer.toString();
-						Assert.assertEquals("The model parsed for intro did not match the expected result for: " + id, expected, actual);
+						assertThat(actual).as("the model parsed for intro did not match the expected result for: " + id)
+								.isEqualTo(expected);
 
 						Map<String, String> map = IntroModelSerializerTest.getXHTMLFiles(model);
-						Iterator<Entry<String, String>> iter = map.entrySet().iterator();
-						while (iter.hasNext()) {
-							Entry<String, String> entry = iter.next();
+						for (Entry<String, String> entry : map.entrySet()) {
 							String relativePath = entry.getKey();
 
 							expected = FileUtil.getContents(bundle, FileUtil.getResultFile(relativePath));
 							actual = entry.getValue();
-							Assert.assertEquals("The XHTML generated for intro did not match the expected result for: " + relativePath, expected, actual);
+							assertThat(actual)
+									.as("the XHTML generated for intro did not match the expected result for: "
+											+ relativePath)
+									.isEqualTo(expected);
 						}
 					}
 					return;


### PR DESCRIPTION
Improves the assertions in org.eclipse.ua.tests in order to ease migration to JUnit 5. This includes:
* Replacing assertions with a custom message with AssertJ statements
* Replacing non-static Assert imports