### PR TITLE
Take default tab in LaunchConfigurationTabGroupViewer from CTabFolder

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/ui/LaunchConfigurationTabGroupViewerTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/ui/LaunchConfigurationTabGroupViewerTest.java
@@ -194,6 +194,26 @@ public class LaunchConfigurationTabGroupViewerTest {
 		assertThat(((SpyTab) tabs[secondTabIndex])).matches(SpyTab::isActivated, "should have been activated");
 	}
 
+	@Test
+	public void testActivateAllTabs() {
+		ThrowingRunnable<CoreException> activateSeveralTab = () -> {
+			// Create and select launch config
+			fLaunchConfigurationsDialog.getTabViewer().setInput(createLaunchConfigurationInstance());
+
+			// Select all tabs
+			for (int i = 0; i < fLaunchConfigurationsDialog.getTabViewer().getTabs().length; i++) {
+				fLaunchConfigurationsDialog.getTabViewer().setActiveTab(i);
+			}
+		};
+
+		final ILaunchConfigurationTab[] tabs = runOnDialog(activateSeveralTab);
+
+		// All tabs should have been activated exactly once
+		for (int i = 0; i < tabs.length; i++) {
+			assertThat(((SpyTab) tabs[i])).matches(SpyTab::isActivatedExactlyOnce, "Tab '" + i + "' should have been activated exactly once");
+		}
+	}
+
 	private ILaunchConfigurationWorkingCopy createLaunchConfigurationInstance() throws CoreException {
 		return fLaunchConfigurationType.newInstance(null, "MyLaunchConfiguration_" + System.currentTimeMillis());
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -871,15 +871,16 @@ public class LaunchConfigurationTabGroupViewer {
 		// Update the name field
 		fNameWidget.setText(getWorkingCopy().getName());
 
-		fCurrentTabIndex = fTabFolder.getSelectionIndex();
+		fCurrentTabIndex = -1;
 
 		// Turn off initializing flag to update message
 		fInitializingTabs = false;
 
 		// Try to activate the same (type of) tab that was active before.
 		if (!setActiveTab(lastActiveTabKind)) {
-			// The tab with the wanted class wasn't found. Try to activate the first one
-			setActiveTab(0);
+			// The tab with the wanted class wasn't found. Try to activate the default tab
+			int defaultTabIndex = Math.max(fTabFolder.getSelectionIndex(), 0);
+			setActiveTab(defaultTabIndex);
 		}
 
 		if (!fViewform.isVisible()) {


### PR DESCRIPTION
When setting the active tab of the `LaunchConfigurationTabGroupViewer` for the first time (right after setting its input), activate the tab that the `CTabFolder` considers as the default tab.

This PR is a pre-requisite for https://github.com/eclipse-platform/eclipse.platform.swt/pull/1164 and addresses the problem described in https://github.com/eclipse-platform/eclipse.platform/pull/1287#issuecomment-2046538195

After this PR is merged, @deepika-u can finally fix https://github.com/eclipse-platform/eclipse.platform.swt/issues/46