### PR TITLE
Fix link to RunAndTrack in RunAndTrackTest

### DIFF
--- a/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/contexts/RunAndTrackTest.java
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/contexts/RunAndTrackTest.java
@@ -31,7 +31,7 @@ import org.junit.After;
 import org.junit.Test;
 
 /**
- * Tests for {@link org.eclipse.e4.core.RunAndTrack.context.IRunAndTrack}.
+ * Tests for {@link org.eclipse.e4.core.contexts.RunAndTrack}.
  */
 public class RunAndTrackTest {
 
@@ -398,7 +398,7 @@ public class RunAndTrackTest {
 	 */
 	@Test
 	public void testRemoveContextVar() {
-		doSingleContextChangeTest((root, var) -> root.remove(var), null, 1);
+		doSingleContextChangeTest(IEclipseContext::remove, null, 1);
 
 	}
 


### PR DESCRIPTION
Fixes the following warning in build log:
```
07:07:30.081 [INFO] --- javadoc:3.6.3:jar (attach-javadocs) @
org.eclipse.e4.core.javax.tests ---
07:07:30.365 [INFO] No previous run data found, generating javadoc.
07:07:34.697 [ERROR] MavenReportException: Error while generating
Javadoc:
Exit code: 1
/home/jenkins/agent/workspace/eclipse.platform_master/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/contexts/RunAndTrackTest.java:34:
error: reference not found
 * Tests for {@link
org.eclipse.e4.core.RunAndTrack.context.IRunAndTrack}.
                    ^
1 error
Command line was: /opt/tools/java/openjdk/jdk-17/17.0.2+8/bin/javadoc
@options @packages

Refer to the generated Javadoc files in
'/home/jenkins/agent/workspace/eclipse.platform_master/runtime/tests/org.eclipse.e4.core.javax.tests/target/apidocs'
dir.

org.apache.maven.reporting.MavenReportException:
Exit code: 1
```