### PR TITLE
Add org.eclipse.jdt.* filter to org.eclipse.javaDevelopment activity.

### DIFF
--- a/platform/org.eclipse.sdk/plugin.xml
+++ b/platform/org.eclipse.sdk/plugin.xml
@@ -117,7 +117,11 @@
       <activityPatternBinding
             activityId="org.eclipse.javaDevelopment"
             pattern="org\.eclipse\.jdt\.core/javanature">
-
+      </activityPatternBinding>
+      
+      <activityPatternBinding
+            activityId="org.eclipse.javaDevelopment"
+            pattern="org\.eclipse\.jdt.*">
       </activityPatternBinding>
       
       <activityPatternBinding


### PR DESCRIPTION
Existing patterns does not filter out commands from JDT. This pattern will filter out all the commands.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/1828