### PR TITLE
ContentType file associations can't be extended by product customization

### DIFF
--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentType.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentType.java
@@ -544,24 +544,25 @@ public final class ContentType implements IContentType, IContentTypeInfo {
 		return validation == STATUS_VALID;
 	}
 
-	void processPreferences(Preferences contentTypeNode) {
+	void processPreferences(Preferences contentTypeNode, boolean userDefined) {
+		int definedByFlag = userDefined ? SPEC_USER_DEFINED : SPEC_PRE_DEFINED;
 		// user set default charset
 		this.userCharset = contentTypeNode.get(PREF_DEFAULT_CHARSET, null);
 		// user set file names
 		String userSetFileNames = contentTypeNode.get(PREF_FILE_NAMES, null);
 		String[] fileNames = Util.parseItems(userSetFileNames);
 		for (String fileName : fileNames)
-			internalAddFileSpec(fileName, FILE_NAME_SPEC | SPEC_USER_DEFINED);
+			internalAddFileSpec(fileName, FILE_NAME_SPEC | definedByFlag);
 		// user set file extensions
 		String userSetFileExtensions = contentTypeNode.get(PREF_FILE_EXTENSIONS, null);
 		String[] fileExtensions = Util.parseItems(userSetFileExtensions);
 		for (String fileExtension : fileExtensions)
-			internalAddFileSpec(fileExtension, FILE_EXTENSION_SPEC | SPEC_USER_DEFINED);
+			internalAddFileSpec(fileExtension, FILE_EXTENSION_SPEC | definedByFlag);
 		// user set file name regexp
 		String userSetFileRegexp = contentTypeNode.get(PREF_FILE_PATTERNS, null);
 		String[] fileRegexps = Util.parseItems(userSetFileRegexp);
 		for (String fileRegexp : fileRegexps) {
-			internalAddFileSpec(fileRegexp, FILE_PATTERN_SPEC | SPEC_USER_DEFINED);
+			internalAddFileSpec(fileRegexp, FILE_PATTERN_SPEC | definedByFlag);
 		}
 	}
 

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeManager.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeManager.java
@@ -165,6 +165,7 @@ public class ContentTypeManager extends ContentTypeMatcher implements IContentTy
 		ContentTypeBuilder builder = createBuilder(newCatalog);
 		try {
 			builder.buildCatalog(getContext());
+			builder.applyProductPreferences();
 			// only remember catalog if building it was successful
 			catalog = newCatalog;
 		} catch (InvalidRegistryObjectException e) {


### PR DESCRIPTION
Allow products define custom file associations for existing content types, example below will link custom `*.cplus` files to the tm4e provided "C++" content type

`org.eclipse.core.runtime/content-types/org.eclipse.tm4e.language_pack.cpp/file-extensions=cplus`

![image](https://github.com/eclipse-platform/eclipse.platform/assets/964108/711e19ba-fc83-472a-ae24-a992db14cd4c)


Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1338