### PR TITLE
MT hardening ProjectDescription.natures

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -775,8 +775,8 @@ public class Project extends Container implements IProject {
 		projectDesc.setVariableDescriptions(internalDesc.getVariables());
 
 		//clear properties, markers, and description for the new project, because they shouldn't be copied.
-		info.description = null;
-		info.natures = null;
+		info.discardDescription();
+		info.discardNatures();
 		info.setMarkers(null);
 		info.clearSessionProperties();
 	}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectInfo.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectInfo.java
@@ -23,17 +23,17 @@ import org.eclipse.core.runtime.content.IContentTypeMatcher;
 
 public class ProjectInfo extends ResourceInfo {
 
-	/** The description of this object */
-	protected ProjectDescription description;
+	/** The description of this object, synchronized access */
+	private ProjectDescription description;
 
-	/** The list of natures for this project */
-	protected HashMap<String, IProjectNature> natures;
+	/** The list of natures for this project, synchronized access */
+	private HashMap<String, IProjectNature> natures;
 
 	/** The property store for this resource (used only by the compatibility fragment) */
-	protected Object propertyStore;
+	private volatile Object propertyStore;
 
 	/** The content type matcher for this project. */
-	protected IContentTypeMatcher matcher;
+	private volatile IContentTypeMatcher matcher;
 
 	/**
 	 * Discards stale natures on this project after project description
@@ -41,6 +41,10 @@ public class ProjectInfo extends ResourceInfo {
 	 */
 	public synchronized void discardNatures() {
 		natures = null;
+	}
+
+	synchronized void discardDescription() {
+		description = null;
 	}
 
 	/**
@@ -68,7 +72,7 @@ public class ProjectInfo extends ResourceInfo {
 	/**
 	 * Returns the description associated with this info.  The return value may be null.
 	 */
-	public ProjectDescription getDescription() {
+	public synchronized ProjectDescription getDescription() {
 		return description;
 	}
 
@@ -79,8 +83,7 @@ public class ProjectInfo extends ResourceInfo {
 		return matcher;
 	}
 
-	public IProjectNature getNature(String natureId) {
-		// thread safety: (Concurrency001)
+	public synchronized IProjectNature getNature(String natureId) {
 		HashMap<String, IProjectNature> temp = natures;
 		if (temp == null)
 			return null;
@@ -98,7 +101,7 @@ public class ProjectInfo extends ResourceInfo {
 	/**
 	 * Sets the description associated with this info.  The value may be null.
 	 */
-	public void setDescription(ProjectDescription value) {
+	public synchronized void setDescription(ProjectDescription value) {
 		if (description != null) {
 			//if we already have a description, assign the new
 			//build spec on top of the old one to ensure we maintain


### PR DESCRIPTION
It is reported that sometimes ProjectDescription#hasNature(String) returns wrong values. While it is not clear how that happens chances are that this a concurrency problem: ProjectDescription can be used from arbitrary threads and yet totally missed any synchronization.
https://github.com/eclipse-pde/eclipse.pde/issues/1185

"when multiple threads share mutable data, each thread that reads or writes data must perform synchronization."
https://ahdak.github.io/blog/effective-java-part-10/
