### PR TITLE
Correct native charset in TestWorkspaceEncodingExistingWorkspace #128

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
@@ -48,7 +48,7 @@ public class TestWorkspaceEncodingExistingWorkspace extends WorkspaceSessionTest
 	}
 
 	public void testExpectedEncoding1() throws Exception {
-		String defaultValue = System.getProperty("file.encoding");
+		String defaultValue = System.getProperty("native.encoding");
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		// Should be system default


### PR DESCRIPTION
TestWorkspaceEncodingExistingWorkspace retrieves the expected native charset via the "file.encoding" system property, but with Java 21 this always returns UTF-8 and the native encoding can be retrieved via "native.encoding" since Java 17. This change adapts the test to properly run with Java 21.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/128