### PR TITLE
Improve contenttype test source folder name #219

### DIFF
--- a/runtime/tests/org.eclipse.core.contenttype.tests/test.xml
+++ b/runtime/tests/org.eclipse.core.contenttype.tests/test.xml
@@ -22,11 +22,11 @@
 
   <!-- This target defines the tests that need to be run. -->
   <target name="suite">
-    <property name="expressions-folder" 
-              value="${eclipse-home}/expressions_folder"/>
-    <delete dir="${expressions-folder}" quiet="true"/>
+    <property name="contenttype-folder" 
+              value="${eclipse-home}/contenttype_folder"/>
+    <delete dir="${contenttype-folder}" quiet="true"/>
     <ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
-      <property name="data-dir" value="${expressions-folder}"/>
+      <property name="data-dir" value="${contenttype-folder}"/>
       <property name="plugin-name" value="${plugin-name}"/>
       <property name="classname" 
                 value="org.eclipse.core.internal.contenttype.tests.AllContenttypeTests"/>


### PR DESCRIPTION
Makes the org.eclipse.core.contenttype.tests use a different test resources folder than the org.eclipse.core.expressions.tests project.

The folder name is rather misleading than a real issue, as tests are not executed in parallel and the folder is cleaned before each test execution. Still, to avoid any kind of unanticipated issue, let's improve test isolation and avoid conflicting folders of different test projects.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/219