### PR TITLE
Improve assertions in org.eclipse.tips.tests

### DIFF
--- a/ua/org.eclipse.tips.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.tips.tests/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.tips.ui;bundle-version="0.1.0",
  org.eclipse.tips.json;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.tips.tests
-Import-Package: com.google.gson;version="[2.8.6,3.0.0)"
+Import-Package: com.google.gson;version="[2.8.6,3.0.0)",
+ org.assertj.core.api

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageBas64Test.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageBas64Test.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.tips.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.junit.Test;
@@ -29,67 +29,68 @@ public class TipImageBas64Test {
 		return new TipImage(BASE64);
 	}
 
-	@Test(expected = AssertionFailedException.class)
+	@Test
 	public void testAssertHeight() {
-		new TipImage(BASE64).setAspectRatio(1000, 0, false);
+		assertThrows(AssertionFailedException.class, () -> new TipImage(BASE64).setAspectRatio(1000, 0, false));
 	}
 
-	@Test(expected = AssertionFailedException.class)
+	@Test
 	public void testAssertWidth() {
-		new TipImage(BASE64).setAspectRatio(0, 100, false);
+		assertThrows(AssertionFailedException.class, () -> new TipImage(BASE64).setAspectRatio(0, 100, false));
 	}
 
 	@Test
 	public void testSetExtension() {
-		assertTrue(getTipImage().getBase64Image().contains("png"));
+		assertThat(getTipImage().getBase64Image()).contains("png");
 	}
 
 	@Test
 	public void testSetExtension2() {
-		assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
+		assertThat(getTipImage().setExtension("bmp").getBase64Image()).contains("bmp");
 	}
 
 	@Test
 	public void testGetIMGAttributes() {
 		String result = getTipImage().setAspectRatio(1.5).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"555\" height=\"370\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"555\" height=\"370\"");
 	}
 
 	@Test
 	public void testGetBase64() {
-		assertEquals(BASE64, getTipImage().getBase64Image());
+		assertThat(getTipImage().getBase64Image()).isEqualTo(BASE64);
 	}
 
 	@Test
 	public void testSetAspectRatioDouble() {
 		String result = getTipImage().setAspectRatio(1.5).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"555\" height=\"370\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"555\" height=\"370\"");
 	}
 
 	@Test
 	public void testSetAspectRatioIntIntFalse() {
 		String result = getTipImage().setAspectRatio(200, 50, false).getIMGAttributes(100, 100).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"100\" height=\"25\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"100\" height=\"25\"");
 	}
 
 	@Test
 	public void testSetAspectRatioIntIntTrue() {
 		String result = getTipImage().setAspectRatio(400, 300, true).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"400\" height=\"300\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"400\" height=\"300\"");
 	}
 
 	@Test
 	public void testSetMaxHeight() {
 		String imgAttributes = new TipImage(BASE64).setAspectRatio(2).setMaxHeight(300).getIMGAttributes(200, 200);
-		assertTrue(imgAttributes, imgAttributes.trim().equalsIgnoreCase("width=\"200\" height=\"100\""));
+		assertThat(imgAttributes.trim()).isEqualToIgnoringCase("width=\"200\" height=\"100\"");
 	}
 
 	@Test
 	public void testSetMaxWidth() {
 		String imgAttributes = new TipImage(BASE64).setAspectRatio(1.6).setMaxWidth(200).getIMGAttributes(400, 300);
-		assertTrue(imgAttributes, imgAttributes.trim().equalsIgnoreCase("width=\"200\" height=\"125\""));
+		assertThat(imgAttributes.trim()).isEqualToIgnoringCase("width=\"200\" height=\"125\"");
 	}
 
+	@Test
 	public void testTipImage() {
 		new TipImage(BASE64);
 	}
