### PR TITLE
Use boolean value rather than comparison against true/false

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
@@ -134,7 +134,7 @@ public class AntModel implements IAntModel {
 
 	private final IPreferenceChangeListener fCoreListener = event -> {
 		if (IAntCoreConstants.PREFERENCE_CLASSPATH_CHANGED.equals(event.getKey())) {
-			if (Boolean.parseBoolean((String) event.getNewValue()) == true) {
+			if (Boolean.parseBoolean((String) event.getNewValue())) {
 				reconcileForPropertyChange(true);
 			}
 		}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/JFaceViewerTopIndexTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/JFaceViewerTopIndexTests.java
@@ -178,7 +178,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Validate that the first node is expanded
-		assertTrue(getCTargetViewer().getExpandedState(firstElemPath) == true);
+		assertTrue(getCTargetViewer().getExpandedState(firstElemPath));
 
 		// Stop forcing view updates.
 		autopopulateAgent.dispose();
@@ -260,7 +260,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		TreePath lastElemePath = model.findElement(lastElem.getLabel());
 
 		// Validate that the last node is expanded
-		assertTrue(getCTargetViewer().getExpandedState(lastElemePath) == true);
+		assertTrue(getCTargetViewer().getExpandedState(lastElemePath));
 
 		// Stop forcing view updates.
 		fViewer.setAutoExpandLevel(0);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PopupTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PopupTests.java
@@ -192,12 +192,12 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
-		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
+		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
 		// On windows, getExpandedState() may return true for an element with no children:
 		// assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.0 - new")) == false);
-		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.2")) == true); //$NON-NLS-1$
-		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.3")) == true); //$NON-NLS-1$
+		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.2"))); //$NON-NLS-1$
+		assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.3"))); //$NON-NLS-1$
 		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
 	}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/StateTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/StateTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.debug.tests.viewer.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -303,14 +304,14 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	@Test
@@ -347,16 +348,16 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	@Test
@@ -401,14 +402,14 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 
 		// Note: in past it was observed sub-optimal coalescing in this test due
 		// to scattered update requests from viewer.
@@ -583,13 +584,13 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
 		// On windows, getExpandedState() may return true for an element with no children:
 		// assertTrue(getCTargetViewer().getExpandedState(model.findElement("3.0 - new")) == false);
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.2")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.3")) == true); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.3"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	@Test
@@ -614,7 +615,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 //            new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findElement("6") });
 		TreeSelection originalSelection = new TreeSelection(model.findElement("5.1.1")); //$NON-NLS-1$
 		fViewer.setSelection(originalSelection);
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 
 		// Run this test ten times as we've seen intermittent failures related
 		// to timing in it.
@@ -630,14 +631,14 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			// Validate data
 			model.validateData(fViewer, TreePath.EMPTY, true);
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-			assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+			assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 
 			// Update the model again
 			model.addElementChild(TreePath.EMPTY, null, 0, new TestElement(model, "1", new TestElement[0])); //$NON-NLS-1$
@@ -650,14 +651,14 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			// Validate data
 			model.validateData(fViewer, TreePath.EMPTY, true);
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-			assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-			assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+			assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+			assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+			assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 		}
 	}
 
@@ -692,14 +693,14 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 
 		// Update the model again
 		model.addElementChild(TreePath.EMPTY, null, 0, new TestElement(model, "1", new TestElement[0])); //$NON-NLS-1$
