### PR TITLE
Migrate test suites in org.eclipse.core.tests.runtime to JUnit 5 #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -14,7 +14,9 @@ Require-Bundle: org.junit,
  org.eclipse.test.performance;resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.core.tests.harness;bundle-version="3.11.0"
-Import-Package: org.assertj.core.api
+Import-Package: org.assertj.core.api,
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Plugin-Class: org.eclipse.core.tests.runtime.RuntimeTestsPlugin

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/AllPreferenceTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/AllPreferenceTests.java
@@ -13,14 +13,23 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
-import org.eclipse.core.tests.runtime.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.eclipse.core.tests.runtime.PreferenceExportTest;
+import org.eclipse.core.tests.runtime.PreferenceForwarderTest;
+import org.eclipse.core.tests.runtime.PreferencesTest;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ EclipsePreferencesTest.class, PreferencesServiceTest.class, IScopeContextTest.class,
-		TestBug388004.class, TestBug380859.class, PreferenceExportTest.class, PreferenceForwarderTest.class,
-		PreferencesTest.class })
+@Suite
+@SelectClasses({ //
+		EclipsePreferencesTest.class, //
+		PreferencesServiceTest.class, //
+		IScopeContextTest.class, //
+		TestBug388004.class, //
+		TestBug380859.class, //
+		PreferenceExportTest.class, //
+		PreferenceForwarderTest.class, //
+		PreferencesTest.class, //
+})
 @SuppressWarnings("deprecation")
 public class AllPreferenceTests {
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/AllInternalRuntimeTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/AllInternalRuntimeTests.java
@@ -13,10 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.runtime;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ LogSerializationTest.class, PlatformURLLocalTest.class, PlatformURLSessionTest.class })
+@Suite
+@SelectClasses({ //
+		LogSerializationTest.class, //
+		PlatformURLLocalTest.class, //
+		PlatformURLSessionTest.class })
 public class AllInternalRuntimeTests {
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/AllRuntimeTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/AllRuntimeTests.java
@@ -13,11 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ PlatformTest.class })
+@Suite
+@SelectClasses({ //
+		PlatformTest.class, //
+})
 public class AllRuntimeTests {
 
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/AutomatedRuntimeTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/AutomatedRuntimeTests.java
@@ -16,27 +16,24 @@ package org.eclipse.core.tests.runtime;
 import org.eclipse.core.tests.internal.preferences.AllPreferenceTests;
 import org.eclipse.core.tests.internal.runtime.AllInternalRuntimeTests;
 import org.eclipse.core.tests.runtime.jobs.AllJobTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Runs the sniff tests for the build. All tests listed here should be
  * automated.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-		AllInternalRuntimeTests.class,
-
-		AllRuntimeTests.class,
-
-		AllPreferenceTests.class,
-
-		XmlProcessorFactoryTest.class,
+@Suite
+@SelectClasses({ //
+		AllInternalRuntimeTests.class, //
+		AllRuntimeTests.class, //
+		AllPreferenceTests.class, //
+		XmlProcessorFactoryTest.class, //
 		/*
-		 * Intentional the LAST TEST in the list to let JobEventTest.testNoTimeoutOccured() verify the other
-		 * tests:
+		 * Intentional the LAST TEST in the list to let
+		 * JobEventTest.testNoTimeoutOccured() verify the other tests:
 		 */
-		AllJobTests.class
+		AllJobTests.class, //
 })
 public class AutomatedRuntimeTests {
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllJobTests.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AllJobTests.java
@@ -14,25 +14,43 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Runs all job tests
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-		YieldTest.class, IJobManagerTest.class, JobGroupTest.class, JobQueueTest.class, OrderedLockTest.class,
-		BeginEndRuleTest.class, JobTest.class, DeadlockDetectionTest.class, Bug_129551.class, Bug_211799.class,
-		Bug_307282.class, Bug_307391.class, MultiRuleTest.class, Bug_311756.class, Bug_311863.class, Bug_316839.class,
-		Bug_320329.class, Bug_478634.class, Bug_550738.class, Bug_574883.class, Bug_412138.class,
-		Bug_574883Join.class, GithubBug_193.class,
-		WorkerPoolTest.class,
+@Suite
+@SelectClasses({ //
+		YieldTest.class, //
+		IJobManagerTest.class, //
+		JobGroupTest.class, //
+		JobQueueTest.class, //
+		OrderedLockTest.class, //
+		BeginEndRuleTest.class, //
+		JobTest.class, //
+		DeadlockDetectionTest.class, //
+		Bug_129551.class, //
+		Bug_211799.class, //
+		Bug_307282.class, //
+		Bug_307391.class, //
+		MultiRuleTest.class, //
+		Bug_311756.class, //
+		Bug_311863.class, //
+		Bug_316839.class, //
+		Bug_320329.class, //
+		Bug_478634.class, //
+		Bug_550738.class, //
+		Bug_574883.class, //
+		Bug_412138.class, //
+		Bug_574883Join.class, //
+		GithubBug_193.class, //
+		WorkerPoolTest.class, //
 		/*
 		 * Intentional the LAST TEST in the list to testNoTimeoutOccured() in the other
 		 * tests:
 		 */
-		JobEventTest.class
+		JobEventTest.class, //
 })
 public class AllJobTests {
 }


### PR DESCRIPTION
Prepares the migration of the org.eclipse.core.tests.runtime project by migrating the test suites to JUnit 5.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

Preparation for #1086.