### PR TITLE
Migrate session tests in org.eclipse.core.tests.runtime to JUnit 5 #903 

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
@@ -47,9 +47,11 @@ public class SessionTestExtension implements InvocationInterceptor {
 
 	private final RemoteTestExecutor testExecutor;
 
+	private final Setup setup;
+
 	private SessionTestExtension(String pluginId, String applicationId) {
 		try {
-			Setup setup = SetupManager.getInstance().getDefaultSetup();
+			this.setup = SetupManager.getInstance().getDefaultSetup();
 			setup.setSystemProperty("org.eclipse.update.reconcile", "false");
 			testExecutor = new RemoteTestExecutor(setup, applicationId, pluginId);
 		} catch (SetupException e) {
@@ -86,6 +88,10 @@ public class SessionTestExtension implements InvocationInterceptor {
 		public SessionTestExtension create() {
 			return new SessionTestExtension(storedPluginId, storedApplicationId);
 		}
+	}
+
+	public void setEclipseArgument(String key, String value) {
+		setup.setEclipseArgument(key, value);
 	}
 
 	@Override

--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -16,6 +16,8 @@ Require-Bundle: org.junit,
  org.eclipse.core.tests.harness;bundle-version="3.11.0"
 Import-Package: org.assertj.core.api,
  org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.io,
  org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.21.400.qualifier
+Bundle-Version: 3.21.500.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestBug380859.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestBug380859.java
@@ -13,114 +13,105 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
-import java.io.*;
-import junit.framework.Test;
-import junit.framework.TestCase;
+import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.*;
-import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
-import org.eclipse.core.tests.session.*;
-import org.eclipse.core.tests.session.SetupManager.SetupException;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for bug 380859.
  */
-public class TestBug380859 extends TestCase {
+public class TestBug380859 {
+	private static final String CUSTOMIZATION_FILE_NAME = "plugin_customization_380859.ini";
 	private static final String NOT_FOUND = "not_found";
-	private static final String FILE_NAME = FileSystemHelper.getTempDir().append("plugin_customization_380859.ini").toOSString();
 
-	public static Test suite() {
-		SessionTestSuite suite = new SessionTestSuite(RuntimeTestsPlugin.PI_RUNTIME_TESTS, TestBug380859.class.getName());
-		try {
-			// create plugin_customization.ini file
-			File file = new File(FILE_NAME);
-			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/a=v1\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "//b=v2\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "///c=v3\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "////d=v4\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/a/b=v5\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/c//d=v6\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "//e//f=v7\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/a/b/c=v8\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/a/b//c/d=v9\n");
-				writer.write(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/a/b//c//d=v10\n");
-			}
+	@TempDir
+	static Path tempDirectory;
 
-			// add pluginCustomization argument
-			Setup setup = suite.getSetup();
-			setup.setEclipseArgument("pluginCustomization", file.toString());
-		} catch (IOException | SetupException e) {
-			// ignore, the test will fail for us
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RUNTIME_TESTS).create();
+
+	@BeforeAll
+	public static void createCustomizationFile() throws IOException {
+		Path customizationFilePath = tempDirectory.resolve(CUSTOMIZATION_FILE_NAME);
+		try (BufferedWriter writer = Files.newBufferedWriter(customizationFilePath)) {
+			writer.write(PI_RUNTIME_TESTS + "/a=v1\n");
+			writer.write(PI_RUNTIME_TESTS + "//b=v2\n");
+			writer.write(PI_RUNTIME_TESTS + "///c=v3\n");
+			writer.write(PI_RUNTIME_TESTS + "////d=v4\n");
+			writer.write(PI_RUNTIME_TESTS + "/a/b=v5\n");
+			writer.write(PI_RUNTIME_TESTS + "/c//d=v6\n");
+			writer.write(PI_RUNTIME_TESTS + "//e//f=v7\n");
+			writer.write(PI_RUNTIME_TESTS + "/a/b/c=v8\n");
+			writer.write(PI_RUNTIME_TESTS + "/a/b//c/d=v9\n");
+			writer.write(PI_RUNTIME_TESTS + "/a/b//c//d=v10\n");
 		}
-		suite.addTest(new TestBug380859("testBug"));
-		return suite;
+		sessionTestExtension.setEclipseArgument("pluginCustomization", customizationFilePath.toString());
 	}
 
-	public TestBug380859() {
-		super();
-	}
-
-	public TestBug380859(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		new File(FILE_NAME).delete();
-	}
-
+	@Test
 	public void testBug() {
 		IPreferencesService preferenceService = Platform.getPreferencesService();
-		IScopeContext[] defaultScope = {DefaultScope.INSTANCE};
+		IScopeContext[] defaultScope = { DefaultScope.INSTANCE };
 
-		assertEquals("v1", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a", NOT_FOUND, defaultScope));
-		assertEquals("v1", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a", NOT_FOUND, defaultScope));
-		assertEquals("v1", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//a", NOT_FOUND, defaultScope));
+		assertEquals("v1", preferenceService.getString(PI_RUNTIME_TESTS, "a", NOT_FOUND, defaultScope));
+		assertEquals("v1", preferenceService.getString(PI_RUNTIME_TESTS, "/a", NOT_FOUND, defaultScope));
+		assertEquals("v1", preferenceService.getString(PI_RUNTIME_TESTS, "//a", NOT_FOUND, defaultScope));
 
-		assertEquals("v2", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "b", NOT_FOUND, defaultScope));
-		assertEquals("v2", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/b", NOT_FOUND, defaultScope));
-		assertEquals("v2", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//b", NOT_FOUND, defaultScope));
+		assertEquals("v2", preferenceService.getString(PI_RUNTIME_TESTS, "b", NOT_FOUND, defaultScope));
+		assertEquals("v2", preferenceService.getString(PI_RUNTIME_TESTS, "/b", NOT_FOUND, defaultScope));
+		assertEquals("v2", preferenceService.getString(PI_RUNTIME_TESTS, "//b", NOT_FOUND, defaultScope));
 
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "c", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/c", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//c", NOT_FOUND, defaultScope));
-		assertEquals("v3", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "///c", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "c", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "/c", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "//c", NOT_FOUND, defaultScope));
+		assertEquals("v3", preferenceService.getString(PI_RUNTIME_TESTS, "///c", NOT_FOUND, defaultScope));
 
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "d", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/d", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//d", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "///d", NOT_FOUND, defaultScope));
-		assertEquals("v4", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "////d", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "d", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "/d", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "//d", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "///d", NOT_FOUND, defaultScope));
+		assertEquals("v4", preferenceService.getString(PI_RUNTIME_TESTS, "////d", NOT_FOUND, defaultScope));
 
-		assertEquals("v5", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a/b", NOT_FOUND, defaultScope));
-		assertEquals("v5", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a/b", NOT_FOUND, defaultScope));
-		assertEquals("v5", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a//b", NOT_FOUND, defaultScope));
-		assertEquals("v5", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a//b", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//a//b", NOT_FOUND, defaultScope));
+		assertEquals("v5", preferenceService.getString(PI_RUNTIME_TESTS, "a/b", NOT_FOUND, defaultScope));
+		assertEquals("v5", preferenceService.getString(PI_RUNTIME_TESTS, "/a/b", NOT_FOUND, defaultScope));
+		assertEquals("v5", preferenceService.getString(PI_RUNTIME_TESTS, "a//b", NOT_FOUND, defaultScope));
+		assertEquals("v5", preferenceService.getString(PI_RUNTIME_TESTS, "/a//b", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "//a//b", NOT_FOUND, defaultScope));
 
-		assertEquals("v6", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "c/d", NOT_FOUND, defaultScope));
-		assertEquals("v6", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/c/d", NOT_FOUND, defaultScope));
-		assertEquals("v6", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "c//d", NOT_FOUND, defaultScope));
-		assertEquals("v6", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/c//d", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//c//d", NOT_FOUND, defaultScope));
+		assertEquals("v6", preferenceService.getString(PI_RUNTIME_TESTS, "c/d", NOT_FOUND, defaultScope));
+		assertEquals("v6", preferenceService.getString(PI_RUNTIME_TESTS, "/c/d", NOT_FOUND, defaultScope));
+		assertEquals("v6", preferenceService.getString(PI_RUNTIME_TESTS, "c//d", NOT_FOUND, defaultScope));
+		assertEquals("v6", preferenceService.getString(PI_RUNTIME_TESTS, "/c//d", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "//c//d", NOT_FOUND, defaultScope));
 
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "e/f", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/e/f", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "e//f", NOT_FOUND, defaultScope));
-		assertEquals(NOT_FOUND, preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/e//f", NOT_FOUND, defaultScope));
-		assertEquals("v7", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "//e//f", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "e/f", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "/e/f", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "e//f", NOT_FOUND, defaultScope));
+		assertEquals(NOT_FOUND, preferenceService.getString(PI_RUNTIME_TESTS, "/e//f", NOT_FOUND, defaultScope));
+		assertEquals("v7", preferenceService.getString(PI_RUNTIME_TESTS, "//e//f", NOT_FOUND, defaultScope));
 
-		assertEquals("v8", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a/b/c", NOT_FOUND, defaultScope));
-		assertEquals("v8", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a/b/c", NOT_FOUND, defaultScope));
-		assertEquals("v8", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a/b//c", NOT_FOUND, defaultScope));
-		assertEquals("v8", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a/b//c", NOT_FOUND, defaultScope));
+		assertEquals("v8", preferenceService.getString(PI_RUNTIME_TESTS, "a/b/c", NOT_FOUND, defaultScope));
+		assertEquals("v8", preferenceService.getString(PI_RUNTIME_TESTS, "/a/b/c", NOT_FOUND, defaultScope));
+		assertEquals("v8", preferenceService.getString(PI_RUNTIME_TESTS, "a/b//c", NOT_FOUND, defaultScope));
+		assertEquals("v8", preferenceService.getString(PI_RUNTIME_TESTS, "/a/b//c", NOT_FOUND, defaultScope));
 
-		assertEquals("v9", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a/b//c/d", NOT_FOUND, defaultScope));
-		assertEquals("v9", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a/b//c/d", NOT_FOUND, defaultScope));
+		assertEquals("v9", preferenceService.getString(PI_RUNTIME_TESTS, "a/b//c/d", NOT_FOUND, defaultScope));
+		assertEquals("v9", preferenceService.getString(PI_RUNTIME_TESTS, "/a/b//c/d", NOT_FOUND, defaultScope));
 
-		assertEquals("v10", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "a/b//c//d", NOT_FOUND, defaultScope));
-		assertEquals("v10", preferenceService.getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, "/a/b//c//d", NOT_FOUND, defaultScope));
+		assertEquals("v10", preferenceService.getString(PI_RUNTIME_TESTS, "a/b//c//d", NOT_FOUND, defaultScope));
+		assertEquals("v10", preferenceService.getString(PI_RUNTIME_TESTS, "/a/b//c//d", NOT_FOUND, defaultScope));
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestBug388004.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/TestBug388004.java
@@ -13,84 +13,72 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
-import java.io.*;
-import junit.framework.Test;
-import junit.framework.TestCase;
+import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
-import org.eclipse.core.tests.session.*;
-import org.eclipse.core.tests.session.SetupManager.SetupException;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 /**
  * Test for bug 388004.
  */
-public class TestBug388004 extends TestCase {
-	private static final String FILE_NAME = FileSystemHelper.getTempDir().append("plugin_customization.ini").toOSString();
+public class TestBug388004 {
+	private static final String CUSTOMIZATION_FILE_NAME = "plugin_customization.ini";
 	private static final String NODE = "dummy_node";
 	private static final String KEY = "key";
 	private static final String VALUE = "value";
 
-	public static Test suite() {
-		SessionTestSuite suite = new SessionTestSuite(RuntimeTestsPlugin.PI_RUNTIME_TESTS, TestBug388004.class.getName());
-		try {
-			// create plugin_customization.ini file
-			File file = new File(FILE_NAME);
-			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
-				writer.write("org.eclipse.core.tests.runtime/dummy_node/key=value");
-			}
+	@TempDir
+	static Path tempDirectory;
 
-			// add pluginCustomization argument
-			Setup setup = suite.getSetup();
-			setup.setEclipseArgument("pluginCustomization", file.toString());
-		} catch (IOException | SetupException e) {
-			// ignore, the test will fail for us
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RUNTIME_TESTS).create();
+
+	@BeforeAll
+	public static void createCustomizationFile() throws IOException {
+		Path customizationFilePath = tempDirectory.resolve(CUSTOMIZATION_FILE_NAME);
+		try (BufferedWriter writer = Files.newBufferedWriter(customizationFilePath)) {
+			writer.write("org.eclipse.core.tests.runtime/dummy_node/key=value");
 		}
-		suite.addTest(new TestBug388004("testBug"));
-		return suite;
+		sessionTestExtension.setEclipseArgument("pluginCustomization", customizationFilePath.toString());
 	}
 
-	public TestBug388004() {
-		super();
-	}
-
-	public TestBug388004(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		new File(FILE_NAME).delete();
-	}
-
+	@Test
 	public void testBug() throws BackingStoreException {
 		Preferences node = Platform.getPreferencesService().getRootNode().node(DefaultScope.SCOPE);
 
 		// test relative path of ancestor
-		if (!node.nodeExists(RuntimeTestsPlugin.PI_RUNTIME_TESTS))
-			fail("This node exists in pluginCustomization file.");
+		assertTrue(node.nodeExists(PI_RUNTIME_TESTS), "This node exists in pluginCustomization file.");
 		// test absolute path of ancestor
-		if (!node.nodeExists("/default/" + RuntimeTestsPlugin.PI_RUNTIME_TESTS))
-			fail("This node exists in pluginCustomization file.");
+		assertTrue(node.nodeExists("/default/" + PI_RUNTIME_TESTS), "This node exists in pluginCustomization file.");
 
 		// test relative path
-		if (!node.nodeExists(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/" + NODE))
-			fail("This node exists in pluginCustomization file.");
+		assertTrue(node.nodeExists(PI_RUNTIME_TESTS + "/" + NODE), "This node exists in pluginCustomization file.");
 		// test absolute path
-		if (!node.nodeExists("/default/" + RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/" + NODE))
-			fail("This node exists in pluginCustomization file.");
+		assertTrue(node.nodeExists("/default/" + PI_RUNTIME_TESTS + "/" + NODE),
+				"This node exists in pluginCustomization file.");
 
 		// test relative path of non-existing node
-		if (node.nodeExists(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/" + NODE + "/" + KEY))
-			fail("This node does not exist in pluginCustomization file.");
+		assertFalse(node.nodeExists(PI_RUNTIME_TESTS + "/" + NODE + "/" + KEY),
+				"This node does not exist in pluginCustomization file.");
 		// test absolute path of non-existing node
-		if (node.nodeExists("/default/" + RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/" + NODE + "/" + KEY))
-			fail("This node does not exist in pluginCustomization file.");
+		assertFalse(node.nodeExists("/default/" + PI_RUNTIME_TESTS + "/" + NODE + "/" + KEY),
+				"This node does not exist in pluginCustomization file.");
 
-		node = node.node(RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/" + NODE);
+		node = node.node(PI_RUNTIME_TESTS + "/" + NODE);
 		String value = node.get(KEY, null);
 		assertEquals(VALUE, value);
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_412138.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_412138.java
@@ -13,33 +13,42 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import java.io.*;
+import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.concurrent.atomic.AtomicIntegerArray;
-import junit.framework.*;
-import org.eclipse.core.runtime.*;
+import junit.framework.AssertionFailedError;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.harness.TestBarrier2;
-import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
-import org.eclipse.core.tests.session.SessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionShouldError;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 412138.
  */
-public class Bug_412138 extends TestCase {
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class Bug_412138 {
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RUNTIME_TESTS).create();
+
 	private static final String FILE_NAME = FileSystemHelper.getTempDir().append(Bug_412138.class.getName()).toOSString();
 
-	public static Test suite() {
-		SessionTestSuite suite = new SessionTestSuite(RuntimeTestsPlugin.PI_RUNTIME_TESTS, Bug_412138.class.getName());
-		suite.addCrashTest(new Bug_412138("testRunScenario"));
-		suite.addTest(new Bug_412138("testVerifyResult"));
-		return suite;
-	}
-
-	public Bug_412138(String name) {
-		super(name);
-	}
-
+	@Test
+	@SessionShouldError
 	public void testRunScenario() throws InterruptedException {
 		// delete the file so that we don't report previous results
 		new File(FILE_NAME).delete();
@@ -59,7 +68,7 @@ public class Bug_412138 extends TestCase {
 						return Status.OK_STATUS;
 					}
 				} catch (InterruptedException e) {
-					return new Status(IStatus.ERROR, RuntimeTestsPlugin.PI_RUNTIME_TESTS, e.getMessage(), e);
+					return new Status(IStatus.ERROR, PI_RUNTIME_TESTS, e.getMessage(), e);
 				}
 			}
 		};
@@ -72,7 +81,7 @@ public class Bug_412138 extends TestCase {
 					status.set(0, TestBarrier2.STATUS_DONE);
 					return Status.OK_STATUS;
 				} catch (InterruptedException e) {
-					return new Status(IStatus.ERROR, RuntimeTestsPlugin.PI_RUNTIME_TESTS, e.getMessage(), e);
+					return new Status(IStatus.ERROR, PI_RUNTIME_TESTS, e.getMessage(), e);
 				}
 			}
 		};
@@ -104,6 +113,7 @@ public class Bug_412138 extends TestCase {
 		}
 	}
 
+	@Test
 	public void testVerifyResult() throws IOException, ClassNotFoundException {
 		File file = new File(FILE_NAME);
 		// if the file does not exist, there was no deadlock so the whole test pass


### PR DESCRIPTION
Migrates the existing session tests in the org.eclipse.core.tests.runtime plug-in to JUnit 5 by using the new
SessionTestExtension. Also replaces some conditional fail statments in the test classes with assertions.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903