### PR TITLE
Clear viewers set to TextEditorPropertyAction on dispose

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ShowWhitespaceAction.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ShowWhitespaceAction.java
@@ -128,6 +128,9 @@ public class ShowWhitespaceAction extends TextEditorPropertyAction {
 			for (int i = 0; i < viewers.length; i++) {
 				if (fNeedsPainters[i]) {
 					MergeSourceViewer viewer = viewers[i];
+					if (viewer == null) {
+						continue;
+					}
 					SourceViewer sourceViewer = viewer.getSourceViewer();
 					WhitespaceCharacterPainter painter;
 					if (fStore != null) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/TextEditorPropertyAction.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/TextEditorPropertyAction.java
@@ -77,8 +77,14 @@ public class TextEditorPropertyAction extends Action implements IPropertyChangeL
 	}
 
 	public void dispose() {
-		if (store != null)
+		if (viewers != null) {
+			for (int i = 0; i < viewers.length; i++) {
+				viewers[i] = null;
+			}
+		}
+		if (store != null) {
 			store.removePropertyChangeListener(this);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1804