### PR TITLE
[performance] do not normalize locations that are already normalized

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.21.300.qualifier
+Bundle-Version: 3.21.400.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.18.300.qualifier
+Bundle-Version: 3.18.400.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/platform/org.eclipse.platform/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.platform/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform; singleton:=true
-Bundle-Version: 4.31.100.qualifier
+Bundle-Version: 4.31.200.qualifier
 Bundle-ClassPath: platform.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.20.100.qualifier
+Bundle-Version: 3.20.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -853,12 +853,21 @@ public class Project extends Container implements IProject {
 	 * during workspace restore (i.e., when you cannot do an operation)
 	 */
 	void internalSetDescription(IProjectDescription value, boolean incrementContentId) {
+		internalSetDescription(value, incrementContentId, false);
+	}
+
+	void internalSetDescription(IProjectDescription value, boolean incrementContentId,
+			boolean locationAlreadyNormalized) {
 		// Project has been added / removed. Build order is out-of-step
 		workspace.flushBuildOrder();
 
 		ProjectInfo info = (ProjectInfo) getResourceInfo(false, true);
 		info.setDescription((ProjectDescription) value);
-		getLocalManager().setLocation(this, info, value.getLocationURI());
+		if (locationAlreadyNormalized) {
+			getLocalManager().setNormalizedLocation(this, info, value.getLocationURI());
+		} else {
+			getLocalManager().setLocation(this, info, value.getLocationURI());
+		}
 		if (incrementContentId) {
 			info.incrementContentId();
 			//if the project is not accessible, stamp will be null and should remain null

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -967,7 +967,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 			//try to read private metadata and add to the description
 			workspace.getMetaArea().readPrivateDescription(project, description);
 		}
-		project.internalSetDescription(description, false);
+		project.internalSetDescription(description, false, true);
 		if (failure != null) {
 			try {
 				// write the project tree ...

--- a/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_base_plugin_name
 Bundle-SymbolicName: org.eclipse.help.base; singleton:=true
-Bundle-Version: 4.4.300.qualifier
+Bundle-Version: 4.4.400.qualifier
 Bundle-Activator: org.eclipse.help.internal.base.HelpBasePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.base/pom.xml
+++ b/ua/org.eclipse.help.base/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.help</groupId>
   <artifactId>org.eclipse.help.base</artifactId>
-  <version>4.4.300-SNAPSHOT</version>
+  <version>4.4.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/ua/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_webapp_plugin_name
 Bundle-SymbolicName: org.eclipse.help.webapp;singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.11.400.qualifier
 Bundle-Activator: org.eclipse.help.internal.webapp.HelpWebappPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.webapp/pom.xml
+++ b/ua/org.eclipse.help.webapp/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.help</groupId>
   <artifactId>org.eclipse.help.webapp</artifactId>
-  <version>3.11.300-SNAPSHOT</version>
+  <version>3.11.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>


### PR DESCRIPTION
When projects or links are added to the workspace the file location is normalized and saved to disk. Good. However it is not needed to do that for those already normalized paths that are loaded back from disk.

Saves some startup time on windows, where name capitalization of each path segment is expensive IO.