### PR TITLE
Remove local test support from SessionTestSuite #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/SessionTestSuite.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/SessionTestSuite.java
@@ -28,7 +28,6 @@ public class SessionTestSuite extends TestSuite {
 	public static final String UI_TEST_APPLICATION = "org.eclipse.pde.junit.runtime.uitestapplication"; //$NON-NLS-1$
 	protected String applicationId = CORE_TEST_APPLICATION;
 	private final Set<TestCase> crashTests = new HashSet<>();
-	private final Set<TestCase> localTests = new HashSet<>();
 	// the id for the plug-in whose classloader ought to be used to load the test case class
 	protected String pluginId;
 	private Setup setup;
@@ -59,14 +58,6 @@ public class SessionTestSuite extends TestSuite {
 	 */
 	public void addCrashTest(TestCase test) {
 		crashTests.add(test);
-		super.addTest(test);
-	}
-
-	/**
-	 * Adds a local test, a test that is run locally, not in a separate session.
-	 */
-	public void addLocalTest(TestCase test) {
-		localTests.add(test);
 		super.addTest(test);
 	}
 
@@ -116,11 +107,6 @@ public class SessionTestSuite extends TestSuite {
 		return allTests;
 	}
 
-	private boolean isLocalTest(Test test) {
-		return localTests.contains(test);
-	}
-
-
 	protected Setup newSetup() throws SetupException {
 		Setup base =  SetupManager.getInstance().getDefaultSetup();
 		base.setSystemProperty("org.eclipse.update.reconcile", "false"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -142,12 +128,7 @@ public class SessionTestSuite extends TestSuite {
 		if (test instanceof TestDescriptor) {
 			runSessionTest((TestDescriptor) test, result);
 		} else if (test instanceof TestCase) {
-			if (isLocalTest(test)) {
-				// local, ordinary test - just run it
-				test.run(result);
-			} else {
-				runSessionTest(new TestDescriptor((TestCase) test), result);
-			}
+			runSessionTest(new TestDescriptor((TestCase) test), result);
 		} else if (test instanceof TestSuite) {
 			// find and run the test cases that make up the suite
 			runTestSuite((TestSuite) test, result);


### PR DESCRIPTION
The SessionTestSuite currently supports local test execution. However, this functionality is unused and only introduces unnecessary complexity to the session test framework.  I have checked the Eclipse SDK (with platform, Equinox, JDT and PDE), none of them using the functionality.

This unnecessary complexity in the JUnit 3 implementation of session tests complicates their migration to JUnit 5. I propose to incrementally remove all unused functionality from the JUnit 3 session test implementation while migrating the actual test classes to the JUnit 5 equivalent and incrementally enhancing the JUnit 5 implementation with what is required. This applies one step of that incremental removal of unused functionality in the JUnit 3 implementation of session tests.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903