### PR TITLE
mac, linux: Lots of errors in Tip of the Day dialog

### DIFF
--- a/ua/org.eclipse.tips.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.tips.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.tips.ui;singleton:=true
-Bundle-Version: 0.3.300.qualifier
+Bundle-Version: 0.3.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.jface;bundle-version="3.30.0",

--- a/ua/org.eclipse.tips.ui/src/org/eclipse/tips/ui/internal/Slider.java
+++ b/ua/org.eclipse.tips.ui/src/org/eclipse/tips/ui/internal/Slider.java
@@ -37,7 +37,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -424,9 +423,10 @@ public class Slider extends Composite {
 			int imageHeight = textExtent.y + 5;
 			int imageWidth = number > 9 ? textExtent.x + 8 : imageHeight;
 
-			PaletteData palette = new PaletteData(new RGB(255, 255, 255));
-			ImageData transparentBackground = new ImageData(imageWidth, imageHeight, 32, palette);
-			transparentBackground.transparentPixel = transparentBackground.getPixel(0, 0);
+			/* Create a 24 bit image data with alpha channel */
+			PaletteData palette = new PaletteData(0xFF, 0xFF00, 0xFF0000);
+			ImageData transparentBackground = new ImageData(imageWidth, imageHeight, 24, palette);
+			transparentBackground.alpha = 0;
 
 			Image image = new Image(display, transparentBackground);
 			GC gc = new GC(image);


### PR DESCRIPTION
Fixed SWT.ERROR_UNSUPPORTED_DEPTH error on Image.init() (called from org.eclipse.tips.ui.internal.Slider.CircleNumberDescriptor.getImageData(int)), because of the wrong PaletteData.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1217