### PR TITLE
Fixes link in API Deprecation policy

### DIFF
--- a/docs/Eclipse_API_Central_Deprecation_Policy.md
+++ b/docs/Eclipse_API_Central_Deprecation_Policy.md
@@ -56,5 +56,5 @@ References
 ==========
 
 *   [Java Deprecation Guidelines](http://java.sun.com/j2se/1.4.2/docs/guide/misc/deprecation/deprecation.html)
-*   [Architecture Council/Meetings/API Deprecation 20080119](/Architecture_Council/Meetings/API_Deprecation_20080119 "Architecture Council/Meetings/API Deprecation 20080119")
+*   [Architecture Council/Meetings/API Deprecation 20080119](https://wiki.eclipse.org/Architecture_Council/Meetings/API_Deprecation_20080119 "Architecture Council/Meetings/API Deprecation 20080119")
 


### PR DESCRIPTION
Fixes the architecture link  to the Eclipse wiki.