### PR TITLE
Migrate test suites in org.eclipse.core.tests.resources to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -35,6 +35,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.pde.junit.runtime;bundle-version="3.5.0"
 Import-Package: org.assertj.core.api,
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api,
  org.mockito
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/AllFileSystemTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/AllFileSystemTests.java
@@ -14,14 +14,22 @@
  *******************************************************************************/
 package org.eclipse.core.tests.filesystem;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Class for collecting all test classes that deal with the file system API.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ CreateDirectoryTest.class, DeleteTest.class, EFSTest.class, FileCacheTest.class,
-		FileStoreTest.class, OpenOutputStreamTest.class, PutInfoTest.class, SymlinkTest.class, URIUtilTest.class })
+@Suite
+@SelectClasses({ CreateDirectoryTest.class, //
+		DeleteTest.class, //
+		EFSTest.class, //
+		FileCacheTest.class, //
+		FileStoreTest.class, //
+		OpenOutputStreamTest.class, //
+		PutInfoTest.class, //
+		SymlinkTest.class, //
+		URIUtilTest.class, //
+})
 public class AllFileSystemTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/AllAliasTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/AllAliasTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.alias;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Class for collecting all test classes that deal with alias support. An alias
@@ -22,7 +22,10 @@ import org.junit.runners.Suite;
  * another resource in the workspace. When a resource changes in a way that
  * affects the contents on disk, all aliases need to be updated.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ BasicAliasTest.class, SyncAliasTest.class })
+@Suite
+@SelectClasses({ //
+		BasicAliasTest.class, //
+		SyncAliasTest.class, //
+})
 public class AllAliasTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuilderTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/AllBuilderTests.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		AutoBuildJobTest.class, //
 		BuildConfigurationsTest.class, //
 		BuildContextTest.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/AllDtreeTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/dtree/AllDtreeTests.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.dtree;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ DeltaDataTreeTest.class })
+@Suite
+@SelectClasses({ //
+		DeltaDataTreeTest.class, //
+})
 public class AllDtreeTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/AllEventsTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/AllEventsTests.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.events;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ BuildProjectFromMultipleJobsTest.class })
+@Suite
+@SelectClasses({ //
+		BuildProjectFromMultipleJobsTest.class, //
+})
 public class AllEventsTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/AllLocalStoreTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/AllLocalStoreTests.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		BlobStoreTest.class, //
 		BucketTreeTests.class, //
 		CaseSensitivityTest.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/AllMappingTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/AllMappingTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.mapping;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Suite containing all tests in the org.eclipse.core.tests.internal.mapping
@@ -22,10 +22,10 @@ import org.junit.runners.Suite;
  *
  * @since 3.2
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ 
-	ChangeValidationTest.class,
-	TestProjectDeletion.class
-	})
+@Suite
+@SelectClasses({ //
+		ChangeValidationTest.class, //
+		TestProjectDeletion.class, //
+})
 public class AllMappingTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/AllPropertiesTests.java
@@ -14,11 +14,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.properties;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-
-@Suite.SuiteClasses({ PropertyManagerTest.class })
+@Suite
+@SelectClasses({ //
+		PropertyManagerTest.class, //
+})
 public class AllPropertiesTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/AllPropertytesterTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/propertytester/AllPropertytesterTests.java
@@ -13,11 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.propertytester;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ FilePropertyTesterTest.class })
+@Suite
+@SelectClasses({ //
+		FilePropertyTesterTest.class, //
+})
 public class AllPropertytesterTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/AllInternalResourcesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/AllInternalResourcesTests.java
@@ -14,15 +14,15 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The suite method for this class contains test suites for all automated tests
  * in this test package.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		Bug544975Test.class, //
 		ModelObjectReaderWriterTest.class, //
 		ProjectBuildConfigsTest.class, //
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
 		ProjectReferencesTest.class, //
 		ResourceInfoTest.class, //
 		WorkspaceConcurrencyTest.class, //
-		WorkspacePreferencesTest.class, })
+		WorkspacePreferencesTest.class, //
+})
 public class AllInternalResourcesTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/AllUtilsTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/AllUtilsTests.java
@@ -14,10 +14,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.utils;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ ObjectMapTest.class, CacheTest.class, FileUtilTest.class })
+@Suite
+@SelectClasses({ //
+		ObjectMapTest.class, //
+		CacheTest.class, //
+		FileUtilTest.class, })
 public class AllUtilsTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/AllWatsonTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/AllWatsonTests.java
