### PR TITLE
Don't return null in JobManager::createMonitor

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -555,10 +555,12 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 	 * Returns a new progress monitor for this job.  Never returns null.
 	 */
 	private IProgressMonitor createMonitor(Job job) {
-		if (progressProvider != null) {
-			return progressProvider.createMonitor(job);
-		}
-		return new NullProgressMonitor();
+		IProgressMonitor monitor = null;
+		if (progressProvider != null)
+			monitor = progressProvider.createMonitor(job);
+		if (monitor == null)
+			monitor = new NullProgressMonitor();
+		return monitor;
 	}
 
 	@Override


### PR DESCRIPTION
Revert unintentional change made in 9c3525cbd3fbd1e2618e8c9edf4871f5c8d70cb2 and don't return null when creating a progress monitor. This is part of the contract of the method.

Replaces #1282 

Contributes to
https://github.com/eclipse-platform/eclipse.platform/issues/664