### PR TITLE
Use primitive types instead of wrapper types

### DIFF
--- a/ua/org.eclipse.help.base/src_demo/org/apache/lucene/demo/html/Entities.java
+++ b/ua/org.eclipse.help.base/src_demo/org/apache/lucene/demo/html/Entities.java
@@ -32,9 +32,9 @@ public class Entities {
 	start++;
 	radix = 16;
       }
-      Character c =
-	Character.valueOf((char)Integer.parseInt(entity.substring(start), radix));
-      return c.toString();
+      char c =
+	(char)Integer.parseInt(entity.substring(start), radix);
+      return Character.toString(c);
     } else {
       String s = decoder.get(entity);
       if (s != null)


### PR DESCRIPTION
Applies the cleanup rule for using primitive instead of wrapper types in all projects to be conform with defined save actions.