### PR TITLE
Remove sorting parameter from ConfigurationSessionTestSuite #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/ConfigurationSessionTestSuite.java
@@ -62,12 +62,9 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 	private IPath configurationPath = FileSystemHelper.getRandomLocation(FileSystemHelper.getTempDir());
 	private boolean prime = true;
 	private boolean readOnly;
-	// should the test cases be run in alphabetical order?
-	private boolean shouldSort;
 
 	public ConfigurationSessionTestSuite(String pluginId, Class<?> theClass) {
 		super(pluginId, theClass);
-		this.shouldSort = true;
 	}
 
 	public ConfigurationSessionTestSuite(String pluginId, String name) {
@@ -269,7 +266,7 @@ public class ConfigurationSessionTestSuite extends SessionTestSuite {
 					fail(e);
 				}
 			}
-			if (!shouldSort || isSharedSession()) {
+			if (isSharedSession()) {
 				// for shared sessions, we don't control the execution of test cases
 				super.run(result);
 				return;


### PR DESCRIPTION
The ConfigurationSessionTestSuite sorts the test methods by default. A field identifies whether sorting is activated, but the field cannot even be set but is always true. So, this parameterization is completely obsolete and only introduces unnecessary complexity to the session test framework.

This unnecessary complexity in the JUnit 3 implementation of session tests complicates their migration to JUnit 5. I propose to incrementally remove all unused functionality from the JUnit 3 session test implementation while migrating the actual test classes to the JUnit 5 equivalent and incrementally enhancing the JUnit 5 implementation with what is required. This applies one step of that incremental removal of unused functionality in the JUnit 3 implementation of session tests.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

❗This removal becomes particularly useful when also #1354 removing shared session support is applied, as in combination even more code can be removed due to conditions becoming empty.