### PR TITLE
Increment the minor version of org.eclipse.help.ui

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.300.qualifier
+Bundle-Version: 4.7.0.qualifier
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
The version range change of the re-exported required bundle org.eclipse.ui mandates a minor version increment.