### PR TITLE
Add debug information to JobManager to report blocked jobs

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -103,6 +103,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 	private static final String OPTION_DEBUG_JOBS = PI_JOBS + "/jobs"; //$NON-NLS-1$
 	private static final String OPTION_LOCKS = PI_JOBS + "/jobs/locks"; //$NON-NLS-1$
 	private static final String OPTION_SHUTDOWN = PI_JOBS + "/jobs/shutdown"; //$NON-NLS-1$
+	private static final String OPTION_DEBUG_BLOCKED_UNBLOCKED = PI_JOBS + "/jobs/blockedunblocked"; //$NON-NLS-1$
 
 	static DebugTrace DEBUG_TRACE;
 	static boolean DEBUG = false;
@@ -112,6 +113,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 	static boolean DEBUG_DEADLOCK = false;
 	static boolean DEBUG_LOCKS = false;
 	static boolean DEBUG_SHUTDOWN = false;
+	static boolean DEBUG_BLOCKED_UNBLOCKED = false;
 
 	/**
 	 * The singleton job manager instance. It must be a singleton because
@@ -1304,6 +1306,7 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 		DEBUG_DEADLOCK = options.getBooleanOption(OPTION_DEADLOCK_ERROR, false);
 		DEBUG_LOCKS = options.getBooleanOption(OPTION_LOCKS, false);
 		DEBUG_SHUTDOWN = options.getBooleanOption(OPTION_SHUTDOWN, false);
+		DEBUG_BLOCKED_UNBLOCKED = options.getBooleanOption(OPTION_DEBUG_BLOCKED_UNBLOCKED, false);
 	}
 
 	@Override
@@ -1332,6 +1335,10 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 			reason = new JobStatus(IStatus.INFO, (Job) blockingJob, msg);
 		}
 		monitor.setBlocked(reason);
+
+		if (DEBUG_BLOCKED_UNBLOCKED) {
+			JobManager.debug(reason.getMessage());
+		}
 	}
 
 	/**
@@ -1342,6 +1349,9 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 	 */
 	final void reportUnblocked(IProgressMonitor monitor) {
 		monitor.clearBlocked();
+		if (DEBUG_BLOCKED_UNBLOCKED) {
+			JobManager.debug(JobMessages.jobs_unblocked);
+		}
 	}
 
 	@Override

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobMessages.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobMessages.java
@@ -25,6 +25,7 @@ public class JobMessages extends NLS {
 	// Job Manager and Locks
 	public static String jobs_blocked0;
 	public static String jobs_blocked1;
+	public static String jobs_unblocked;
 	public static String jobs_internalError;
 	public static String jobs_waitFamSub;
 	public static String jobs_waitFamSubOne;

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/messages.properties
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/messages.properties
@@ -16,6 +16,7 @@
 ### Job Manager and Locks
 jobs_blocked0=The user operation is waiting for background work to complete.
 jobs_blocked1=The user operation is waiting for \"{0}\" to complete.
+jobs_unblocked=The user operation is not waiting anymore.
 jobs_internalError=An internal error occurred during: \"{0}\".
 jobs_waitFamSub={0} operations remaining.
 jobs_waitFamSubOne={0} operation remaining.


### PR DESCRIPTION
This should help debugging cases were some jobs are not finished because they are waiting for other (more important) jobs to finish.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1427 
Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1807