### PR TITLE
SafeFileOutputStream: avoid touching files #1220

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileInputStream.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileInputStream.java
@@ -18,7 +18,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 
 /**
  * Given a target and a temporary locations, it tries to read the contents
@@ -33,12 +33,12 @@ public class SafeFileInputStream {
 	public static InputStream of(String targetPath, String tempPath) throws IOException {
 		File target = new File(targetPath);
 		try {
-			return new ByteArrayInputStream(Files.readAllBytes(target.toPath()));
-		} catch (FileNotFoundException e) {
+			return new ByteArrayInputStream(SafeFileOutputStream.read(target.toPath()));
+		} catch (FileNotFoundException | NoSuchFileException e) {
 			if (tempPath == null)
 				tempPath = target.getAbsolutePath() + EXTENSION;
 			target = new File(tempPath);
-			return new ByteArrayInputStream(Files.readAllBytes(target.toPath()));
+			return new ByteArrayInputStream(SafeFileOutputStream.read(target.toPath()));
 		}
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileInputStream.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileInputStream.java
@@ -13,7 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.internal.localstore;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 /**
  * Given a target and a temporary locations, it tries to read the contents
@@ -22,35 +27,18 @@ import java.io.*;
  *
  * @see SafeFileOutputStream
  */
