### PR TITLE
Support Platform.getOS/WS/Arch() in non OSGi runtimes and use it in LocalFileSystem

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Convert.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Convert.java
@@ -16,7 +16,6 @@ package org.eclipse.core.internal.filesystem.local;
 
 import java.io.UnsupportedEncodingException;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.osgi.service.environment.Constants;
 
 public class Convert {
 
@@ -24,7 +23,7 @@ public class Convert {
 	private static String defaultEncoding = Platform.getSystemCharset().name();
 
 	/** Indicates if we are running on windows */
-	private static final boolean isWindows = Constants.OS_WIN32.equals(LocalFileSystem.getOS());
+	private static final boolean IS_WINDOWS = Platform.OS.isWindows();
 
 	private static final String WIN32_FILE_PREFIX = "\\\\?\\"; //$NON-NLS-1$
 	private static final String WIN32_UNC_FILE_PREFIX = "\\\\?\\UNC"; //$NON-NLS-1$
@@ -126,8 +125,9 @@ public class Convert {
 	 */
 	public static char[] toPlatformChars(String target) {
 		//Windows use special prefix to handle long filenames
-		if (!isWindows)
+		if (!IS_WINDOWS) {
 			return target.toCharArray();
+		}
 		//convert UNC path of form \\server\path to unicode form \\?\UNC\server\path
 		if (target.startsWith("\\\\")) { //$NON-NLS-1$
 			int nameLength = target.length();

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
@@ -23,7 +23,7 @@ import org.eclipse.core.internal.filesystem.local.nio.DosHandler;
 import org.eclipse.core.internal.filesystem.local.nio.PosixHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileHandler;
 import org.eclipse.core.internal.filesystem.local.unix.UnixFileNatives;
-import org.eclipse.osgi.service.environment.Constants;
+import org.eclipse.core.runtime.Platform;
 
 /**
  * <p>Dispatches methods backed by native code to the appropriate platform specific
@@ -59,7 +59,7 @@ public class LocalFileNativesManager {
 	 */
 	public static boolean setUsingNative(boolean useNatives) {
 		boolean nativesAreUsed;
-		boolean isWindowsOS = Constants.OS_WIN32.equals(LocalFileSystem.getOS());
+		boolean isWindowsOS = Platform.OS.isWindows();
 
 		if (useNatives && !isWindowsOS && UnixFileNatives.isUsingNatives()) {
 			HANDLER = new UnixFileHandler();

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -431,10 +431,6 @@ public final class InternalPlatform {
 		return new Log(bundle, null);
 	}
 
-	public String getNL() {
-		return getBundleContext().getProperty(PROP_NL);
-	}
-
 	/**
 	 * Unicode locale extensions are defined using command line parameter -nlExtensions,
 	 * or the system property "osgi.nl.extensions".
@@ -459,17 +455,29 @@ public final class InternalPlatform {
 	}
 
 	public String getOS() {
-		return getBundleContext().getProperty(PROP_OS);
+		return getContextProperty(PROP_OS);
+	}
+
+	public String getWS() {
+		return getContextProperty(PROP_WS);
 	}
 
 	public String getOSArch() {
-		return getBundleContext().getProperty(PROP_ARCH);
+		return getContextProperty(PROP_ARCH);
+	}
+
+	public String getNL() {
+		return getContextProperty(PROP_NL);
+	}
+
+	private String getContextProperty(String key) {
+		BundleContext ctx = context;
+		return ctx != null ? ctx.getProperty(key) : System.getProperty(key);
 	}
 
 	public PlatformAdmin getPlatformAdmin() {
 		return platformTracker == null ? null : platformTracker.getService();
 	}
-
 
 	public IPreferencesService getPreferencesService() {
 		return preferencesTracker == null ? null : preferencesTracker.getService();
@@ -547,10 +555,6 @@ public final class InternalPlatform {
 	public Location getUserLocation() {
 		assertInitialized();
 		return userLocation.getService();
-	}
-
-	public String getWS() {
-		return getBundleContext().getProperty(PROP_WS);
 	}
 
 	private void initializeAuthorizationHandler() {


### PR DESCRIPTION
Unless the bundle's context has its own local configuration, `BundleContext.getProperty()` delegates to `System.getProperty()` anyways.
Use it in `LocalFileSystem`, which had it implemented again explicitly for non-OSGi environments.

Does anybody has concerns about this?