### PR TITLE
testFirstTabIsActivatedByDefault is no more passing with SWT fix for issue #46

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -1180,10 +1180,7 @@ public class LaunchConfigurationTabGroupViewer {
 	 * @return if the dialog can launch in its current state
 	 */
 	public boolean canLaunch() {
-		if(fInitializingTabs) {
-			return false;
-		}
-		if (getWorkingCopy() == null) {
+		if (fInitializingTabs || (getWorkingCopy() == null)) {
 			return false;
 		}
 		try {
@@ -1271,11 +1268,7 @@ public class LaunchConfigurationTabGroupViewer {
 	 * @return the error message for the tab
 	 */
 	public String getErrorMesssage() {
-		if (fInitializingTabs) {
-			return null;
-		}
-
-		if (getWorkingCopy() == null) {
+		if (fInitializingTabs || (getWorkingCopy() == null)) {
 			return null;
 		}
 		try {
@@ -1452,12 +1445,14 @@ public class LaunchConfigurationTabGroupViewer {
 		fCurrentTabIndex = fTabFolder.getSelectionIndex();
 
 		ILaunchConfigurationTab[] tabs = getTabs();
-		if (previousTabIndex == fCurrentTabIndex || tabs == null || tabs.length == 0
+		if (tabs == null || tabs.length == 0
 				|| previousTabIndex > (tabs.length - 1)) {
 			return;
 		}
 
-		propagateTabDeactivation(previousTabIndex);
+		if (previousTabIndex != fCurrentTabIndex) {
+			propagateTabDeactivation(previousTabIndex);
+		}
 
 		propagateTabActivation();
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1239

With the swt fix for [https://github.com/eclipse-platform/eclipse.platform.swt/issues/46](https://github.com/eclipse-platform/eclipse.platform.swt/issues/46) via pr https://github.com/eclipse-platform/eclipse.platform.swt/pull/1044 we are seeing propagateTabActivation() is not being called on all platforms.

For more details please see -> https://github.com/eclipse-platform/eclipse.platform.swt/issues/46#issuecomment-2037102845