@@ -710,14 +711,14 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	/**
@@ -821,7 +822,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == false); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
 	}
 
 	@Test
@@ -860,7 +861,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
 	}
 
 	@Test
@@ -1094,16 +1095,16 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data (only select visible elements).
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	/**
@@ -1162,16 +1163,16 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("4")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1")) == true); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("6")) == false); //$NON-NLS-1$
-		assertTrue( areTreeSelectionsEqual(originalSelection, (ITreeSelection)fViewer.getSelection()) );
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("1.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("4"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5"))); //$NON-NLS-1$
+		assertTrue(getInternalViewer().getExpandedState(model.findElement("5.1"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("6"))); //$NON-NLS-1$
+		assertTrue(areTreeSelectionsEqual(originalSelection, (ITreeSelection) fViewer.getSelection()));
 	}
 
 	@Test
@@ -1233,8 +1234,8 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		waitWhile(t -> !fListener.isFinished(STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("2")) == false); //$NON-NLS-1$
-		assertTrue(getInternalViewer().getExpandedState(model.findElement("3")) == false); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
+		assertFalse(getInternalViewer().getExpandedState(model.findElement("3"))); //$NON-NLS-1$
 		assertEquals(new TreeSelection(model.findElement("1")), fViewer.getSelection()); //$NON-NLS-1$
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/memory/provisional/AbstractAsyncTableRendering.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/memory/provisional/AbstractAsyncTableRendering.java
@@ -2374,7 +2374,7 @@ public abstract class AbstractAsyncTableRendering extends AbstractBaseTableRende
 		}
 
 		// do not do anything if already visible
-		if (isVisible() == true) {
+		if (isVisible()) {
 			// super should always be called
 			super.becomesVisible();
 			return;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointWorkingSetPage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointWorkingSetPage.java
@@ -183,7 +183,7 @@ public class BreakpointWorkingSetPage extends WizardPage implements IWorkingSetP
 		String errorMessage= null;
 		String newText= fWorkingSetName.getText();
 
-		if (newText.equals(newText.trim()) == false) {
+		if (!newText.equals(newText.trim())) {
 			errorMessage = DebugUIViewsMessages.BreakpointWorkingSetPage_4;
 		}
 		if (newText.equals(IInternalDebugCoreConstants.EMPTY_STRING)) {
@@ -195,7 +195,7 @@ public class BreakpointWorkingSetPage extends WizardPage implements IWorkingSetP
 			errorMessage= DebugUIViewsMessages.BreakpointWorkingSetPage_5;
 		}
 		fFirstCheck= false;
-		if (errorMessage == null && (fWorkingSet == null || newText.equals(fWorkingSet.getName()) == false)) {
+		if (errorMessage == null && (fWorkingSet == null || !newText.equals(fWorkingSet.getName()))) {
 			for (IWorkingSet workingSet : PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSets()) {
 				if (newText.equals(workingSet.getName())) {
 					errorMessage= DebugUIViewsMessages.BreakpointWorkingSetPage_6;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/TableRenderingCellModifier.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/TableRenderingCellModifier.java
@@ -57,7 +57,7 @@ public class TableRenderingCellModifier implements ICellModifier {
 				return false;
 			}
 
-			if (fRendering.getMemoryBlock().supportsValueModification() == false) {
+			if (!fRendering.getMemoryBlock().supportsValueModification()) {
 				return false;
 			}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/WorkingDirectoryBlock.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/WorkingDirectoryBlock.java
@@ -473,7 +473,7 @@ public abstract class WorkingDirectoryBlock extends AbstractLaunchConfigurationT
 			fFileSystemButton.setEnabled(enabled);
 		}
 		// in the case where the 'other' text is selected and we want to enable
-		if(fUseOtherDirButton.getSelection() && enabled == true) {
+		if(fUseOtherDirButton.getSelection() && enabled) {
 			fOtherWorkingText.setEnabled(enabled);
 		}
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/memory/AbstractTableRendering.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/memory/AbstractTableRendering.java
@@ -3146,7 +3146,7 @@ public abstract class AbstractTableRendering extends AbstractBaseTableRendering 
 	@Override
 	public void becomesHidden() {
 
-		if (isVisible() == false)
+		if (!isVisible())
 		{
 			// super should always be called
 			super.becomesHidden();
@@ -3171,7 +3171,7 @@ public abstract class AbstractTableRendering extends AbstractBaseTableRendering 
 	public void becomesVisible() {
 
 		// do not do anything if already visible
-		if (isVisible() == true)
+		if (isVisible())
 		{
 			// super should always be called
 			super.becomesVisible();

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/TestViewer.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/TestViewer.java
@@ -468,7 +468,7 @@ class TestViewer {
 				viewer.setInput(null);
 				// Set either the failures or the skipped tests filter
 				ViewerFilter filter = fFailuresOnlyFilter;
-				if (ignoredOnly == true) {
+				if (ignoredOnly) {
 					filter = fIgnoredOnlyFilter;
 				}
 				viewer.addFilter(filter);
@@ -678,7 +678,7 @@ class TestViewer {
 				}
 			}
 
-			while (parent != null && !fTestRunSession.equals(parent) && fTreeViewer.getExpandedState(parent) == false) {
+			while (parent != null && !fTestRunSession.equals(parent) && !fTreeViewer.getExpandedState(parent)) {
 				fAutoClose.add(parent); // add to auto-opened elements -> close later if STATUS_OK
 				parent = (ITestSuiteElement) fTreeContentProvider.getParent(parent);
 			}

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/search/InfoCenterPage.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/search/InfoCenterPage.java
@@ -199,7 +199,7 @@ public class InfoCenterPage extends RootScopePage {
 			@Override
 			public void treeExpanded(TreeExpansionEvent event) {
 				final Object element = event.getElement();
-				if (tree.getGrayed(element) == false)
+				if (!tree.getGrayed(element))
 					BusyIndicator.showWhile(getShell().getDisplay(),
 							() -> setSubtreeChecked(element, tree.getChecked(element), false));
 			}

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/search/LocalHelpPage.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/search/LocalHelpPage.java
@@ -189,7 +189,7 @@ public class LocalHelpPage extends RootScopePage {
 			@Override
 			public void treeExpanded(TreeExpansionEvent event) {
 				final Object element = event.getElement();
-				if (contentTree.getGrayed(element) == false)
+				if (!contentTree.getGrayed(element))
 					BusyIndicator.showWhile(getShell().getDisplay(),
 							() -> setSubtreeChecked(element, contentTree.getChecked(element), false,
 									contentTree, contentTreeContentProvider));
@@ -238,7 +238,7 @@ public class LocalHelpPage extends RootScopePage {
 			@Override
 			public void treeExpanded(TreeExpansionEvent event) {
 				final Object element = event.getElement();
-				if (criteriaTree.getGrayed(element) == false)
+				if (!criteriaTree.getGrayed(element))
 					BusyIndicator.showWhile(getShell().getDisplay(),
 							() -> setSubtreeChecked(element, criteriaTree.getChecked(element), false,
 									criteriaTree, criteriaTreeContentProvider));

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ReusableHelpPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ReusableHelpPart.java
@@ -1068,7 +1068,7 @@ public class ReusableHelpPart implements IHelpUIConstants, IActivityManagerListe
 	}
 
 	private boolean flipPages(HelpPartPage oldPage, HelpPartPage newPage) {
-		if (newPage.canOpen() == false)
+		if (!newPage.canOpen())
 			return false;
 		if (oldPage != null) {
 			oldPage.stop();
@@ -1094,7 +1094,7 @@ public class ReusableHelpPart implements IHelpUIConstants, IActivityManagerListe
 			mform.refresh();
 		mform.getForm().getBody().layout(true);
 		mform.reflow(true);
-		if (newPage.getId().equals(IHelpUIConstants.HV_BROWSER_PAGE) == false) {
+		if (!newPage.getId().equals(IHelpUIConstants.HV_BROWSER_PAGE)) {
 			if (!history.isBlocked()) {
 				history.addEntry(new HistoryEntry(HistoryEntry.PAGE, newPage
 						.getId(), null));

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopeSetDialog.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ScopeSetDialog.java
@@ -483,7 +483,7 @@ public class ScopeSetDialog extends TrayDialog  {
 
 	private void updateButtons() {
 		IStructuredSelection ssel = viewer.getStructuredSelection();
-		editButton.setEnabled(ssel.isEmpty()==false);
+		editButton.setEnabled(!ssel.isEmpty());
 		ScopeSet set = (ScopeSet)ssel.getFirstElement();
 		boolean editableSet = set!=null && set.isEditable() && !set.isImplicit();
 		removeButton.setEnabled(editableSet);

--- a/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/BundleUtil.java
+++ b/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/BundleUtil.java
@@ -167,7 +167,7 @@ public class BundleUtil {
 			localURL = FileLocator.toFileURL(localURL);
 			String result = localURL.toExternalForm();
 			if (result.startsWith("file:/")) { //$NON-NLS-1$
-				if (result.startsWith("file:///")==false) { //$NON-NLS-1$
+				if (!result.startsWith("file:///")) { //$NON-NLS-1$
 					result = "file:///"+result.substring(6); //$NON-NLS-1$
 				}
 			}

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroContainer.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroContainer.java
@@ -515,7 +515,7 @@ public abstract class AbstractIntroContainer extends AbstractBaseIntroElement {
 	private void handleIncludeStyleInheritence(IntroInclude include,
 			AbstractIntroElement target) {
 
-		if (include.getMergeStyle() == false)
+		if (!include.getMergeStyle())
 			// target styles are not needed. nothing to do.
 			return;
 

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/url/ShowHelpURLHandler.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/url/ShowHelpURLHandler.java
@@ -39,7 +39,7 @@ public class ShowHelpURLHandler {
 
 		boolean isEmbedded = (embed != null && embed
 			.equals(IntroURL.VALUE_TRUE)) ? true : false;
-		if (isEmbedded == false)
+		if (!isEmbedded)
 			// still false, check the embedTarget. If embedTarget is set, then
 			// we
 			// have embedded by default.

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/BundleUtil.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/BundleUtil.java
@@ -249,7 +249,7 @@ public class BundleUtil {
 			localURL = FileLocator.toFileURL(localURL);
 			String result = localURL.toExternalForm();
 			if (result.startsWith("file:/")) { //$NON-NLS-1$
-				if (result.startsWith("file:///")==false) { //$NON-NLS-1$
+				if (!result.startsWith("file:///")) { //$NON-NLS-1$
 					result = "file:///"+result.substring(6); //$NON-NLS-1$
 				}
 			}

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/BrowserIntroPartLocationListener.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/BrowserIntroPartLocationListener.java
@@ -69,14 +69,14 @@ public class BrowserIntroPartLocationListener implements LocationListener {
 			if (browser.getData("frameNavigation") != null) { //$NON-NLS-1$
 				// this is at least the second frame navigation, remove last
 				// history since it was added just as a filler.
-				if (event.top == false && browser.getData("tempUrl") != null //$NON-NLS-1$
+				if (!event.top && browser.getData("tempUrl") != null //$NON-NLS-1$
 						&& browser.getData("tempUrl").equals("true")) { //$NON-NLS-1$ //$NON-NLS-2$
 					implementation.getHistory().removeLastHistory();
 					flagRemovedTempUrl();
 				}
 			}
 
-			if (event.top == true) {
+			if (event.top) {
 				// we are navigating to a regular fully qualified URL. Event.top
 				// is true.
 				flagStartOfFrameNavigation();
@@ -84,7 +84,7 @@ public class BrowserIntroPartLocationListener implements LocationListener {
 			}
 
 			if (browser.getData("frameNavigation") == null //$NON-NLS-1$
-					&& event.top == false) {
+					&& !event.top) {
 				// a new url navigation that is not in a top frame. It can
 				// be a navigation url due to frames, it can be due to a true
 				// single Frame navigation (when you click on a link inside a


### PR DESCRIPTION
Applies the cleanup rule to use boolean values in conditions directly instead of comparing them against true or false to all project in order to be conform with defined save actions.