### PR TITLE
Simplify workspace setup for SessionTestExtension #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspacePreferencesTest.java
@@ -21,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,17 +38,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("deprecation")
 public class WorkspacePreferencesTest {
 
-	@TempDir
-	static Path tempDirectory;
-
 	@RegisterExtension
-	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
-			.withWorkspaceAt(tempDirectory).create();
+	SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
 	private IWorkspace workspace;
 	private Preferences preferences;

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionWorkspace.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionWorkspace.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session;
+
+import java.nio.file.Path;
+import org.eclipse.core.tests.harness.session.customization.SessionCustomization;
+
+/**
+ * A session customization to use a custom workspace directory.
+ */
+public interface CustomSessionWorkspace extends SessionCustomization {
+
+	/**
+	 * Sets the given workspace directory. If not called, a temporary folder is used
+	 * as the workspace directory.
+	 *
+	 * @param workspaceDirectory the path of the directory to place the workspace
+	 *                           in, must not be {@code null}
+	 *
+	 * @return this
+	 */
+	public CustomSessionWorkspace setWorkspaceDirectory(Path workspaceDirectory);
+
+}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.customization;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import org.eclipse.core.tests.harness.session.CustomSessionWorkspace;
+import org.eclipse.core.tests.session.Setup;
+
+/**
+ * A session customization to use a custom workspace directory.
+ */
+public class CustomSessionWorkspaceImpl implements CustomSessionWorkspace {
+	private Path workspaceDirectory;
+
+	public CustomSessionWorkspaceImpl() {
+		// nothing to initialize
+	}
+
+	@Override
+	public CustomSessionWorkspace setWorkspaceDirectory(Path workspaceDirectory) {
+		Objects.nonNull(workspaceDirectory);
+		this.workspaceDirectory = workspaceDirectory;
+		return this;
+	}
+
+	private Path getWorkspaceDirectory() throws IOException {
+		if (workspaceDirectory == null) {
+			this.workspaceDirectory = Files.createTempDirectory(null);
+			this.workspaceDirectory.toFile().deleteOnExit();
+		}
+		return workspaceDirectory;
+	}
+
+	@Override
+	public void prepareSession(Setup setup) throws Exception {
+		setup.setEclipseArgument(Setup.DATA, getWorkspaceDirectory().toString());
+	}
+
+	@Override
+	public void cleanupSession(Setup setup) throws Exception {
+		// nothing to cleanup in this customization
+	}
+
+}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/SessionCustomization.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/SessionCustomization.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.customization;
+
+import org.eclipse.core.tests.session.Setup;
+
+public interface SessionCustomization {
+	void prepareSession(Setup setup) throws Exception;
+
+	void cleanupSession(Setup setup) throws Exception;
+}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/samples/SampleSessionTests.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/samples/SampleSessionTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  */
 public class SampleSessionTests {
 	@RegisterExtension
-	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_HARNESS).create();
+	SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_HARNESS).create();
 
 	@Nested
 	public class Successful {


### PR DESCRIPTION
In order to avoid the repetitive creation of temporary workspace folders in session tests, this change encapsulation the temporary folder creation in a customization object for the session test extension. The specification of a custom workspace folder is now optional. The simplification is exemplarily applied to the WorkspacePreferencesTest. The change also removes unnecessary static declarations of the SessionTestExtension.

The design of the customization application already prepares for further customization options, such as for customizing the workbench configuration (see #1348, of which parts of this PR are an extract to have each PR address a single concern).

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903