-public class SafeFileInputStream extends FilterInputStream {
+public class SafeFileInputStream {
 	protected static final String EXTENSION = ".bak"; //$NON-NLS-1$
-	private static final int DEFAUT_BUFFER_SIZE = 2048;
 
-	public SafeFileInputStream(File file) throws IOException {
-		this(file.getAbsolutePath(), null);
-	}
-
-	/**
-	 * If targetPath is null, the file will be created in the default-temporary directory.
-	 */
-	public SafeFileInputStream(String targetPath, String tempPath) throws IOException {
-		super(getInputStream(targetPath, tempPath, DEFAUT_BUFFER_SIZE));
-	}
-
-	/**
-	 * If targetPath is null, the file will be created in the default-temporary directory.
-	 */
-	public SafeFileInputStream(String targetPath, String tempPath, int bufferSize) throws IOException {
-		super(getInputStream(targetPath, tempPath, bufferSize));
-	}
-
-	private static InputStream getInputStream(String targetPath, String tempPath, int bufferSize) throws IOException {
+	public static InputStream of(String targetPath, String tempPath) throws IOException {
 		File target = new File(targetPath);
-		if (!target.exists()) {
+		try {
+			return new ByteArrayInputStream(Files.readAllBytes(target.toPath()));
+		} catch (FileNotFoundException e) {
 			if (tempPath == null)
 				tempPath = target.getAbsolutePath() + EXTENSION;
 			target = new File(tempPath);
+			return new ByteArrayInputStream(Files.readAllBytes(target.toPath()));
 		}
-		return new BufferedInputStream(new FileInputStream(target), bufferSize);
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileOutputStream.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/SafeFileOutputStream.java
@@ -19,8 +19,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class should be used when there's a file already in the
@@ -34,6 +39,7 @@ public class SafeFileOutputStream extends OutputStream {
 	private final String targetPath;
 	private final ByteArrayOutputStream output;
 	private static final String EXTENSION = ".bak"; //$NON-NLS-1$
+	private static final Map<Path, Integer> fileHashes = Collections.synchronizedMap(new HashMap<>());
 
 	/**
 	 * Creates an output stream on a file at the given location
@@ -59,37 +65,45 @@ public class SafeFileOutputStream extends OutputStream {
 	@Override
 	public void close() throws IOException {
 		File target = new File(targetPath);
+		Path targetP = target.toPath();
 		File temp = getTempFile();
+		byte[] newContent = output.toByteArray();
+		Integer newHash = hash(newContent);
+		Integer oldHash = fileHashes.put(targetP, newHash);
 		if (!target.exists()) {
 			if (!temp.exists()) {
-				Files.write(target.toPath(), output.toByteArray());
+				Files.write(targetP, newContent);
 				return;
 			}
 			// If we do not have a file at target location, but we do have at temp location,
 			// it probably means something wrong happened the last time we tried to write
 			// it.
 			// So, try to recover the backup file. And, if successful, write the new one.
-			Files.copy(temp.toPath(), target.toPath());
+			Files.copy(temp.toPath(), targetP);
 		}
-		byte[] oldContent = Files.readAllBytes(target.toPath());
-		byte[] newContent = output.toByteArray();
-		if (Arrays.equals(oldContent, newContent)) {
-			return;
+
+		if (Objects.equals(oldHash, newHash)) {
+			// quick path: since hash did not change it is likely that content did not
+			// change:
+			byte[] oldContent = Files.readAllBytes(targetP);
+			if (Arrays.equals(oldContent, newContent)) {
+				return;
+			}
 		}
 
 		try {
 			Files.write(temp.toPath(), newContent);
-			commit(temp, target);
+			commit(temp, targetP);
 		} catch (IOException e) {
 			temp.delete();
 			throw e; // rethrow
 		}
 	}
 
-	private void commit(File temp, File target) throws IOException {
+	private void commit(File temp, Path targetP) throws IOException {
 		if (!temp.exists())
 			return;
-		Files.copy(temp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		Files.copy(temp.toPath(), targetP, StandardCopyOption.REPLACE_EXISTING);
 		temp.delete();
 	}
 
@@ -110,5 +124,15 @@ public class SafeFileOutputStream extends OutputStream {
 	@Override
 	public void write(int b) throws IOException {
 		output.write(b);
+	}
+
+	private static int hash(byte[] content) {
+		return Arrays.hashCode(content) + content.length;
+	}
+
+	public static byte[] read(Path path) throws IOException {
+		byte[] content = Files.readAllBytes(path);
+		fileHashes.put(path, hash(content));
+		return content;
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/MarkerManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/MarkerManager.java
@@ -15,16 +15,31 @@
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
-import java.io.*;
-import java.util.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
 import org.eclipse.core.internal.localstore.SafeFileInputStream;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
-import org.eclipse.core.internal.watson.*;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.internal.watson.ElementTree;
+import org.eclipse.core.internal.watson.ElementTreeIterator;
+import org.eclipse.core.internal.watson.IElementContentVisitor;
+import org.eclipse.core.internal.watson.IPathRequestor;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.osgi.util.NLS;
 
 /**
@@ -534,7 +549,7 @@ public class MarkerManager implements IManager {
 		if (!sourceFile.exists() && !tempFile.exists())
 			return;
 		try (DataInputStream input = new DataInputStream(
-				new SafeFileInputStream(sourceLocation.toOSString(), tempLocation.toOSString()))) {
+				SafeFileInputStream.of(sourceLocation.toOSString(), tempLocation.toOSString()))) {
 			MarkerReader reader = new MarkerReader(workspace);
 			reader.read(input, generateDeltas);
 		} catch (Exception e) {

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
@@ -22,6 +22,7 @@ package org.eclipse.core.internal.resources;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayDeque;
@@ -994,7 +995,7 @@ public class ProjectDescriptionReader extends DefaultHandler implements IModelOb
 	 */
 	public ProjectDescription read(IPath location, IPath tempLocation) throws IOException {
 		try (
-			SafeFileInputStream file = new SafeFileInputStream(location.toOSString(), tempLocation.toOSString());
+				InputStream file = SafeFileInputStream.of(location.toOSString(), tempLocation.toOSString());
 		) {
 			return read(new InputSource(file));
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -196,7 +196,6 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 	private static final String DEBUG_FULL_SAVE = "Full save on workspace: "; //$NON-NLS-1$
 	private static final String DEBUG_PROJECT_SAVE = "Save on project "; //$NON-NLS-1$
 	private static final String DEBUG_SNAPSHOT = "Snapshot: "; //$NON-NLS-1$
-	private static final int TREE_BUFFER_SIZE = 1024 * 64;//64KB buffer
 
 	public SaveManager(Workspace workspace) {
 		this.workspace = workspace;
@@ -1102,7 +1101,8 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 			savedStates = Collections.synchronizedMap(new HashMap<>(10));
 			return;
 		}
-		try (DataInputStream input = new DataInputStream(new SafeFileInputStream(treeLocation.toOSString(), tempLocation.toOSString(), TREE_BUFFER_SIZE))) {
+		try (DataInputStream input = new DataInputStream(
+				SafeFileInputStream.of(treeLocation.toOSString(), tempLocation.toOSString()))) {
 			WorkspaceTreeReader.getReader(workspace, input.readInt()).readTree(input, monitor);
 		} catch (Exception e) { // "Unknown format" is passed as ResourceException
 			String msg = NLS.bind(Messages.resources_readMeta, treeLocation.toOSString());
@@ -1133,7 +1133,8 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 			if (!treeLocation.toFile().exists() && !tempLocation.toFile().exists())
 				return false;
 			try (
-				DataInputStream input = new DataInputStream(new SafeFileInputStream(treeLocation.toOSString(), tempLocation.toOSString()));
+					DataInputStream input = new DataInputStream(
+							SafeFileInputStream.of(treeLocation.toOSString(), tempLocation.toOSString()));
 			) {
 				WorkspaceTreeReader reader = WorkspaceTreeReader.getReader(workspace, input.readInt());
 				reader.readTree(project, input, Policy.subMonitorFor(monitor, Policy.totalWork));

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Synchronizer.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Synchronizer.java
@@ -15,15 +15,31 @@
  *******************************************************************************/
 package org.eclipse.core.internal.resources;
 
-import java.io.*;
-import java.util.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
 import org.eclipse.core.internal.localstore.SafeFileInputStream;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.internal.watson.IPathRequestor;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.ISynchronizer;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.osgi.util.NLS;
 
 //
@@ -156,7 +172,7 @@ public class Synchronizer implements ISynchronizer {
 		if (!sourceLocation.toFile().exists() && !tempLocation.toFile().exists())
 			return;
 		try (DataInputStream input = new DataInputStream(
-				new SafeFileInputStream(sourceLocation.toOSString(), tempLocation.toOSString()))) {
+				SafeFileInputStream.of(sourceLocation.toOSString(), tempLocation.toOSString()))) {
 			SyncInfoReader reader = new SyncInfoReader(workspace, this);
 			reader.readSyncInfo(input);
 		} catch (Exception e) {

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.400.qualifier
+Bundle-Version: 3.11.500.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.32.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.400-SNAPSHOT</version>
+  <version>3.11.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -50,7 +50,7 @@ public class SafeFileInputOutputStreamTest {
 	}
 
 	private InputStream getContents(java.io.File target) throws IOException {
-		return new SafeFileInputStream(target);
+		return SafeFileInputStream.of(target.getAbsolutePath(), null);
 	}
 
 	@Before
@@ -83,7 +83,7 @@ public class SafeFileInputOutputStreamTest {
 		}
 		assertTrue(target.exists());
 		assertFalse(tempFile.exists());
-		InputStream diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath());
+		InputStream diskContents = SafeFileInputStream.of(tempLocation.toOSString(), target.getAbsolutePath());
 		assertTrue(compareContent(diskContents, createInputStream(contents)));
 		Workspace.clear(target); // make sure there was nothing here before
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -106,7 +107,6 @@ public class SafeFileInputOutputStreamTest {
 		File tempFile;
 		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
 			tempFile = new File(safeStream.getTempFilePath());
-			assertTrue(tempFile.exists());
 			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
@@ -140,7 +140,6 @@ public class SafeFileInputOutputStreamTest {
 		contents = createRandomString();
 		// now we should have a temp file
 		try (SafeFileOutputStream safeStream = createSafeStream(target.getAbsolutePath(), tempLocation.toOSString())) {
-			assertTrue(tempFile.exists());
 			// update target contents
 			createInputStream(contents).transferTo(safeStream);
 		}
@@ -150,4 +149,36 @@ public class SafeFileInputOutputStreamTest {
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
+	@Test
+	public void testContentSame() throws Exception {
+		File target = new File(temp.toFile(), "target");
+		Workspace.clear(target); // make sure there was nothing here before
+		assertTrue(!target.exists());
+		String contentsA = createRandomString();
+
+		// basic use (like a FileOutputStream)
+		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
+			createInputStream(contentsA).transferTo(safeStream);
+		}
+		long lastModified1 = target.lastModified();
+		try {
+			// wait at least lastModified accuracy:
+			Thread.sleep(1);
+		} catch (InterruptedException e) {
+			throw e;
+		}
+		// "write" same content again:
+		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
+			createInputStream(contentsA).transferTo(safeStream);
+		}
+		long lastModified2 = target.lastModified();
+		assertEquals(lastModified1, lastModified2);
+		String contentsB = "B" + contentsA;
+		// change content:
+		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
+			createInputStream(contentsB).transferTo(safeStream);
+		}
+		InputStream diskContents = getContents(target);
+		assertTrue(compareContent(diskContents, createInputStream(contentsB)));
+	}
 }


### PR DESCRIPTION
SafeFileOutputStream is used to write Workspace metadata on eclipse exit. This did touch the existing files even when the content stayed the same. With this change the content is prepared in a byte array and flushed to disk if and only if the content changed.

https://github.com/eclipse-platform/eclipse.platform/issues/1220