### PR TITLE
Improve update.configurator test source folder name #219

### DIFF
--- a/update/org.eclipse.update.configurator.tests/test.xml
+++ b/update/org.eclipse.update.configurator.tests/test.xml
@@ -35,11 +35,11 @@
 
   <!-- This target defines the regression tests that need to be run. -->
   <target name="suite">
-    <property name="platform-debug-folder" 
-              value="${eclipse-home}/platform_debug_folder"/>
-    <delete dir="${platform-debug-folder}" quiet="true"/>
+    <property name="update-configurator-folder" 
+              value="${eclipse-home}/update_configurator_folder"/>
+    <delete dir="${update-configurator-folder}" quiet="true"/>
     <ant target="ui-test" antfile="${library-file}" dir="${eclipse-home}">
-      <property name="data-dir" value="${platform-debug-folder}"/>
+      <property name="data-dir" value="${update-configurator-folder}"/>
       <property name="plugin-name" value="${plugin-name}"/>
       <property name="classname" 
                 value="org.eclipse.update.configurator.tests.AutomatedConfiguratorSuite"/>


### PR DESCRIPTION
Makes the org.eclipse.update.configurator.tests use a different test resources folder than the org.eclipse.debug.tests project.

The folder name is rather misleading than a real issue, as tests are not executed in parallel and the folder is cleaned before each test execution. Still, to avoid any kind of unanticipated issue, let's improve test isolation and avoid conflicting folders of different test projects.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/219