### PR TITLE
Improves assertions in org.eclipse.compare.tests

### DIFF
--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AsyncExecTests.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AsyncExecTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -22,7 +23,9 @@ import java.util.List;
 
 import org.eclipse.compare.internal.WorkQueue;
 import org.eclipse.compare.internal.Worker;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.junit.Test;
 
@@ -99,8 +102,7 @@ public class AsyncExecTests {
 		w.run(new NullProgressMonitor());
 		assertFalse(w.hasWork());
 		assertFalse(w.isWorking());
-		assertEquals(1, worked.size());
-		assertEquals(r, worked.get(0));
+		assertThat(worked).containsExactly(r);
 		// Test two tasks
 		worked.clear();
 		w.add(r);
@@ -112,9 +114,7 @@ public class AsyncExecTests {
 		w.run(new NullProgressMonitor());
 		assertFalse(w.hasWork());
 		assertFalse(w.isWorking());
-		assertEquals(2, worked.size());
-		assertEquals(r, worked.get(0));
-		assertEquals(r2, worked.get(1));
+		assertThat(worked).containsExactly(r, r2);
 		// Test re-add order
 		worked.clear();
 		w.add(r);
@@ -129,9 +129,7 @@ public class AsyncExecTests {
 		w.run(new NullProgressMonitor());
 		assertFalse(w.hasWork());
 		assertFalse(w.isWorking());
-		assertEquals(2, worked.size());
-		assertEquals(r, worked.get(1));
-		assertEquals(r2, worked.get(0));
+		assertThat(worked).containsExactly(r2, r);
 	}
 
 	@Test
@@ -170,9 +168,6 @@ public class AsyncExecTests {
 		w.run(new NullProgressMonitor());
 		assertFalse(w.hasWork());
 		assertFalse(w.isWorking());
-		assertEquals(3, worked.size());
-		assertEquals(r, worked.get(0));
-		assertEquals(r2, worked.get(1));
-		assertEquals(r, worked.get(2));
+		assertThat(worked).containsExactly(r, r2, r);
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ContentMergeViewerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ContentMergeViewerTest.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.contentmergeviewer.ContentMergeViewer;
@@ -107,8 +108,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setLeftDirty(true);
 
-		assertEquals(true, result[0]);
-		assertEquals(true, result[1]);
+		assertTrue(result[0]);
+		assertTrue(result[1]);
 	}
 
 	@Test
@@ -117,8 +118,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setLeftDirty(true);
 
-		assertEquals(true, result[0]);
-		assertEquals(true, result[1]);
+		assertTrue(result[0]);
+		assertTrue(result[1]);
 	}
 
 	@Test
@@ -127,7 +128,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setLeftDirty(true);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -136,7 +137,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setLeftDirty(true);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	// set left to false
@@ -146,7 +147,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setLeftDirty(false);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -155,7 +156,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setLeftDirty(false);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -164,8 +165,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setLeftDirty(false);
 
-		assertEquals(true, result[0]);
-		assertEquals(false, result[1]);
+		assertTrue(result[0]);
+		assertFalse(result[1]);
 	}
 
 	@Test
@@ -174,8 +175,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setLeftDirty(false);
 
-		assertEquals(true, result[0]);
-		assertEquals(false, result[1]);
+		assertTrue(result[0]);
+		assertFalse(result[1]);
 	}
 
 	// set right to true
@@ -185,8 +186,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setRightDirty(true);
 
-		assertEquals(true, result[0]);
-		assertEquals(true, result[1]);
+		assertTrue(result[0]);
+		assertTrue(result[1]);
 	}
 
 	@Test
@@ -195,7 +196,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setRightDirty(true);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -204,8 +205,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setRightDirty(true);
 
-		assertEquals(true, result[0]);
-		assertEquals(true, result[1]);
+		assertTrue(result[0]);
+		assertTrue(result[1]);
 	}
 
 	@Test
@@ -214,7 +215,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setRightDirty(true);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	// set right to false
@@ -224,7 +225,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setRightDirty(false);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -233,8 +234,8 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setRightDirty(false);
 
-		assertEquals(true, result[0]);
-		assertEquals(false, result[1]);
+		assertTrue(result[0]);
+		assertFalse(result[1]);
 	}
 
 	@Test
@@ -243,7 +244,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = false;
 		myContentMergeViewer.setRightDirty(false);
 
-		assertEquals(false, result[0]);
+		assertFalse(result[0]);
 	}
 
 	@Test
@@ -252,7 +253,7 @@ public class ContentMergeViewerTest  {
 		myContentMergeViewer.rightDirty = true;
 		myContentMergeViewer.setRightDirty(false);
 
-		assertEquals(true, result[0]);
-		assertEquals(false, result[1]);
+		assertTrue(result[0]);
+		assertFalse(result[1]);
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DocLineComparatorTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DocLineComparatorTest.java
@@ -13,14 +13,20 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Optional;
 
 import org.eclipse.compare.ICompareFilter;
 import org.eclipse.compare.internal.DocLineComparator;
 import org.eclipse.compare.rangedifferencer.IRangeComparator;
-import org.eclipse.jface.text.*;
-import org.junit.Assert;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
 import org.junit.Test;
 
 public class DocLineComparatorTest {
@@ -36,7 +42,7 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc1, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc2, null, true);
 
-		Assert.assertFalse(comp1.rangesEqual(0, comp2, 0));
+		assertFalse(comp1.rangesEqual(0, comp2, 0));
 	}
 
 	@Test
