### PR TITLE
ResourcesPlugin: Multithreaded lazy start

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.20.100.qualifier
+Bundle-Version: 3.20.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_base_plugin_name
 Bundle-SymbolicName: org.eclipse.help.base; singleton:=true
-Bundle-Version: 4.4.300.qualifier
+Bundle-Version: 4.4.400.qualifier
 Bundle-Activator: org.eclipse.help.internal.base.HelpBasePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.base/pom.xml
+++ b/ua/org.eclipse.help.base/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.help</groupId>
   <artifactId>org.eclipse.help.base</artifactId>
-  <version>4.4.300-SNAPSHOT</version>
+  <version>4.4.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>


### PR DESCRIPTION
Reads all projects in parallel. As this was done during ResourcePlugin.start() it had to be deferred as multithreaded classloading during BundleActivator#start(BundleContext) is not supported.

All that happens while splash screen still shown.