### PR TITLE
Migrate WorkspacePreferencesTest to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -36,6 +36,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.pde.junit.runtime;bundle-version="3.5.0"
 Import-Package: org.assertj.core.api,
  org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.io,
  org.junit.platform.suite.api,
  org.mockito
 Bundle-ActivationPolicy: lazy

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
@@ -11,6 +11,7 @@
 package org.eclipse.core.tests.harness.session;
 
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.Objects;
 import org.eclipse.core.tests.harness.session.samples.SampleSessionTests;
 import org.eclipse.core.tests.session.Setup;
@@ -74,6 +75,7 @@ public class SessionTestExtension implements InvocationInterceptor {
 	public static class SessionTestExtensionBuilder {
 		private final String storedPluginId;
 		private String storedApplicationId = CORE_TEST_APPLICATION;
+		private Path storedWorkspaceDirectory;
 
 		private SessionTestExtensionBuilder(String pluginId) {
 			Objects.requireNonNull(pluginId);
@@ -85,8 +87,37 @@ public class SessionTestExtension implements InvocationInterceptor {
 			return this;
 		}
 
+		/**
+		 * Sets the used workspace folder by using the passed path for the "data"
+		 * property of the Eclipse instance. Usually, a temporary folder can be used.
+		 * <p>
+		 * <b>Example Usage:</b>
+		 *
+		 * <pre>
+		 * &#64;TempDir
+		 * static Path tempDirectory;
+		 *
+		 * &#64;RegisterExtension
+		 * static SessionTestExtension extension = SessionTestExtension.forPlugin("").withWorkspaceAt(tempDirectory).create();
+		 * </pre>
+		 *
+		 * @param workspaceDirectory the folder to be used for the workspace
+		 */
+		public SessionTestExtensionBuilder withWorkspaceAt(Path workspaceDirectory) {
+			this.storedWorkspaceDirectory = workspaceDirectory;
+			return this;
+		}
+
+		/**
+		 * {@return a <code>SessionTestExtension</code> created with the information in
+		 * this builder}
+		 */
 		public SessionTestExtension create() {
-			return new SessionTestExtension(storedPluginId, storedApplicationId);
+			SessionTestExtension extension = new SessionTestExtension(storedPluginId, storedApplicationId);
+			if (storedWorkspaceDirectory != null) {
+				extension.setEclipseArgument(Setup.DATA, storedWorkspaceDirectory.toString());
+			}
+			return extension;
 		}
 	}
 


### PR DESCRIPTION
This makes the WorkspacePreferencesTest use the SessionTestExtension to be executed with JUnit 5. It adds a method to the
SessionTestExtensionBuilder to allow setting a workspace directory for a test class. In addition, this replaces assertions in the test class using numbers as messages with proper AssertJ assertions.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903