@@ -50,7 +56,7 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc1, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc2, null, true);
 
-		Assert.assertTrue(comp1.rangesEqual(0, comp2, 0));
+		assertTrue(comp1.rangesEqual(0, comp2, 0));
 	}
 
 	@Test
@@ -89,15 +95,15 @@ public class DocLineComparatorTest {
 
 		IRangeComparator comp1 = new DocLineComparator(doc1, null, false, new ICompareFilter[] { filter }, 'L', Optional.empty());
 		IRangeComparator comp2 = new DocLineComparator(doc2, null, false, new ICompareFilter[] { filter }, 'R', Optional.empty());
-		Assert.assertTrue(comp1.rangesEqual(0, comp2, 0));
+		assertTrue(comp1.rangesEqual(0, comp2, 0));
 
 		IRangeComparator comp3 = new DocLineComparator(doc1, null, true, new ICompareFilter[] { filter }, 'L', Optional.empty());
 		IRangeComparator comp4 = new DocLineComparator(doc3, null, true, new ICompareFilter[] { filter }, 'R', Optional.empty());
-		Assert.assertTrue(comp3.rangesEqual(0, comp4, 0));
+		assertTrue(comp3.rangesEqual(0, comp4, 0));
 
 		IRangeComparator comp5 = new DocLineComparator(doc1, null, false, new ICompareFilter[] { filter }, 'L', Optional.empty());
 		IRangeComparator comp6 = new DocLineComparator(doc3, null, false, new ICompareFilter[] { filter }, 'R', Optional.empty());
-		Assert.assertFalse(comp5.rangesEqual(0, comp6, 0));
+		assertFalse(comp5.rangesEqual(0, comp6, 0));
 	}
 
 	@Test
@@ -181,13 +187,13 @@ public class DocLineComparatorTest {
 				new ICompareFilter[] { filter1, filter2, filter3 }, 'L', Optional.empty());
 		IRangeComparator comp2 = new DocLineComparator(doc2, null, false,
 				new ICompareFilter[] { filter1, filter2, filter3 }, 'R', Optional.empty());
-		Assert.assertTrue(comp1.rangesEqual(0, comp2, 0));
+		assertTrue(comp1.rangesEqual(0, comp2, 0));
 
 		IRangeComparator comp3 = new DocLineComparator(doc1, null, false, new ICompareFilter[] { filter2, filter3 },
 				'L', Optional.empty());
 		IRangeComparator comp4 = new DocLineComparator(doc2, null, false, new ICompareFilter[] { filter2, filter3 },
 				'R', Optional.empty());
-		Assert.assertFalse(comp3.rangesEqual(0, comp4, 0));
+		assertFalse(comp3.rangesEqual(0, comp4, 0));
 	}
 
 	@Test
@@ -261,10 +267,10 @@ public class DocLineComparatorTest {
 				for (ICompareFilter[] filter : filters) {
 					l = new DocLineComparator(docs[i], null, false, filter, 'L', Optional.empty());
 					r = new DocLineComparator(docs[j], null, false, filter, 'R', Optional.empty());
-					Assert.assertFalse(l.rangesEqual(0, r, 0));
+					assertFalse(l.rangesEqual(0, r, 0));
 					l = new DocLineComparator(docs[i], null, true, filter, 'L', Optional.empty());
 					r = new DocLineComparator(docs[j], null, true, filter, 'R', Optional.empty());
-					Assert.assertTrue(l.rangesEqual(0, r, 0));
+					assertTrue(l.rangesEqual(0, r, 0));
 				}
 	}
 
@@ -272,8 +278,10 @@ public class DocLineComparatorTest {
 	public void noWhitespaceContributorSupplied_whitespaceInStringLiteralIgnored() {
 		DocLineComparator left = new DocLineComparator(new Document("str = \"Hello World\""), null, true, null, 'L', Optional.empty());
 		DocLineComparator right = new DocLineComparator(new Document("str = \"HelloWorld\""), null, true, null, 'R', Optional.empty());
-		Assert.assertTrue("whitespace in left document between 'Hello' and 'World' not ignored",left.rangesEqual(0, right, 0));
-		Assert.assertTrue("whitespace in left document between 'Hello' and 'World' not ignored",right.rangesEqual(0, left, 0));
+		assertThat(left.rangesEqual(0, right, 0))
+				.as("whitespace in left document between 'Hello' and 'World' not ignored").isTrue();
+		assertThat(right.rangesEqual(0, left, 0))
+				.as("whitespace in left document between 'Hello' and 'World' not ignored").isTrue();
 	}
 
 	@Test
@@ -313,8 +321,8 @@ public class DocLineComparatorTest {
 		Document rightDocument = new Document(rightSource);
 		DocLineComparator right = new DocLineComparator(rightDocument, null, true, null, 'R',
 				Optional.of(new SimpleIgnoreWhitespaceContributor(rightDocument)));
-		Assert.assertFalse(message, left.rangesEqual(0, right, 0));
-		Assert.assertFalse(message, right.rangesEqual(0, left, 0));
+		assertThat(left.rangesEqual(0, right, 0)).as(message).isFalse();
+		assertThat(right.rangesEqual(0, left, 0)).as(message).isFalse();
 	}
 
 	private void assertRangesEqualWithSimpleIgnoreWhitespaceContrbutor(String message, String leftSource,
@@ -326,8 +334,8 @@ public class DocLineComparatorTest {
 		Document rightDocument = new Document(rightSource);
 		DocLineComparator right = new DocLineComparator(rightDocument, null, true, null, 'R',
 				Optional.of(new SimpleIgnoreWhitespaceContributor(rightDocument)));
-		Assert.assertTrue(message, left.rangesEqual(0, right, 0));
-		Assert.assertTrue(message, right.rangesEqual(0, left, 0));
+		assertThat(left.rangesEqual(0, right, 0)).as(message).isTrue();
+		assertThat(right.rangesEqual(0, left, 0)).as(message).isTrue();
 	}
 
 	@Test
@@ -341,7 +349,7 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc1, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc2, null, true);
 
-		Assert.assertTrue(comp1.rangesEqual(0, comp2, 0));
+		assertTrue(comp1.rangesEqual(0, comp2, 0));
 	}
 
 	@Test
