### PR TITLE
Migration of Javadoc and API_Central to markdown

### DIFF
--- a/docs/API_Central.md
+++ b/docs/API_Central.md
@@ -1,0 +1,20 @@
+Eclipse/API Central
+===================
+
+This page is a hub to collect information about Eclipse Project APIs.
+
+### API Guidelines
+
+*   [How to use the Eclipse API](http://www.eclipse.org/articles/Article-API-Use/index.html) Guidelines for using Eclipse APIs to ensure that your code will keep working as Eclipse evolves.
+*   [Evolving Java-based APIs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md) Guidelines for how to evolve Java-based APIs while maintaining compatibility with existing client code.
+*   [Javadoc](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Javadoc.md) How to write Javadoc
+*   [Provisional API Guidelines](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Provisional_API_Guidelines.md)
+*   [API Removal Process](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/ApiRemovalProcess.md)
+*   [Deprecation Policy](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Eclipse_API_Central_Deprecation_Policy.md)
+*   [Policy on use of Export-Package](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Export-Package.md)
+*   [Version Numbering](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/VersionNumbering.md) Guidelines on how to assign and evolve plug-in version numbers
+*   [Naming Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/api-central/docs/Naming_Conventions.md)  How to name things like packages, classes, and methods
+*   [Code Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/api-central/docs/Coding_Conventions.md)  How to make Java code readable
+*   [Eclipse Doc Conventions](https://github.com/vogellacompany/eclipse.platform/blob/api-central/docs/Eclipse_Doc_Style_Guide.md) Guide how to write Eclipse docs
+*   [User interface guidelines](https://github.com/eclipse-platform/ui-best-practices)
+

--- a/docs/Coding_Conventions.md
+++ b/docs/Coding_Conventions.md
@@ -1,0 +1,36 @@
+Coding Conventions
+==================
+
+Oracle has established coding standards that are generally considered reasonable, as evidenced by their widespread adoption by other Java-based development efforts. One of the goals is to make the Eclipse Platform blend in with the Java platform. This goal is furthered by our following suit.
+
+[Oracle's Code Conventions for the Java Programming Language](https://www.oracle.com/java/technologies/javase/codeconventions-contents.html) covers filenames, file organization, indentation, comments, declarations, statements, white space, naming conventions, and programming practices. 
+All code written for the Eclipse Platform should follow these conventions except as noted below. 
+We deviate only in places where our needs differ from Oracle's; when we do deviate, we explain why. (The section numbers shown below are Oracle's.)
+
+*   Section 3.1.1 Beginning Comments
+
+The Eclipse project has specific guidelines for copyright notices to appear at the beginning of source files. See the [Eclipse Project Charter](http://www.eclipse.org/eclipse/eclipse-charter.php) for details.
+
+*   Section 4 Indentation
+
+We indent with tabs (4 spaces wide), since mixed indents are a mess.
+
+*   Section 9 Naming Conventions
+
+The Eclipse project has more specific naming conventions. See Eclipse Project [Naming Conventions](/Naming_Conventions "Naming Conventions") for details.
+
+Modifiers should be ordered as specified in the JLS and summarized in [AST#newModifiers(int)](http://help.eclipse.org/neon/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/dom/AST.html#newModifiers-int-):
+
+    public protected private
+    abstract default static final
+    synchronized native strictfp transient volatile
+    
+
+For Javadoc conventions, see Oracle's [How to Write Doc Comments for the Javadoc Tool](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html) and [Eclipse/API_Central](/https://github.com/eclipse-platform/eclipse.platform/blob/api-central/docs/API_Central.md).
+
+For Eclipse projects, there is no policy that requires a specific coding format or style, though the Eclipse style in the formatter and cleanup is preferred. Project teams typically determine their own styles and then commit the appropriate files. One way is to commit files on a per-project basis, the other is to have a central set of files that should be imported by each committer. See [Eclipse Incubation Mailing List, 20-June-2016](https://dev.eclipse.org/mhonarc/lists/incubation/msg00141.html).
+
+It is possible to configure the Eclipse formatter to skip certain sections, see [How to turn off the Eclipse code formatter for certain sections of Java code?](https://stackoverflow.com/questions/1820908/how-to-turn-off-the-eclipse-code-formatter-for-certain-sections-of-java-code).
+
+
+

--- a/docs/Eclipse_Doc_Style_Guide.md
+++ b/docs/Eclipse_Doc_Style_Guide.md
@@ -1,0 +1,100 @@
+
+
+Eclipse Doc Style Guide
+=======================
+
+This document gives the style conventions to be used in [Eclipse help](/Eclipse_Documentation "Eclipse Documentation"). The Eclipse help has the following topic types: Tutorial (Getting Started), Concept, Task, and Reference. These topic types are based on the [Darwin Information Typing Architecture (DITA)](http://www.ibm.com/developerworks/library/x-dita1/) standards.
+
+Contents
+--------
+
+*   [1 Topic Titles](#Topic-Titles)
+*   [2 Lists](#Lists)
+*   [3 Inline Markup](#Inline-Markup)
+*   [4 Topic Content](#Topic-Content)
+*   [5 Tables](#Tables)
+*   [6 CSS Class Summary](#CSS-Class-Summary)
+*   [7 Graphics](#Graphics)
+*   [8 Indexing](#Indexing)
+
+### Topic Titles
+
+| Guideline | Example |
+| --- | --- |
+| A topic's _title_ (heading) is marked with a heading value that matches the topic's position in the table of contents. The topic shown here is at the top level, so it is tagged as an **<h1>**. | `<h1>A Tour of the Workbench</h1>` |
+| The text in a topic's <title\> must match the text in the heading. | From concepts-2.htm:           <title>The Workbench</title>   ...   <h1>Workbench</h1>       |
+| A topic's <title\> must be _unique_ to enable users to make a correct choice after a search.  Use sentence capitalization for all titles.   | Results of searching for **workbench**:           88% The workbench (concepts-2.htm)       74% Workbench (ref-10.htm)       70% The workbench (qs-02a.htm)      Better titles:           88% What is the workbench? (concepts-2.htm)       74% Workbench reference (ref-10.htm)       70% Launching the workbench (qs-02a.htm)       |
+| Begin "task" and "getting started" titles with a [gerund](http://en.wikipedia.org/wiki/Gerund). | **Creating a project** |
+
+### Lists
+
+| Guideline | Example |
+| --- | --- |
+| Use a sentence fragment followed by a colon before numbered steps. | To hide files by type: |
+| Each numbered list item should include only one step. |   |
+| If you have an ordered list within an ordered list, use:     <ol type="a"></ol>   | To do X:  1.  Step 1 text. 2.  Step 2 introductory text:     1.  Sub-step 1.     2.  Sub-step 2.   |
+| If you need to start an ordered list at a number other than 1, use     <li value="3">text</li>   |   1.  text   |
+| Each task topic should contain a reasonable number of steps.  "Reasonable" is a judgment call, and your freedom may be restricted by the complexity of the software. However, if you find that you are over 10 steps, see if you can break the steps into two sub-topics.   |   |
+| When describing menu items, use third-person descriptive verb tenses rather than imperative ones. | ~~Create~~ a new file -> **Creates** a new file |
+
+### Inline Markup
+
+| Guideline | Example |
+| --- | --- |
+| Elements names that appear in the GUI should be identified as such.  The standard convention for GUI elements is to display the name in a bold font. There are different ways this can be done:  *   Use <b> tags *   Use the <strong> tags and expect that they will render as bold *   Use <span> tags with different class types. For example:     *   <em class="UILabel">Preferences</em>     *   <span class="guibutton">OK</span>  The benefit of using class types is that the CSS file can then declare:                   EM.UILabel {font-weight: bold;}          Or for a more elaborate display:                   .guibutton { color: #000000; font-weight: bold;      font-family: helvetica, sans-serif;      background-color: #DCDCDC; padding: 1px 5px;       font-size: 10pt; border: outset 2px;      text-decoration: none; line-height:175%; }           | **Preferences**     OK   |
+
+### Topic Content
+
+| Guideline | Example |
+| --- | --- |
+| Provide a short description of what the user will accomplish. | Files that you do not need to see can be hidden by file type in  the **C/C++ Projects** view.  (Note: That wording could be better—see below.)   |
+| Use the active voice. | You can hide file types that you do not need to see in  the **C/C++ Projects** view.  (Note: That wording could _still_ be better—see below.)   |
+| Wherever possible, make statements positive. | In the **C/C++ Projects** view, you can display only the file types that you need to see. |
+| Include no more than one task for each topic. |   |
+| Document how to access a feature through the menu bar, as opposed to using toolbar buttons or the context menu.  Avoid providing multiple ways to do something unless the menu-driven method is not always available. Project properties are an example of this: you can set project properties in the New Project wizard, but after the project is created you can set properties only by right-clicking on an individual project or in preferences (for all projects).   | Click **File > New > Project**.  Note that the term "menu" is not used and that the menu path is in bold.   |
+| When you must provide multiple ways to do something use the format in the example. |   1.  Do one of the following:     *   To set properties for future Standard Make projects, click **Window > Preferences** . Expand **C/C++,** click **New Make Projects**.     *   In the **C/C++ Projects** view, right-click a project, and select **Properties**. Select **C/C++ Make Project** from the list.   |
+| To instruct the user to make a choice, use the format in the example. |   1.  Do one of the following:     *   To stop the build when an error is encountered, select **Stop on error**.     *   To continue the build even if an error is encountered, select **Keep going on error**.   |
+| When describing how to use the context menu (shortcut menu), instruct the user to "right-click <something> and select <something>."  Do not say, "From the context-menu, choose <something> as the term context-menu is not obvious to new users.   | In the **C/C++ Projects** view, right-click a project and select **Properties**. |
+| Bold the name of the item being acted on (that is, the text), not the name of interface control. | Type the name `**JanesProject**` in the **Project name** field. |
+| For the results of a step, do not add the sentence, "The New Project wizard opens." Instead, give the name of the dialog box or wizard that opens as an introductory phrase at the beginning of the next step. |   1.  Click **File > New > Project**. 2.  In the **New Project** wizard, click **C** or **C++**.   |
+| Begin a step, where applicable, by telling the user "To <do this>, <do that>."  In other words, give the consequences of the action before you give the instructions to perform.   | To change tab settings, type a value in the **Value** box. |
+| Do not use the word "button", simply tell the reader to "click <**name of button**>." | Click **Next**. |
+| Use the verbs "select" or "clear" for check boxes; bold only the name of the check box. | Select or clear the **Blank** check box. |
+| Do not use the word "radio button". Use "click <**name of radio button**>." | To change the background color, click **Custom**. |
+| Do not instruct the user to "click on" something. Use "click", "right-click" or "double-click." | In the **C/C++ Projects** view, double-click your project. |
+| Do not instruct the user to "click on". Use "click the <**name of tab**\> tab." | Click the **General** tab. |
+| Do not use the word "tree". Use "Expand <**something**>, click <**something else**>. |   1.  Click **Window > Preferences**. 2.  Expand **C/C++**, click **C/C++ Editor**.   |
+| Use "type" instead of "enter."  ("Enter" means "type <text> and press \[Enter\].)   | In the **Name** box, type a name. |
+| Use the [second person](http://en.wikipedia.org/wiki/Grammatical_person) when referring to the intended audience of the document. Do not use "the user" or "the client" to refer to members of your audience. | ~~The user~~ _You_ can preview the files that are about to be committed from the comments page. |
+| Consider having inline links to concepts that are Eclipse-specific. |   <p>This tutorial provides a step-by-step walk-through of the features in the Eclipse  <a href="../concepts/concepts-2.htm">Workbench</a>. You will learn how to use these features by creating a <a href="../concepts/concepts-12.htm">project</a>, then creating, running, and debugging a simple program.</p>  This tutorial provides a step-by-step walk-through of the features in the Eclipse Workbench. You will learn how to use these features by creating a project, then creating, running, and debugging a simple program.   |
+| Do not use Eclipse implementation details such as plug-in ids, component names, project names, or version numbers in user documentation. Such content is fine in plug-in developer (ISV) documentation. Keep in mind the end user may be using a branded product with a different version number. | ~~Since Equinox 3.3, you can...~~You can... |
+
+### Tables
+
+| Guideline | Example |
+| --- | --- |
+| Declare tables consistently. |   <table border="1" cellpadding="3" cellspacing="0">   |
+| Set the vertical alignment for rows to "top" in the CSS file. |   tr { vertical-align: top; }   |
+
+### CSS Class Summary
+
+| Guideline | Example |
+| --- | --- |
+|   To call the book.css file, change the current markup from   `<link rel="stylesheet" href="../book.css" type="text/css">`   to   `<link rel="stylesheet" href="../../PRODUCT_PLUGIN/book.css" type="text/css">`   (The help system will make the appropriate changes to the path at run time.)   |
+
+### Graphics
+
+| Guideline | Example |
+| --- | --- |
+| There are two types of graphics in the online help at present: icons and screen captures.  Icons are system-independent, so there are no reasons to give them class names or to be concerned about their file type. For icons the ".svg" version of the icons (that are used to generate the ".png" files used in the user interface) should directly be used. This ensures that they are rendered at the exact screen resolution and therefor appear super crisp also on high resolution displays.  On the other hand, screen captures are system-dependent, so it is important that different systems can display the appropriate screen captures. To do this, vendors need to be able to create a zip file of screen captures that the help system can display properly and automatically:  *   Screen captures must be ".png" files. *   Image declarations must **_not_** specify image sizes. *   Image declarations should have "alt" attributes (this is an accessibility feature). *   Image declarations may have a <title> attribute. *   Screen captures should be taken at the minimum supported resolution of 1152x864. *   Images should be no more than 650 pixels wide.  Here are some general guidelines on taking screen shots:  *   Ensure consistent look within a document: if a document has most of its screenshots done under a certain OS then additional screenshots must also be made under that OS. Ask a friend to capture them for you if it's hard for yourself. *   Use a default theme and not your custom colors and fonts. *   Trim the screenshot to only show the relevant information.  Here is how to setup Windows XP for taking screen shots:  *   Display Properties > Themes > Theme: Windows XP *   Display Properties > Appearance > Windows and Buttons: Windows XP Style *   Color Scheme: Default (blue) *   Font Size: Normal *   Display Properties > Appearance > Effects > Use the following method to smooth edges of screen fonts: Off (Not checked)  Here is how to setup Windows 7 for taking screen shots:  *   Control Panel > System > Advanced system settings > Advanced > (Performance) Settings > Visual Effects > Select 'Custom' and uncheck 'Smooth edges of screen fonts'   | `<img border="0" src="../images/Image201_fillet" alt="Define a New File Type dialog">` |
+| Screen captures should generally be PNG-8 (8 bit color) to keep image sizes small. If a particular screen shot uses enough color to warrant additional color depth, use PNG-24. Use your judgement. Start with PNG-8, and if it looks bad then use PNG-24 instead. |  |
+
+### Indexing
+
+| Guideline | Example |
+| --- | --- |
+| Eclipse indexes its help files by looking at the text in the page and weighting titles over paragraphs. However, there can be times when you want the index to show text that does not display on the page. For example, if Eclipse uses its own terminology for a function, you might want users to be able to look up synonyms.  To have the Eclipse index generate a hit for "autosave" (a function that Eclipse has under another name) add a meta "keywords" tag before the </head> tag.   |                    <meta name="keywords" content="autosave">           |
+
+* * *
+Back to [Eclipse Documentation](/Eclipse_Documentation "Eclipse Documentation")
+

--- a/docs/Javadoc.md
+++ b/docs/Javadoc.md
@@ -1,0 +1,30 @@
+
+
+Javadoc
+=======
+
+The specifications for the Eclipse platform APIs are captured in the form of Javadoc comments on API packages, interfaces and classes, methods and constructors, and fields. The [Javadoc tool](http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html) (running the standard doclet) extracts these specifications and formats them into browsable form (HTML web pages) which become the reference section of the documentation set describing the Eclipse platform to ISVs. As a consequence, the bar is significantly higher for API Javadoc than for non-API. [Oracle's Requirements for Writing Java API Specifications](http://www.oracle.com/technetwork/java/javase/documentation/index-142372.html) deals with required semantic content of documentation comments for API specifications for the Java platform. All Eclipse project APIs should follow these conventions.
+
+[Oracle's How to Write Doc Comments for Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html) contains style guide and tag conventions for documentation comments. These conventions lead to high-quality code and API documentation. All code written for the Eclipse Platform should follow these conventions except as noted below.
+
+@version
+--------
+
+Do not use @version tags.
+
+All HTML tags must be explicitly terminated
+-------------------------------------------
+
+All HTML tags appearing in Javadoc comments must be explicitly terminated, even the ones that are considered optional in older versions of HTML such as
+
+<p>...</p>
+
+Various internal tools that post-process the extracted HTML documentation into other forms (e.g., Windows help file) need these tags.
+
+Documenting interface method implementations
+--------------------------------------------
+
+When a method declared in an interface gets implemented in some class, there's often not a lot more to say about the method that wasn't already said in the Javadoc for the interface. In such cases, the Javadoc for the method can be omitted entirely. If the interface and the class will be Javadoc'd together, the standard 1.2 doclet automatically copies the method's description and tags from the interface to the class; if Javadoc'd separately, the automatically generated Javadoc for the method in the class will at least link it to the method in the interface.
+
+In the source code, the implementation method should be annotated with the @Override annotation to alert the reader that the contract for the method is inherited from a super type. This reduces the amount of method contract duplication---a serious maintenance headache---without compromising readability of the code.
+


### PR DESCRIPTION
Javadoc wiki is migrates as it, API_Central has been updated to include the relevant links from https://wiki.eclipse.org/Eclipse/API_Central and https://wiki.eclipse.org/Development_Conventions_and_Guidelines

Coding_Conventions has been updated to include already some of new links

Eclipse_Doc_Style_Guide has been also include