### PR TITLE
Remove dummy "1.0" junit test failure messages

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 
 import java.util.concurrent.atomic.AtomicReference;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -33,6 +33,8 @@ import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
+
+import junit.framework.Test;
 
 public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	private static final String DIR_NAME = ".settings";
@@ -65,8 +67,8 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		node.flush();
 		waitForRefresh();
 		IFile file = project.getFile(IPath.fromOSString(DIR_NAME).append(qualifier).addFileExtension(FILE_EXTENSION));
-		assertTrue("2.0", file.exists());
-		assertTrue("2.1", file.getLocation().toFile().exists());
+		assertTrue(file.exists());
+		assertTrue(file.getLocation().toFile().exists());
 		saveWorkspace();
 	}
 
@@ -113,7 +115,7 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		IProject project = getProject("testSaveLoad");
 		IScopeContext context = new ProjectScope(project);
 		Preferences node = context.getNode("test.save.load");
-		assertEquals("1.0", "value", node.get("key", null));
+		assertEquals("value", node.get("key", null));
 		saveWorkspace();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
@@ -16,13 +16,14 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * This class is a simple example of how session tests operate.  Each method
@@ -47,8 +48,8 @@ public class SampleSessionTest extends WorkspaceSessionTest {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject p1 = workspace.getRoot().getProject("P1");
 		IFile file = p1.getFile("foo.txt");
-		assertTrue("1.0", p1.exists());
-		assertTrue("1.1", file.exists());
+		assertTrue(p1.exists());
+		assertTrue(file.exists());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug113943.java
@@ -18,7 +18,6 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
@@ -29,6 +28,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests regression of bug 113943 - linked resources not having
@@ -55,8 +56,8 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 		child.openOutputStream(EFS.NONE, createTestMonitor()).close();
 		link.createLink(location, IResource.NONE, createTestMonitor());
 
-		assertTrue("1.0", link.exists());
-		assertTrue("1.1", linkChild.exists());
+		assertTrue(link.exists());
+		assertTrue(linkChild.exists());
 
 		getWorkspace().save(true, createTestMonitor());
 	}
