### PR TITLE
Auto-refresh fragment for Windows on Arm64 (WoA) platform.

### DIFF
--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/.project
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/.project
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.core.resources.win32.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/.settings/org.eclipse.core.resources.prefs
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/.settings/org.eclipse.core.runtime.prefs
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/BUILD_INFO.txt
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/BUILD_INFO.txt
@@ -1,0 +1,10 @@
+Native Build Info:
+------------------
+
+platform:         win32.aarch64
+built by:         chirontt@gmail.com
+build date:       18-Aug-2022
+OS Name:          Microsoft Windows 11 on ARM64
+Compiler version: Microsoft (R) C/C++ Optimizing Compiler Version 19.34.31721 for ARM64
+Linker version:   Microsoft (R) Incremental Linker Version 14.34.31721.0
+Java version:     OpenJDK 64-Bit Server VM Microsoft-38106 (build 11.0.16+8-LTS)

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %win32FragmentName
+Bundle-SymbolicName: org.eclipse.core.resources.win32.aarch64;singleton:=true
+Bundle-Version: 3.5.500.qualifier
+Bundle-Vendor: %providerName
+Fragment-Host: org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)"
+Bundle-Localization: fragment
+Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.arch=aarch64))

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/about.html
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/build.properties
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/build.properties
@@ -1,0 +1,21 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Eclipse Foundation.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     Tue Ton - initial API and implementation
+###############################################################################
+bin.includes = fragment.xml,\
+               os/,\
+               .,\
+               META-INF/,\
+               about.html,\
+               fragment.properties
+generateSourceBundle=false
+

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/fragment.properties
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/fragment.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Eclipse Foundation.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Tue Ton - initial API and implementation
+###############################################################################
+providerName = Eclipse.org
+win32FragmentName = Core Resource Management Win32 Arm64 Fragment
+win32MonitorFactoryName = Windows Auto-refresh monitor

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/fragment.xml
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/fragment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<fragment>
+    <extension
+         id="win32"
+         point="org.eclipse.core.resources.refreshProviders">
+      <refreshProvider
+            name="%win32MonitorFactoryName"
+            class="org.eclipse.core.internal.resources.refresh.win32.Win32RefreshProvider">
+      </refreshProvider>
+   </extension>
+</fragment>

--- a/resources/bundles/org.eclipse.core.resources.win32.aarch64/pom.xml
+++ b/resources/bundles/org.eclipse.core.resources.win32.aarch64/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.platform.resources</artifactId>
+    <groupId>org.eclipse.platform</groupId>
+    <version>4.32.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>org.eclipse.core.resources.win32.aarch64</artifactId>
+  <version>3.5.500-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/resources/bundles/org.eclipse.core.resources/natives/make.bat
+++ b/resources/bundles/org.eclipse.core.resources/natives/make.bat
@@ -1,5 +1,5 @@
 @rem ***************************************************************************
-@rem Copyright (c) 2007, 2014 IBM Corporation and others.
+@rem Copyright (c) 2007, 2024 IBM Corporation and others.
 @rem
 @rem This program and the accompanying materials
 @rem are made available under the terms of the Eclipse Public License 2.0
@@ -10,23 +10,185 @@
 @rem
 @rem Contributors:
 @rem     IBM Corporation - initial API and implementation
+@rem     Tue Ton - add auto-search for MSVC compiler
 @rem ***************************************************************************