@@ -13,13 +13,17 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.watson;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-		DeltaChainFlatteningTest.class, DeltaFlatteningTest.class, ElementTreeDeltaChainTest.class,
-		ElementTreeIteratorTest.class, ElementTreeHasChangesTest.class, TreeFlatteningTest.class
+@Suite
+@SelectClasses({ //
+		DeltaChainFlatteningTest.class, //
+		DeltaFlatteningTest.class, //
+		ElementTreeDeltaChainTest.class, //
+		ElementTreeIteratorTest.class, //
+		ElementTreeHasChangesTest.class, //
+		TreeFlatteningTest.class, //
 })
 public class AllWatsonTests {
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllResourcesTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AllResourcesTests.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		CharsetTest.class, //
 		ContentDescriptionManagerTest.class, //
 		FilteredResourceTest.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/AutomatedResourceTests.java
@@ -13,28 +13,33 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Runs the sniff tests for the build. All tests listed here should be
  * automated.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ org.eclipse.core.tests.filesystem.AllFileSystemTests.class,
-		org.eclipse.core.tests.internal.alias.AllAliasTests.class, org.eclipse.core.tests.internal.builders.AllBuilderTests.class,
-		org.eclipse.core.tests.internal.dtree.AllDtreeTests.class,
-		org.eclipse.core.tests.internal.localstore.AllLocalStoreTests.class,
-		org.eclipse.core.tests.internal.mapping.AllMappingTests.class,
-		org.eclipse.core.tests.internal.properties.AllPropertiesTests.class,
-		org.eclipse.core.tests.internal.propertytester.AllPropertytesterTests.class,
-		org.eclipse.core.tests.internal.utils.AllUtilsTests.class, org.eclipse.core.tests.internal.watson.AllWatsonTests.class,
-		org.eclipse.core.tests.resources.AllResourcesTests.class, org.eclipse.core.tests.resources.refresh.AllRefreshTests.class,
-		org.eclipse.core.tests.resources.regression.AllRegressionTests.class,
-		org.eclipse.core.tests.resources.usecase.AllUsecaseTests.class,
-		org.eclipse.core.tests.resources.session.AllSessionTests.class,
-		org.eclipse.core.tests.resources.content.AllContentTests.class, org.eclipse.core.tests.internal.events.AllEventsTests.class,
-		org.eclipse.core.tests.internal.resources.AllInternalResourcesTests.class,
+@Suite
+@SelectClasses({ //
+		org.eclipse.core.tests.filesystem.AllFileSystemTests.class, //
+		org.eclipse.core.tests.internal.alias.AllAliasTests.class, //
+		org.eclipse.core.tests.internal.builders.AllBuilderTests.class, //
+		org.eclipse.core.tests.internal.dtree.AllDtreeTests.class, //
+		org.eclipse.core.tests.internal.localstore.AllLocalStoreTests.class, //
+		org.eclipse.core.tests.internal.mapping.AllMappingTests.class, //
+		org.eclipse.core.tests.internal.properties.AllPropertiesTests.class, //
+		org.eclipse.core.tests.internal.propertytester.AllPropertytesterTests.class, //
+		org.eclipse.core.tests.internal.utils.AllUtilsTests.class, //
+		org.eclipse.core.tests.internal.watson.AllWatsonTests.class, //
+		org.eclipse.core.tests.resources.AllResourcesTests.class, //
+		org.eclipse.core.tests.resources.refresh.AllRefreshTests.class, //
+		org.eclipse.core.tests.resources.regression.AllRegressionTests.class, //
+		org.eclipse.core.tests.resources.usecase.AllUsecaseTests.class, //
+		org.eclipse.core.tests.resources.session.AllSessionTests.class, //
+		org.eclipse.core.tests.resources.content.AllContentTests.class, //
+		org.eclipse.core.tests.internal.events.AllEventsTests.class, //
+		org.eclipse.core.tests.internal.resources.AllInternalResourcesTests.class, //
 })
 public class AutomatedResourceTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/AllContentTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/AllContentTests.java
@@ -13,15 +13,22 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.content;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Runs all content type tests
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ IContentTypeManagerTest.class, SpecificContextTest.class, ContentDescriptionTest.class,
-		XMLContentDescriberTest.class, LazyInputStreamTest.class, LazyReaderTest.class, TestBug94498.class })
+@Suite
+@SelectClasses({ //
+		IContentTypeManagerTest.class, //
+		SpecificContextTest.class, //
+		ContentDescriptionTest.class, //
+		XMLContentDescriberTest.class, //
+		LazyInputStreamTest.class, //
+		LazyReaderTest.class, //
+		TestBug94498.class, //
+})
 public class AllContentTests {
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/AllResourcePerfTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/AllResourcePerfTests.java
@@ -13,19 +13,19 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * @since 3.1
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		BenchCopyFile.class, //
 		BenchElementTree.class, //
 		// BenchFileStore.class, // very long running
 		BenchMiscWorkspace.class, //
-		BenchWorkspace.class,
+		BenchWorkspace.class, //
 		BuilderPerformanceTest.class, //
 		ConcurrencyPerformanceTest.class, //
 		ContentDescriptionPerformanceTest.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/AllRefreshTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/refresh/AllRefreshTests.java
@@ -13,13 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.refresh;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Runs all tests in this package.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ RefreshProviderTest.class, RefreshJobTest.class })
+@Suite
+@SelectClasses({ //
+		RefreshProviderTest.class, //
+		RefreshJobTest.class //
+})
 public class AllRefreshTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * A suite that runs all regression tests.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		Bug_006708.class, //
 		Bug_025457.class, //
 		Bug_026294.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/AllSessionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/AllSessionTests.java