@@ -70,7 +71,7 @@ public class TestBug113943 extends WorkspaceSerializationTest {
 		IFile linkChild = link.getFile("child.txt");
 		link.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("1.0", link.exists());
-		assertTrue("1.1", linkChild.exists());
+		assertTrue(link.exists());
+		assertTrue(linkChild.exists());
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug20127.java
@@ -21,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -29,6 +28,8 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests regression of bug 20127 - error restoring builder state after
@@ -72,9 +73,9 @@ public class TestBug20127 extends WorkspaceSerializationTest {
 		IProject oldLocation = workspace.getRoot().getProject("Project1");
 		IProject newLocation = workspace.getRoot().getProject("MovedProject");
 
-		assertTrue("1.0", !oldLocation.exists());
-		assertTrue("1.0", newLocation.exists());
-		assertTrue("1.1", newLocation.isOpen());
+		assertFalse(oldLocation.exists());
+		assertTrue(newLocation.exists());
+		assertTrue(newLocation.isOpen());
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -17,7 +17,6 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -25,6 +24,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.TestUtil;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Test for bug 202384
@@ -36,7 +37,7 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		IProject project = workspace.getRoot().getProject("project");
 		createInWorkspace(project);
 		project.setDefaultCharset("UTF-8", createTestMonitor());
-		assertEquals("2.0", "UTF-8", project.getDefaultCharset(false));
+		assertEquals("UTF-8", project.getDefaultCharset(false));
 		project.close(createTestMonitor());
 		workspace.save(true, createTestMonitor());
 	}
@@ -44,20 +45,20 @@ public class TestBug202384 extends WorkspaceSessionTest {
 	public void testStartWithClosedProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
-		assertFalse("1.0", project.isOpen());
+		assertFalse(project.isOpen());
 		// project is closed so it is not possible to read correct encoding
-		assertNull("2.0", project.getDefaultCharset(false));
+		assertNull(project.getDefaultCharset(false));
 		// opening the project should initialize ProjectPreferences
 		project.open(createTestMonitor());
 		// correct values should be available after initialization
-		assertEquals("5.0", "UTF-8", project.getDefaultCharset(false));
+		assertEquals("UTF-8", project.getDefaultCharset(false));
 		workspace.save(true, createTestMonitor());
 	}
 
 	public void testStartWithOpenProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
-		assertTrue("1.0", project.isOpen());
+		assertTrue(project.isOpen());
 		// correct values should be available if ProjectPreferences got
 		// initialized upon creation
 		String expectedEncoding = "UTF-8";
@@ -69,7 +70,7 @@ public class TestBug202384 extends WorkspaceSessionTest {
 			TestUtil.dumpRunnigOrWaitingJobs(getName());
 			TestUtil.waitForJobs(getName(), 500, 1000);
 		}
-		assertEquals("2.0", expectedEncoding, project.getDefaultCharset(false));
+		assertEquals(expectedEncoding, project.getDefaultCharset(false));
 		workspace.save(true, createTestMonitor());
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -19,13 +19,15 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 
 import java.io.File;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests regression of bug 208833 - project resource tree is deleted when Eclipse fails to access its metainfo
@@ -50,7 +52,8 @@ public class TestBug208833 extends WorkspaceSessionTest {
 
 		// move the project to another location, before the workbench is started again
 		// to emulate disconnection of a device (e.g. USB key) or a remote file system
-		assertTrue("2.0", project.getLocation().toFile().renameTo(new File(project.getLocation().toFile().getAbsolutePath() + "_temp")));
+		assertTrue(project.getLocation().toFile()
+				.renameTo(new File(project.getLocation().toFile().getAbsolutePath() + "_temp")));
 	}
 
 	/**
@@ -62,19 +65,19 @@ public class TestBug208833 extends WorkspaceSessionTest {
 		IProject p1 = workspace.getRoot().getProject("Project1");
 
 		// the project should exist, but closed
-		assertTrue("1.0", p1.exists());
-		assertTrue("2.0", !p1.isOpen());
+		assertTrue(p1.exists());
+		assertFalse(p1.isOpen());
 
 		// move the project back
-		assertTrue("3.0", new File(p1.getLocation().toFile().getAbsolutePath() + "_temp").renameTo(p1.getLocation().toFile()));
+		assertTrue(new File(p1.getLocation().toFile().getAbsolutePath() + "_temp").renameTo(p1.getLocation().toFile()));
 
 		// now the project should be opened without any problems
 		p1.open(null);
 
 		// the project should be opened and the file should exist
-		assertTrue("5.0", p1.isOpen());
+		assertTrue(p1.isOpen());
 		IFile file1 = p1.getFile("file1.txt");
-		assertTrue("6.0", file1.exists());
+		assertTrue(file1.exists());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug294854.java
@@ -18,8 +18,6 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
 import org.eclipse.core.internal.resources.TestingSupport;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -30,6 +28,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.SessionTestSuite;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 /**
  * Test for bug 294854
@@ -75,7 +76,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_OLD_NAME);
 		createInWorkspace(project);
-		assertTrue("1.0", project.exists());
+		assertTrue(project.exists());
 
 		// make sure we do not have .snap file
 		TestingSupport.waitForSnapshot();
@@ -110,8 +111,8 @@ public class TestBug294854 extends WorkspaceSessionTest {
 	}
 
 	public void testRenameUsingProjectDescription_02() {
-		assertFalse("1.0", checkProjectExists(PROJECT_OLD_NAME));
-		assertTrue("2.0", checkProjectExists(PROJECT_NEW_NAME));
+		assertFalse(checkProjectExists(PROJECT_OLD_NAME));
+		assertTrue(checkProjectExists(PROJECT_NEW_NAME));
 	}
 
 	public void testRenameUsingResourcePath_01() throws CoreException, InterruptedException {
@@ -128,8 +129,8 @@ public class TestBug294854 extends WorkspaceSessionTest {
 	}
 
 	public void testRenameUsingResourcePath_02() {
-		assertFalse("1.0", checkProjectExists(PROJECT_OLD_NAME));
-		assertTrue("2.0", checkProjectExists(PROJECT_NEW_NAME));
+		assertFalse(checkProjectExists(PROJECT_OLD_NAME));
+		assertTrue(checkProjectExists(PROJECT_NEW_NAME));
 	}
 
 	public void testDelete_01() throws CoreException {
@@ -146,7 +147,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 	}
 
 	public void testDelete_02() {
-		assertFalse("1.0", checkProjectExists(PROJECT_OLD_NAME));
+		assertFalse(checkProjectExists(PROJECT_OLD_NAME));
 	}
 
 	public void testDeleteWithoutWaitingForSnapshot_01() throws CoreException {
@@ -168,7 +169,7 @@ public class TestBug294854 extends WorkspaceSessionTest {
 	}
 
 	public void testDeleteWithoutWaitingForSnapshot_02() {
-		assertTrue("1.0", checkProjectExists(PROJECT_OLD_NAME));
-		assertFalse("1.1", checkProjectIsOpen(PROJECT_OLD_NAME));
+		assertTrue(checkProjectExists(PROJECT_OLD_NAME));
+		assertFalse(checkProjectIsOpen(PROJECT_OLD_NAME));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
@@ -17,7 +17,6 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
@@ -25,6 +24,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests regression of bug 30015.  Due to this bug, it was impossible to restore
@@ -62,11 +63,11 @@ public class TestBug30015 extends WorkspaceSessionTest {
 		rawLocation = IPath.fromOSString(VAR_NAME).append("ProjectLocation");
 		IProject project = getWorkspace().getRoot().getProject(PROJECT_NAME);
 
-		assertEquals("1.0", varValue, getWorkspace().getPathVariableManager().getValue(VAR_NAME));
-		assertTrue("1.1", project.exists());
-		assertTrue("1.2", project.isOpen());
-		assertEquals("1.3", rawLocation, project.getRawLocation());
-		assertEquals("1.4", varValue.append(rawLocation.lastSegment()), project.getLocation());
+		assertEquals(varValue, getWorkspace().getPathVariableManager().getValue(VAR_NAME));
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
+		assertEquals(rawLocation, project.getRawLocation());
+		assertEquals(varValue.append(rawLocation.lastSegment()), project.getLocation());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 
 import java.io.File;
-import junit.framework.Test;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -30,6 +30,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Test for bug 323833
@@ -55,8 +57,8 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		IFileInfo cachedFileInfo = new LocalFile(cachedFile).fetchInfo();
 
 		// check that the file in the cache has attributes set
-		assertTrue("3.0", cachedFileInfo.getAttribute(EFS.ATTRIBUTE_READ_ONLY));
-		assertTrue("4.0", cachedFileInfo.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
+		assertTrue(cachedFileInfo.getAttribute(EFS.ATTRIBUTE_READ_ONLY));
+		assertTrue(cachedFileInfo.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
 	}
 
 	public void test2() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -21,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
@@ -30,6 +29,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests the fix for bug 6995.  In this bug, a snapshot immediately after startup and
@@ -77,8 +78,8 @@ public class TestBug6995 extends WorkspaceSessionTest {
 
 		//make sure an incremental build occurred
 		SortBuilder builder = SortBuilder.getInstance();
-		assertTrue("3.0", !builder.wasDeltaNull());
-		assertTrue("3.1", builder.wasIncrementalBuild());
+		assertFalse(builder.wasDeltaNull());
+		assertTrue(builder.wasIncrementalBuild());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2012 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.internal.resources.ContentDescriptionManager;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -32,6 +31,8 @@ import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.tests.resources.ContentDescriptionManagerTest;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests that the content description cache is preserved across sessions.
@@ -52,7 +53,8 @@ public class TestBug93473 extends WorkspaceSessionTest {
 
 		// cache is invalid at this point (does not match platform timestamp), no flush job has been scheduled (should not have to wait)
 		ContentDescriptionManagerTest.waitForCacheFlush();
-		assertEquals("0.0", ContentDescriptionManager.INVALID_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
+		assertEquals(ContentDescriptionManager.INVALID_CACHE,
+				((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
 		IProject project = workspace.getRoot().getProject("proj1");
 		assertDoesNotExistInWorkspace(project);
@@ -64,20 +66,23 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		file.getContentDescription();
 		// after waiting cache flushing, cache should be new
 		ContentDescriptionManagerTest.waitForCacheFlush();
-		assertEquals("2.0", ContentDescriptionManager.EMPTY_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
+		assertEquals(ContentDescriptionManager.EMPTY_CACHE,
+				((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
 		// obtains a content description again - should come from cache
 		file.getContentDescription();
 		// cache now is not empty anymore (should not have to wait)
 		ContentDescriptionManagerTest.waitForCacheFlush();
-		assertEquals("4.0", ContentDescriptionManager.USED_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
+		assertEquals(ContentDescriptionManager.USED_CACHE,
+				((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
 		workspace.save(true, createTestMonitor());
 	}
 
 	public void test2ndSession() {
 		// cache should preserve state across sessions
-		assertEquals("1.0", ContentDescriptionManager.USED_CACHE, ((Workspace) getWorkspace()).getContentDescriptionManager().getCacheState());
+		assertEquals(ContentDescriptionManager.USED_CACHE,
+				((Workspace) getWorkspace()).getContentDescriptionManager().getCacheState());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestCloseNoSave.java
@@ -18,13 +18,14 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests closing a workspace without save.
@@ -47,7 +48,7 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 		IResource[] members = workspace.getRoot().members();
 		assertThat(members).hasSize(1).allSatisfy(member -> assertThat(member.getType()).isEqualTo(IResource.PROJECT));
 		IProject project = (IProject) members[0];
-		assertTrue("1.2", project.exists());
+		assertTrue(project.exists());
 		IFolder folder = project.getFolder(FOLDER);
 		IFile file = folder.getFile(FILE);
 
@@ -57,8 +58,8 @@ public class TestCloseNoSave extends WorkspaceSerializationTest {
 		}
 
 		assertThat(project.members()).hasSize(3);
-		assertTrue("2.1", folder.exists());
-		assertTrue("2.2", file.exists());
+		assertTrue(folder.exists());
+		assertTrue(file.exists());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestClosedProjectLocation.java
@@ -18,7 +18,6 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -26,6 +25,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * This is a test for bug 12507.  Immediately after workspace startup, closed projects
@@ -47,7 +48,7 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 		project.open(createTestMonitor());
 		createInWorkspace(file);
 		project.close(createTestMonitor());
-		assertEquals("1.1", location, project.getLocation());
+		assertEquals(location, project.getLocation());
 
 		workspace.save(true, createTestMonitor());
 	}
@@ -59,9 +60,9 @@ public class TestClosedProjectLocation extends WorkspaceSerializationTest {
 		try {
 			IProject project = workspace.getRoot().getProject(PROJECT);
 			IFile file = project.getFile(FILE);
-			assertTrue("1.0", project.exists());
-			assertTrue("1.1", !project.isOpen());
-			assertTrue("1.2", !file.exists());
+			assertTrue(project.exists());
+			assertFalse(project.isOpen());
+			assertFalse(file.exists());
 			assertEquals("1.3", location, project.getLocation());
 		} finally {
 			clear(location.toFile());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestInterestingProjectPersistence.java
@@ -23,7 +23,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 
 import java.util.ArrayList;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -33,6 +33,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * When a builder is run, it reports what projects it is interested in obtaining
@@ -121,16 +123,16 @@ public class TestInterestingProjectPersistence extends WorkspaceSessionTest {
 		ArrayList<IProject> received = builder.getReceivedDeltas();
 
 		// should have received deltas for 1, 2, and 4
-		assertEquals("1.0", 3, received.size());
-		assertTrue("1.1", received.contains(project1));
-		assertTrue("1.2", received.contains(project2));
-		assertTrue("1.3", !received.contains(project3));
-		assertTrue("1.4", received.contains(project4));
+		assertEquals(3, received.size());
+		assertTrue(received.contains(project1));
+		assertTrue(received.contains(project2));
+		assertFalse(received.contains(project3));
+		assertTrue(received.contains(project4));
 
 		// delta for project4 should be empty
 		ArrayList<IProject> empty = builder.getEmptyDeltas();
-		assertEquals("1.2", 1, empty.size());
-		assertTrue("1.3", empty.contains(project4));
+		assertEquals(1, empty.size());
+		assertTrue(empty.contains(project4));
 
 		// save
 		getWorkspace().save(true, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMasterTableCleanup.java
@@ -17,12 +17,14 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 
 import java.util.Properties;
-import junit.framework.Test;
+
 import org.eclipse.core.internal.resources.TestingSupport;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * This is an internal test that makes sure the workspace master table does not
@@ -61,8 +63,8 @@ public class TestMasterTableCleanup extends WorkspaceSerializationTest {
 		//ensure master table does not contain entries for stale projects
 		IProject closeOpen = getWorkspace().getRoot().getProject(CLOSE_OPEN);
 		IProject closeDelete = getWorkspace().getRoot().getProject(CLOSE_DELETE);
-		assertTrue("2.0", !masterTable.containsKey(closeOpen.getFullPath().append(".tree").toString()));
-		assertTrue("2.1", !masterTable.containsKey(closeDelete.getFullPath().append(".tree").toString()));
+		assertFalse(masterTable.containsKey(closeOpen.getFullPath().append(".tree").toString()));
+		assertFalse(masterTable.containsKey(closeDelete.getFullPath().append(".tree").toString()));
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -24,7 +24,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -37,6 +37,8 @@ import org.eclipse.core.tests.internal.builders.SnowBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
 import org.eclipse.core.tests.resources.WorkspaceSessionTest;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests persistence cases for builders that are missing or disabled.
@@ -117,7 +119,7 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
 
 		//assert that the builder is still in the build spec
-		assertTrue("1.0", hasBuilder(project, SnowBuilder.BUILDER_NAME));
+		assertTrue(hasBuilder(project, SnowBuilder.BUILDER_NAME));
 
 		//perform a build and ensure snow builder isn't called
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMultiSnap.java
@@ -19,13 +19,14 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests performing multiple snapshots on a workspace that has
@@ -68,8 +69,8 @@ public class TestMultiSnap extends WorkspaceSerializationTest {
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
 		assertThat(children).containsExactly(project);
-		assertTrue("1.2", project.exists());
-		assertTrue("1.3", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveSnap.java
@@ -21,13 +21,15 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 
 import java.io.ByteArrayInputStream;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests saving the workspace, then performing snapshots, then crashing and recovering
@@ -73,8 +75,8 @@ public class TestSaveSnap extends WorkspaceSerializationTest {
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
 		assertThat(children).containsExactly(project);
-		assertTrue("1.2", project.exists());
-		assertTrue("1.3", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSaveWithClosedProject.java
@@ -17,12 +17,13 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Create a project, close it, save, crash, recover.  Recovered project should still be closed.
@@ -44,14 +45,14 @@ public class TestSaveWithClosedProject extends WorkspaceSerializationTest {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
 		IFile file = project.getFile(FILE);
 
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", !project.isOpen());
-		assertTrue("1.2", !file.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(file.exists());
 
 		project.open(createTestMonitor());
 
-		assertTrue("2.0", project.isOpen());
-		assertTrue("2.1", file.exists());
+		assertTrue(project.isOpen());
+		assertTrue(file.exists());
 	}
 
 	public static Test suite() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestSnapSaveSnap.java
@@ -20,13 +20,15 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWo
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
 import java.io.ByteArrayInputStream;
-import junit.framework.Test;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+
+import junit.framework.Test;
 
 /**
  * Tests snapshoting, saving, snapshoting, then crash and recover.
@@ -69,8 +71,8 @@ public class TestSnapSaveSnap extends WorkspaceSerializationTest {
 		/* see if the workspace contains the resources created earlier*/
 		IResource[] children = getWorkspace().getRoot().members();
 		assertThat(children).containsExactly(project);
-		assertTrue("1.2", project.exists());
-		assertTrue("1.3", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		assertExistsInWorkspace(new IResource[] { project, folder, file });
 	}


### PR DESCRIPTION
Test failed in today's I-buld and "junit.framework.AssertionFailedError: 1.0" is really annoying.