### PR TITLE
Add support for "editor" content types for compare editor

### DIFF
--- a/team/bundles/org.eclipse.compare/.settings/.api_filters
+++ b/team/bundles/org.eclipse.compare/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.compare" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="Changed contentMergeViewers extension point" id="926941240">
+            <message_arguments>
+                <message_argument value="3.11.0"/>
+                <message_argument value="3.10.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.10.100.qualifier
+Bundle-Version: 3.11.0.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareViewerSwitchingPane.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareViewerSwitchingPane.java
@@ -15,6 +15,7 @@ package org.eclipse.compare;
 
 import java.text.MessageFormat;
 
+import org.eclipse.compare.contentmergeviewer.ContentMergeViewer;
 import org.eclipse.compare.contentmergeviewer.IFlushable;
 import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.IFlushable2;
@@ -279,9 +280,15 @@ public abstract class CompareViewerSwitchingPane extends CompareViewerPane {
 		if (fViewer != null) {
 			Control c= fViewer.getControl();
 			if (c != null) {
-				Object data= c.getData(CompareUI.COMPARE_VIEWER_TITLE);
-				if (data instanceof String)
-					title= (String) data;
+				if (fViewer instanceof ContentMergeViewer cmv) {
+					title = cmv.getTitle();
+				}
+				if (title == null || title.isBlank()) {
+					Object data = c.getData(CompareUI.COMPARE_VIEWER_TITLE);
+					if (data instanceof String) {
+						title = (String) data;
+					}
+				}
 				if (hadFocus)
 					c.setFocus();
 			}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ViewerDescriptor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ViewerDescriptor.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.widgets.Composite;
 public class ViewerDescriptor implements IViewerDescriptor {
 	private final static String CLASS_ATTRIBUTE= "class"; //$NON-NLS-1$
 	private final static String EXTENSIONS_ATTRIBUTE= "extensions"; //$NON-NLS-1$
+	private final static String LINKED_EDITOR_ATTRIBUTE = "linkedEditor"; //$NON-NLS-1$
 	private final static String LABEL_ATTRIBUTE = "label"; //$NON-NLS-1$
 
 	private final IConfigurationElement fConfiguration;
@@ -79,4 +80,42 @@ public class ViewerDescriptor implements IViewerDescriptor {
 	String getLabel() {
 		return fConfiguration.getAttribute(LABEL_ATTRIBUTE);
 	}
+
+	String getLinkedEditorId() {
+		return fConfiguration.getAttribute(LINKED_EDITOR_ATTRIBUTE);
+	}
+
+	String getViewerClass() {
+		return fConfiguration.getAttribute(CLASS_ATTRIBUTE);
+	}
+
+	@SuppressWarnings("nls")
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("ViewerDescriptor [");
+		if (fViewerClass != null) {
+			sb.append("viewerClass=");
+			sb.append(fViewerClass);
+			sb.append(", ");
+		}
+		if (fViewerCreator != null) {
+			sb.append("viewerCreator=");
+			sb.append(fViewerCreator);
+			sb.append(", ");
+		}
+		String viewerClass = getViewerClass();
+		if (viewerClass != null) {
+			sb.append("viewerClass=");
+			sb.append(viewerClass);
+			sb.append(", ");
+		}
+		if (fConfiguration != null) {
+			sb.append("configuration=");
+			sb.append(fConfiguration);
+		}
+		sb.append("]");
+		return sb.toString();
+	}
+
 }

--- a/team/bundles/org.eclipse.compare/schema/contentMergeViewers.exsd
+++ b/team/bundles/org.eclipse.compare/schema/contentMergeViewers.exsd
@@ -90,6 +90,17 @@ content merge viewer and implements &lt;samp&gt;org.eclipse.compare.IViewerCreat
                </appInfo>
             </annotation>
          </attribute>
+         <attribute name="linkedEditor" type="string">
+            <annotation>
+               <documentation>
+                  Since 3.11. Editor id to consider while searching for a viewer matching a content type. 
+If the specified &quot;linked&quot; editor has content type associations, they will be also considered as possible bindings for this viewer. This is useful in cases where viewer supports same content types as &quot;linked&quot; editor (like in generic editor).
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="identifier" basedOn="org.eclipse.ui.editors/editor/@id"/>
+               </appInfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -123,6 +134,7 @@ content merge viewer and implements &lt;samp&gt;org.eclipse.compare.IViewerCreat
       </complexType>
    </element>
 
+
    <annotation>
       <appInfo>
          <meta.section type="examples"/>
@@ -153,7 +165,6 @@ for text files (extension &quot;txt&quot;):
          The contributed class must implement &lt;code&gt;org.eclipse.compare.IViewerCreator&lt;/code&gt;
       </documentation>
    </annotation>
-
 
    <annotation>
       <appInfo>


### PR DESCRIPTION
Extend `contentMergeViewers` extension point: add an attribute to consider "linked" editor content type associations. The code checks if contentMergeViewers contribution refers to such "linked" editor id in extension, and check if editor supports other content types. In case there are more content types supported by same "linked" editor, these would be automatically considered as valid contentTypes for the contentMergeViewers.

Updated CompareViewerSwitchingPane to consider more precise title calculations for ContentMergeViewer instances (where concrete type info is available after instantiation of a particular viewer).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747