### PR TITLE
Replace assertArrayEquals assertions

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.console;
 
+import static java.nio.file.Files.readAllBytes;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -303,7 +303,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, outFile.getCanonicalPath());
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, true);
 		doConsoleOutputTest(testContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", testContent.getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly(testContent.getBytes());
 	}
 
 	/**
@@ -318,11 +318,11 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_APPEND_TO_FILE, true);
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, true);
 		doConsoleOutputTest(testContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", testContent.getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly(testContent.getBytes());
 
 		String appendedContent = "append";
 		doConsoleOutputTest(appendedContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", (testContent + appendedContent).getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly((testContent + appendedContent).getBytes());
 	}
 
 	/**
@@ -340,19 +340,19 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, outFile.getCanonicalPath());
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, false);
 		IOConsole console = doConsoleOutputTest(testContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", testContent.getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly(testContent.getBytes());
 		assertEquals("Output in console.", 2, console.getDocument().getNumberOfLines());
 
 		outFile = createTmpFile("exhaustive[128-32].out");
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, outFile.getCanonicalPath());
 		console = doConsoleOutputTest(testContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", testContent.getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly(testContent.getBytes());
 		assertEquals("Output in console.", 2, console.getDocument().getNumberOfLines());
 
 		outFile = createTmpFile("ug(ly.out");
 		launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, outFile.getCanonicalPath());
 		console = doConsoleOutputTest(testContent.getBytes(), launchConfigAttributes);
-		assertArrayEquals("Wrong content redirected to file.", testContent.getBytes(), Files.readAllBytes(outFile.toPath()));
+		assertThat(readAllBytes(outFile.toPath())).as("content redirected to file").containsExactly(testContent.getBytes());
 		assertEquals("Output in console.", 2, console.getDocument().getNumberOfLines());
 	}
 
@@ -500,7 +500,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				Predicate<AbstractDebugTest> waitForFileWritten = __ -> {
 					try {
 						TestUtil.processUIEvents(20);
-						return Files.readAllBytes(outFile.toPath()).length < output.length;
+						return readAllBytes(outFile.toPath()).length < output.length;
 					} catch (Exception e) {
 						// try again
 					}
@@ -509,7 +509,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				Function<AbstractDebugTest, String> errorMessageProvider = __ -> {
 					byte[] actualOutput = new byte[0];
 					try {
-						actualOutput = Files.readAllBytes(outFile.toPath());
+						actualOutput = readAllBytes(outFile.toPath());
 					} catch (IOException e) {
 						// Proceed as if output was empty
 					}
@@ -560,6 +560,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		}
 
 		byte[] receivedInput = mockProcess.getReceivedInput();
-		assertArrayEquals(input, receivedInput);
+		assertThat(receivedInput).as("received input").isEqualTo(input);
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/TableRenderingTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/TableRenderingTests.java
@@ -13,10 +13,11 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.view.memory;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigInteger;
+
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IMemoryBlockExtension;
 import org.eclipse.debug.core.model.MemoryByte;
@@ -99,11 +100,11 @@ public class TableRenderingTests {
 
 		rendering.setDisplayEndianess(RenderingsUtil.BIG_ENDIAN);
 		assertEquals(bigEndianString, rendering.getString(null, null, memoryBytes));
-		assertArrayEquals(bytes, rendering.getBytes(null, null, memoryBytes, bigEndianString));
+		assertThat(rendering.getBytes(null, null, memoryBytes, bigEndianString)).containsExactly(bytes);
 
 		rendering.setDisplayEndianess(RenderingsUtil.LITTLE_ENDIAN);
 		assertEquals(littleEndianString, rendering.getString(null, null, memoryBytes));
-		assertArrayEquals(bytes, rendering.getBytes(null, null, memoryBytes, littleEndianString));
+		assertThat(rendering.getBytes(null, null, memoryBytes, littleEndianString)).containsExactly(bytes);
 	}
 
 	private HexIntegerRendering createHexIntegerRendering(int addressableSize) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTransformTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTransformTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -74,8 +74,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 3)); //$NON-NLS-1$
 		transform.removeElementFromFilters(TreePath.EMPTY, element3);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 3)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				0, 2, 5, 6 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(0, 2, 5, 6);
 	}
 
 	@Test
@@ -83,8 +82,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 0)); //$NON-NLS-1$
 		transform.removeElementFromFilters(TreePath.EMPTY, element0);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 0)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				1, 2, 5, 6 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(1, 2, 5, 6);
 	}
 
 	@Test
@@ -92,8 +90,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 7)); //$NON-NLS-1$
 		transform.removeElementFromFilters(TreePath.EMPTY, element7);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 7)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				0, 2, 3, 6 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(0, 2, 3, 6);
 	}
 
 	@Test
@@ -101,8 +98,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 3)); //$NON-NLS-1$
 		transform.clear(TreePath.EMPTY, 3);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 3)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				0, 2, 6, 7 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(0, 2, 6, 7);
 	}
 
 	@Test
@@ -110,8 +106,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 0)); //$NON-NLS-1$
 		transform.clear(TreePath.EMPTY, 0);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 0)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				2, 3, 6, 7 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(2, 3, 6, 7);
 	}
 
 	@Test
@@ -119,8 +114,7 @@ public class FilterTransformTests extends AbstractDebugTest {
 		assertTrue("Element should be filtered", transform.isFiltered(TreePath.EMPTY, 7)); //$NON-NLS-1$
 		transform.clear(TreePath.EMPTY, 7);
 		assertFalse("Element should be unfiltered", transform.isFiltered(TreePath.EMPTY, 7)); //$NON-NLS-1$
-		assertArrayEquals("Wrong filter state", transform.getFilteredChildren(TreePath.EMPTY), new int[] { //$NON-NLS-1$
-				0, 2, 3, 6 });
+		assertThat(transform.getFilteredChildren(TreePath.EMPTY)).as("filter state").containsExactly(0, 2, 3, 6);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileCacheTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileCacheTest.java
@@ -15,7 +15,6 @@ package org.eclipse.core.tests.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -67,7 +66,7 @@ public class FileCacheTest {
 		File cachedFile = store.toLocalFile(EFS.CACHE, getMonitor());
 		assertTrue("1.0", cachedFile.exists());
 		assertTrue("1.1", !cachedFile.isDirectory());
-		assertArrayEquals("1.2", contents, getBytes(cachedFile));
+		assertThat(getBytes(cachedFile)).containsExactly(contents);
 
 		// write out new file contents
 		byte[] newContents = "newContents".getBytes();
@@ -82,7 +81,7 @@ public class FileCacheTest {
 		cachedFile = store.toLocalFile(EFS.CACHE, getMonitor());
 		assertTrue("3.0", cachedFile.exists());
 		assertTrue("3.1", !cachedFile.isDirectory());
-		assertArrayEquals("3.2", newContents, getBytes(cachedFile));
+		assertThat(getBytes(cachedFile)).containsExactly(newContents);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -25,7 +25,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -920,8 +919,7 @@ public class BuilderTest {
 		}
 
 		byte[] result = out.toByteArray();
-		byte[] expected = new byte[] {1, 2, 3, 4, 5};
-		assertArrayEquals(expected, result);
+		assertThat(result).containsExactly(1, 2, 3, 4, 5);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -28,7 +28,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -394,7 +393,7 @@ public class WorkspaceTest {
 		p1.open(new NullProgressMonitor());
 		assertFalse(getWorkspace().getDanglingReferences().containsKey(p1));
 		p2.delete(true, true, new NullProgressMonitor());
-		assertArrayEquals(new IProject[] { p2 }, getWorkspace().getDanglingReferences().get(p1));
+		assertThat(getWorkspace().getDanglingReferences().get(p1)).containsExactly(p2);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTestRule.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTestRule.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
@@ -131,8 +131,7 @@ public class WorkspaceTestRule extends ExternalResource {
 		File workspaceLocation = getWorkspace().getRoot().getLocation().toFile();
 		File[] remainingFilesInWorkspace = workspaceLocation
 				.listFiles(file -> !file.getName().equals(metadataDirectoryName));
-		assertArrayEquals("There are unexpected contents in the workspace folder", new File[0],
-				remainingFilesInWorkspace);
+		assertThat(remainingFilesInWorkspace).as("contents in the workspace folder").isEmpty();
 	}
 
 	/**

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.core.tests.internal.preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -298,18 +297,18 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertArrayEquals("1.1", defaultValue, prefs.getByteArray(key, defaultValue));
+			assertThat(prefs.getByteArray(key, defaultValue)).containsExactly(defaultValue);
 
 			// try for each value in the set
-			for (int i = 0; i < values.length; i++) {
-				byte[] v1 = values[i];
+			for (byte[] value : values) {
+				byte[] v1 = value;
 				byte[] v2 = new byte[] {54};
 				prefs.putByteArray(key, v1);
-				assertArrayEquals("1.2." + i, v1, prefs.getByteArray(key, defaultValue));
+				assertThat(prefs.getByteArray(key, defaultValue)).as(value.toString()).containsExactly(v1);
 				prefs.putByteArray(key, v2);
-				assertArrayEquals("1.3." + i, v2, prefs.getByteArray(key, defaultValue));
+				assertThat(prefs.getByteArray(key, defaultValue)).as(value.toString()).containsExactly(v2);
 				prefs.remove(key);
-				assertArrayEquals("1.4." + i, defaultValue, prefs.getByteArray(key, defaultValue));
+				assertThat(prefs.getByteArray(key, defaultValue)).as(value.toString()).containsExactly(defaultValue);
 			}
 
 			// spec'd to throw a NPE if key is null

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.core.tests.internal.preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -389,8 +388,7 @@ public class PreferencesServiceTest {
 		String[] setOrder = new String[] {TestScope.SCOPE, DefaultScope.SCOPE};
 		service.setDefaultLookupOrder(qualifier, null, setOrder);
 		String[] order = service.getLookupOrder(qualifier, null);
-		assertNotNull("6.0", order);
-		assertArrayEquals("6.1", setOrder, order);
+		assertThat(order).containsExactly(setOrder);
 
 		// get the value, should be the real one
 		for (int i = 0; i < contexts.length; i++) {
@@ -403,8 +401,7 @@ public class PreferencesServiceTest {
 		setOrder = new String[] {DefaultScope.SCOPE, TestScope.SCOPE};
 		service.setDefaultLookupOrder(qualifier, key, setOrder);
 		order = service.getLookupOrder(qualifier, key);
-		assertNotNull("8.0", order);
-		assertArrayEquals("8.1", setOrder, order);
+		assertThat(order).containsExactly(setOrder);
 
 		// get the value, should be the default one
 		for (int i = 0; i < contexts.length; i++) {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
@@ -15,7 +15,6 @@ package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +35,6 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class PatchBuilderTest {
@@ -214,8 +212,7 @@ public class PatchBuilderTest {
 		addLineDelimiters(lines, lineDelimiter);
 		Hunk hunk = (Hunk) PatchBuilder.createHunk(0, lines);
 		String[] actual = hunk.getUnifiedLines();
-		assertTrue(lines != actual);
-		Assert.assertArrayEquals(lines, actual);
+		assertThat(actual).isNotSameAs(lines).containsExactly(lines);
 
 		assertHunkEquals(hunk, (Hunk) filePatches[0].getHunks()[0]);
 	}
@@ -233,8 +230,7 @@ public class PatchBuilderTest {
 		addLineDelimiters(lines, lineDelimiter);
 		Hunk hunk = (Hunk) PatchBuilder.createHunk(0, lines);
 		String[] actual = hunk.getUnifiedLines();
-		assertTrue(lines != actual);
-		Assert.assertArrayEquals(lines, actual);
+		assertThat(actual).isNotSameAs(lines).containsExactly(lines);
 
 		assertHunkEquals(hunk, (Hunk) filePatches[0].getHunks()[0]);
 	}
@@ -251,8 +247,7 @@ public class PatchBuilderTest {
 		addLineDelimiters(lines, lineDelimiter);
 		Hunk hunk = (Hunk) PatchBuilder.createHunk(0, lines);
 		String[] actual = hunk.getUnifiedLines();
-		assertTrue(lines != actual);
-		Assert.assertArrayEquals(lines, actual);
+		assertThat(actual).isNotSameAs(lines).containsExactly(lines);
 
 		assertHunkEquals(hunk, (Hunk) filePatches[0].getHunks()[0]);
 	}
@@ -269,8 +264,7 @@ public class PatchBuilderTest {
 		addLineDelimiters(lines, lineDelimiter);
 		Hunk hunk = (Hunk) PatchBuilder.createHunk(0, lines);
 		String[] actual = hunk.getUnifiedLines();
-		assertTrue(lines != actual);
-		Assert.assertArrayEquals(lines, actual);
+		assertThat(actual).isNotSameAs(lines).containsExactly(lines);
 
 		assertHunkEquals(hunk, (Hunk) filePatches[0].getHunks()[0]);
 	}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
@@ -63,7 +63,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.junit.Assert;
 import org.junit.Test;
 
 import junit.framework.AssertionFailedError;
@@ -495,7 +494,7 @@ public class PatchTest {
 		LineReader expectedContents = new LineReader(PatchUtils.getReader(expt));
 		List<String> expectedLines = expectedContents.readLines();
 
-		Assert.assertArrayEquals(expectedLines.toArray(), inLines.toArray());
+		assertThat(inLines).containsExactlyElementsOf(expectedLines);
 	}
 
 	private void patchWorkspace(String[] originalFiles, String patch, String[] expectedOutcomeFiles, boolean reverse,
@@ -554,7 +553,7 @@ public class PatchTest {
 			LineReader resultReader = new LineReader(new BufferedReader(new StringReader(resultString)));
 			Object[] result = resultReader.readLines().toArray();
 
-			Assert.assertArrayEquals(msg, expected, result);
+			assertThat(result).as(msg).containsExactly(expected);
 		}
 	}
 }


### PR DESCRIPTION
In order to reduce/avoid usage of ambiguous assertArrayEquals (hard to distinguish expected/actual) and prepare for a migration to JUnit 5, this change replaces all calls of `assertArrayEquals` with calls:
* Replace `assertArrayEquals(MESSAGE, EXPECTED, ACTUAL)` with `assertThat(ACTUAL).as(MESSAGE).containsExactly(EXPECTED)` and remove obsolete message where possible
* Remove unnecessary array conversion when lists can be compared