### PR TITLE
Simplify lambda expression and method reference syntax

### DIFF
--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAContentAssistant.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAContentAssistant.java
@@ -34,6 +34,6 @@ public class PDAContentAssistant extends ContentAssistant {
 	}
 
 	private IInformationControlCreator getInformationControlCreator() {
-		return parent -> new DefaultInformationControl(parent);
+		return DefaultInformationControl::new;
 	}
 }


### PR DESCRIPTION
Applies the cleanup action to simplify lambda expression and method reference syntax in all projects to conform to defined save actions.