### PR TITLE
Remove shared session support from SessionTestSuite #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
@@ -269,7 +269,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 					fail(e);
 				}
 			}
-			if (!shouldSort || isSharedSession()) {
+			if (!shouldSort) {
 				// for shared sessions, we don't control the execution of test cases
 				super.run(result);
 				return;

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleTests.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/samples/SampleTests.java
@@ -29,7 +29,6 @@ public class SampleTests extends TestSuite {
 		// these tests should run in the same session (don't add to a non-shared session test suite)
 		SessionTestSuite shared = new SessionTestSuite(PI_HARNESS);
 		shared.addTestSuite(SameSessionTest.class);
-		shared.setSharedSession(true);
 		addTest(shared);
 		// play with a crash test
 		addTest(SampleCrashTest.suite());


### PR DESCRIPTION
The SessionTestSuite currently supports shared session. However, this functionality is unused and only introduces unnecessary complexity to the session test framework. I have checked the Eclipse SDK (with platform, Equinox, JDT and PDE), none of them using the functionality.

This unnecessary complexity in the JUnit 3 implementation of session tests complicates their migration to JUnit 5. I propose to incrementally remove all unused functionality from the JUnit 3 session test implementation while migrating the actual test classes to the JUnit 5 equivalent and incrementally enhancing the JUnit 5 implementation with what is required. This applies one step of that incremental removal of unused functionality in the JUnit 3 implementation of session tests.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903