### PR TITLE
Log stack trace when error occurs during ProcessConsoleTest #1033

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
@@ -108,7 +110,18 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 
 		super.tearDown();
 
-		assertThat(loggedErrors).as("logged errors").isEmpty();
+		assertThat(errorsToStrings()).as("logged errors").isEmpty();
+	}
+
+	private Stream<String> errorsToStrings() {
+		return loggedErrors.stream().map(status -> status.toString() + throwableToString(status.getException()));
+	}
+
+	private static String throwableToString(Throwable throwable) {
+		if (throwable == null) {
+			return "";
+		}
+		return System.lineSeparator() + "Stack trace: " + Stream.of(throwable.getStackTrace()).map(Object::toString).collect(Collectors.joining(System.lineSeparator()));
 	}
 
 	/**


### PR DESCRIPTION
To ease debugging of errors during the execution of ProcessConsoleTest, this extends the logging by the stack trace of the original error. This allows to identify where the error occurred and not only which kind of error it was.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/1033