### PR TITLE
Do not override eclipse.buildScript in ant.tests.ui

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
@@ -930,7 +930,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		TestTextCompletionProcessor processor = new TestTextCompletionProcessor(getAntModel("customBoolean.xml")); //$NON-NLS-1$
 
 		int lineNumber = 2;
-		int columnNumber = 44;
+		int columnNumber = 45;
 		int lineOffset = getCurrentDocument().getLineOffset(lineNumber);
 		processor.setLineNumber(lineNumber);
 		processor.setColumnNumber(columnNumber);

--- a/ant/org.eclipse.ant.tests.ui/plugin.xml
+++ b/ant/org.eclipse.ant.tests.ui/plugin.xml
@@ -34,7 +34,7 @@
 	    	eclipseRuntime="false">
 	    </antTask>
 	    <antTask 
-	    	name="eclipse.buildScript" 
+	    	name="eclipse.buildAScript" 
 	    	class="org.eclipse.ant.tests.ui.support.tasks.CustomBooleanTask"
 	    	library="lib/antUITestsSupport.jar"
 	    	eclipseRuntime="false">

--- a/ant/org.eclipse.ant.tests.ui/testbuildfiles/customBoolean.xml
+++ b/ant/org.eclipse.ant.tests.ui/testbuildfiles/customBoolean.xml
@@ -1,5 +1,5 @@
 <project default="defaultTargetName">
 	<target name="defaultTargetName">
-		<eclipse.buildScript recursivegeneration=""/>
+		<eclipse.buildAScript recursivegeneration=""/>
 	</target>
 </project>


### PR DESCRIPTION
This prevents the message for overriding existing ant task that causes failures in BuildTests.
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1155