### PR TITLE
Update links for removals and shortens description

### DIFF
--- a/docs/ApiRemovalProcess.md
+++ b/docs/ApiRemovalProcess.md
@@ -1,16 +1,17 @@
 # API removal process
 
-See [Eclipse Project Deprecation Policy](https://wiki.eclipse.org/Eclipse/API_Central/Deprecation_Policy) for more information.
+See [Eclipse Project Deprecation Policy](https://github.com/vogellacompany/eclipse.platform/blob/master/docs/Eclipse_API_Central_Deprecation_Policy.md) for more information.
 
 For new API planned removals use:
 
-* For Java code use the @Deprecated annotation (see below for an example) and optional additional Javadoc. This can only be applied for bundles using a minimum BREE of Java 11. An extra entry in the removal document from [removal document](https://github.com/eclipse-platform/eclipse.platform.common/blob/master/bundles/org.eclipse.platform.doc.isv/porting/removals.html) is not necessary anymore
-* Keep the [removal document](https://github.com/eclipse-platform/eclipse.platform.common/blob/master/bundles/org.eclipse.platform.doc.isv/porting/removals.html) for cases in which the bundle is below Java 11 or for other special which do not fit into the Java code. For such cases a new entry is necessary for planned API removals
+* For Java code use the @Deprecated annotation (see below for an example) and optional additional Javadoc. 
+An extra entry in the removal document from [removal document](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fporting%2Fremovals.html) is not necessary anymore
 * If appropriate the @noextend @noreference and @noinstantiate Javadoc annotation should be added to code
 
 PMC approval for planned API removal is required, either via the pull request or via the mailing list
 After 2 years of announced deletion, the API can be removed
-Javadoc generates a detailed [list of forRemoval](http://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/reference/api/deprecated-list.html#forRemoval) API which is also link to in the [removal document](https://github.com/eclipse-platform/eclipse.platform.common/blob/master/bundles/org.eclipse.platform.doc.isv/porting/removals.html)
+
+Javadoc generates a detailed [list of forRemoval](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Fdeprecated-list.html&anchor=forRemoval) API which is also linked to in the [removal document](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fporting%2Fremovals.html)
 
 Example of a deprecation comment:
 


### PR DESCRIPTION
The removal document updates are not necessary anymore for new API removals.