### PR TITLE
Synchronize annotationPreset map in InjectorImpl to prevent a ConcurrentModificationExeption with DI 

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/InjectorImpl.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/InjectorImpl.java
@@ -75,7 +75,8 @@ public class InjectorImpl implements IInjector {
 	private final Set<IdentityWeakReference<Class<?>>> injectedClasses = new LinkedHashSet<>();
 	private final Map<Class<?>, Object> singletonCache = new HashMap<>();
 	private final Map<Class<?>, Set<Binding>> bindings = new HashMap<>();
-	private final Map<AnnotationProxy, Map<AnnotatedElement, Boolean>> annotationsPresent = new HashMap<>();
+	private final Map<AnnotationProxy, Map<AnnotatedElement, Boolean>> annotationsPresent = Collections
+			.synchronizedMap(new HashMap<>());
 
 	// Performance improvement:
 	private final Map<Class<?>, Method[]> methodsCache = Collections.synchronizedMap(new WeakHashMap<>());


### PR DESCRIPTION
InjectorImpl: synchronize annotationPreset map to prevent a ConcurrentModificationException

Fixes: #1256