### PR TITLE
Migrate non-serialization WorkspaceSessionTests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/TestBug94498.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/TestBug94498.java
@@ -16,22 +16,28 @@ package org.eclipse.core.tests.resources.content;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TestBug94498 extends TestCase {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug94498 {
 
 	private static final String FILE_NAME = "foo.bar.zoo";
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug94498.class);
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IContentType text = Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		assertThat(text).isNotNull();
@@ -40,10 +46,13 @@ public class TestBug94498 extends TestCase {
 		assertThat(fileSpecs).containsExactly(FILE_NAME);
 	}
 
+	@Test
+	@Order(2)
 	public void test2() {
 		IContentType text = Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 		assertThat(text).isNotNull();
 		String[] fileSpecs = text.getFileSpecs(IContentType.FILE_NAME_SPEC | IContentType.IGNORE_PRE_DEFINED);
 		assertThat(fileSpecs).containsExactly(FILE_NAME);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Bug_266907.java
@@ -26,30 +26,36 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for bug 266907
  */
-public class Bug_266907 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class Bug_266907 {
 
 	private static final String PROJECT_NAME = "Project";
 	private static final String FILE_NAME = "File";
 	private static final String MARKER_ATTRIBUTE_NAME = "AttributeName";
 	private static final String MARKER_ATTRIBUTE = "Attribute";
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, Bug_266907.class);
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
+	@Test
+	@Order(1)
 	public void test1CreateProjectAndDeleteProjectFile() throws Exception {
 		// Ensure that no asynchronous save job restores the .project file after
 		// deleting it by suspending the JobManager for this workspace session
@@ -81,6 +87,8 @@ public class Bug_266907 extends WorkspaceSessionTest {
 		dotProject.delete();
 	}
 
+	@Test
+	@Order(2)
 	public void test2RestoreWorkspaceFile() throws Exception {
 		final IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject(PROJECT_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/FindDeletedMembersTest.java
@@ -20,36 +20,45 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Copies the tests from HistoryStoreTest#testFindDeleted, phrased
  * as a session test.
  */
-public class FindDeletedMembersTest extends WorkspaceSessionTest {
-	//common objects
-	protected IWorkspaceRoot root;
-	protected IProject project;
-	protected IFile pfile;
-	protected IFile folderAsFile;
-	protected IFolder folder;
-	protected IFile file;
-	protected IFile file1;
-	protected IFile file2;
-	protected IFolder folder2;
-	protected IFile file3;
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class FindDeletedMembersTest {
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	//common objects
+	private IWorkspaceRoot root;
+	private IProject project;
+	private IFile pfile;
+	private IFile folderAsFile;
+	private IFolder folder;
+	private IFile file;
+	private IFile file1;
+	private IFile file2;
+	private IFolder folder2;
+	private IFile file3;
+
+	@BeforeEach
+	public void setUp() throws Exception {
 		root = getWorkspace().getRoot();
 		project = root.getProject("MyProject");
 		pfile = project.getFile("file.txt");
@@ -66,6 +75,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		getWorkspace().save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(1)
 	public void test1() throws Exception {
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
@@ -80,6 +91,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(2)
 	public void test2() throws Exception {
 		// the deleted file should show up as a deleted member of project
 		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor()))
@@ -100,6 +113,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(3)
 	public void test3() throws Exception {
 		// the deleted file should no longer show up as a deleted member of project
 		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
@@ -127,6 +142,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(4)
 	public void test4() throws Exception {
 		// the deleted file should show up as a deleted member
 		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
@@ -148,6 +165,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(5)
 	public void test5() throws Exception {
 		// the deleted file should show up as a deleted member of project
 		assertThat(project.findDeletedMembersWithHistory(IResource.DEPTH_ONE, createTestMonitor())).isEmpty();
@@ -187,6 +206,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(6)
 	public void test6() throws Exception {
 		// under root
 		assertThat(root.findDeletedMembersWithHistory(IResource.DEPTH_ZERO, createTestMonitor())).isEmpty();
@@ -215,6 +236,8 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(7)
 	public void test7() throws Exception {
 		// once the project is gone, so is all the history for that project
 		// under root
@@ -240,7 +263,4 @@ public class FindDeletedMembersTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, FindDeletedMembersTest.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/ProjectPreferenceSessionTest.java
@@ -18,9 +18,10 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -29,21 +30,23 @@ import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IScopeContext;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
-import junit.framework.Test;
-
-public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ProjectPreferenceSessionTest {
 	private static final String DIR_NAME = ".settings";
 	private static final String FILE_EXTENSION = "prefs";
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, ProjectPreferenceSessionTest.class);
-		//						return new ProjectPreferenceSessionTest("testDeleteFileBeforeLoad2");
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
 	private void saveWorkspace() throws Exception {
 		getWorkspace().save(true, createTestMonitor());
@@ -57,6 +60,8 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	 * - startup
 	 * - delete the .prefs file from disk
 	 */
+	@Test
+	@Order(1)
 	public void testDeleteFileBeforeLoad1() throws Exception {
 		IProject project = getProject("testDeleteFileBeforeLoad");
 		String qualifier = "test.delete.file.before.load";
@@ -72,6 +77,8 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(2)
 	public void testDeleteFileBeforeLoad2() throws Exception {
 		IProject project = getProject("testDeleteFileBeforeLoad");
 		Platform.getPreferencesService().getRootNode().node(ProjectScope.SCOPE).node(project.getName());
@@ -101,6 +108,8 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 	 * Test saving a key/value pair in one session and then ensure that they exist
 	 * in the next session.
 	 */
+	@Test
+	@Order(3)
 	public void testSaveLoad1() throws Exception {
 		IProject project = getProject("testSaveLoad");
 		createInWorkspace(project);
@@ -111,6 +120,8 @@ public class ProjectPreferenceSessionTest extends WorkspaceSessionTest {
 		saveWorkspace();
 	}
 
+	@Test
+	@Order(4)
 	public void testSaveLoad2() throws Exception {
 		IProject project = getProject("testSaveLoad");
 		IScopeContext context = new ProjectScope(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/SampleSessionTest.java
@@ -15,26 +15,36 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * This class is a simple example of how session tests operate.  Each method
- * starting with "test" will be invoked, in the order they are declared, in a separate
- * runtime instance of the workspace.  Contents on disk are automatically
- * cleaned up after the last test method is run.
+ * This class is a simple example of how session tests operate. Each method
+ * starting with "test" will be invoked, in the order they are declared, in a
+ * separate runtime instance of the workspace. Contents on disk are
+ * automatically cleaned up after the last test method is run.
  */
-public class SampleSessionTest extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SampleSessionTest {
 
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	@Test
+	@Order(1)
 	public void test1() throws Exception {
-		//create a project, save workspace
+		// create a project, save workspace
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject p1 = workspace.getRoot().getProject("P1");
 		p1.create(null);
@@ -44,16 +54,14 @@ public class SampleSessionTest extends WorkspaceSessionTest {
 		workspace.save(true, null);
 	}
 
+	@Test
+	@Order(2)
 	public void test2() {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject p1 = workspace.getRoot().getProject("P1");
 		IFile file = p1.getFile("foo.txt");
 		assertTrue(p1.exists());
 		assertTrue(file.exists());
-	}
-
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, SampleSessionTest.class);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/Test1GALH44.java
@@ -18,26 +18,32 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.harness.session.SessionShouldError;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.core.tests.internal.builders.DeltaVerifierBuilder;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.SessionTestSuite;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class Test1GALH44 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class Test1GALH44 {
 
-	public Test1GALH44(String name) {
-		super(name);
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
 	/**
 	 * Prepares the environment.  Create some resources and save the workspace.
 	 */
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IProjectDescription description = getWorkspace().newProjectDescription("MyProject");
@@ -57,6 +63,9 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 	/**
 	 * Step 2, edit a file then immediately crash.
 	 */
+	@Test
+	@SessionShouldError
+	@Order(2)
 	public void test2() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile file = project.getFile("foo.txt");
@@ -68,15 +77,10 @@ public class Test1GALH44 extends WorkspaceSessionTest {
 	/**
 	 * Now immediately try to save after recovering from crash.
 	 */
+	@Test
+	@Order(3)
 	public void test3() throws CoreException {
 		getWorkspace().save(true, createTestMonitor());
 	}
 
-	public static Test suite() {
-		SessionTestSuite suite = new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, Test1GALH44.class.getName());
-		suite.addTest(new Test1GALH44("test1"));
-		suite.addCrashTest(new Test1GALH44("test2"));
-		suite.addTest(new Test1GALH44("test3"));
-		return suite;
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug202384.java
@@ -16,22 +16,44 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.core.tests.resources.TestUtil;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 202384
  */
-public class TestBug202384 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug202384 {
 
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	private String testName;
+
+	@BeforeEach
+	public void setUpTestName(TestInfo testInfo) {
+		testName = testInfo.getDisplayName();
+	}
+
+	@Test
+	@Order(1)
 	public void testInitializeWorkspace() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
@@ -42,6 +64,8 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(2)
 	public void testStartWithClosedProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
@@ -55,6 +79,8 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(3)
 	public void testStartWithOpenProject() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
@@ -67,14 +93,11 @@ public class TestBug202384 extends WorkspaceSessionTest {
 		long start = System.currentTimeMillis();
 		while (!expectedEncoding.equals(project.getDefaultCharset(false))
 				&& System.currentTimeMillis() - start < timeout) {
-			TestUtil.dumpRunnigOrWaitingJobs(getName());
-			TestUtil.waitForJobs(getName(), 500, 1000);
+			TestUtil.dumpRunnigOrWaitingJobs(testName);
+			TestUtil.waitForJobs(testName, 500, 1000);
 		}
 		assertEquals(expectedEncoding, project.getDefaultCharset(false));
 		workspace.save(true, createTestMonitor());
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug202384.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug208833.java
@@ -17,26 +17,37 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests regression of bug 208833 - project resource tree is deleted when Eclipse fails to access its metainfo
  * during startup. It results in empty resource tree when the project's metadata is accessible again and the project is open.
  */
-public class TestBug208833 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug208833 {
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
 	/**
 	 * Setup.  Creates a project with a file.
 	 */
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 
@@ -59,6 +70,8 @@ public class TestBug208833 extends WorkspaceSessionTest {
 	/**
 	 * Eclipse started again.
 	 */
+	@Test
+	@Order(2)
 	public void test2() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 
@@ -80,7 +93,4 @@ public class TestBug208833 extends WorkspaceSessionTest {
 		assertTrue(file1.exists());
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug208833.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug30015.java
@@ -16,30 +16,44 @@ package org.eclipse.core.tests.resources.session;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests regression of bug 30015.  Due to this bug, it was impossible to restore
  * a project whose location was relative to a workspace path variable.
  */
-public class TestBug30015 extends WorkspaceSessionTest {
-	protected static final String PROJECT_NAME = "Project";
-	protected static final String VAR_NAME = "ProjectLocatio";
-	protected IPath varValue;
-	protected IPath rawLocation;
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug30015 {
+
+	private static final String PROJECT_NAME = "Project";
+	private static final String VAR_NAME = "ProjectLocatio";
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	private IPath varValue;
+	private IPath rawLocation;
 
 	/**
 	 * Create and open the project
 	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		varValue = Platform.getLocation().removeLastSegments(1);
 		rawLocation = IPath.fromOSString(VAR_NAME).append("ProjectLocation");
@@ -58,6 +72,9 @@ public class TestBug30015 extends WorkspaceSessionTest {
 	/**
 	 * See if the project was successfully restored.
 	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	@Order(2)
 	public void test2() {
 		varValue = Platform.getLocation().removeLastSegments(1);
 		rawLocation = IPath.fromOSString(VAR_NAME).append("ProjectLocation");
@@ -70,7 +87,4 @@ public class TestBug30015 extends WorkspaceSessionTest {
 		assertEquals(varValue.append(rawLocation.lastSegment()), project.getLocation());
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug30015.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug316182.java
@@ -17,21 +17,31 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 316182
  */
-public class TestBug316182 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug316182 {
 	public static Exception CAUGHT_EXCEPTION = null;
 
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	@Test
+	@Order(1)
 	public void test01_prepareWorkspace() throws CoreException {
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, true);
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
@@ -42,6 +52,8 @@ public class TestBug316182 extends WorkspaceSessionTest {
 		CAUGHT_EXCEPTION = null;
 	}
 
+	@Test
+	@Order(2)
 	public void test02_startWorkspace() throws Exception {
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
 		if (CAUGHT_EXCEPTION != null) {
@@ -49,7 +61,4 @@ public class TestBug316182 extends WorkspaceSessionTest {
 		}
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug316182.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug323833.java
@@ -14,35 +14,57 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.session;
 
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-
+import java.io.IOException;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.filesystem.FileCache;
 import org.eclipse.core.internal.filesystem.local.LocalFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.eclipse.core.runtime.Platform.OS;
+import org.eclipse.core.tests.harness.session.CustomSessionWorkspace;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 323833
  */
-public class TestBug323833 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug323833 {
+	private static final String READONLY_FILE_NAME = "test";
+
+	private static CustomSessionWorkspace sessionWorkspace = SessionTestExtension.createCustomWorkspace();
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(sessionWorkspace).create();
+
+	@AfterAll
+	public static void restoreFileWriabilityForCleanup() throws CoreException, IOException {
+		sessionWorkspace.getWorkspaceDirectory().resolve(READONLY_FILE_NAME).toFile().setWritable(true, false);
+	}
+
+	@Test
+	@Order(1)
 	public void test1() throws Exception {
-		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
+		if (!OS.isMac()) {
 			return;
 		}
 
-		IFileStore fileStore = workspaceRule.getTempStore().getChild(createUniqueString());
+		IFileStore fileStore = EFS.getLocalFileSystem().getStore(getWorkspace().getRoot().getLocation())
+				.getChild(READONLY_FILE_NAME);
 		createInFileSystem(fileStore);
 
 		// set EFS.ATTRIBUTE_READ_ONLY which also sets EFS.IMMUTABLE on Mac
@@ -61,15 +83,14 @@ public class TestBug323833 extends WorkspaceSessionTest {
 		assertTrue(cachedFileInfo.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
 	}
 
+	@Test
+	@Order(2)
 	public void test2() throws CoreException {
-		if (!Platform.getOS().equals(Platform.OS_MACOSX)) {
+		if (!OS.isMac()) {
 			return;
 		}
 
 		FileCache.getCache();
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug323833.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug369177.java
@@ -19,20 +19,31 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 369177
  */
-public class TestBug369177 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug369177 {
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	@Test
+	@Order(1)
 	public void test01_prepareWorkspace() throws CoreException, URISyntaxException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot().getProject("project");
@@ -44,11 +55,10 @@ public class TestBug369177 extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(2)
 	public void test02_startWorkspace() {
 		// nothing to do, if we get this far without an error then we have already passed the test
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug369177.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug426263.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug426263.java
@@ -15,22 +15,26 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IPathVariableManager;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for bug 426263
  */
-public class TestBug426263 extends WorkspaceSessionTest {
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug426263.class);
-	}
+public class TestBug426263 {
 
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	@Test
 	public void testBug() {
 		IPathVariableManager manager = getWorkspace().getPathVariableManager();
 		assertFalse(manager.isUserDefined("ECLIPSE_HOME"));
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug6995.java
@@ -20,28 +20,39 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the fix for bug 6995.  In this bug, a snapshot immediately after startup and
  * before doing any builds was losing the old built tree.  A subsequent build would
  * revert to a full build.
  */
-public class TestBug6995 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug6995 {
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
 	/**
 	 * Create a project and configure a builder for it.
 	 */
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		setAutoBuilding(false);
@@ -64,6 +75,8 @@ public class TestBug6995 extends WorkspaceSessionTest {
 	/**
 	 * After restarted the workspace, do a snapshot, then try to build.
 	 */
+	@Test
+	@Order(2)
 	public void test2() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		IProject project = workspace.getRoot().getProject("Project");
@@ -82,7 +95,4 @@ public class TestBug6995 extends WorkspaceSessionTest {
 		assertTrue(builder.wasIncrementalBuild());
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug6995.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestBug93473.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.internal.resources.ContentDescriptionManager;
 import org.eclipse.core.internal.resources.Workspace;
@@ -28,11 +29,13 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.core.tests.resources.ContentDescriptionManagerTest;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that the content description cache is preserved across sessions.
@@ -42,12 +45,15 @@ import junit.framework.Test;
  * in the second session.  For details, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=94859.
  * @since 3.2
  */
-public class TestBug93473 extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestBug93473 {
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestBug93473.class);
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
+	@Test
+	@Order(1)
 	public void test1stSession() throws CoreException {
 		final IWorkspace workspace = getWorkspace();
 
@@ -79,6 +85,8 @@ public class TestBug93473 extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(2)
 	public void test2ndSession() {
 		// cache should preserve state across sessions
 		assertEquals(ContentDescriptionManager.USED_CACHE,

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestMissingBuilder.java
@@ -21,10 +21,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -33,17 +33,25 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.core.tests.internal.builders.SnowBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
-
-import junit.framework.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests persistence cases for builders that are missing or disabled.
  */
-public class TestMissingBuilder extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestMissingBuilder {
+
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
 	/**
 	 * Returns true if this project's build spec has the given builder,
 	 * and false otherwise.
@@ -67,6 +75,8 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	 * Setup.  Create a project that has a disabled builder due to
 	 * missing nature prerequisite.
 	 */
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
 		createInWorkspace(project);
@@ -95,6 +105,8 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	 * Now assert that the disabled builder was carried forward and that
 	 * it still doesn't build.
 	 */
+	@Test
+	@Order(2)
 	public void test2() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
 
@@ -115,6 +127,8 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 	 * Test again in another workspace.  This ensures that disabled builders
 	 * that were never instantiated get carried forward correctly.
 	 */
+	@Test
+	@Order(3)
 	public void test3() throws CoreException {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("P1");
 
@@ -138,10 +152,6 @@ public class TestMissingBuilder extends WorkspaceSessionTest {
 		waitForBuild();
 		builder.assertLifecycleEvents();
 		assertTrue(builder.wasDeltaNull());
-
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, TestMissingBuilder.class);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingExistingWorkspace.java
@@ -14,39 +14,38 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import junit.framework.Test;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.CustomSessionWorkspace;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that explicit workspace encoding not set if there are projects defined
  */
-public class TestWorkspaceEncodingExistingWorkspace extends WorkspaceSessionTest {
+public class TestWorkspaceEncodingExistingWorkspace {
 
-	public static Test suite() {
-		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS,
-				TestWorkspaceEncodingExistingWorkspace.class);
-		Path wspRoot = suite.getInstanceLocation().toFile().toPath();
-		Path projectsTree = wspRoot.resolve(".metadata/.plugins/org.eclipse.core.resources/.projects");
-		try {
-			Files.createDirectories(projectsTree);
-		} catch (IOException e) {
-			fail("Unable to create directories: " + projectsTree + System.lineSeparator() + e);
-		}
-		return suite;
+	private CustomSessionWorkspace sessionWorkspace = SessionTestExtension.createCustomWorkspace();
+
+	@RegisterExtension
+	SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(sessionWorkspace).create();
+
+	@BeforeEach
+	public void setUpWorkspace() throws IOException {
+		Path projectsTree = sessionWorkspace.getWorkspaceDirectory().resolve(".metadata/.plugins/org.eclipse.core.resources/.projects");
+		Files.createDirectories(projectsTree);
 	}
 
-	public TestWorkspaceEncodingExistingWorkspace() {
-		super();
-	}
-
+	@Test
 	public void testExpectedEncoding1() throws Exception {
 		String defaultValue = System.getProperty("native.encoding");
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingNewWorkspace.java
@@ -15,32 +15,32 @@ package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that encoding is set to UTF-8 in an empty workspace and only if no
  * preference set already
  */
-public class TestWorkspaceEncodingNewWorkspace extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestWorkspaceEncodingNewWorkspace {
 
 	private static final String CHARSET = "UTF-16";
 
-	public static Test suite() {
-		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS,
-				TestWorkspaceEncodingNewWorkspace.class);
-		// no special setup
-		return suite;
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
-	public TestWorkspaceEncodingNewWorkspace() {
-		super();
-	}
-
+	@Test
+	@Order(1)
 	public void testExpectedEncoding1() throws Exception {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		String charset = workspace.getRoot().getDefaultCharset(false);
@@ -51,10 +51,13 @@ public class TestWorkspaceEncodingNewWorkspace extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(2)
 	public void testExpectedEncoding2() throws Exception {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		String charset = workspace.getRoot().getDefaultCharset(false);
 		// Shouldn't be changed anymore
 		assertEquals(CHARSET, charset);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithJvmArgs.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/TestWorkspaceEncodingWithJvmArgs.java
@@ -14,40 +14,32 @@
 package org.eclipse.core.tests.resources.session;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.Setup;
-import org.eclipse.core.tests.session.SetupManager.SetupException;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that encoding is set according to jvm arguments
  */
-public class TestWorkspaceEncodingWithJvmArgs extends WorkspaceSessionTest {
+public class TestWorkspaceEncodingWithJvmArgs {
 
 	private static final String CHARSET = "UTF-16";
 
-	public static Test suite() {
-		WorkspaceSessionTestSuite suite = new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS,
-				TestWorkspaceEncodingWithJvmArgs.class);
-		try {
+	@RegisterExtension
+	SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
-			// add pluginCustomization argument
-			Setup setup = suite.getSetup();
-			setup.setSystemProperty("file.encoding", CHARSET);
-		} catch (SetupException e) {
-			// ignore, the test will fail for us
-		}
-		return suite;
+	@BeforeEach
+	public void setUpSession() {
+		sessionTestExtension.setSystemProperty("file.encoding", "UTF-16");
 	}
 
-	public TestWorkspaceEncodingWithJvmArgs() {
-		super();
-	}
-
+	@Test
 	public void testExpectedEncoding() throws Exception {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		// Should be system default
@@ -58,4 +50,5 @@ public class TestWorkspaceEncodingWithJvmArgs extends WorkspaceSessionTest {
 		String charset = workspace.getRoot().getDefaultCharset(false);
 		assertEquals(CHARSET, charset);
 	}
+
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/session/WorkspaceDescriptionTest.java
@@ -18,19 +18,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 
-import junit.framework.Test;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Ensures that the workspace description is correctly persisted across
  * sessions.
  */
-public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class WorkspaceDescriptionTest {
 	private static final String[] BUILD_ORDER = new String[] {"Foo"};
 	private static final boolean APPLY_POLICY = false;
 	private static final long STATE_LONGEVITY = 123456;
@@ -38,6 +42,12 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 	private static final long MAX_FILE_SIZE = 1024 * 53;
 	private static final long SNAPSHOT_INTERVAL = 4321;
 
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
+
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IWorkspaceDescription desc = workspace.getDescription();
@@ -52,6 +62,8 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 		workspace.save(true, createTestMonitor());
 	}
 
+	@Test
+	@Order(2)
 	public void test2() {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IWorkspaceDescription desc = workspace.getDescription();
@@ -66,7 +78,4 @@ public class WorkspaceDescriptionTest extends WorkspaceSessionTest {
 				.isEqualTo(SNAPSHOT_INTERVAL);
 	}
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, WorkspaceDescriptionTest.class);
-	}
 }

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionWorkspace.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionWorkspace.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness.session;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import org.eclipse.core.tests.harness.session.customization.SessionCustomization;
 
@@ -17,6 +18,11 @@ import org.eclipse.core.tests.harness.session.customization.SessionCustomization
  * A session customization to use a custom workspace directory.
  */
 public interface CustomSessionWorkspace extends SessionCustomization {
+
+	/**
+	 * {@return the path of the used workspace directory}
+	 */
+	public Path getWorkspaceDirectory() throws IOException;
 
 	/**
 	 * Sets the given workspace directory. If not called, a temporary folder is used

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
@@ -220,8 +220,28 @@ public class SessionTestExtension implements InvocationInterceptor {
 		return new CustomSessionConfigurationImpl();
 	}
 
+	/**
+	 * Sets the given Eclipse program argument to the given value for sessions
+	 * executed with this extension.
+	 *
+	 * @param key   the Eclipse argument key, must not be {@code null}
+	 * @param value the Eclipse argument value to set, may be {@code null} to remove
+	 *              the key
+	 */
 	public void setEclipseArgument(String key, String value) {
 		setup.setEclipseArgument(key, value);
+	}
+
+	/**
+	 * Sets the given system property to the given value for sessions executed with
+	 * this extension.
+	 *
+	 * @param key   the system property key, must not be {@code null}
+	 * @param value the system property value to set, may be {@code null} to remove
+	 *              the key
+	 */
+	public void setSystemProperty(String key, String value) {
+		setup.setSystemProperty(key, value);
 	}
 
 	@Override

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
@@ -37,7 +37,8 @@ public class CustomSessionWorkspaceImpl implements CustomSessionWorkspace {
 		return this;
 	}
 
-	private Path getWorkspaceDirectory() throws IOException {
+	@Override
+	public Path getWorkspaceDirectory() throws IOException {
 		if (workspaceDirectory == null) {
 			this.workspaceDirectory = Files.createTempDirectory(TEMP_DIR_PREFIX);
 			deleteOnShutdownRecursively(workspaceDirectory);


### PR DESCRIPTION
This migrates all WorkspaceSessionTests that are not specializations of WorkspaceSerializationTest to JUnit 5, using the SessionTestExtension with the CustomSessionWorkspace. It extends the SessionTestExtension with functionality to set a system property as required for specific tests.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903