### PR TITLE
Remember computed content type in CompareConfiguration

### DIFF
--- a/team/bundles/org.eclipse.compare/.settings/.api_filters
+++ b/team/bundles/org.eclipse.compare/.settings/.api_filters
@@ -8,4 +8,12 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="compare/org/eclipse/compare/CompareConfiguration.java" type="org.eclipse.compare.CompareConfiguration">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.compare.CompareConfiguration"/>
+                <message_argument value="CONTENT_TYPE"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
@@ -79,6 +79,14 @@ public class CompareConfiguration {
 	 */
 	public static final String MIRRORED = "MIRRORED"; //$NON-NLS-1$
 
+	/**
+	 * (Optional) id of the common content type for compare input detected by the
+	 * compare editor
+	 *
+	 * @since 3.11
+	 */
+	public static final String CONTENT_TYPE = "CONTENT_TYPE"; //$NON-NLS-1$
+
 	private static ImageDescriptor[] fgImages= new ImageDescriptor[32];
 
 	static {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -1030,8 +1030,11 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		if (ctype != null) {
 			initializeRegistries();
 			List<ViewerDescriptor> list = fContentMergeViewers.searchAll(ctype);
-			if (list != null)
+			if (list != null) {
 				result.addAll(list);
+			}
+			// Add a hint for the viewers which content type we have detected
+			cc.setProperty(CompareConfiguration.CONTENT_TYPE, ctype.getId());
 		}
 
 		String[] types= getTypes(input);


### PR DESCRIPTION
Remember detected content type id in CompareConfiguration with the CONTENT_TYPE key. This value can be picked up as a hint by TextMergeViewer implementations (like GenericEditorMergeViewer) that need to know which content type was detected by compare editor.

Most TextMergeViewer implementations don't need that hint because they aren't generic and usually always know which content type they will have
- not so for GenericEditorMergeViewer which is generic.

The hint allows GenericEditorMergeViewer to know for which content type was it actually created and so use that in cases where the content type can't be always derived from the input (like data from git revisions that don't have regular files or buffers associated to the viewer).

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747