@@ -13,23 +13,50 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ SampleSessionTest.class, TestBug93473.class, TestSave.class, Test1G1N9GZ.class,
-		TestCloseNoSave.class, TestMultiSnap.class, TestSaveCreateProject.class, TestSaveSnap.class,
-		TestSaveWithClosedProject.class, TestSnapSaveSnap.class, TestBug6995.class,
-		TestInterestingProjectPersistence.class, TestBuilderDeltaSerialization.class, Test1GALH44.class,
-		TestMissingBuilder.class, TestClosedProjectLocation.class, FindDeletedMembersTest.class, TestBug20127.class,
-		TestBug12575.class, WorkspaceDescriptionTest.class, TestBug30015.class,
-		TestMasterTableCleanup.class,
-		ProjectPreferenceSessionTest.class, TestBug113943.class, TestCreateLinkedResourceInHiddenProject.class,
-		Bug_266907.class, TestBug323833.class,
-		org.eclipse.core.tests.resources.regression.TestMultipleBuildersOfSameType.class,
-		org.eclipse.core.tests.resources.usecase.SnapshotTest.class, ProjectDescriptionDynamicTest.class,
-		TestBug202384.class, TestBug369177.class, TestBug316182.class, TestBug294854.class, TestBug426263.class,
-		TestWorkspaceEncodingExistingWorkspace.class, TestWorkspaceEncodingNewWorkspace.class,
-		TestWorkspaceEncodingWithJvmArgs.class, TestWorkspaceEncodingWithPluginCustomization.class, })
+@Suite
+@SelectClasses({ //
+		SampleSessionTest.class, //
+		TestBug93473.class, //
+		TestSave.class, //
+		Test1G1N9GZ.class, //
+		TestCloseNoSave.class, //
+		TestMultiSnap.class, //
+		TestSaveCreateProject.class, //
+		TestSaveSnap.class, //
+		TestSaveWithClosedProject.class, //
+		TestSnapSaveSnap.class, //
+		TestBug6995.class, //
+		TestInterestingProjectPersistence.class, //
+		TestBuilderDeltaSerialization.class, //
+		Test1GALH44.class, //
+		TestMissingBuilder.class, //
+		TestClosedProjectLocation.class, //
+		FindDeletedMembersTest.class, //
+		TestBug20127.class, //
+		TestBug12575.class, //
+		WorkspaceDescriptionTest.class, //
+		TestBug30015.class, //
+		TestMasterTableCleanup.class, //
+		ProjectPreferenceSessionTest.class, //
+		TestBug113943.class, //
+		TestCreateLinkedResourceInHiddenProject.class, //
+		Bug_266907.class, //
+		TestBug323833.class, //
+		org.eclipse.core.tests.resources.regression.TestMultipleBuildersOfSameType.class, //
+		org.eclipse.core.tests.resources.usecase.SnapshotTest.class, //
+		ProjectDescriptionDynamicTest.class, //
+		TestBug202384.class, //
+		TestBug369177.class, //
+		TestBug316182.class, //
+		TestBug294854.class, //
+		TestBug426263.class, //
+		TestWorkspaceEncodingExistingWorkspace.class, //
+		TestWorkspaceEncodingNewWorkspace.class, //
+		TestWorkspaceEncodingWithJvmArgs.class, //
+		TestWorkspaceEncodingWithPluginCustomization.class, //
+})
 public class AllSessionTests {
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/AllUsecaseTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/AllUsecaseTests.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.usecase;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({ //
 		ConcurrencyTest.class, //
 		IFileTest.class, //
 		IFolderTest.class, //
 		IProjectTest.class, //
-		IWorkspaceRunnableUseCaseTest.class
+		IWorkspaceRunnableUseCaseTest.class, //
 })
 public class AllUsecaseTests {
 }


### PR DESCRIPTION
Prepares the migration of the org.eclipse.core.tests.resources project by migrating the test suites to JUnit 5.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

Also serves as a preparation for #1086.