@@ -351,9 +359,8 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc, new Region(0, doc.getLength()), true);
 
-		Assert.assertTrue(comp1.rangesEqual(0, comp2, 0));
-		Assert.assertEquals(comp1.getRangeCount(), comp2.getRangeCount());
-		Assert.assertEquals(1, comp2.getRangeCount());
+		assertTrue(comp1.rangesEqual(0, comp2, 0));
+		assertThat(comp1.getRangeCount()).isEqualTo(comp2.getRangeCount()).isEqualTo(1);
 	}
 
 	@Test
@@ -364,8 +371,7 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc, new Region(0, doc.getLength()), true);
 
-		Assert.assertEquals(comp1.getRangeCount(), comp2.getRangeCount());
-		Assert.assertEquals(1, comp2.getRangeCount());
+		assertThat(comp1.getRangeCount()).isEqualTo(comp2.getRangeCount()).isEqualTo(1);
 	}
 
 	@Test
@@ -376,14 +382,13 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc, new Region(0, doc.getLength()), true);
 
-		Assert.assertEquals(comp1.getRangeCount(), comp2.getRangeCount());
-		Assert.assertEquals(2, comp2.getRangeCount());
+		assertThat(comp1.getRangeCount()).isEqualTo(comp2.getRangeCount()).isEqualTo(2);
 
 		IRangeComparator comp3 = new DocLineComparator(doc, new Region(0, "line1".length()), true);
-		Assert.assertEquals(1, comp3.getRangeCount());
+		assertThat(comp3.getRangeCount()).isEqualTo(1);
 
 		comp3 = new DocLineComparator(doc, new Region(0, "line1".length() + 1), true);
-		Assert.assertEquals(2, comp3.getRangeCount()); // two lines
+		assertThat(comp3.getRangeCount()).isEqualTo(2);
 	}
 
 	@Test
