### PR TITLE
fix CharsetDeltaJob Deadlock #1290

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
@@ -76,6 +76,7 @@ public class CharsetDeltaJob extends Job implements IContentTypeManager.IContent
 	public CharsetDeltaJob(Workspace workspace) {
 		super(Messages.resources_charsetBroadcasting);
 		this.workspace = workspace;
+		setRule(workspace.getRoot()); // make sure workspace.prepareOperation() does not block
 	}
 
 	private void addToQueue(ICharsetListenerFilter filter) {
@@ -237,10 +238,10 @@ public class CharsetDeltaJob extends Job implements IContentTypeManager.IContent
 
 	public void shutdown() {
 		try {
-			// try to prevent execution of this job to avoid prevent "already shutdown.":
+			// try to prevent execution of this job to avoid "already shutdown.":
 			cancel();
 			// if job is already running wait for it to finish:
-			join();
+			join(3000, null);
 		} catch (InterruptedException e) {
 			// ignore
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -2382,11 +2382,14 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	}
 
 	/**
-	 * Called before checking the pre-conditions of an operation.  Optionally supply
-	 * a scheduling rule to determine when the operation is safe to run.  If a scheduling
-	 * rule is supplied, this method will block until it is safe to run.
+	 * Called before checking the pre-conditions of an operation. Optionally supply
+	 * a scheduling rule to determine when the operation is safe to run. If a
+	 * scheduling rule is supplied, this method will block until it is safe to run.
+	 * Even if no scheduling is supplied this method blocks until no other workspace
+	 * operation concurrently runs.
 	 *
-	 * @param rule the scheduling rule that describes what this operation intends to modify.
+	 * @param rule the scheduling rule that describes what this operation intends to
+	 *             modify.
 	 */
 	public void prepareOperation(ISchedulingRule rule, IProgressMonitor monitor) throws CoreException {
 		try {


### PR DESCRIPTION
Unlike documented Workspace.prepareOperation() blocks on WorkManager.lock.acquire() even without ISchedulingRule

https://github.com/eclipse-platform/eclipse.platform/issues/1290