### PR TITLE
Fix AbstractJobTest#waitForCompletion() and Bug_32039#testBug() #1115

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1441,7 +1442,7 @@ public class JobGroupTest extends AbstractJobTest {
 		};
 		job.setJobGroup(jobGroup);
 		job.schedule();
-		waitForCompletion(job, 100);
+		waitForCompletion(job, Duration.ofMillis(100));
 
 		boolean completed = jobGroup.join(1000, null);
 		assertTrue("2.0", completed);

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/YieldTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/YieldTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -430,7 +431,7 @@ public class YieldTest extends AbstractJobTest {
 		barrier.waitForStatus(TestBarrier2.STATUS_START);
 		t.start();
 
-		waitForCompletion(yielding, 5000);
+		waitForCompletion(yielding, Duration.ofSeconds(5));
 		assertTrue(yielding.getResult().isOK());
 	}
 
@@ -518,7 +519,7 @@ public class YieldTest extends AbstractJobTest {
 		barrier.waitForStatus(TestBarrier2.STATUS_START);
 		conflicting.schedule();
 
-		waitForCompletion(conflicting, 5000);
+		waitForCompletion(conflicting, Duration.ofSeconds(5));
 		assertTrue(conflicting.getResult().isOK());
 		barrier.waitForStatus(TestBarrier2.STATUS_BLOCKED);
 	}


### PR DESCRIPTION
The test case Bug_32039#testBug() randomly fails because
* AbstractJobTest#waitForCompletion() is can succeed even if the job is not complete and
* Bug_32039#testBug() does not ensure a proper execution order of rule acquisitions

This change fixes the waitForCompletion() method in terms of enforcing a Duration instead of an integer to be passed as a timeout to avoid faulty units and in terms of really throwing an exception of the job does not complete (in time). It also ensures that the rule acquisition in the Bug_32039#testBug() method always happens in the same order. Since the correction of waitForCompletion() reveals that IJobManagerTest#testBug57656() and IJobManagerTest#testScheduleRace() contained bugs that made the test rely on waitForCompletion() not working properly, they are fixed as well by correcting the job execution times and terminate conditions.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1115