### PR TITLE
Add missing SWT for Windows on Arm64 (WoA) fragment

### DIFF
--- a/team/bundles/org.eclipse.compare.win32/META-INF/p2.inf
+++ b/team/bundles/org.eclipse.compare.win32/META-INF/p2.inf
@@ -4,3 +4,8 @@ requires.0.name = org.eclipse.swt.win32.win32.x86_64
 #requires.0.range = [$version$,$version$]
 requires.0.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=x86_64))
 
+requires.1.namespace = org.eclipse.equinox.p2.iu
+requires.1.name = org.eclipse.swt.win32.win32.aarch64
+#requires.1.range = [$version$,$version$]
+requires.1.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64))
+


### PR DESCRIPTION
Add missing SWT for Windows on Arm64 (WoA) fragment to the compare win32 plug-in.
