### PR TITLE
Fix tests expecting TextMergeViewer class only

### DIFF
--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ReflectionUtils.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ReflectionUtils.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class ReflectionUtils {
 
@@ -48,7 +50,12 @@ public class ReflectionUtils {
 	public static Object getField(Object object, String name)
 			throws IllegalArgumentException, IllegalAccessException,
 			SecurityException, NoSuchFieldException {
-		Field field = object.getClass().getDeclaredField(name);
+		Field field;
+		try {
+			field = object.getClass().getDeclaredField(name);
+		} catch (NoSuchFieldException e) {
+			field = object.getClass().getSuperclass().getDeclaredField(name);
+		}
 		field.setAccessible(true);
 		Object ret = field.get(object);
 		return ret;


### PR DESCRIPTION
TextMergeViewer was expected by SaveableCompareEditorInputTest but more specific implementation (subclass of it) - GenericEditorMergeViewer was seen by the test after changes made to allow more specific viewer to "win" in the compare editor for text content.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747 
See https://github.com/eclipse-platform/eclipse.platform/pull/1277