### PR TITLE
Remove unnecessary and unused code

### DIFF
--- a/platform/org.eclipse.platform/src-intro/org/eclipse/platform/internal/LaunchUpdateIntroAction.java
+++ b/platform/org.eclipse.platform/src-intro/org/eclipse/platform/internal/LaunchUpdateIntroAction.java
@@ -43,8 +43,8 @@ public class LaunchUpdateIntroAction implements IIntroAction {
 	}
 
 	boolean executeUpdateCommand(String command) {
-		ICommandService commandService = (ICommandService) PlatformUI.getWorkbench().getService(ICommandService.class);
-		IHandlerService handlerService = (IHandlerService) PlatformUI.getWorkbench().getService(IHandlerService.class);
+		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
 		Command cmd = commandService.getCommand(command);
 		ExecutionEvent executionEvent = handlerService.createExecutionEvent(cmd, null);
 		try {

--- a/team/bundles/org.eclipse.core.net.win32/src/org/eclipse/core/net/ProxyProvider.java
+++ b/team/bundles/org.eclipse.core.net.win32/src/org/eclipse/core/net/ProxyProvider.java
@@ -331,7 +331,7 @@ public class ProxyProvider extends AbstractProxyProvider {
 		String NO_PROXY_BYPASS = null;
 
 		// Flags for WINHTTP_AUTOPROXY_OPTIONS::dwFlags
-		int AUTOPROXY_AUTO_DETECT = 0x00000001;;
+		int AUTOPROXY_AUTO_DETECT = 0x00000001;
 		int AUTOPROXY_CONFIG_URL = 0x00000002;
 
 		// Flags for WINHTTP_AUTOPROXY_OPTIONS::dwAutoDetectFlags

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/DefaultUIFileModificationValidator.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/DefaultUIFileModificationValidator.java
@@ -127,7 +127,7 @@ public class DefaultUIFileModificationValidator extends DefaultFileModificationV
 			}
 			if (ok[0]) {
 				setWritable(readOnlyFiles);
-			};
+			}
 		} else if (readOnlyFiles.length > 0 && context == null) {
 			if (isMakeWrittableWhenContextNotProvided()) {
 				setWritable(readOnlyFiles);

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/MergeAllOperation.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/MergeAllOperation.java
@@ -118,7 +118,7 @@ public final class MergeAllOperation extends SynchronizationOperation {
 	}
 
 	@Override
-	protected String getJobName() {;
+	protected String getJobName() {
 		return jobName;
 	}
 }

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeManager.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeManager.java
@@ -529,7 +529,7 @@ public class SynchronizeManager implements ISynchronizeManager {
 
 		if(perspectiveDescriptor != null) {
 
-			String message;;
+			String message;
 			String desc = perspectiveDescriptor.getDescription();
 			if (desc == null) {
 				message = NLS.bind(TeamUIMessages.SynchronizeManager_30, new String[] { perspectiveDescriptor.getLabel() });

--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/NetTest.java
@@ -140,7 +140,7 @@ public class NetTest {
 	}
 
 	private IProxyData getProxyData(String type) {
-		IProxyData data = (IProxyData) dataCache.get(type);
+		IProxyData data = dataCache.get(type);
 		if (data == null) {
 			data = this.getProxyManager().getProxyData(type);
 			assertProxyDataEqual(data);
@@ -230,7 +230,7 @@ public class NetTest {
 	}
 
 	private void performSettingData() throws CoreException {
-		IProxyData[] data = (IProxyData[]) dataCache.values().toArray(new IProxyData[dataCache.size()]);
+		IProxyData[] data = dataCache.values().toArray(new IProxyData[dataCache.size()]);
 		this.getProxyManager().setProxyData(data);
 		for (IProxyData proxyData : data) {
 			assertProxyDataEqual(proxyData);

--- a/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
+++ b/team/tests/org.eclipse.core.tests.net/src/org/eclipse/core/tests/net/SystemProxyTest.java
@@ -109,7 +109,7 @@ public class SystemProxyTest {
 
 		Map<String, String> typeMap = new HashMap<>();
 		for (IProxyData p : proxiesData) {
-			assertProxyDataEqual(p, (IProxyData) proxyDataMap.get(p.getType()));
+			assertProxyDataEqual(p, proxyDataMap.get(p.getType()));
 			typeMap.put(p.getType(), p.getType());
 		}
 
@@ -122,7 +122,7 @@ public class SystemProxyTest {
 
 		Map<String, String> typeMap = new HashMap<>();
 		for (IProxyData p : proxiesData) {
-			assertProxyDataEqual(p, (IProxyData) proxyDataMap.get(p.getType()));
+			assertProxyDataEqual(p, proxyDataMap.get(p.getType()));
 			typeMap.put(p.getType(), p.getType());
 		}
 

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/synchronize/ResourceContentTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/synchronize/ResourceContentTests.java
@@ -172,7 +172,7 @@ public class ResourceContentTests {
 				resources.add(project.getFile(path));
 			}
 		}
-		return (IResource[]) resources.toArray(new IResource[resources.size()]);
+		return resources.toArray(new IResource[resources.size()]);
 	}
 
 	@Test

--- a/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/WebappResources.java
+++ b/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/WebappResources.java
@@ -157,7 +157,6 @@ public class WebappResources {
 	private static ResourceBundle getResourceBundle(String key) {
 		ResourceBundle bundle;
 
-	;
 		Bundle hostBundle = Platform.getBundle(FrameworkUtil.getBundle(HelpWebappPlugin.class).getSymbolicName());
 		if (hostBundle == null)
 			return null;

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/Utils.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/Utils.java
@@ -85,7 +85,7 @@ public class Utils {
 			((MultiStatus) status).add(childrenStatus);
 			((MultiStatus) status).addAll(childrenStatus);
 		} else {
-			StringBuilder completeString = new StringBuilder(); //$NON-NLS-1$
+			StringBuilder completeString = new StringBuilder();
 			if (s != null)
 				completeString.append(s);
 			if (e != null) {


### PR DESCRIPTION
Applies the following cleanup rules to all project to be conform with defined save actions:
* Remove unused imports
* Remove unnecessary casts
* Remove unused non-NLS tags
* Remove redundant semicolons