@@ -99,13 +100,13 @@ public class TipImageBas64Test {
 		getTipImage();
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testTipImage3() {
-		new TipImage(BASE64WRONG);
+		assertThrows(RuntimeException.class, () -> new TipImage(BASE64WRONG));
 	}
 
 	public void testTipImage4() {
 		TipImage tipImage = new TipImage(BASE64WRONG2);
-		assertTrue(tipImage.getIMGAttributes(1, 1).contains("plip"));
+		assertThat(tipImage.getIMGAttributes(1, 1)).contains("plip");
 	}
 }

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageURLTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageURLTest.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.tips.core;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -26,14 +27,14 @@ public class TipImageURLTest {
 
 	private static final String URL = "http://remainsoftware.com/img.png";
 
-	@Test(expected = Exception.class)
-	public void testTipImage() throws IOException {
-		new TipImage((URL) null);
+	@Test
+	public void testTipImage() {
+		assertThrows(Exception.class, () -> new TipImage((URL) null));
 	}
 
-	@Test(expected = MalformedURLException.class)
-	public void testTipImage3() throws IOException {
-		new TipImage(new URL("0gl kjfslkfjsl dkfjsldkfjl"));
+	@Test
+	public void testTipImage3() {
+		assertThrows(MalformedURLException.class, () -> new TipImage(new URL("0gl kjfslkfjsl dkfjsldkfjl")));
 	}
 
 	@Test
@@ -49,58 +50,57 @@ public class TipImageURLTest {
 	public void testSetMaxHeight() throws IOException {
 		String imgAttributes = new TipImage(new URL(URL)).setAspectRatio(2).setMaxHeight(300).getIMGAttributes(200,
 				200);
-		assertTrue(imgAttributes, imgAttributes.trim().equalsIgnoreCase("width=\"200\" height=\"100\""));
+		assertThat(imgAttributes.trim()).isEqualToIgnoringCase("width=\"200\" height=\"100\"");
 	}
 
 	@Test
 	public void testSetMaxWidth() throws IOException {
 		String imgAttributes = new TipImage(new URL(URL)).setAspectRatio(1.6).setMaxWidth(200).getIMGAttributes(400,
 				300);
-		assertTrue(imgAttributes, imgAttributes.trim().equalsIgnoreCase("width=\"200\" height=\"125\""));
-
+		assertThat(imgAttributes.trim()).isEqualToIgnoringCase("width=\"200\" height=\"125\"");
 	}
 
-	@Test(expected = AssertionFailedException.class)
-	public void testAssertWidth() throws IOException {
-		new TipImage(new URL(URL)).setAspectRatio(0, 100, false);
+	@Test
+	public void testAssertWidth() {
+		assertThrows(AssertionFailedException.class, () -> new TipImage(new URL(URL)).setAspectRatio(0, 100, false));
 	}
 
-	@Test(expected = AssertionFailedException.class)
-	public void testAssertHeight() throws IOException {
-		new TipImage(new URL(URL)).setAspectRatio(1000, 0, false);
+	@Test
+	public void testAssertHeight() {
+		assertThrows(AssertionFailedException.class, () -> new TipImage(new URL(URL)).setAspectRatio(1000, 0, false));
 	}
 
 	@Test
 	public void testSetAspectRatioIntIntFalse() throws IOException {
 		String result = getTipImage().setAspectRatio(200, 50, false).getIMGAttributes(100, 100).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"100\" height=\"25\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"100\" height=\"25\"");
 	}
 
 	@Test
 	public void testSetAspectRatioIntIntTrue() throws IOException {
 		String result = getTipImage().setAspectRatio(400, 300, true).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"400\" height=\"300\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"400\" height=\"300\"");
 	}
 
 	@Test
 	public void testSetAspectRatioDouble() throws IOException {
 		String result = getTipImage().setAspectRatio(1.5).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"555\" height=\"370\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"555\" height=\"370\"");
 	}
 
 	@Test
 	public void testGetIMGAttributes() throws IOException {
 		String result = getTipImage().setAspectRatio(1.5).getIMGAttributes(740, 370).trim();
-		assertTrue(result, result.equalsIgnoreCase("width=\"555\" height=\"370\""));
+		assertThat(result).isEqualToIgnoringCase("width=\"555\" height=\"370\"");
 	}
 
 	@Test
 	public void testSetExtension() throws IOException {
-		assertTrue(getTipImage().getBase64Image().contains("png"));
+		assertThat(getTipImage().getBase64Image()).contains("png");
 	}
 
 	@Test
 	public void testSetExtension2() throws IOException {
-		assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
+		assertThat(getTipImage().setExtension("bmp").getBase64Image()).contains("bmp");
 	}
 }

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipManagerTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipManagerTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tips.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -66,7 +67,7 @@ public class TipManagerTest {
 		fManager.register(fProvider1);
 		fManager.register(fProvider2);
 		fManager.register(fProvider2);
-		assertEquals(fManager.getProviders().size() + "", 1, fManager.getProviders().size());
+		assertThat(fManager.getProviders()).hasSize(1);
 	}
 
 	@Test
@@ -97,7 +98,7 @@ public class TipManagerTest {
 			}
 		};
 		fManager.register(testTipProvider);
-		assertFalse(test.isEmpty());
+		assertThat(test).isNotEmpty();
 	}
 
 	@Test
@@ -111,7 +112,7 @@ public class TipManagerTest {
 			}
 		};
 		fManager.register(testTipProvider);
-		assertFalse(test.isEmpty());
+		assertThat(test).isNotEmpty();
 	}
 
 	@Test
@@ -130,10 +131,10 @@ public class TipManagerTest {
 			}
 		};
 		m.open(true);
-		assertEquals(1, test.size());
+		assertThat(test).hasSize(1);
 		test.clear();
 		m.open(false);
-		assertEquals(2, test.size());
+		assertThat(test).hasSize(2);
 	}
 
 	@Test