+REM ----------------------------------------------------------------------------
+REM
+REM Required environment variables:
+REM   JAVA_HOME - path to the JDK11+ installation for x64 or ARM64 architecture
+REM
+REM ----------------------------------------------------------------------------
+@echo off
+echo
+echo INFO Starting build of Win32 resource binaries.
+
+@rem Specify VisualStudio Edition: 'Community', 'Enterprise', 'Professional' etc.
+IF "x.%MSVC_EDITION%"=="x." set "MSVC_EDITION=auto"
+
+@rem Specify VisualStudio Version: '2022', '2019', '2017' etc.
+IF "x.%MSVC_VERSION%"=="x." set "MSVC_VERSION=auto"
+
+@rem Search for a usable Visual Studio
+@rem ---------------------------------
+IF "%MSVC_HOME%"=="" CALL :ECHO "'MSVC_HOME' was not provided, auto-searching for Visual Studio..."
+@rem Bug 574007: Path used on Azure build machines
+IF "%MSVC_HOME%"=="" CALL :FindVisualStudio "%ProgramFiles(x86)%\Microsoft Visual Studio\$MSVC_VERSION$\BuildTools"
+@rem Bug 578519: Common installation paths; VisualStudio is installed in x64 ProgramFiles since VS2022
+IF "%MSVC_HOME%"=="" CALL :FindVisualStudio "%ProgramFiles%\Microsoft Visual Studio\$MSVC_VERSION$\$MSVC_EDITION$"
+@rem Bug 578519: Common installation paths; VisualStudio is installed in x86 ProgramFiles before VS2022
+IF "%MSVC_HOME%"=="" CALL :FindVisualStudio "%ProgramFiles(x86)%\Microsoft Visual Studio\$MSVC_VERSION$\$MSVC_EDITION$"
+@rem Report
+IF NOT EXIST "%MSVC_HOME%" (
+	CALL :ECHO "WARNING: Microsoft Visual Studio was not found (for edition=%MSVC_EDITION% version=%MSVC_VERSION%)"
+    CALL :ECHO "         Refer steps for Windows native setup: https://www.eclipse.org/swt/swt_win_native.php"
+) ELSE (
+	CALL :ECHO "MSVC_HOME: %MSVC_HOME%"
+)
+
+@rem Check for a usable JDK
+IF "%JAVA_HOME%"=="" CALL :ECHO "'JAVA_HOME' was not provided"
+IF NOT EXIST "%JAVA_HOME%" (
+    CALL :ECHO "WARNING: 64-bit Java JDK not found. Please set JAVA_HOME to the JDK directory containing the intended JDK native headers."
+)
+
+@REM Compose host architecture string for MSVC
+IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+  SET HOST_ARCH=x64
+) ELSE IF "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+  SET HOST_ARCH=arm64
+) ELSE (
+  CALL :ECHO "ERROR: Unknown host architecture: %PROCESSOR_ARCHITECTURE%."
+  EXIT /B 1
+)
+
+@REM %TARGET_ARCH% may be specified by the caller for cross-compiling.
+@REM If not, build for builder machine's architecture
+IF "%TARGET_ARCH%"=="" (
+  SET TARGET_ARCH=%HOST_ARCH%
+)
+
+@REM Compose build argument for MSVC
+IF "%TARGET_ARCH%"=="%HOST_ARCH%" (
+  SET BUILD_ARCH=%TARGET_ARCH%
+) ELSE (
+  SET BUILD_ARCH=%HOST_ARCH%_%TARGET_ARCH%
+)
+
+@REM Select build's output directory (if not specified) based on target arch
+IF "%TARGET_ARCH%"=="x64" (
+  IF "x.%OUTPUT_DIR%"=="x." SET OUTPUT_DIR=..\..\..\org.eclipse.core.resources.win32.x86_64\os\win32\x86_64
+) ELSE IF "%TARGET_ARCH%"=="arm64" (
+  IF "x.%OUTPUT_DIR%"=="x." SET OUTPUT_DIR=..\..\..\org.eclipse.core.resources.win32.aarch64\os\win32\aarch64
+) ELSE (
+  CALL :ECHO "ERROR: Unknown target architecture: %TARGET_ARCH%."
+  EXIT /B 1
+)
+
+call "%MSVC_HOME%\VC\Auxiliary\Build\vcvarsall.bat" %BUILD_ARCH%
+
+@rem if call to vcvarsall.bat (which sets up environment) silently fails, then provide advice to user.
+WHERE cl
+if %ERRORLEVEL% NEQ 0 (
+    CALL :ECHO "ERROR: cl (Microsoft C compiler) not found on path. Please install Microsoft Visual Studio."
+    CALL :ECHO "         If already installed, try launching eclipse from the 'Developer Command Prompt for VS'"
+    CALL :ECHO "         Refer steps for SWT Windows native setup: https://www.eclipse.org/swt/swt_win_native.php"
+    CALL :ECHO "ERROR: exit 1"	
+    EXIT 1
+)
+
 REM build JNI header file
-cd ..\bin
-"C:\Program Files\Java\jdk1.8.0_65\bin\javah.exe" org.eclipse.core.internal.resources.refresh.win32.Win32Natives
-move org_eclipse_core_internal_resources_refresh_win32_Win32Natives.h ..\natives\ref2.h
+mkdir bin
+cd ..\src
+"%JAVA_HOME%\bin\javac.exe" -d ..\natives\bin -h . org\eclipse\core\internal\resources\refresh\win32\Win32Natives.java
+move /y org_eclipse_core_internal_resources_refresh_win32_Win32Natives.h ..\natives\bin\ref.h
 
 REM compile and link
-cd ..\natives
-set win_include="C:\Program Files\Microsoft Visual Studio 14.0\VC\include"
-set jdk_include="C:\Program Files\Java\jdk1.8.0_65\include"
-
+cd ..\natives\bin
+copy ..\ref.c .
+set jdk_include="%JAVA_HOME%\include"
 set dll_name=win32refresh.dll
 
-call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64_x86
-"cl.exe" -I%win_include% -I%jdk_include% -I%jdk_include%\win32 -LD ref.c -Fe%dll_name%
-move %dll_name% ..\..\org.eclipse.core.resources.win32.x86\os\win32\x86\%dll_name%
+cl.exe -I%jdk_include% -I%jdk_include%\win32 -LD ref.c -Fe%dll_name%
+mkdir %OUTPUT_DIR%
+move /y %dll_name% %OUTPUT_DIR%\%dll_name%
 
