### PR TITLE
Add Ant test.xml for org.eclipse.tips.tests

### DIFF
--- a/ua/org.eclipse.tips.tests/build.properties
+++ b/ua/org.eclipse.tips.tests/build.properties
@@ -15,6 +15,7 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                icons/,\
+               test.xml,\
                .
 src.includes = about.html
 pom.model.property.testClass = org.eclipse.tips.tests.AllTipsTests

--- a/ua/org.eclipse.tips.tests/test.xml
+++ b/ua/org.eclipse.tips.tests/test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<project name="Tips Tests" default="run" basedir=".">
+	<!-- The property ${eclipse-home} should be passed into this script -->
+	<property name="eclipse-home" value="${basedir}/../.."/>
+	
+	<property name="plugin-name" value="org.eclipse.tips.tests"/>
+	<property name="library-file" value="${eclipse-home}/plugins/org.eclipse.test/library.xml"/>
+	<property name="resources_location" value="${eclipse-home}/tips_tests_resources"/>
+
+	<!-- This target holds all initialization code that needs to be done for -->
+	<!-- all tests that are to be run. Initialization for individual tests -->
+	<!-- should be done within the body of the suite target. -->
+	<target name="init">
+		<tstamp/>
+	</target>
+
+	<target name="suite">
+		<ant target="ui-test" antfile="${library-file}" dir="${eclipse-home}">
+			<property name="data-dir" value="${resources_location}"/>
+			<property name="plugin-name" value="org.eclipse.tips.tests"/>
+			<property name="classname" value="org.eclipse.tips.tests.AllTipsTests"/>
+		</ant>
+	</target>
+
+	<!-- This target holds code to cleanup the testing environment after -->
+	<!-- after all of the tests have been run. You can use this target to -->
+	<!-- delete temporary files that have been created. -->
+	<target name="cleanup">
+		<delete dir="${resources_location}" quiet="true"/>
+	</target>
+	
+	<!-- This target runs the test suite. Any actions that need to happen -->
+	<!-- after all the tests have been run should go here. -->
+	<target name="run" depends="init,suite,cleanup">
+		<ant target="collect" antfile="${library-file}" dir="${eclipse-home}">
+			<property name="includes" value="org*.xml"/>
+			<property name="output-file" value="${plugin-name}.xml"/>
+		</ant>
+	</target>
+
+</project>


### PR DESCRIPTION
This adds a test.xml for Ant-based execution of tests in org.eclipse.tips.tests. It is a follow-up to the addition of these tests to the Maven build in #1119. 

This is supposed to enable the execution of the tips tests in I-Builds. I have checked the wiki, namely
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Automated-Testing#automated-unit-and-integration-testing
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Eclipse-Test-Framework

but I am still not sure whether anything else has to be changed (and whether the specification is completely correct) to enable the tests. The wiki refers to some "overall, main test.xml" ([here](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Automated-Testing#appendix)), but the link is broken.