@@ -177,9 +178,9 @@ public class TipManagerTest {
 		fProvider1.setTips(Arrays.asList(new TestTip(fProvider1.getID(), "<b>bold</b>", "Tip 1"),
 				new TestTip(fProvider1.getID(), "<b>bold2</b>", "Tip 2")));
 		fManager.setAsRead(fProvider1.getCurrentTip());
-		assertTrue(fProvider1.getTips().size() + "", fProvider1.getTips().size() == 1);
+		assertThat(fProvider1.getTips()).hasSize(1);
 		fManager.setServeReadTips(true);
-		assertEquals(2, fProvider1.getTips().size());
+		assertThat(fProvider1.getTips()).hasSize(2);
 	}
 
 	@Test

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipProviderTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipProviderTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tips.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -67,14 +68,14 @@ public class TipProviderTest {
 
 	@Test
 	public void testGetTips() {
-		assertEquals(0, fProvider.getTips(null).size());
+		assertThat(fProvider.getTips(null)).isEmpty();
 		createTestData();
 		fManager.setAsRead(fProvider.getNextTip());
-		assertEquals(2, fProvider.getTips(null).size());
-		assertEquals(2, fProvider.getTips(null).size());
-		assertEquals(1, fProvider.getTips().size());
+		assertThat(fProvider.getTips(null)).hasSize(2);
+		assertThat(fProvider.getTips(null)).hasSize(2);
+		assertThat(fProvider.getTips()).hasSize(1);
 		((TipManager) fProvider.getManager()).setServeReadTips(true);
-		assertEquals(2, fProvider.getTips(null).size());
+		assertThat(fProvider.getTips(null)).hasSize(2);
 	}
 
 	private void createTestData() {
@@ -173,9 +174,9 @@ public class TipProviderTest {
 				return Status.OK_STATUS;
 			}
 		};
-		assertEquals(0, p.getTips(null).size());
+		assertThat(p.getTips(null)).isEmpty();
 		fManager.register(p);
-		assertEquals(1, p.getTips(null).size());
+		assertThat(p.getTips(null)).hasSize(1);
 	}
 
 	@Test

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipTest.java
@@ -106,8 +106,8 @@ public class TipTest {
 	public void testEqualsObject() {
 		TestTip testTip = new TestTip(fProvider.getID(), HTML, SUBJECT_TIP);
 		TestTip testTipx = new TestTip(fProvider.getID(), HTML, SUBJECT_TIP);
-		assertFalse(testTip.equals(fTip));
-		assertTrue(testTip.equals(testTipx));
+		assertNotEquals(testTip, fTip);
+		assertEquals(testTip, testTipx);
 		assertNotEquals(fTip, testTip);
 		assertEquals(testTipx, testTip);
 

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/json/internal/UtilTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/json/internal/UtilTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.tips.json.internal;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -58,7 +57,7 @@ public class UtilTest {
 		String jsonString = "{\"first\": \"Wim\", \"last\": \"Jongman\", \"variables\": {\"title\": \"Mr.\", \"age\": 53}}";
 		JsonObject jsonObject = (JsonObject) JsonParser.parseString(jsonString);
 		String replace = Util.replace(jsonObject, input);
-		assertTrue(replace, replace.equals(result));
+		assertEquals(replace, result);
 	}
 
 	@SuppressWarnings("restriction")
@@ -69,7 +68,7 @@ public class UtilTest {
 		String jsonString = "{\"first\": \"Wim\", \"last\": \"Jongman\", \"variables\": {\"title\": \"Mr.\", \"age\": 53}}";
 		JsonObject jsonObject = (JsonObject) JsonParser.parseString(jsonString);
 		String replace = Util.replace(jsonObject, input);
-		assertTrue(replace, replace.equals(result));
+		assertEquals(replace, result);
 	}
 
 	@SuppressWarnings("restriction")
@@ -80,6 +79,6 @@ public class UtilTest {
 		String jsonString = "{\"first\": \"Wim\", \"empty\": \"\", \"variables\": {\"title\": \"Mr.\", \"age\": 53}}";
 		JsonObject jsonObject = (JsonObject) JsonParser.parseString(jsonString);
 		String replace = Util.replace(jsonObject, input);
-		assertTrue(replace, replace.equals(result));
+		assertEquals(replace, result);
 	}
 }

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/util/ImageUtilTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/util/ImageUtilTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.tips.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -51,7 +50,7 @@ public class ImageUtilTest {
 		image.dispose();
 		image = new Image(null, ImageUtil.decodeToImage(base64Image));
 		String base64Image2 = ImageUtil.decodeFromImage(image, SWT.IMAGE_PNG);
-		assertTrue(base64Image, base64Image.equals(base64Image2));
+		assertEquals(base64Image2, base64Image);
 		image.dispose();
 
 		Image image2 = new Image(null, ImageUtil.decodeToImage(fImageBase64HTML));
@@ -59,7 +58,7 @@ public class ImageUtilTest {
 		image2.dispose();
 		image2 = new Image(null, ImageUtil.decodeToImage(base64Image3));
 		String base64Image4 = ImageUtil.decodeFromImage(image2, SWT.IMAGE_PNG);
-		assertTrue(base64Image3, base64Image3.equals(base64Image4));
+		assertEquals(base64Image4, base64Image3);
 		image2.dispose();
 	}
 


### PR DESCRIPTION
Improves the assertions in org.eclipse.tips.tests in order to ease migration to JUnit 5. This includes:
* Replacing assertions with a custom message with AssertJ statements
* Replacing equality comparisons in assertTrue/assertFalse statements with AssertJ statements