### PR TITLE
Unify access to static members

### DIFF
--- a/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/WordMergeViewer.java
+++ b/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/WordMergeViewer.java
@@ -122,7 +122,7 @@ public class WordMergeViewer extends AbstractMergeViewer implements IFlushable, 
 			toolBarManager.appendToGroup("file", saveAction); //$NON-NLS-1$
 		}
 		
-		inplaceAction = new Action(CompareWin32Messages.WordMergeViewer_2, Action.AS_CHECK_BOX) {
+		inplaceAction = new Action(CompareWin32Messages.WordMergeViewer_2, IAction.AS_CHECK_BOX) {
 			@Override
 			public void run() {
 				toggleInplaceExternalState();

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ModelSelectionDropDownAction.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/mapping/ModelSelectionDropDownAction.java
@@ -42,7 +42,6 @@ import org.eclipse.team.ui.TeamUI;
 import org.eclipse.team.ui.mapping.ITeamContentProviderDescriptor;
 import org.eclipse.team.ui.mapping.ITeamContentProviderManager;
 import org.eclipse.team.ui.synchronize.ISynchronizePageConfiguration;
-import org.eclipse.team.ui.synchronize.ModelMergeOperation;
 import org.eclipse.team.ui.synchronize.ModelOperation;
 import org.eclipse.team.ui.synchronize.ModelSynchronizeParticipant;
 
@@ -147,7 +146,7 @@ public class ModelSelectionDropDownAction extends Action implements ISynchroniza
 	private ModelProvider[] getEnabledModelProviders() {
 		Set<ModelProvider> result = new HashSet<>();
 		ModelProvider[] providers = ((ModelSynchronizeParticipant)configuration.getParticipant()).getEnabledModelProviders();
-		providers = ModelMergeOperation.sortByExtension(providers);
+		providers = ModelOperation.sortByExtension(providers);
 		for (ModelProvider provider : providers) {
 			ITeamContentProviderDescriptor desc = TeamUI.getTeamContentProviderManager().getDescriptor(provider.getId());
 			if (desc != null && desc.isEnabled()) {

--- a/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/filesystem/ui/NonSyncModelMergePage.java
+++ b/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/filesystem/ui/NonSyncModelMergePage.java
@@ -52,7 +52,7 @@ import org.eclipse.team.core.mapping.provider.ResourceDiffTree;
 import org.eclipse.team.examples.filesystem.FileSystemPlugin;
 import org.eclipse.team.internal.ui.mapping.SynchronizationResourceMappingContext;
 import org.eclipse.team.ui.mapping.ISynchronizationCompareAdapter;
-import org.eclipse.team.ui.synchronize.ModelMergeOperation;
+import org.eclipse.team.ui.synchronize.ModelOperation;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.Page;
 
@@ -159,7 +159,7 @@ public class NonSyncModelMergePage extends Page {
 			return super.compare(viewer, e1, e2);
 		}
 		private int compare(ResourceMapping m1, ResourceMapping m2) {
-			ModelProvider[] sorted = ModelMergeOperation.sortByExtension(new ModelProvider[] { m1.getModelProvider(), m2.getModelProvider() });
+			ModelProvider[] sorted = ModelOperation.sortByExtension(new ModelProvider[] { m1.getModelProvider(), m2.getModelProvider() });
 			return sorted[0] == m1.getModelProvider() ? -1 : 1;
 		}
 		private String getLabel(ResourceMapping mapping) {

--- a/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/model/mapping/ModelMerger.java
+++ b/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/model/mapping/ModelMerger.java
@@ -38,10 +38,10 @@ import org.eclipse.team.core.diff.IThreeWayDiff;
 import org.eclipse.team.core.history.IFileRevision;
 import org.eclipse.team.core.mapping.IMergeContext;
 import org.eclipse.team.core.mapping.IResourceDiff;
+import org.eclipse.team.core.mapping.ISynchronizationContext;
 import org.eclipse.team.core.mapping.ResourceMappingMerger;
 import org.eclipse.team.core.mapping.provider.MergeStatus;
 import org.eclipse.team.core.mapping.provider.ResourceDiffTree;
-import org.eclipse.team.core.mapping.provider.SynchronizationContext;
 import org.eclipse.team.examples.filesystem.FileSystemPlugin;
 import org.eclipse.team.examples.model.ModelObject;
 import org.eclipse.team.examples.model.ModelObjectDefinitionFile;
@@ -68,7 +68,7 @@ public class ModelMerger extends ResourceMappingMerger {
 		try {
 			IStatus status;
 			// Only override the merge for three-way synchronizations
-			if (mergeContext.getType() == SynchronizationContext.THREE_WAY) {
+			if (mergeContext.getType() == ISynchronizationContext.THREE_WAY) {
 				monitor.beginTask("Merging model elements", 100);
 				status = mergeModelElements(mergeContext, SubMonitor.convert(monitor, 50));
 				// Stop the merge if there was a failure

--- a/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProviderPlugin.java
+++ b/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProviderPlugin.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -93,7 +94,7 @@ public class PessimisticFilesystemProviderPlugin extends AbstractUIPlugin {
 	 */
 	public void logError(Throwable exception, String message) {
 		String pluginId= getBundle().getSymbolicName();
-		Status status= new Status(Status.ERROR, pluginId, Status.OK, message, exception);
+		Status status= new Status(IStatus.ERROR, pluginId, IStatus.OK, message, exception);
 		getLog().log(status);
 		if (isDebugging()) {
 			System.out.println(message);

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ContextHelpPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ContextHelpPart.java
@@ -74,6 +74,7 @@ import org.eclipse.ui.forms.events.ExpansionAdapter;
 import org.eclipse.ui.forms.events.ExpansionEvent;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.events.IHyperlinkListener;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
@@ -181,9 +182,9 @@ public class ContextHelpPart extends SectionPart implements IHelpPart {
 	}
 
 	private static int getSectionStyle() {
-		int style = Section.EXPANDED ;
+		int style = ExpandableComposite.EXPANDED ;
 		if (RelatedTopicsPart.isUseDynamicHelp()) {
-			style = style | Section.TWISTIE;
+			style = style | ExpandableComposite.TWISTIE;
 		}
 		return style;
 	}

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/DynamicHelpPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/DynamicHelpPart.java
@@ -49,6 +49,7 @@ import org.eclipse.ui.forms.events.ExpansionAdapter;
 import org.eclipse.ui.forms.events.ExpansionEvent;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.events.IHyperlinkListener;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
@@ -85,8 +86,8 @@ public class DynamicHelpPart extends SectionPart implements IHelpPart {
 	}
 
 	public DynamicHelpPart(Composite parent, FormToolkit toolkit) {
-		super(parent, toolkit, Section.EXPANDED | Section.TWISTIE
-				| Section.TITLE_BAR);
+		super(parent, toolkit, ExpandableComposite.EXPANDED | ExpandableComposite.TWISTIE
+				| ExpandableComposite.TITLE_BAR);
 		// configure section
 		Section section = getSection();
 		section.setText(Messages.SearchPart_title);

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/EngineResultSection.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/EngineResultSection.java
@@ -52,6 +52,7 @@ import org.eclipse.ui.forms.events.ExpansionEvent;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.events.IHyperlinkListener;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ImageHyperlink;
@@ -112,8 +113,8 @@ public class EngineResultSection {
 	}
 
 	public Control createControl(Composite parent, final FormToolkit toolkit) {
-		section = toolkit.createSection(parent, Section.SHORT_TITLE_BAR | Section.COMPACT | Section.TWISTIE
-				| Section.EXPANDED | Section.LEFT_TEXT_CLIENT_ALIGNMENT);
+		section = toolkit.createSection(parent, ExpandableComposite.SHORT_TITLE_BAR | ExpandableComposite.COMPACT | ExpandableComposite.TWISTIE
+				| ExpandableComposite.EXPANDED | ExpandableComposite.LEFT_TEXT_CLIENT_ALIGNMENT);
 		// section.marginHeight = 10;
 		container = toolkit.createComposite(section);
 		TableWrapLayout layout = new TableWrapLayout();
@@ -421,7 +422,7 @@ public class EngineResultSection {
 			String elabel = null;
 			if (isPotentialHit) {
 				// add "(potential hit)"
-				elabel = Messages.bind(Messages.SearchPart_potential_hit, hit.getLabel());
+				elabel = NLS.bind(Messages.SearchPart_potential_hit, hit.getLabel());
 			}
 			else {
 				elabel = hit.getLabel();

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/HelpTray.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/HelpTray.java
@@ -41,7 +41,7 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.HyperlinkGroup;
+import org.eclipse.ui.forms.HyperlinkSettings;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
 /**
@@ -96,7 +96,7 @@ public class HelpTray extends DialogTray implements IPageChangedListener {
 		ensureMinimumHeight(parent.getShell());
 
 		toolkit = new FormToolkit(parent.getDisplay());
-		toolkit.getHyperlinkGroup().setHyperlinkUnderlineMode(HyperlinkGroup.UNDERLINE_HOVER);
+		toolkit.getHyperlinkGroup().setHyperlinkUnderlineMode(HyperlinkSettings.UNDERLINE_HOVER);
 		toolkit.getColors().initializeSectionToolBarColors();
 		Composite container = new Composite(parent, SWT.NONE);
 		GridLayout layout = new GridLayout();

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/HelpView.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/HelpView.java
@@ -42,7 +42,7 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.HyperlinkGroup;
+import org.eclipse.ui.forms.HyperlinkSettings;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.part.ViewPart;
 
@@ -60,7 +60,7 @@ public class HelpView extends ViewPart implements IPartListener2, ISelectionChan
 	@Override
 	public void createPartControl(Composite parent) {
 		toolkit = new FormToolkit(parent.getDisplay());
-		toolkit.getHyperlinkGroup().setHyperlinkUnderlineMode(HyperlinkGroup.UNDERLINE_HOVER);
+		toolkit.getHyperlinkGroup().setHyperlinkUnderlineMode(HyperlinkSettings.UNDERLINE_HOVER);
 		toolkit.getColors().initializeSectionToolBarColors();
 		reusableHelpPart.createControl(parent, toolkit);
 		reusableHelpPart.setDefaultContextHelpText(Messages.HelpView_defaultText);

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ReusableHelpPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ReusableHelpPart.java
@@ -69,6 +69,7 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
@@ -1701,7 +1702,7 @@ public class ReusableHelpPart implements IHelpUIConstants, IActivityManagerListe
 								getShowAllMessage(),
 								Messages.AskShowAll_toggleMessage, false,
 								store, PROMPT_KEY);
-				if (dialog.getReturnCode() != MessageDialogWithToggle.OK) {
+				if (dialog.getReturnCode() != Window.OK) {
 					showAllAction.setChecked(false);
 					return;
 				}

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopePreferenceDialog.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopePreferenceDialog.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.preference.PreferenceManager;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -126,7 +127,7 @@ public class ScopePreferenceDialog extends PreferenceDialog {
 		WizardDialog dialog = new WizardDialog(getShell(), wizard);
 		dialog.create();
 		dialog.getShell().setSize(400, 500);
-		if (dialog.open()==WizardDialog.OK) {
+		if (dialog.open()==Window.OK) {
 			EngineTypeDescriptor etdesc = wizard.getSelectedEngineType();
 			EngineDescriptor desc = new EngineDescriptor(descManager);
 			desc.setEngineType(etdesc);

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopeSetDialog.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopeSetDialog.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -453,7 +454,7 @@ public class ScopeSetDialog extends TrayDialog  {
 		String dialogTitle = isRename ?
 		  Messages.RenameDialog_wtitle : Messages.NewDialog_wtitle;
 		dialog.getShell().setText(dialogTitle);
-		if (dialog.open()==RenameDialog.OK) {
+		if (dialog.open()==Window.OK) {
 			return dialog.getNewName();
 		}
 		return null;

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/ResetTaskAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/ResetTaskAction.java
@@ -17,6 +17,7 @@ package org.eclipse.ui.internal.cheatsheets.composite.explorer;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.window.Window;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.cheatsheets.CheatSheetPlugin;
 import org.eclipse.ui.internal.cheatsheets.Messages;
@@ -49,7 +50,7 @@ public class ResetTaskAction extends Action {
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), restartTasks, labelProvider);
 		dlg.open();
 		labelProvider.dispose();
-		if (dlg.getReturnCode() == ConfirmRestartDialog.OK) {
+		if (dlg.getReturnCode() == Window.OK) {
 			CompositeCheatSheetModel model = (CompositeCheatSheetModel) restartTasks[0].getCompositeCheatSheet();
 			model.resetTasks(restartTasks);
 		}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
@@ -852,7 +852,7 @@ public class CheatSheetViewer implements ICheatSheetViewer, IMenuContributor {
 		if (!parseStatus.isOK()) {
 			CheatSheetPlugin.getPlugin().getLog().log(parseStatus);
 		}
-		if(parseStatus.getSeverity() == Status.ERROR){
+		if(parseStatus.getSeverity() == IStatus.ERROR){
 
 			// Error during parsing.
 			// Something is wrong with the Cheat sheet content file at the xml level.

--- a/ua/org.eclipse.ui.intro.quicklinks/src/org/eclipse/ui/intro/quicklinks/QuicklinksViewer.java
+++ b/ua/org.eclipse.ui.intro.quicklinks/src/org/eclipse/ui/intro/quicklinks/QuicklinksViewer.java
@@ -56,6 +56,7 @@ import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandImageService;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.internal.intro.impl.model.AbstractIntroPartImplementation;
@@ -459,7 +460,7 @@ public class QuicklinksViewer implements IIntroContentProvider {
 
 	@Override
 	public void createContent(String id, Composite parent, FormToolkit toolkit) {
-		Section section = toolkit.createSection(parent, Section.EXPANDED);
+		Section section = toolkit.createSection(parent, ExpandableComposite.EXPANDED);
 		TableViewer tableViewer = new TableViewer(toolkit.createTable(section, SWT.FULL_SELECTION));
 		tableViewer.setLabelProvider(new URLLabelProvider() {
 			@Override

--- a/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
+++ b/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
@@ -30,8 +30,8 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.util.ProductPreferences;
 import org.eclipse.help.internal.util.SequenceResolver;
 import org.eclipse.jface.action.Action;
+import org.eclipse.ui.internal.intro.impl.model.AbstractIntroIdElement;
 import org.eclipse.ui.internal.intro.impl.model.ExtensionMap;
-import org.eclipse.ui.internal.intro.impl.model.IntroTheme;
 import org.eclipse.ui.internal.intro.universal.contentdetect.ContentDetector;
 import org.eclipse.ui.internal.intro.universal.util.ImageUtil;
 import org.eclipse.ui.internal.intro.universal.util.PreferenceArbiter;
@@ -219,7 +219,7 @@ public class UniversalIntroConfigurer extends IntroConfigurer implements
 	 * @return same path with a prefixed theme directory component
 	 */
 	private String getThemePrefixedPath(String path) {
-		String prefix = themeProperties != null ? themeProperties.get(IntroTheme.ATT_ID) : null;
+		String prefix = themeProperties != null ? themeProperties.get(AbstractIntroIdElement.ATT_ID) : null;
 		prefix = prefix == null ? "" : prefix.trim(); //$NON-NLS-1$
 		if (prefix.length() == 0) {
 			return null;


### PR DESCRIPTION
Applies the following cleanup rules concerning static member access to all projects in order to be conform with defined save actions:
* change non-static accesses to static members using declaring type
* change indirect accesses to static members to direct accesses