### PR TITLE
Simplify HEX-encoded byte string to byte conversion

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/RenderingsUtil.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/RenderingsUtil.java
@@ -556,23 +556,7 @@ public class RenderingsUtil {
 		{
 			// convert string to byte
 			String oneByte = str.substring(i*2, i*2+2);
-
-			Integer number = Integer.valueOf(oneByte, 16);
-			if (number.compareTo(Integer.valueOf(Byte.toString(Byte.MAX_VALUE))) > 0)
-			{
-				int temp = number.intValue();
-				temp = temp - 256;
-
-				String tempStr = Integer.toString(temp);
-
-				Byte myByte = Byte.valueOf(tempStr);
-				bytes[i] = myByte.byteValue();
-			}
-			else
-			{
-				Byte myByte = Byte.valueOf(oneByte, 16);
-				bytes[i] = myByte.byteValue();
-			}
+			bytes[i] = (byte) Integer.parseInt(oneByte, 16);
 		}
 
 		return bytes;


### PR DESCRIPTION
The code to convert a string containing a single byte encoded in HEX to a byte is done in an unnecessary complex way. A parsing to int is already performed and this integer value can directly be used as a byte value instead of making an explicit conversion of an unsigned to a signed value before parsing the byte again.

As proposed by @tomaswolf: https://github.com/eclipse-platform/eclipse.platform/pull/1306#discussion_r1565296760