@@ -394,7 +399,7 @@ public class DocLineComparatorTest {
 		IRangeComparator comp1 = new DocLineComparator(doc, null, true);
 		IRangeComparator comp2 = new DocLineComparator(doc, new Region(0, doc.getLength()), true);
 
-		Assert.assertEquals(comp1.getRangeCount(), comp2.getRangeCount());
+		assertThat(comp1.getRangeCount()).isEqualTo(comp2.getRangeCount());
 	}
 
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
@@ -20,10 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -79,16 +76,16 @@ public class FileDiffResultTest {
 		file.create(createInputStream(createPatchAddingFile(project, NEW_FILENAME, false /* the file doesn't exist */)),
 				true, null);
 
-		assertFalse(project.getFile(NEW_FILENAME).exists());
+		assertThat(project.getFile(NEW_FILENAME)).matches(not(IFile::exists), "does not exist");
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
 		assertThat(filePatch).hasSize(1);
 
 		IFilePatchResult filePatchResult = filePatch[0].apply((IStorage) null, patchConfiguration, createTestMonitor());
-		assertTrue(filePatchResult.hasMatches());
+		assertThat(filePatchResult).matches(IFilePatchResult::hasMatches, "has matches");
 		assertThat(filePatchResult.getRejects()).isEmpty();
-		assertEquals("", getStringFromStream(filePatchResult.getOriginalContents()));
-		assertEquals(NEW_FILE_CONTENT, getStringFromStream(filePatchResult.getPatchedContents()));
+		assertThat(getStringFromStream(filePatchResult.getOriginalContents())).isEmpty();
+		assertThat(getStringFromStream(filePatchResult.getPatchedContents())).isEqualTo(NEW_FILE_CONTENT);
 	}
 
 	/**
@@ -106,7 +103,7 @@ public class FileDiffResultTest {
 		IFile file = project.getFile(PATCH_FILE);
 		file.create(createInputStream(createPatchAddingFile(project, NEW_FILENAME, true)), true, null);
 
-		assertTrue(project.getFile(NEW_FILENAME).exists());
+		assertThat(project.getFile(NEW_FILENAME)).matches(IFile::exists, "exists");
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
 		assertThat(filePatch).hasSize(1);
@@ -114,11 +111,11 @@ public class FileDiffResultTest {
 		IFilePatchResult filePatchResult = filePatch[0].apply(project.getFile(NEW_FILENAME), patchConfiguration,
 				createTestMonitor());
 
-		assertFalse(filePatchResult.hasMatches());
+		assertThat(filePatchResult).matches(not(IFilePatchResult::hasMatches), "has no matches");
 		assertThat(filePatchResult.getRejects()).hasSize(1);
 
-		assertNotNull(filePatchResult.getOriginalContents());
-		assertNotNull(filePatchResult.getPatchedContents());
+		assertThat(filePatchResult.getOriginalContents()).isNotNull();
+		assertThat(filePatchResult.getPatchedContents()).isNotNull();
 
 		compareContent(new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile()),
 				filePatchResult.getOriginalContents());
@@ -141,22 +138,22 @@ public class FileDiffResultTest {
 		IFile file = project.getFile(PATCH_FILE);
 		file.create(createInputStream(createPatchAddingFile(project, NEW_FILENAME, false)), true, null);
 
-		assertTrue(project.getFile(NEW_FILENAME).exists());
+		assertThat(project.getFile(NEW_FILENAME)).matches(IFile::exists, "exists");
 
 		IFilePatch[] filePatch = ApplyPatchOperation.parsePatch(file);
 		assertThat(filePatch).hasSize(1);
 
 		IFilePatchResult filePatchResult = filePatch[0].apply(project.getFile(NEW_FILENAME), patchConfiguration,
 				createTestMonitor());
-		assertFalse(filePatchResult.hasMatches());
+		assertThat(filePatchResult).matches(not(IFilePatchResult::hasMatches), "has no matches");
 		assertThat(filePatchResult.getRejects()).hasSize(1);
 
-		assertNotNull(filePatchResult.getOriginalContents());
-		assertNotNull(filePatchResult.getPatchedContents());
+		assertThat(filePatchResult.getOriginalContents()).isNotNull();
+		assertThat(filePatchResult.getPatchedContents()).isNotNull();
 
 		compareContent(new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile()),
 				filePatchResult.getOriginalContents());
-		assertEquals("I'm a different content", getStringFromStream(filePatchResult.getOriginalContents()));
+		assertThat(getStringFromStream(filePatchResult.getOriginalContents())).isEqualTo("I'm a different content");
 		compareContent(filePatchResult.getOriginalContents(), filePatchResult.getPatchedContents());
 	}
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.eclipse.compare.internal.CompareResourceFilter;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class FilterTest {
@@ -24,45 +25,45 @@ public class FilterTest {
 	@Test
 	public void testFilterFile() {
 		CompareResourceFilter f = new CompareResourceFilter();
-		f.setFilters("*.class"); //$NON-NLS-1$
-		Assert.assertTrue("file foo.class should be filtered", f.filter("foo.class", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file foo.java shouldn't be filtered", f.filter("foo.java", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		f.setFilters("*.class");
+		assertThat(f.filter("foo.class", false, false)).as("file foo.class should be filtered").isTrue();
+		assertThat(f.filter("foo.java", false, false)).as("file foo.java should not be filtered").isFalse();
 	}
 
 	@Test
 	public void testFilterDotFile() {
 		CompareResourceFilter f = new CompareResourceFilter();
-		f.setFilters(".cvsignore"); //$NON-NLS-1$
-		Assert.assertTrue("file .cvsignore should be filtered", f.filter(".cvsignore", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file foo.cvsignore shouldn't be filtered", f.filter("foo.cvsignore", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		f.setFilters(".cvsignore");
+		assertThat(f.filter(".cvsignore", false, false)).as("file .cvsignore should be filtered").isTrue();
+		assertThat(f.filter("foo.cvsignore", false, false)).as("file foo.cvsignore should not be filtered").isFalse();
 	}
 
 	@Test
 	public void testFilterFolder() {
 		CompareResourceFilter f = new CompareResourceFilter();
-		f.setFilters("bin/"); //$NON-NLS-1$
-		Assert.assertTrue("folder bin should be filtered", f.filter("bin", true, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file bin shouldn't be filtered", f.filter("bin", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		f.setFilters("bin/");
+		assertThat(f.filter("bin", true, false)).as("folder bin should be filtered").isTrue();
+		assertThat(f.filter("bin", false, false)).as("file bin should not be filtered").isFalse();
 	}
 
 	@Test
 	public void testMultiFilter() {
 		CompareResourceFilter f = new CompareResourceFilter();
-		f.setFilters("*.class, .cvsignore, bin/, src/"); //$NON-NLS-1$
-		Assert.assertTrue("file foo.class should be filtered", f.filter("foo.class", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file foo.java shouldn't be filtered", f.filter("foo.java", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertTrue("file .cvsignore should be filtered", f.filter(".cvsignore", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file foo.cvsignore shouldn't be filtered", f.filter("foo.cvsignore", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertTrue("folder bin should be filtered", f.filter("bin", true, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file bin shouldn't be filtered", f.filter("bin", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertTrue("folder src should be filtered", f.filter("src", true, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		Assert.assertFalse("file src shouldn't be filtered", f.filter("src", false, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		f.setFilters("*.class, .cvsignore, bin/, src/");
+		assertThat(f.filter("foo.class", false, false)).as("file foo.class should be filtered").isTrue();
+		assertThat(f.filter("foo.java", false, false)).as("file foo.java should not be filtered").isFalse();
+		assertThat(f.filter(".cvsignore", false, false)).as("file .cvsignore should be filtered").isTrue();
+		assertThat(f.filter("foo.cvsignore", false, false)).as("file foo.cvsignore should not be filtered").isFalse();
+		assertThat(f.filter("bin", true, false)).as("folder bin should be filtered").isTrue();
+		assertThat(f.filter("bin", false, false)).as("file bin should not be filtered").isFalse();
+		assertThat(f.filter("src", true, false)).as("folder src should be filtered").isTrue();
+		assertThat(f.filter("src", false, false)).as("file src should not be filtered").isFalse();
 	}
 
 	@Test
 	public void testVerify() {
-		Assert.assertNull("filters don't verify",
-				CompareResourceFilter.validateResourceFilters("*.class, .cvsignore, bin/"));
-		Assert.assertNotNull("filters shouldn't verify", CompareResourceFilter.validateResourceFilters("bin//"));
+		assertThat(CompareResourceFilter.validateResourceFilters("*.class, .cvsignore, bin/"))
+				.as("filters don't verify").isNull();
+		assertThat(CompareResourceFilter.validateResourceFilters("bin//")).as("filters shouldn't verify").isNotNull();
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/LineReaderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/LineReaderTest.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -30,20 +29,24 @@ import org.junit.Test;
 public class LineReaderTest  {
 
 	@Test
-	public void testReadEmpty() {
-		LineReader lr= new LineReader(getReader("empty.txt")); //$NON-NLS-1$
-		List<String> inLines= lr.readLines();
-		assertEquals(0, inLines.size());
+	public void testReadEmpty() throws IOException {
+		try (BufferedReader reader = getReader("empty.txt")) {
+			LineReader lr = new LineReader(reader);
+			List<String> inLines = lr.readLines();
+			assertThat(inLines).isEmpty();
+		}
 	}
 
 	@Test
-	public void testReadNormal() {
-		LineReader lr= new LineReader(getReader("normal.txt")); //$NON-NLS-1$
+	public void testReadNormal() throws IOException {
+		try (BufferedReader reader = getReader("normal.txt")) {
+			LineReader lr = new LineReader(reader);
 		List<String> inLines= lr.readLines();
-		assertEquals(3, inLines.size());
-		assertEquals("[1]\n", convertLineDelimeters(inLines.get(0))); //$NON-NLS-1$
-		assertEquals("[2]\n", convertLineDelimeters(inLines.get(1))); //$NON-NLS-1$
-		assertEquals("[3]\n", convertLineDelimeters(inLines.get(2))); //$NON-NLS-1$
+		assertThat(inLines).hasSize(3).satisfiesExactlyInAnyOrder(
+				first -> assertThat(convertLineDelimeters(first)).isEqualTo("[1]\n"),
+				second -> assertThat(convertLineDelimeters(second)).isEqualTo("[2]\n"),
+				third -> assertThat(convertLineDelimeters(third)).isEqualTo("[3]\n"));
+		}
 	}
 
 	private String convertLineDelimeters(Object object) {
@@ -54,26 +57,22 @@ public class LineReaderTest  {
 	}
 
 	@Test
-	public void testReadUnterminatedLastLine() {
-		LineReader lr= new LineReader(getReader("unterminated.txt")); //$NON-NLS-1$
+	public void testReadUnterminatedLastLine() throws IOException {
+		try (BufferedReader reader = getReader("unterminated.txt")) {
+			LineReader lr = new LineReader(reader);
 		List<String> inLines= lr.readLines();
-		assertEquals(3, inLines.size());
-		assertEquals("[1]\n", convertLineDelimeters(inLines.get(0))); //$NON-NLS-1$
-		assertEquals("[2]\n", convertLineDelimeters(inLines.get(1))); //$NON-NLS-1$
-		assertEquals("[3]", inLines.get(2)); //$NON-NLS-1$
+		assertThat(inLines).hasSize(3).satisfiesExactlyInAnyOrder(
+				first -> assertThat(convertLineDelimeters(first)).isEqualTo("[1]\n"),
+				second -> assertThat(convertLineDelimeters(second)).isEqualTo("[2]\n"),
+				third -> assertThat(third).isEqualTo("[3]"));
+		}
 	}
 
-	private BufferedReader getReader(String name) {
+	private BufferedReader getReader(String name) throws IOException {
 		IPath path = IPath.fromOSString("linereaderdata/" + name);
-		URL url;
-		try {
-			url = new URL(CompareTestPlugin.getDefault().getBundle().getEntry("/"), path.toString());
-			InputStream resourceAsStream = url.openStream();
-			InputStreamReader reader2 = new InputStreamReader(resourceAsStream);
-			return new BufferedReader(reader2);
-		} catch ( IOException e) {
-			fail(e.getMessage());
-		}
-		return null;
+		URL url = new URL(CompareTestPlugin.getDefault().getBundle().getEntry("/"), path.toString());
+		InputStream resourceAsStream = url.openStream();
+		InputStreamReader reader2 = new InputStreamReader(resourceAsStream);
+		return new BufferedReader(reader2);
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,14 +57,14 @@ public class PatchBuilderTest {
 
 		IHunk[] hunksAfter = filePatch.getHunks();
 		assertThat(hunksAfter).hasSize(4);
-		assertEquals(3, ((Hunk) hunksAfter[0]).getStart(false));
-		assertEquals(3, ((Hunk) hunksAfter[0]).getStart(true));
-		assertEquals(7, ((Hunk) hunksAfter[1]).getStart(false));
-		assertEquals(11, ((Hunk) hunksAfter[1]).getStart(true));
-		assertEquals(18, ((Hunk) hunksAfter[2]).getStart(false));
-		assertEquals(22, ((Hunk) hunksAfter[2]).getStart(true));
-		assertEquals(28, ((Hunk) hunksAfter[3]).getStart(false));
-		assertEquals(33, ((Hunk) hunksAfter[3]).getStart(true));
+		assertThat(((Hunk) hunksAfter[0]).getStart(false)).isEqualTo(3);
+		assertThat(((Hunk) hunksAfter[0]).getStart(true)).isEqualTo(3);
+		assertThat(((Hunk) hunksAfter[1]).getStart(false)).isEqualTo(7);
+		assertThat(((Hunk) hunksAfter[1]).getStart(true)).isEqualTo(11);
+		assertThat(((Hunk) hunksAfter[2]).getStart(false)).isEqualTo(18);
+		assertThat(((Hunk) hunksAfter[2]).getStart(true)).isEqualTo(22);
+		assertThat(((Hunk) hunksAfter[3]).getStart(false)).isEqualTo(28);
+		assertThat(((Hunk) hunksAfter[3]).getStart(true)).isEqualTo(33);
 
 		IFilePatchResult result = filePatch.apply(Utilities.getReaderCreator(contextStorage), new PatchConfiguration(),
 				new NullProgressMonitor());
@@ -79,7 +78,7 @@ public class PatchBuilderTest {
 		List<String> inLines = lr.readLines();
 		String expected = LineReader.createString(false, inLines);
 
-		assertEquals(expected, PatchUtils.asString(actual));
+		assertThat(PatchUtils.asString(actual)).isEqualTo(expected);
 	}
 
 	@Test
@@ -105,16 +104,16 @@ public class PatchBuilderTest {
 
 		IHunk[] hunksAfter = filePatch.getHunks();
 		assertThat(hunksAfter).hasSize(5);
-		assertEquals(0, ((Hunk) hunksAfter[0]).getStart(false));
-		assertEquals(0, ((Hunk) hunksAfter[0]).getStart(true));
-		assertEquals(3, ((Hunk) hunksAfter[1]).getStart(false));
-		assertEquals(5, ((Hunk) hunksAfter[1]).getStart(true));
-		assertEquals(19, ((Hunk) hunksAfter[2]).getStart(false));
-		assertEquals(25, ((Hunk) hunksAfter[2]).getStart(true));
-		assertEquals(36, ((Hunk) hunksAfter[3]).getStart(false));
-		assertEquals(40, ((Hunk) hunksAfter[3]).getStart(true));
-		assertEquals(46, ((Hunk) hunksAfter[4]).getStart(false));
-		assertEquals(51, ((Hunk) hunksAfter[4]).getStart(true));
+		assertThat(((Hunk) hunksAfter[0]).getStart(false)).isEqualTo(0);
+		assertThat(((Hunk) hunksAfter[0]).getStart(true)).isEqualTo(0);
+		assertThat(((Hunk) hunksAfter[1]).getStart(false)).isEqualTo(3);
+		assertThat(((Hunk) hunksAfter[1]).getStart(true)).isEqualTo(5);
+		assertThat(((Hunk) hunksAfter[2]).getStart(false)).isEqualTo(19);
+		assertThat(((Hunk) hunksAfter[2]).getStart(true)).isEqualTo(25);
+		assertThat(((Hunk) hunksAfter[3]).getStart(false)).isEqualTo(36);
+		assertThat(((Hunk) hunksAfter[3]).getStart(true)).isEqualTo(40);
+		assertThat(((Hunk) hunksAfter[4]).getStart(false)).isEqualTo(46);
+		assertThat(((Hunk) hunksAfter[4]).getStart(true)).isEqualTo(51);
 
 		IFilePatchResult result = filePatch.apply(Utilities.getReaderCreator(contextStorage), new PatchConfiguration(),
 				new NullProgressMonitor());
@@ -128,7 +127,7 @@ public class PatchBuilderTest {
 		List<String> inLines = lr.readLines();
 		String expected = LineReader.createString(false, inLines);
 
-		assertEquals(expected, PatchUtils.asString(actual));
+		assertThat(PatchUtils.asString(actual)).isEqualTo(expected);
 	}
 
 	@Test
@@ -145,12 +144,12 @@ public class PatchBuilderTest {
 
 		IHunk[] hunksAfter = filePatch.getHunks();
 		assertThat(hunksAfter).hasSize(3);
-		assertEquals(19, ((Hunk) hunksAfter[0]).getStart(false));
-		assertEquals(19, ((Hunk) hunksAfter[0]).getStart(true));
-		assertEquals(29, ((Hunk) hunksAfter[1]).getStart(false));
-		assertEquals(27, ((Hunk) hunksAfter[1]).getStart(true));
-		assertEquals(46, ((Hunk) hunksAfter[2]).getStart(false));
-		assertEquals(43, ((Hunk) hunksAfter[2]).getStart(true));
+		assertThat(((Hunk) hunksAfter[0]).getStart(false)).isEqualTo(19);
+		assertThat(((Hunk) hunksAfter[0]).getStart(true)).isEqualTo(19);
+		assertThat(((Hunk) hunksAfter[1]).getStart(false)).isEqualTo(29);
+		assertThat(((Hunk) hunksAfter[1]).getStart(true)).isEqualTo(27);
+		assertThat(((Hunk) hunksAfter[2]).getStart(false)).isEqualTo(46);
+		assertThat(((Hunk) hunksAfter[2]).getStart(true)).isEqualTo(43);
 
 		IFilePatchResult result = filePatch.apply(Utilities.getReaderCreator(contextStorage), new PatchConfiguration(),
 				new NullProgressMonitor());
@@ -164,7 +163,7 @@ public class PatchBuilderTest {
 		List<String> inLines = lr.readLines();
 		String expected = LineReader.createString(false, inLines);
 
-		assertEquals(expected, PatchUtils.asString(actual));
+		assertThat(PatchUtils.asString(actual)).isEqualTo(expected);
 	}
 
 	@Test
@@ -197,7 +196,7 @@ public class PatchBuilderTest {
 		List<String> inLines = lr.readLines();
 		String expected = LineReader.createString(false, inLines);
 
-		assertEquals(expected, PatchUtils.asString(actual));
+		assertThat(PatchUtils.asString(actual)).isEqualTo(expected);
 	}
 
 	@Test
@@ -273,12 +272,12 @@ public class PatchBuilderTest {
 		String[] l1 = h1.getLines();
 		String[] l2 = h2.getLines();
 		assertThat(l1).containsExactly(l2);
-		assertEquals(h1.getStart(false), h2.getStart(false));
-		assertEquals(h1.getStart(true), h2.getStart(true));
-		assertEquals(h1.getLength(false), h2.getLength(false));
-		assertEquals(h1.getLength(true), h2.getLength(true));
-		assertEquals(h1.getHunkType(false), h2.getHunkType(false));
-		assertEquals(h1.getHunkType(true), h2.getHunkType(true));
+		assertThat(h1.getStart(false)).isEqualTo(h2.getStart(false));
+		assertThat(h1.getStart(true)).isEqualTo(h2.getStart(true));
+		assertThat(h1.getLength(false)).isEqualTo(h2.getLength(false));
+		assertThat(h1.getLength(true)).isEqualTo(h2.getLength(true));
+		assertThat(h1.getHunkType(false)).isEqualTo(h2.getHunkType(false));
+		assertThat(h1.getHunkType(true)).isEqualTo( h2.getHunkType(true));
 	}
 
 	private String getLineDelimiter(IStorage storage) throws CoreException, IOException {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchLinesTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchLinesTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.compare.tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -106,7 +105,8 @@ public class PatchLinesTest {
 		assertEquals(2, lines[1]);
 	}
 
-	private int[] parsePatch(String patch) {
+	private int[] parsePatch(String patch)
+			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 		WorkspacePatcher patcher = new WorkspacePatcher();
 		try {
 			patcher.parse(getReader(patch));
@@ -140,41 +140,19 @@ public class PatchLinesTest {
 		return PatchUtils.getReader(name);
 	}
 
-	private int getNewLength(IHunk hunk) {
+	private int getNewLength(IHunk hunk)
+			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 		Class<?> cls = hunk.getClass();
-		try {
-			Field fld = cls.getDeclaredField("fNewLength");
-			fld.setAccessible(true);
-			return fld.getInt(hunk);
-		} catch (SecurityException e) {
-			fail(e.getMessage());
-		} catch (NoSuchFieldException e) {
-			fail(e.getMessage());
-		} catch (IllegalArgumentException e) {
-			fail(e.getMessage());
-		} catch (IllegalAccessException e) {
-			fail(e.getMessage());
-		}
-		fail();
-		return -1;
+		Field fld = cls.getDeclaredField("fNewLength");
+		fld.setAccessible(true);
+		return fld.getInt(hunk);
 	}
 
-	private int getOldLength(IHunk hunk) {
+	private int getOldLength(IHunk hunk)
+			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 		Class<?> cls = hunk.getClass();
-		try {
-			Field fld = cls.getDeclaredField("fOldLength");
-			fld.setAccessible(true);
-			return fld.getInt(hunk);
-		} catch (SecurityException e) {
-			fail(e.getMessage());
-		} catch (NoSuchFieldException e) {
-			fail(e.getMessage());
-		} catch (IllegalArgumentException e) {
-			fail(e.getMessage());
-		} catch (IllegalAccessException e) {
-			fail(e.getMessage());
-		}
-		fail();
-		return -1;
+		Field fld = cls.getDeclaredField("fOldLength");
+		fld.setAccessible(true);
+		return fld.getInt(hunk);
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUtils.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUtils.java
@@ -31,7 +31,6 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Assert;
 import org.osgi.framework.Bundle;
 
 public class PatchUtils {
@@ -168,8 +167,7 @@ public class PatchUtils {
 			URL url = new URL(getBundle().getEntry("/"), path.toString());
 			return url.openStream();
 		} catch (IOException e) {
-			Assert.fail("Failed while reading " + name);
-			return null; // never reached
+			throw new IllegalStateException("failed while reading " + name, e);
 		}
 	}
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/SimpleIgnoreWhitespaceContributor.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/SimpleIgnoreWhitespaceContributor.java
@@ -19,7 +19,6 @@ import java.util.TreeMap;
 import org.eclipse.compare.contentmergeviewer.IIgnoreWhitespaceContributor;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-import org.junit.Assert;
 
 public class SimpleIgnoreWhitespaceContributor implements IIgnoreWhitespaceContributor {
 
@@ -64,7 +63,7 @@ public class SimpleIgnoreWhitespaceContributor implements IIgnoreWhitespaceContr
 				}
 			}
 		} catch (BadLocationException e) {
-			Assert.fail("BadLocationException not expected");
+			throw new IllegalStateException("BadLocationException not expected", e);
 		}
 		return true;
 	}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StructureCreatorTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StructureCreatorTest.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.regex.Matcher;
@@ -21,11 +23,16 @@ import java.util.regex.Pattern;
 
 import org.eclipse.compare.ICompareFilter;
 import org.eclipse.compare.ISharedDocumentAdapter;
-import org.eclipse.compare.structuremergeviewer.*;
+import org.eclipse.compare.structuremergeviewer.DocumentRangeNode;
+import org.eclipse.compare.structuremergeviewer.IStructureComparator;
+import org.eclipse.compare.structuremergeviewer.StructureCreator;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.text.*;
-import org.junit.Assert;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
 import org.junit.Test;
 
 public class StructureCreatorTest {
@@ -173,8 +180,8 @@ public class StructureCreatorTest {
 					r = new DocumentRangeNode(1, "ID", docs[j], 0,
 							docs[j].getLength());
 					creator.contentsEquals(l, 'L', r, 'R', true, filter);
-					Assert.assertFalse(creator.contentsEquals(l, 'L', r, 'R', false, filter));
-					Assert.assertTrue(creator.contentsEquals(l, 'L', r, 'R', true, filter));
+					assertFalse(creator.contentsEquals(l, 'L', r, 'R', false, filter));
+					assertTrue(creator.contentsEquals(l, 'L', r, 'R', true, filter));
 			}
 	}
 }

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -428,8 +429,8 @@ public class TextMergeViewerTest  {
 					@Override
 					public void setInput(Object input, Object ancestor,
 							Object left, Object right) {
-						assertTrue(leftElement == left);
-						assertTrue(rightElement == right);
+						assertThat(leftElement).isSameAs(left);
+						assertThat(rightElement).isSameAs(right);
 					}
 
 					@Override
@@ -509,13 +510,11 @@ public class TextMergeViewerTest  {
 			assertNotNull(firstDiff);
 			assertNotNull(secondDiff);
 
-			assertEquals("Change direction is wrong", RangeDifference.RIGHT, firstDiff.getKind());
-			assertEquals("Change direction is wrong", RangeDifference.RIGHT, secondDiff.getKind());
+			assertThat(firstDiff.getKind()).as("change direction").isEqualTo(RangeDifference.RIGHT);
+			assertThat(secondDiff.getKind()).as("change direction").isEqualTo(RangeDifference.RIGHT);
 
-			assertTrue("Change should be shown", testDocumentMerger.useChange(firstDiff)); // shows this diff in
-																							// DocumentMerger
-			assertTrue("Change should be shown", testDocumentMerger.useChange(secondDiff)); // shows this diff in
-																							// DocumentMerger
+			assertThat(firstDiff).matches(it -> testDocumentMerger.useChange(it), "shown in document merger");
+			assertThat(secondDiff).matches(it -> testDocumentMerger.useChange(it), "shown in document merger");
 
 			cc.setProperty(CompareConfiguration.IGNORE_WHITESPACE, true);// IGNORE_WHITESPACE set to active
 			try {
@@ -530,17 +529,11 @@ public class TextMergeViewerTest  {
 			assertNotNull(firstDiff);
 			assertNotNull(secondDiff);
 
-			assertEquals("Change direction is wrong", RangeDifference.RIGHT, firstDiff.getKind());
-			assertEquals("Change direction is wrong", RangeDifference.RIGHT, secondDiff.getKind());
+			assertThat(firstDiff.getKind()).as("change direction").isEqualTo(RangeDifference.RIGHT);
+			assertThat(secondDiff.getKind()).as("change direction").isEqualTo(RangeDifference.RIGHT);
 
-			org.junit.Assert.assertFalse("Change should not be shown", testDocumentMerger.useChange(firstDiff)); // whitespace
-																													// not
-																													// in
-																								// literal, do not show
-																								// in DocumentMerger
-			assertTrue("Change should be shown", testDocumentMerger.useChange(secondDiff)); // whitespace in literal,
-																							// show in DocumentMerger
-
+			assertThat(firstDiff).matches(it -> !testDocumentMerger.useChange(it), "not shown in document merger");
+			assertThat(secondDiff).matches(it -> testDocumentMerger.useChange(it), "shown in document merger");
 		}, cc);
 	}
 


### PR DESCRIPTION
Improves the assertions in org.eclipse.compare.tests in order to ease migration to JUnit 5. This includes:
* Properly throw exceptions for errors instead of calling fail()
* Combine size and content comparisons to single assertThat() calls
* Replace assertions with custom messages with AssertJ statements
* Replace non-static Assert imports
* Add missing try-with-resources