### PR TITLE
Migrate org.eclipse.update.configurator.tests to JUnit 5

### DIFF
--- a/update/org.eclipse.update.configurator.tests/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-SymbolicName: org.eclipse.update.configurator.tests;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
- org.junit;bundle-version="4.12.0",
  org.eclipse.update.configurator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
@@ -14,3 +13,5 @@ Bundle-Vendor: %providerName
 Export-Package: org.eclipse.update.configurator.tests,
  org.eclipse.update.internal.configurator.tests
 Eclipse-BundleShape: dir
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api

--- a/update/org.eclipse.update.configurator.tests/Platform Update Test Suite.launch
+++ b/update/org.eclipse.update.configurator.tests/Platform Update Test Suite.launch
@@ -13,6 +13,7 @@
     <booleanAttribute key="default" value="true"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../update-junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/org.eclipse.update.configurator.tests/src/org/eclipse/update/configurator/tests/AutomatedConfiguratorSuite.java"/>
     </listAttribute>
@@ -22,7 +23,9 @@
     <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.update.configurator.tests.AutomatedConfiguratorSuite"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>

--- a/update/org.eclipse.update.configurator.tests/src/org/eclipse/update/configurator/tests/AutomatedConfiguratorSuite.java
+++ b/update/org.eclipse.update.configurator.tests/src/org/eclipse/update/configurator/tests/AutomatedConfiguratorSuite.java
@@ -14,16 +14,18 @@
 package org.eclipse.update.configurator.tests;
 
 import org.eclipse.update.internal.configurator.tests.FeatureEntryTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for integration and nightly builds.
  *
  * @since 0.1
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ FeatureEntryTests.class })
+@Suite
+@SelectClasses({ //
+		FeatureEntryTests.class, //
+})
 public class AutomatedConfiguratorSuite {
 
 }

--- a/update/org.eclipse.update.configurator.tests/src/org/eclipse/update/internal/configurator/tests/FeatureEntryTests.java
+++ b/update/org.eclipse.update.configurator.tests/src/org/eclipse/update/internal/configurator/tests/FeatureEntryTests.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.update.internal.configurator.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.eclipse.update.internal.configurator.FeatureEntry;
 import org.eclipse.update.internal.configurator.SiteEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public class FeatureEntryTests {


### PR DESCRIPTION
Replace test and test suite annotations as well as assertions with those from JUnit Platform / Jupiter.