### PR TITLE
MARGINS_DEFAULT leads to IllegalArgumentException

### DIFF
--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.10.300.qualifier
+Bundle-Version: 3.10.400.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/SWTUtils.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/SWTUtils.java
@@ -218,6 +218,7 @@ public class SWTUtils {
 		case MARGINS_DEFAULT:
 			layout.marginLeft= layout.marginRight= layout.marginWidth;
 			layout.marginTop= layout.marginBottom= layout.marginHeight;
+		        break;
 		default:
 			throw new IllegalArgumentException(Integer.toString(margins));
 		}


### PR DESCRIPTION
added missing break; before default case to avoid IllegalArgumentException when calling 
createGridLayout(int numColumns, PixelConverter converter, int margins)
with MARGINS_DEFAULT

Fixes https://github.com/JAndrassy/org.eclipse.team.cvs/issues/5