### PR TITLE
Correct faulty assertion in ExpressionTestsPluginUnloading #1107

### DIFF
--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
@@ -49,7 +49,7 @@ public class ExpressionTestsPluginUnloading {
 		bundle.start();
 		int state = bundle.getState();
 		assertThat(state).withFailMessage("Unexpected bundle state: " + stateToString(state) + " for bundle " + bundle)
-				.isNotEqualTo(Bundle.ACTIVE);
+				.isEqualTo(Bundle.ACTIVE);
 
 		doTestInstanceofICUDecimalFormat(bundle);
 		assertThat(bundle.getState()).as("Instanceof with bundle-local class should load extra bundle")


### PR DESCRIPTION
Fix is verified by local execution.

Note that the affected test is not part of the suite executed in Tycho builds (`AllExpressionTests`), so PR checks will not reflect the fix. The test is only executed in I-Builds via the `test.xml` specification, which is why the regression only showed up in I-Build and fix will also show up there.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1107
