### PR TITLE
Simplify lambda expression and method reference syntax

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/RefreshScopeComparator.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/RefreshScopeComparator.java
@@ -36,9 +36,9 @@ public class RefreshScopeComparator implements Comparator<String> {
 		}
 	}
 
-	private static final Comparator<IResource> RESOURCE = Comparator.nullsFirst(Comparator.comparing(r -> r.toString()));
+	private static final Comparator<IResource> RESOURCE = Comparator.nullsFirst(Comparator.comparing(IResource::toString));
 	private static final Comparator<IResource[]> ARRAY = Comparator.nullsFirst((IResource[] s1, IResource[] s2) -> Arrays.compare(s1, s2, RESOURCE));
-	private static final Comparator<String> MEMENTO = Comparator.nullsFirst(Comparator.comparing(m -> toResources(m), ARRAY));
+	private static final Comparator<String> MEMENTO = Comparator.nullsFirst(Comparator.comparing(RefreshScopeComparator::toResources, ARRAY));
 
 	@Override
 	public int compare(String o1, String o2) {

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/model/LaunchViewModel.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/model/LaunchViewModel.java
@@ -42,7 +42,7 @@ public class LaunchViewModel implements ILaunchModel {
 	private static LaunchViewModel service;
 
 	private final List<Runnable> updateListeners = new ArrayList<>();
-	private final Runnable providerUpdateListener = () -> fireUpdate();
+	private final Runnable providerUpdateListener = this::fireUpdate;
 
 	public Set<ILaunchObjectProvider> getProviders() {
 		return providers;
@@ -53,7 +53,7 @@ public class LaunchViewModel implements ILaunchModel {
 		LaunchObjectContainerModel root = new LaunchObjectContainerModel();
 
 		// find all objects from services, sorted by prio (highest prio first).
-		Set<LaunchObjectModel> allObjects = providers.stream().map(p -> p.getLaunchObjects()).flatMap(o -> o.stream().map(LaunchObjectModel::new)).collect(Collectors.toCollection(TreeSet::new));
+		Set<LaunchObjectModel> allObjects = providers.stream().map(ILaunchObjectProvider::getLaunchObjects).flatMap(o -> o.stream().map(LaunchObjectModel::new)).collect(Collectors.toCollection(TreeSet::new));
 
 		// create favorite container
 		LaunchObjectFavoriteContainerModel favorites = new LaunchObjectFavoriteContainerModel();

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchAction.java
@@ -65,7 +65,7 @@ public class LaunchAction {
 	@CanExecute
 	public boolean isEnabled() {
 		Set<ILaunchObject> elements = view.get();
-		return !elements.isEmpty() && elements.stream().allMatch((m) -> {
+		return !elements.isEmpty() && elements.stream().allMatch(m -> {
 			try {
 				return m.getType().getDelegates(Collections.singleton(mode.getIdentifier())).length > 0;
 			} catch (CoreException e) {

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
@@ -118,7 +118,7 @@ public class LaunchViewImpl implements Supplier<Set<ILaunchObject>> {
 		tree.getViewer().getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		createMenus(part);
 
-		tree.getViewer().addDoubleClickListener((e) -> {
+		tree.getViewer().addDoubleClickListener(e -> {
 			ITreeSelection selection = tree.getViewer().getStructuredSelection();
 			if (selection.isEmpty()) {
 				return;

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/RelaunchAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/RelaunchAction.java
@@ -46,12 +46,12 @@ public class RelaunchAction {
 	@CanExecute
 	public boolean isEnabled() {
 		Set<ILaunchObject> elements = view.get();
-		return !elements.isEmpty() && elements.stream().allMatch(m -> m.canTerminate());
+		return !elements.isEmpty() && elements.stream().allMatch(ILaunchObject::canTerminate);
 	}
 
 	@Execute
 	public void run() {
-		view.get().stream().forEach(m -> m.relaunch());
+		view.get().stream().forEach(ILaunchObject::relaunch);
 	}
 
 }

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/TerminateAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/TerminateAction.java
@@ -46,12 +46,12 @@ public class TerminateAction {
 	@CanExecute
 	public boolean isEnabled() {
 		Set<ILaunchObject> elements = view.get();
-		return !elements.isEmpty() && elements.stream().allMatch(m -> m.canTerminate());
+		return !elements.isEmpty() && elements.stream().allMatch(ILaunchObject::canTerminate);
 	}
 
 	@Execute
 	public void run() {
-		view.get().forEach(e -> e.terminate());
+		view.get().forEach(ILaunchObject::terminate);
 	}
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/EnvironmentTab.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/EnvironmentTab.java
@@ -758,7 +758,7 @@ public class EnvironmentTab extends AbstractLaunchConfigurationTab {
 	 */
 	private void handleEnvCopyButtonSelected() {
 		Iterable<?> iterable = () -> environmentTable.getStructuredSelection().iterator();
-		String data = StreamSupport.stream(iterable.spliterator(), false).filter(o -> o instanceof EnvironmentVariable)
+		String data = StreamSupport.stream(iterable.spliterator(), false).filter(EnvironmentVariable.class::isInstance)
 				.map(EnvironmentVariable.class::cast).map(var -> String.format("%s=%s", var.getName(), var.getValue())) //$NON-NLS-1$
 				.collect(Collectors.joining(System.lineSeparator()));
 

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/AuthorizationHandler.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/AuthorizationHandler.java
@@ -74,7 +74,7 @@ public class AuthorizationHandler {
 			return true;
 		if (keyringFile == null) {
 			boolean found = ServiceCaller.callOnce(AuthorizationHandler.class, Location.class,
-					Location.CONFIGURATION_FILTER, (configurationLocation) -> {
+					Location.CONFIGURATION_FILTER, configurationLocation -> {
 						File file = new File(configurationLocation.getURL().getPath() + "/org.eclipse.core.runtime"); //$NON-NLS-1$
 						file = new File(file, F_KEYRING);
 						keyringFile = file.getAbsolutePath();

--- a/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/ClearTextAction.java
+++ b/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/ClearTextAction.java
@@ -43,9 +43,7 @@ public class ClearTextAction extends GlobalAction {
 		// then we need to provide an action definition id
 		// so clients can register this action in their key binding services
 		this.setActionDefinitionId(IWorkbenchCommandConstants.EDIT_DELETE);
-		this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> {
-			return ClearTextAction.class.getResource("/icons/clear.gif"); //$NON-NLS-1$
-		}));
+		this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> ClearTextAction.class.getResource("/icons/clear.gif")));
 	}
 
 	/**

--- a/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/CollapseAllAction.java
+++ b/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/CollapseAllAction.java
@@ -29,9 +29,7 @@ public class CollapseAllAction extends Action {
 		super(label);
 		this.setToolTipText(label);
 		this.viewer = viewer;
-		this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> {
-			return CollapseAllAction.class.getResource("/icons/collapseall.gif"); //$NON-NLS-1$
-		}));
+		this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> CollapseAllAction.class.getResource("/icons/collapseall.gif")));
 	}
 
 	@Override

--- a/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/runtime/EventsView.java
+++ b/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/runtime/EventsView.java
@@ -234,9 +234,7 @@ public class EventsView extends TableWithTotalView {
 			}
 		};
 		resetAction.setToolTipText("Reset all event statistics"); //$NON-NLS-1$
-		resetAction.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> {
-			return EventsView.class.getResource("/icons/clear.gif"); //$NON-NLS-1$
-		}));
+		resetAction.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> EventsView.class.getResource("/icons/clear.gif")));
 		// Add copy selection action
 
 		IActionBars bars = getViewSite().getActionBars();

--- a/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/runtime/PreferenceStatsView.java
+++ b/runtime/bundles/org.eclipse.core.tools/src/org/eclipse/core/tools/runtime/PreferenceStatsView.java
@@ -64,9 +64,7 @@ public class PreferenceStatsView extends SpyView {
 		UpdateAction() {
 			super("Update view"); //$NON-NLS-1$
 			this.setToolTipText("Update"); //$NON-NLS-1$
-			this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> {
-				return PreferenceStatsView.class.getResource("/icons/refresh.gif"); //$NON-NLS-1$
-			}));
+			this.setImageDescriptor(ImageDescriptor.createFromURLSupplier(true, () -> PreferenceStatsView.class.getResource("/icons/refresh.gif")));
 		}
 
 		@Override

--- a/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/nls/MessageRegistryTest.java
+++ b/runtime/tests/org.eclipse.e4.core.javax.tests/src/org/eclipse/e4/core/internal/tests/nls/MessageRegistryTest.java
@@ -96,7 +96,7 @@ public class MessageRegistryTest {
 		TestObject o = ContextInjectionFactory.make(TestObject.class, this.context);
 
 		TestLocalizableObject control = new TestLocalizableObject();
-		o.registry.register(control::setLocalizableValue, (m) -> m.message);
+		o.registry.register(control::setLocalizableValue, m -> m.message);
 
 		// test value is set
 		assertNotNull(control.getLocalizableValue());

--- a/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/nls/MessageRegistryTest.java
+++ b/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/nls/MessageRegistryTest.java
@@ -96,7 +96,7 @@ public class MessageRegistryTest {
 		TestObject o = ContextInjectionFactory.make(TestObject.class, this.context);
 
 		TestLocalizableObject control = new TestLocalizableObject();
-		o.registry.register(control::setLocalizableValue, (m) -> m.message);
+		o.registry.register(control::setLocalizableValue, m -> m.message);
 
 		// test value is set
 		assertNotNull(control.getLocalizableValue());

--- a/ua/org.eclipse.help/src/org/eclipse/help/internal/util/SequenceResolver.java
+++ b/ua/org.eclipse.help/src/org/eclipse/help/internal/util/SequenceResolver.java
@@ -100,7 +100,7 @@ public class SequenceResolver<T> {
 	 */
 	private void prepareDataStructures(List<T> primary, List<List<T>> secondary) {
 		primaryList = new ListWithIterator<>(primary);
-		secondaryLists = secondary.stream().map(list -> new ListWithIterator<>(list)).collect(toList());
+		secondaryLists = secondary.stream().map(ListWithIterator::new).collect(toList());
 		processedItems = new HashSet<>();
 	}
 

--- a/ua/org.eclipse.ua.tests.doc/src/org/eclipse/ua/tests/doc/internal/linkchecker/ApiDocTest.java
+++ b/ua/org.eclipse.ua.tests.doc/src/org/eclipse/ua/tests/doc/internal/linkchecker/ApiDocTest.java
@@ -280,7 +280,7 @@ public class ApiDocTest {
 		State state = service.getState(false);
 		for (BundleDescription bundle : state.getBundles()) {
 			bundle.getCapabilities(BundleRevision.PACKAGE_NAMESPACE)
-					.forEach((t) -> exportedPackageIds.add((String) t.getAttributes().get("osgi.wiring.package")));
+					.forEach(t -> exportedPackageIds.add((String) t.getAttributes().get("osgi.wiring.package")));
 		}
 
 		TreeSet<String> unexpectedPackageIds = new TreeSet<>(packageIds);


### PR DESCRIPTION
Applies the cleanup action to simplify lambda expression and method reference syntax in all projects to conform to defined save actions. This includes the following:
* replace simple method calls in lambda expressions by method references
* remove unnecessary parentheses around lambda input argument