### PR TITLE
Convert functional interface instances into lambda expressions

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
@@ -75,7 +75,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.VariablesPlugin;
@@ -139,24 +138,21 @@ public class AntModel implements IAntModel {
 			}
 		}
 	};
-	private final IPreferenceChangeListener fUIListener = new IPreferenceChangeListener() {
-		@Override
-		public void preferenceChange(PreferenceChangeEvent event) {
-			String property = event.getKey();
-			if (property.equals(AntEditorPreferenceConstants.PROBLEM)) {
-				IEclipsePreferences node = InstanceScope.INSTANCE.getNode(AntUIPlugin.PI_ANTUI);
-				if (node != null) {
-					node.removePreferenceChangeListener(fUIListener);
-					reconcileForPropertyChange(false);
-					node.addPreferenceChangeListener(fUIListener);
-				}
-			} else if (property.equals(AntEditorPreferenceConstants.CODEASSIST_USER_DEFINED_TASKS)) {
+	private final IPreferenceChangeListener fUIListener = event -> {
+		String property = event.getKey();
+		if (property.equals(AntEditorPreferenceConstants.PROBLEM)) {
+			IEclipsePreferences node = InstanceScope.INSTANCE.getNode(AntUIPlugin.PI_ANTUI);
+			if (node != null) {
+				node.removePreferenceChangeListener(this.fUIListener);
 				reconcileForPropertyChange(false);
-			} else if (property.equals(AntEditorPreferenceConstants.BUILDFILE_NAMES_TO_IGNORE)
-					|| property.equals(AntEditorPreferenceConstants.BUILDFILE_IGNORE_ALL)) {
-				fReportingProblemsCurrent = false;
-				reconcileForPropertyChange(false);
+				node.addPreferenceChangeListener(this.fUIListener);
 			}
+		} else if (property.equals(AntEditorPreferenceConstants.CODEASSIST_USER_DEFINED_TASKS)) {
+			reconcileForPropertyChange(false);
+		} else if (property.equals(AntEditorPreferenceConstants.BUILDFILE_NAMES_TO_IGNORE)
+				|| property.equals(AntEditorPreferenceConstants.BUILDFILE_IGNORE_ALL)) {
+			this.fReportingProblemsCurrent = false;
+			reconcileForPropertyChange(false);
 		}
 	};
 

--- a/ant/org.eclipse.ant.ui/Remote Ant Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/SWTInputHandler.java
+++ b/ant/org.eclipse.ant.ui/Remote Ant Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/SWTInputHandler.java
@@ -20,8 +20,6 @@ import org.apache.tools.ant.input.DefaultInputHandler;
 import org.apache.tools.ant.input.InputRequest;
 import org.apache.tools.ant.input.MultipleChoiceInputRequest;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.FontMetrics;
@@ -34,7 +32,6 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
@@ -67,22 +64,19 @@ public class SWTInputHandler extends DefaultInputHandler {
 	}
 
 	protected Runnable getHandleInputRunnable(final BuildException[] problem) {
-		return new Runnable() {
-			@Override
-			public void run() {
-				String prompt;
-				if (fRequest instanceof MultipleChoiceInputRequest) {
-					prompt = fRequest.getPrompt();
-				} else {
-					prompt = getPrompt(fRequest);
-				}
-				String title = RemoteAntMessages.getString("SWTInputHandler.1"); //$NON-NLS-1$
-				boolean[] result = new boolean[1];
-				open(title, prompt, result);
+		return () -> {
+			String prompt;
+			if (fRequest instanceof MultipleChoiceInputRequest) {
+				prompt = fRequest.getPrompt();
+			} else {
+				prompt = getPrompt(fRequest);
+			}
+			String title = RemoteAntMessages.getString("SWTInputHandler.1"); //$NON-NLS-1$
+			boolean[] result = new boolean[1];
+			open(title, prompt, result);
 
-				if (!result[0]) {
-					problem[0] = new BuildException(RemoteAntMessages.getString("SWTInputHandler.2")); //$NON-NLS-1$
-				}
+			if (!result[0]) {
+				problem[0] = new BuildException(RemoteAntMessages.getString("SWTInputHandler.2")); //$NON-NLS-1$
 			}
 		};
 	}
@@ -134,12 +128,7 @@ public class SWTInputHandler extends DefaultInputHandler {
 		} else {
 			fText = new Text(fDialog, SWT.SINGLE | SWT.BORDER);
 			fText.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_FILL));
-			fText.addModifyListener(new ModifyListener() {
-				@Override
-				public void modifyText(ModifyEvent e) {
-					validateInput();
-				}
-			});
+			fText.addModifyListener(event -> validateInput());
 		}
 
 		String value = null;
@@ -217,12 +206,9 @@ public class SWTInputHandler extends DefaultInputHandler {
 
 		Button cancel = new Button(parent, SWT.PUSH);
 		cancel.setText(RemoteAntMessages.getString("SWTInputHandler.5")); //$NON-NLS-1$
-		Listener listener = new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				result[0] = event.widget == fOkButton;
-				fDialog.close();
-			}
+		Listener listener = event -> {
+			result[0] = event.widget == fOkButton;
+			fDialog.close();
 		};
 		setButtonLayoutData(cancel);
 		fOkButton.addListener(SWT.Selection, listener);

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiMainTab.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiMainTab.java
@@ -26,8 +26,6 @@ import org.eclipse.debug.examples.ui.pda.DebugUIPlugin;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Font;
@@ -80,12 +78,7 @@ public class MidiMainTab extends AbstractLaunchConfigurationTab {
 		gd = new GridData(GridData.FILL_HORIZONTAL);
 		fFileText.setLayoutData(gd);
 		fFileText.setFont(font);
-		fFileText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				updateLaunchConfigurationDialog();
-			}
-		});
+		fFileText.addModifyListener(event -> updateLaunchConfigurationDialog());
 
 		fFileButton = createPushButton(comp, "&Browse...", null); //$NON-NLS-1$
 		fFileButton.addSelectionListener(new SelectionAdapter() {

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAContentAssistant.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAContentAssistant.java
@@ -16,10 +16,8 @@ package org.eclipse.debug.examples.ui.pda.editor;
 
 import org.eclipse.jface.text.DefaultInformationControl;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.IInformationControl;
 import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
-import org.eclipse.swt.widgets.Shell;
 
 public class PDAContentAssistant extends ContentAssistant {
 
@@ -36,11 +34,6 @@ public class PDAContentAssistant extends ContentAssistant {
 	}
 
 	private IInformationControlCreator getInformationControlCreator() {
-		return new IInformationControlCreator() {
-			@Override
-			public IInformationControl createInformationControl(Shell parent) {
-				return new DefaultInformationControl(parent);
-			}
-		};
+		return parent -> new DefaultInformationControl(parent);
 	}
 }

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDAMainTab.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDAMainTab.java
@@ -28,8 +28,6 @@ import org.eclipse.debug.examples.ui.pda.DebugUIPlugin;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Font;
@@ -75,12 +73,7 @@ public class PDAMainTab extends AbstractLaunchConfigurationTab {
 		gd = new GridData(GridData.FILL_HORIZONTAL);
 		fProgramText.setLayoutData(gd);
 		fProgramText.setFont(font);
-		fProgramText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				updateLaunchConfigurationDialog();
-			}
-		});
+		fProgramText.addModifyListener(event -> updateLaunchConfigurationDialog());
 
 		fProgramButton = createPushButton(comp, "&Browse...", null); //$NON-NLS-1$
 		fProgramButton.addSelectionListener(new SelectionAdapter() {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/TestBreakpoint.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/TestBreakpoint.java
@@ -21,7 +21,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.model.Breakpoint;
 import org.eclipse.debug.core.model.IBreakpoint;
 
@@ -43,14 +42,11 @@ public class TestBreakpoint extends Breakpoint {
 
 	TestBreakpoint(String text, final String markerType) {
 		final IResource resource = ResourcesPlugin.getWorkspace().getRoot();
-		IWorkspaceRunnable wr = new IWorkspaceRunnable() {
-			@Override
-			public void run(IProgressMonitor monitor) throws CoreException {
-				// create the marker
-				setMarker(resource.createMarker(markerType));
-				ensureMarker().setAttribute(ID, getModelIdentifier());
-				ensureMarker().setAttribute(TEXT_ATTRIBUTE, text);
-			}
+		IWorkspaceRunnable wr = monitor -> {
+			// create the marker
+			setMarker(resource.createMarker(markerType));
+			ensureMarker().setAttribute(ID, getModelIdentifier());
+			ensureMarker().setAttribute(TEXT_ATTRIBUTE, text);
 		};
 		try {
 			ResourcesPlugin.getWorkspace().run(wr, null);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
@@ -942,12 +942,9 @@ public class ConsoleDocumentAdapterTests extends AbstractDebugTest {
 	@Test
 	public void testInvalidInvocations() {
 		final AtomicInteger expectedErrors = new AtomicInteger(0);
-		final ILogListener logListener = new ILogListener() {
-			@Override
-			public void logging(IStatus status, String plugin) {
-				if (status.matches(IStatus.ERROR)) {
-					expectedErrors.decrementAndGet();
-				}
+		final ILogListener logListener = (status, plugin) -> {
+			if (status.matches(IStatus.ERROR)) {
+				expectedErrors.decrementAndGet();
 			}
 		};
 		try {

--- a/resources/examples/org.eclipse.ui.examples.filesystem/src/org/eclipse/ui/examples/filesystem/NestedProjectCreator.java
+++ b/resources/examples/org.eclipse.ui.examples.filesystem/src/org/eclipse/ui/examples/filesystem/NestedProjectCreator.java
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.*;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
-import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
@@ -70,12 +69,7 @@ public class NestedProjectCreator {
 
 	private void doCreateNestedProjects(final IProject[] projects, Shell shell) throws InvocationTargetException, InterruptedException {
 		final Object[] result = new Object[1];
-		context.run(true, true, new IRunnableWithProgress() {
-			@Override
-			public void run(IProgressMonitor monitor) {
-				result[0] = findNestedProjects(projects);
-			}
-		});
+		context.run(true, true, monitor -> result[0] = findNestedProjects(projects));
 		if (result[0] == null)
 			return;
 		IProjectDescription[] rawDescriptions = (IProjectDescription[]) result[0];

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeCatalog.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeCatalog.java
@@ -708,21 +708,18 @@ public final class ContentTypeCatalog {
 		for (ContentType root : source) {
 			// From a given content type, check if it matches, and
 			// include any children that match as well.
-			internalAccept(new ContentTypeVisitor() {
-				@Override
-				public int visit(ContentType type) {
-					if (type != root && type.hasBuiltInAssociations())
-						// this content type has built-in associations - visit it later as root
-						return RETURN;
-					if (type == root && !type.hasFileSpec(context, fileSpecText, fileSpecType))
-						// it is the root and does not match the file name - do not add it nor look into its children
-						return RETURN;
-					// either the content type is the root and matches the file name or
-					// is a sub content type and does not have built-in files specs
-					if (!existing.contains(type))
-						destination.add(type);
-					return CONTINUE;
-				}
+			internalAccept(contentType -> {
+				if (contentType != root && contentType.hasBuiltInAssociations())
+					// this content type has built-in associations - visit it later as root
+					return ContentTypeVisitor.RETURN;
+				if (contentType == root && !contentType.hasFileSpec(context, fileSpecText, fileSpecType))
+					// it is the root and does not match the file name - do not add it nor look into its children
+					return ContentTypeVisitor.RETURN;
+				// either the content type is the root and matches the file name or
+				// is a sub content type and does not have built-in files specs
+				if (!existing.contains(contentType))
+					destination.add(contentType);
+				return ContentTypeVisitor.CONTINUE;
 			}, root);
 		}
 		return destination;

--- a/runtime/bundles/org.eclipse.e4.core.di.extensions.supplier/src/org/eclipse/e4/core/di/internal/extensions/OSGiObjectSupplier.java
+++ b/runtime/bundles/org.eclipse.e4.core.di.extensions.supplier/src/org/eclipse/e4/core/di/internal/extensions/OSGiObjectSupplier.java
@@ -27,7 +27,6 @@ import org.eclipse.e4.core.di.suppliers.IObjectDescriptor;
 import org.eclipse.e4.core.di.suppliers.IRequestor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleListener;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.SynchronousBundleListener;
@@ -102,14 +101,11 @@ public class OSGiObjectSupplier extends ExtendedObjectSupplier implements EventH
 	private void track(final Bundle bundle, final IRequestor requestor) {
 		// A _synchronous_ BundleListener asserts that the BC is un-injected,
 		// _before_ it becomes invalid (state-wise).
-		BundleListener listener = new SynchronousBundleListener() {
-			@Override
-			public void bundleChanged(BundleEvent event) {
-				if (event.getBundle().equals(bundle)) {
-					if (requestor.isValid()) {
-						requestor.resolveArguments(false);
-						requestor.execute();
-					}
+		SynchronousBundleListener listener = event -> {
+			if (event.getBundle().equals(bundle)) {
+				if (requestor.isValid()) {
+					requestor.resolveArguments(false);
+					requestor.execute();
 				}
 			}
 		};

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/CollectionAdapterFactory.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/CollectionAdapterFactory.java
@@ -14,7 +14,6 @@
 package org.eclipse.core.internal.expressions.tests;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import org.eclipse.core.expressions.ICountable;
 import org.eclipse.core.expressions.IIterable;
@@ -26,21 +25,12 @@ public class CollectionAdapterFactory implements IAdapterFactory {
 
 	@Override
 	public <T> T getAdapter(final Object adaptableObject, Class<T> adapterType) {
-		if (adapterType.equals(IIterable.class) && adaptableObject instanceof ExpressionTests.CollectionWrapper) {
-			return adapterType.cast(new IIterable<String>() {
-				@Override
-				public Iterator<String> iterator() {
-					return ((ExpressionTests.CollectionWrapper)adaptableObject).collection.iterator();
-				}
-			});
-		}
-		if (adapterType.equals(ICountable.class) && adaptableObject instanceof ExpressionTests.CollectionWrapper) {
-			return adapterType.cast(new ICountable() {
-				@Override
-				public int count() {
-					return ((ExpressionTests.CollectionWrapper)adaptableObject).collection.size();
-				}
-			});
+		if (adaptableObject instanceof ExpressionTests.CollectionWrapper wrapper) {
+			if (adapterType.equals(IIterable.class)) {
+				return adapterType.cast(((IIterable<String>) () -> wrapper.collection.iterator()));
+			} else if (adapterType.equals(ICountable.class)) {
+				return adapterType.cast((ICountable) () -> wrapper.collection.size());
+			}
 		}
 		return null;
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceExportTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PreferenceExportTest.java
@@ -103,12 +103,7 @@ public class PreferenceExportTest {
 		//add a property change listener that asserts key identity
 		Plugin testPlugin = RuntimeTestsPlugin.getPlugin();
 		Preferences prefs = testPlugin.getPluginPreferences();
-		Preferences.IPropertyChangeListener listener = new Preferences.IPropertyChangeListener() {
-			@Override
-			public void propertyChange(Preferences.PropertyChangeEvent event) {
-				assertSame("1.0", event.getProperty(), key);
-			}
-		};
+		Preferences.IPropertyChangeListener listener = event -> assertSame("1.0", event.getProperty(), key);
 		prefs.addPropertyChangeListener(listener);
 		try {
 			//add a preference on the runtime plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -497,7 +497,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				return null;
 			final Viewer v = CompareUI.findStructureViewer(oldViewer, input, parent, configuration);
 			if (v != null) {
-				v.getControl().addDisposeListener(e -> v.removeSelectionChangedListener(InternalOutlineViewerCreator.this));
+				v.getControl().addDisposeListener(event -> v.removeSelectionChangedListener(InternalOutlineViewerCreator.this));
 				v.addSelectionChangedListener(this);
 			}
 
@@ -2059,7 +2059,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		// 1st row
 		if (fMarginWidth > 0) {
 			fAncestorCanvas = new Canvas(composite, SWT.DOUBLE_BUFFERED);
-			fAncestorCanvas.addPaintListener(e -> paintSides(e.gc, fAncestor, fAncestorCanvas, false));
+			fAncestorCanvas.addPaintListener(event -> paintSides(event.gc, fAncestor, fAncestorCanvas, false));
 			fAncestorCanvas.addMouseListener(
 				new MouseAdapter() {
 					@Override
@@ -2088,7 +2088,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		// 2nd row
 		if (fMarginWidth > 0) {
 			fLeftCanvas = new Canvas(composite, SWT.DOUBLE_BUFFERED);
-			fLeftCanvas.addPaintListener(e -> paintSides(e.gc, fLeft, fLeftCanvas, false));
+			fLeftCanvas.addPaintListener(event -> paintSides(event.gc, fLeft, fLeftCanvas, false));
 			fLeftCanvas.addMouseListener(
 				new MouseAdapter() {
 					@Override
@@ -2144,7 +2144,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 		if (fMarginWidth > 0) {
 			fRightCanvas = new Canvas(composite, SWT.DOUBLE_BUFFERED);
-			fRightCanvas.addPaintListener(e -> paintSides(e.gc, fRight, fRightCanvas, fSynchronizedScrolling));
+			fRightCanvas.addPaintListener(event -> paintSides(event.gc, fRight, fRightCanvas, fSynchronizedScrolling));
 			fRightCanvas.addMouseListener(
 				new MouseAdapter() {
 					@Override
@@ -2163,17 +2163,16 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		fVScrollBar.setIncrement(1);
 		fVScrollBar.setVisible(true);
 		fVScrollBar.addListener(SWT.Selection,
-			e -> {
-				int vpos= ((ScrollBar) e.widget).getSelection();
+			event -> {
+				int vpos= ((ScrollBar) event.widget).getSelection();
 				synchronizedScrollVertical(vpos);
 			}
 		);
 
 		fBirdsEyeCanvas = new Canvas(composite, SWT.DOUBLE_BUFFERED);
-		fBirdsEyeCanvas.addPaintListener(e -> {
+		fBirdsEyeCanvas.addPaintListener(event -> {
 			updateVScrollBar(); // Update scroll bar here as initially viewport height is wrong
-			paintBirdsEyeView((Canvas) e.widget, e.gc);
-
+			paintBirdsEyeView((Canvas) event.widget, event.gc);
 		});
 
 		fBirdsEyeCanvas.addMouseListener(
@@ -2455,7 +2454,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 			final Canvas canvas = new Canvas(parent, SWT.DOUBLE_BUFFERED);
 
-			canvas.addPaintListener(e -> paintCenter((Canvas) e.widget, e.gc));
+			canvas.addPaintListener(event -> paintCenter((Canvas) event.widget, event.gc));
 			new HoverResizer(canvas, HORIZONTAL);
 
 			Cursor normalCursor= canvas.getDisplay().getSystemCursor(SWT.CURSOR_ARROW);
@@ -2641,9 +2640,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		if (!fConfirmSave)
 			viewer.hideSaveAction();
 
-		te.addPaintListener(
-			e -> paint(e, viewer)
-		);
+		te.addPaintListener(event -> paint(event, viewer));
 		te.addKeyListener(
 			new KeyAdapter() {
 				@Override


### PR DESCRIPTION
Apply cleanup to convert functional interface instances into simple lambda expression in all projects to align with defined save actions.