### PR TITLE
fix: PropertyTesterDescriptor for Invalid registry object

### DIFF
--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/PropertyTesterDescriptor.java
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/PropertyTesterDescriptor.java
@@ -44,17 +44,22 @@ public class PropertyTesterDescriptor implements IPropertyTester {
 				null));
 		}
 		StringBuilder buffer= new StringBuilder(","); //$NON-NLS-1$
-		String properties= element.getAttribute(PROPERTIES);
-		if (properties == null) {
+		try {
+			String properties= element.getAttribute(PROPERTIES);
+			if (properties == null) {
+				throw new CoreException(new Status(IStatus.ERROR, PropertyTesterDescriptor.class,
+					IStatus.ERROR,
+					ExpressionMessages.PropertyTesterDescritpri_no_properties,
+					null));
+			}
+			for (int i= 0; i < properties.length(); i++) {
+				char ch= properties.charAt(i);
+				if (!Character.isWhitespace(ch))
+					buffer.append(ch);
+			}
+		} catch (final RuntimeException ex) {
 			throw new CoreException(new Status(IStatus.ERROR, PropertyTesterDescriptor.class,
-				IStatus.ERROR,
-				ExpressionMessages.PropertyTesterDescritpri_no_properties,
-				null));
-		}
-		for (int i= 0; i < properties.length(); i++) {
-			char ch= properties.charAt(i);
-			if (!Character.isWhitespace(ch))
-				buffer.append(ch);
+					IStatus.ERROR, ex.toString(), null));
 		}
 		buffer.append(',');
 		fProperties= buffer.toString();


### PR DESCRIPTION
catch the RuntimeException for the code robustness
```
MESSAGE Problems occurred when invoking code from plug-in: "org.eclipse.e4.ui.workbench.swt".
!STACK 0
org.eclipse.core.runtime.InvalidRegistryObjectException: Invalid registry object
    at org.eclipse.core.internal.registry.RegistryObjectManager.basicGetObject(RegistryObjectManager.java:293)
    at org.eclipse.core.internal.registry.RegistryObjectManager.getObject(RegistryObjectManager.java:283)
    at org.eclipse.core.internal.registry.ConfigurationElementHandle.getConfigurationElement(ConfigurationElementHandle.java:29)
    at org.eclipse.core.internal.registry.ConfigurationElementHandle.getAttribute(ConfigurationElementHandle.java:38)
    at org.eclipse.core.internal.expressions.PropertyTesterDescriptor.<init>(PropertyTesterDescriptor.java:39)
    at org.eclipse.core.internal.expressions.TypeExtensionManager.loadTesters(TypeExtensionManager.java:192)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:79)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:148)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:148)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:148)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:148)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:131)
    at org.eclipse.core.internal.expressions.TypeExtension.findTypeExtender(TypeExtension.java:131)
    at org.eclipse.core.internal.expressions.TypeExtensionManager.getProperty(TypeExtensionManager.java:124)
    at org.eclipse.core.expressions.TestExpression.evaluate(TestExpression.java:104)
    at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
    at org.eclipse.core.expressions.WithExpression.evaluate(WithExpression.java:84)
    at org.eclipse.ui.internal.services.EvaluationReference.evaluate(EvaluationReference.java:79)
    at org.eclipse.ui.internal.services.EvaluationReference.evaluate(EvaluationReference.java:109)
    at org.eclipse.ui.internal.services.EvaluationReference.changed(EvaluationReference.java:103)
    at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:105)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.processScheduled(EclipseContext.java:358)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.set(EclipseContext.java:374)
    at org.eclipse.ui.internal.services.EvaluationService$1.changed(EvaluationService.java:79)
    at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:105)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.processScheduled(EclipseContext.java:358)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.set(EclipseContext.java:374)
    at org.eclipse.e4.core.commands.ExpressionContext.addVariable(ExpressionContext.java:87)
    at org.eclipse.ui.internal.services.EvaluationService.changeVariable(EvaluationService.java:149)
    at org.eclipse.ui.internal.services.EvaluationService$3.sourceChanged(EvaluationService.java:125)
    at org.eclipse.ui.AbstractSourceProvider.fireSourceChanged(AbstractSourceProvider.java:84)
    at org.eclipse.ui.internal.services.WorkbenchSourceProvider.checkActivePart(WorkbenchSourceProvider.java:381)
    at org.eclipse.ui.internal.services.WorkbenchSourceProvider.checkActivePart(WorkbenchSourceProvider.java:277)
    at org.eclipse.ui.internal.services.WorkbenchSourceProvider.handleCheck(WorkbenchSourceProvider.java:266)
    at org.eclipse.ui.internal.services.WorkbenchSourceProvider.checkOtherSources(WorkbenchSourceProvider.java:756)
    at org.eclipse.ui.internal.services.WorkbenchSourceProvider.lambda$2(WorkbenchSourceProvider.java:742)
    at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
    at org.eclipse.swt.widgets.Display.filterEvent(Display.java:1286)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1065)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1090)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1075)
    at org.eclipse.swt.widgets.Decorations.WM_ACTIVATE(Decorations.java:1519)
    at org.eclipse.swt.widgets.Shell.WM_ACTIVATE(Shell.java:2332)
    at org.eclipse.swt.widgets.Control.windowProc(Control.java:4741)
    at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:340)
    at org.eclipse.swt.widgets.Decorations.windowProc(Decorations.java:1478)
    at org.eclipse.swt.widgets.Shell.windowProc(Shell.java:2305)
    at org.eclipse.swt.widgets.Display.windowProc(Display.java:5039)
    at org.eclipse.swt.internal.win32.OS.BringWindowToTop(Native Method)
    at org.eclipse.swt.widgets.Decorations.bringToTop(Decorations.java:211)
    at org.eclipse.swt.widgets.Shell.open(Shell.java:1288)
    at org.eclipse.e4.ui.workbench.renderers.swt.WBWRenderer.postProcess(WBWRenderer.java:739)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:677)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:763)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:728)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:712)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1083)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
    at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:648)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:555)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:402)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:651)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:588)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1459)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1432)
```