### PR TITLE
Fix FinalTip#hashcode() and TipProviderTest#testGetNextTip() #1148

### DIFF
--- a/ua/org.eclipse.tips.core/src/org/eclipse/tips/core/internal/FinalTip.java
+++ b/ua/org.eclipse.tips.core/src/org/eclipse/tips/core/internal/FinalTip.java
@@ -31,17 +31,16 @@ public class FinalTip extends Tip implements IHtmlTip {
 	private static final String EH1 = "</h1>"; //$NON-NLS-1$
 	private static final String H1 = "<h1>"; //$NON-NLS-1$
 
-	/**
-	 * Constructor.
-	 */
+	private final Date creationDate;
+
 	public FinalTip(String providerId) {
 		super(providerId);
+		this.creationDate = Calendar.getInstance().getTime();
 	}
 
 	@Override
 	public Date getCreationDate() {
-		Calendar instance = Calendar.getInstance();
-		return instance.getTime();
+		return creationDate;
 	}
 
 	@Override

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipProviderTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipProviderTest.java
@@ -96,6 +96,7 @@ public class TipProviderTest {
 	@Test
 	public void testGetNextTip() {
 		createTestData();
+		assertEquals(fProvider.getCurrentTip(), fProvider.getNextTip());
 		fManager.setAsRead(fProvider.getNextTip());
 		assertNotEquals(fProvider.getCurrentTip(), fProvider.getNextTip());
 		Tip nextTip = fProvider.getNextTip();


### PR DESCRIPTION
The test case org.eclipse.tips.core.TipProviderTest#testGetNextTip() randomly fails because it checks that the read state of a tip after being set can properly be retrieved. This functionality relies on the hash code of tips staying the same, but the one for the FinalTip currently changes if the system time has changed, as it re-calculates the creation time used for the calculation of the hash code on every access.

With this change, the creation time for the FinalTip is stored such that its hash code does not change. This also fixes the according test case.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1148