### PR TITLE
Use the module timestamp instead of the timestamp of the state object

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -18,6 +18,7 @@ package org.eclipse.core.internal.runtime;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -57,6 +58,7 @@ import org.eclipse.equinox.internal.app.IBranding;
 import org.eclipse.equinox.log.ExtendedLogReaderService;
 import org.eclipse.equinox.log.ExtendedLogService;
 import org.eclipse.equinox.log.Logger;
+import org.eclipse.osgi.container.Module;
 import org.eclipse.osgi.container.ModuleContainer;
 import org.eclipse.osgi.framework.log.FrameworkLog;
 import org.eclipse.osgi.service.datalocation.Location;
@@ -538,8 +540,8 @@ public final class InternalPlatform {
 	}
 
 	public long getStateTimeStamp() {
-		PlatformAdmin admin = getPlatformAdmin();
-		return admin == null ? -1 : admin.getState(false).getTimeStamp();
+		return Arrays.stream(getBundleContext().getBundles()).map(bundle -> bundle.adapt(Module.class))
+				.filter(Objects::nonNull).mapToLong(Module::getLastModified).sum();
 	}
 
 	public Location getUserLocation() {

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -1166,20 +1166,24 @@ public final class Platform {
 	/**
 	 * Returns the platform administrator for this running Eclipse.
 	 * <p>
-	 * Note: This is an internal method and <em>must not</em>
-	 * be used by clients which are not part of the Eclipse Platform.
-	 * This method allows access to classes which are not Eclipse
-	 * Platform API but are part of the OSGi runtime that the Eclipse
-	 * Platform is built on. Even as the Eclipse Platform evolves
-	 * in compatible ways from release to release, the details of
-	 * the OSGi implementation might not.
-	 * </p><p>
-	 * Clients can also acquire the {@link PlatformAdmin} service
-	 * to retrieve this object.
+	 * Note: This is an internal method and <em>must not</em> be used by clients
+	 * which are not part of the Eclipse Platform. This method allows access to
+	 * classes which are not Eclipse Platform API but are part of the OSGi runtime
+	 * that the Eclipse Platform is built on. Even as the Eclipse Platform evolves
+	 * in compatible ways from release to release, the details of the OSGi
+	 * implementation might not.
 	 * </p>
+	 * <p>
+	 * Clients can also acquire the {@link PlatformAdmin} service to retrieve this
+	 * object.
+	 * </p>
+	 *
 	 * @return the platform admin for this instance of Eclipse
+	 * @deprecated only consumer is PDE and this should never be used by other
+	 *             clients, see javadoc for details.
 	 * @since 3.0
 	 */
+	@Deprecated(forRemoval = true)
 	public static PlatformAdmin getPlatformAdmin() {
 		return InternalPlatform.getDefault().getPlatformAdmin();
 	}


### PR DESCRIPTION
Currently the state timestamp is used what can change if a bundle is resolved not only when it is installed/updated/uninstalled, but the Platform#getStateStamp() claims exactly this.

To restore the documented behavior this iterates over all bundles and uses its Module#getTimestamp instead, this also removes the reference to the  PlatformAdmin that currently requires the compatibility module and could therefore be removed from this once we have migrated PDE.