### PR TITLE
Externalize the 'difference/s' text #1236

### DIFF
--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.10.0.qualifier
+Bundle-Version: 3.10.100.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -5421,8 +5421,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		int differenceCount = fMerger.changesCount();
 		if (tbm != null) {
 
-			String label = differenceCount > 1 ? differenceCount + " Differences" //$NON-NLS-1$
-					: differenceCount == 1 ? differenceCount + " Difference" : "No Difference"; //$NON-NLS-1$ //$NON-NLS-2$
+			String label = MessageFormat.format(CompareMessages.TextMergeViewer_differences, differenceCount);
 			LabelContributionItem labelContributionItem = new LabelContributionItem(DIFF_COUNT_ID,
 					label);
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -96,6 +96,7 @@ public final class CompareMessages extends NLS {
 	public static String TextMergeViewer_atEnd_message;
 	public static String TextMergeViewer_atBeginning_title;
 	public static String TextMergeViewer_atBeginning_message;
+	public static String TextMergeViewer_differences;
 	public static String CompareNavigator_atEnd_title;
 	public static String CompareNavigator_atEnd_message;
 	public static String CompareNavigator_atBeginning_title;

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -81,6 +81,8 @@ TextMergeViewer_accessible_right={0} Right: {1}
 TextMergeViewer_atBeginning_message= Beginning of document reached. Continue from end?
 TextMergeViewer_accessible_ancestor=Ancestor: {0}
 
+TextMergeViewer_differences={0,choice,0#No Difference|1#1 Difference|1<{0} Differences}
+
 CompareNavigator_atEnd_title= End Reached
 CompareDialog_commit_button=C&ommit
 CompareDialog_error_title=Error Saving Changes


### PR DESCRIPTION
Externalization of text used in "Textmergeviewer.java" related to number of differences shown in toolbar of compare editor.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1236