-call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-"cl.exe" -I%win_include% -I%jdk_include% -I%jdk_include%\win32 -LD ref.c -Fe%dll_name%
-move %dll_name% ..\..\org.eclipse.core.resources.win32.x86_64\os\win32\x86_64\%dll_name%
+REM clean up
+cd ..
+rmdir /q /s bin
+
+GOTO :EOF
+
+@rem Find Visual Studio
+@rem %1 = path template with '$MSVC_VERSION$' and '$MSVC_EDITION$' tokens
+:FindVisualStudio
+	@rem Early return if already found
+	IF NOT "%MSVC_HOME%"=="" GOTO :EOF
+
+	IF "%MSVC_VERSION%"=="auto" (
+		CALL :FindVisualStudio2 "%~1" "2022"
+		CALL :FindVisualStudio2 "%~1" "2019"
+		CALL :FindVisualStudio2 "%~1" "2017"
+	) ELSE (
+		CALL :FindVisualStudio2 "%~1" "%MSVC_VERSION%"
+	)
+GOTO :EOF
+
+@rem Find Visual Studio
+@rem %1 = path template with '$MSVC_VERSION$' and '$MSVC_EDITION$' tokens
+@rem %2 = value for '$MSVC_VERSION$'
+:FindVisualStudio2
+	@rem Early return if already found
+	IF NOT "%MSVC_HOME%"=="" GOTO :EOF
+
+	IF "%MSVC_EDITION%"=="auto" (
+		CALL :FindVisualStudio3 "%~1" "%~2" "Community"
+		CALL :FindVisualStudio3 "%~1" "%~2" "Enterprise"
+		CALL :FindVisualStudio3 "%~1" "%~2" "Professional"
+	) ELSE (
+		CALL :FindVisualStudio3 "%~1" "%~2" "%MSVC_EDITION%"
+	)
+GOTO :EOF
+
+@rem Find Visual Studio
+@rem %1 = path template with '$MSVC_VERSION$' and '$MSVC_EDITION$' tokens
+@rem %2 = value for '$MSVC_VERSION$'
+@rem %3 = value for '$MSVC_EDITION$'
+:FindVisualStudio3
+	@rem Early return if already found
+	IF NOT "%MSVC_HOME%"=="" GOTO :EOF
+
+	SET "TESTED_VS_PATH=%~1"
+	@rem Substitute '$MSVC_VERSION$' and '$MSVC_EDITION$'
+	CALL SET "TESTED_VS_PATH=%%TESTED_VS_PATH:$MSVC_VERSION$=%~2%%"
+	CALL SET "TESTED_VS_PATH=%%TESTED_VS_PATH:$MSVC_EDITION$=%~3%%"
+
+	@rem If the folder isn't there, then skip it without printing errors
+	IF NOT EXIST "%TESTED_VS_PATH%" GOTO :EOF
+
+	@rem Try this path
+	CALL :TryToUseVisualStudio "%TESTED_VS_PATH%"
+GOTO :EOF
+
+@rem Test Visual Studio and set '%MSVC_HOME%' on success
+@rem %1 = tested path
+:TryToUseVisualStudio
+	SET "TESTED_VS_PATH=%~1"
+	IF NOT EXIST "%TESTED_VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" (
+		CALL :ECHO "-- VisualStudio '%TESTED_VS_PATH%' is bad: 'vcvarsall.bat' not found"
+		GOTO :EOF
+	)
+	CALL :ECHO "-- VisualStudio '%TESTED_VS_PATH%' looks good, selecting it"
+	SET "MSVC_HOME=%TESTED_VS_PATH%"
+GOTO :EOF
+
+@rem Regular ECHO has trouble with special characters such as ().
+@rem At the same time, if its argument is quoted, the quotes are printed literally.
+@rem The workaround is to escape all special characters with ^
+:ECHO
+	SET "ECHO_STRING=%~1"
+	SET "ECHO_STRING=%ECHO_STRING:<=^<%"
+	SET "ECHO_STRING=%ECHO_STRING:>=^>%"
+	SET "ECHO_STRING=%ECHO_STRING:(=^(%"
+	SET "ECHO_STRING=%ECHO_STRING:)=^)%"
+	ECHO %ECHO_STRING%
+GOTO :EOF


### PR DESCRIPTION
The following new fragment for WoA is added to the project to support auto-refresh using native code:
```
org.eclipse.core.resources.win32.aarch64
```
To manually build the auto-refresh native library for WoA, on a WoA box, run the following commands:
```batch
cd resources\bundles\org.eclipse.core.resources\natives\win32
make.bat
```
and the following native library file for WoA is generated and saved in its relevant directory:
```
resources\bundles\org.eclipse.core.resources.win32.aarch64\os\win32\aarch64\win32refresh.dll
```
The existing 'make.bat' file mentioned above has been modified to generate correct binary for the current build environment (x64 or aarch64.)

As discussed [here](https://github.com/eclipse-platform/eclipse.platform/pull/1311#issuecomment-2102434757).