### PR TITLE
Handle IDiff.NO_CHANGE when comparing two files identical files

### DIFF
--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ResourceDiffCompareInput.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ResourceDiffCompareInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2017 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,6 +59,9 @@ public class ResourceDiffCompareInput extends AbstractCompareInput implements IS
 				break;
 			case IDiff.CHANGE:
 				compareKind = Differencer.CHANGE;
+				break;
+			case IDiff.NO_CHANGE:
+				compareKind = Differencer.NO_CHANGE;
 				break;
 			default:
 				throw new IllegalArgumentException(Integer.toString(kind));


### PR DESCRIPTION
When comparing two files while synchronizing with a remote version-control system an exception might be thrown when those happen to be identical.

Add an additional case to the switch-statement to handle this situation. The reason it worked previously is because this case has the ID 0, which corresponds to the initial value of the local integer variable.

Resolves #1159
Amends d2ed9d5ce7f06e0620f57537d835836555708a2a