### PR TITLE
Add missing @Override and @Deprecated annotations

### DIFF
--- a/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/NullBuildLogger.java
+++ b/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/NullBuildLogger.java
@@ -41,6 +41,7 @@ public class NullBuildLogger extends AbstractEclipseBuildLogger implements Build
 		fMessageOutputLevel = level;
 	}
 
+	@Override
 	public int getMessageOutputLevel() {
 		return fMessageOutputLevel;
 	}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/HierarchicalModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/HierarchicalModelProvider.java
@@ -94,6 +94,7 @@ public class HierarchicalModelProvider extends SynchronizeModelProvider {
 		return hierarchicalDescriptor;
 	}
 
+	@Override
 	public ViewerComparator getViewerComparator() {
 		return new SynchronizeModelElementComparator();
 	}


### PR DESCRIPTION
Applies the cleanup rules for adding missing @Override and @Deprecated annotations in all projects to be conform with defined save actions.