### PR TITLE
Migrate SnapshotTest to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot1Test.java
@@ -18,6 +18,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -29,7 +31,7 @@ import org.eclipse.core.runtime.CoreException;
  * as expected (failing or not) and may add more "user actions" to be
  * verified in the next session and so on.
  */
-public class Snapshot1Test extends SnapshotTest {
+public class Snapshot1Test {
 
 	protected static String[] defineHierarchy1() {
 		return new String[] {"/folder110/", "/folder110/folder120/", "/folder110/folder120/folder130/", "/folder110/folder120/folder130/folder140/", "/folder110/folder120/folder130/folder140/folder150/", "/folder110/folder120/folder130/folder140/folder150/file160", "/folder110/folder120/folder130/folder140/file150", "/folder110/folder121/", "/folder110/folder121/folder131/", "/folder110/folder120/folder130/folder141/"};
@@ -41,11 +43,11 @@ public class Snapshot1Test extends SnapshotTest {
 
 	// copy and paste in the scrapbook to run
 	public void testCreateMyProject() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
 		project.create(null);
 		project.open(null);
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
@@ -54,19 +56,19 @@ public class Snapshot1Test extends SnapshotTest {
 		assertExistsInWorkspace(resources);
 
 		project.close(null);
-		assertTrue("2.1", project.exists());
-		assertTrue("2.2", !project.isOpen());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
 	}
 
 	/**
 	 * Create another project and leave it closed for next session.
 	 */
 	public void testCreateProject2() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_2);
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
 		project.create(null);
 		project.open(null);
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot2Test.java
@@ -19,6 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,15 +36,15 @@ import org.eclipse.core.runtime.IPath;
  * but not written to disk (only in the tree).
  * Only snapshots are taken. No full saves.
  */
-public class Snapshot2Test extends SnapshotTest {
+public class Snapshot2Test {
 
 	protected static String[] defineHierarchy1() {
 		List<String> result = new ArrayList<>();
 		String[] old = Snapshot1Test.defineHierarchy1();
 		result.addAll(Arrays.asList(old));
-		result.add(IPath.fromOSString(PROJECT_1).append("added file").toString());
-		result.add(IPath.fromOSString(PROJECT_1).append("yet another file").toString());
-		result.add(IPath.fromOSString(PROJECT_1).append("a folder").addTrailingSeparator().toString());
+		result.add(IPath.fromOSString(SnapshotTest.PROJECT_1).append("added file").toString());
+		result.add(IPath.fromOSString(SnapshotTest.PROJECT_1).append("yet another file").toString());
+		result.add(IPath.fromOSString(SnapshotTest.PROJECT_1).append("a folder").addTrailingSeparator().toString());
 		return result.toArray(new String[result.size()]);
 	}
 
@@ -52,9 +54,9 @@ public class Snapshot2Test extends SnapshotTest {
 
 	public void testChangeMyProject() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// create some children
 		IResource[] resources = buildResources(project, defineHierarchy1());
@@ -64,9 +66,9 @@ public class Snapshot2Test extends SnapshotTest {
 	}
 
 	public void testChangeProject2() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject("Project2");
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// remove all resources
 		IResource[] children = project.members();
@@ -85,12 +87,12 @@ public class Snapshot2Test extends SnapshotTest {
 
 	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.0", project.exists());
-		assertTrue("0.1", !project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
 
 		project.open(null);
-		assertTrue("1.2", project.isOpen());
+		assertTrue(project.isOpen());
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot1Test.defineHierarchy1());
@@ -98,9 +100,9 @@ public class Snapshot2Test extends SnapshotTest {
 		assertExistsInWorkspace(resources);
 
 		// Project2
-		project = getWorkspace().getRoot().getProject(PROJECT_2);
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", project.isOpen());
+		project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot1Test.defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot3Test.java
@@ -18,6 +18,8 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -28,7 +30,7 @@ import org.eclipse.core.runtime.CoreException;
  * This session only performs a full save. The workspace should stay
  * the same.
  */
-public class Snapshot3Test extends SnapshotTest {
+public class Snapshot3Test {
 
 	protected static String[] defineHierarchy1() {
 		return Snapshot2Test.defineHierarchy1();
@@ -44,9 +46,9 @@ public class Snapshot3Test extends SnapshotTest {
 
 	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.0", project.exists());
-		assertTrue("0.1", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot2Test.defineHierarchy1());
@@ -54,12 +56,12 @@ public class Snapshot3Test extends SnapshotTest {
 		assertExistsInWorkspace(resources);
 
 		// Project2
-		project = getWorkspace().getRoot().getProject(PROJECT_2);
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", project.isOpen());
+		project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		assertThat(project.members()).hasSize(4);
-		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
+		assertNotNull(project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot2Test.defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot4Test.java
@@ -21,6 +21,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,15 +39,15 @@ import org.eclipse.core.runtime.IPath;
 /**
  * Change some resources mixing full saves and snapshots.
  */
-public class Snapshot4Test extends SnapshotTest {
+public class Snapshot4Test {
 
 	protected static String[] defineHierarchy1() {
 		List<String> result = new ArrayList<>();
 		String[] old = Snapshot3Test.defineHierarchy1();
 		result.addAll(Arrays.asList(old));
-		result.remove(IPath.fromOSString(PROJECT_1).append("added file").toString());
-		result.remove(IPath.fromOSString(PROJECT_1).append("yet another file").toString());
-		result.remove(IPath.fromOSString(PROJECT_1).append("a folder").addTrailingSeparator().toString());
+		result.remove(IPath.fromOSString(SnapshotTest.PROJECT_1).append("added file").toString());
+		result.remove(IPath.fromOSString(SnapshotTest.PROJECT_1).append("yet another file").toString());
+		result.remove(IPath.fromOSString(SnapshotTest.PROJECT_1).append("a folder").addTrailingSeparator().toString());
 		return result.toArray(new String[result.size()]);
 	}
 
@@ -54,9 +57,9 @@ public class Snapshot4Test extends SnapshotTest {
 
 	public void testChangeMyProject() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// remove resources
 		IFile file = project.getFile("added file");
@@ -87,13 +90,13 @@ public class Snapshot4Test extends SnapshotTest {
 	}
 
 	public void testChangeProject2() throws CoreException {
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_2);
-		assertTrue("0.1", project.exists());
-		assertTrue("0.2", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// remove project
 		project.delete(true, true, null);
-		assertTrue("1.1", !project.exists());
+		assertFalse(project.exists());
 
 		// snapshot
 		getWorkspace().save(false, null);
@@ -101,9 +104,9 @@ public class Snapshot4Test extends SnapshotTest {
 
 	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.0", project.exists());
-		assertTrue("0.1", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot3Test.defineHierarchy1());
@@ -111,12 +114,12 @@ public class Snapshot4Test extends SnapshotTest {
 		assertExistsInWorkspace(resources);
 
 		// Project2
-		project = getWorkspace().getRoot().getProject(PROJECT_2);
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", project.isOpen());
+		project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		assertThat(project.members()).hasSize(4);
-		assertNotNull("4.1", project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
+		assertNotNull(project.findMember(IProjectDescription.DESCRIPTION_FILE_NAME));
 
 		// verify existence of children
 		resources = buildResources(project, Snapshot3Test.defineHierarchy2());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/Snapshot5Test.java
@@ -19,6 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -29,12 +31,12 @@ import org.eclipse.core.runtime.CoreException;
 /**
  * Only verifies previous session.
  */
-public class Snapshot5Test extends SnapshotTest {
+public class Snapshot5Test {
 	public void testVerifyPreviousSession() throws CoreException {
 		// MyProject
-		IProject project = getWorkspace().getRoot().getProject(PROJECT_1);
-		assertTrue("0.0", project.exists());
-		assertTrue("0.1", project.isOpen());
+		IProject project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_1);
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 
 		// verify existence of children
 		IResource[] resources = buildResources(project, Snapshot4Test.defineHierarchy1());
@@ -51,8 +53,8 @@ public class Snapshot5Test extends SnapshotTest {
 		assertDoesNotExistInWorkspace(folder);
 
 		// Project2
-		project = getWorkspace().getRoot().getProject(PROJECT_2);
-		assertTrue("3.0", !project.exists());
+		project = getWorkspace().getRoot().getProject(SnapshotTest.PROJECT_2);
+		assertFalse(project.exists());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/SnapshotTest.java
@@ -15,17 +15,20 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 
-import junit.framework.Test;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.WorkspaceSessionTest;
-import org.eclipse.core.tests.session.WorkspaceSessionTestSuite;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Runs all the snapshot usecase tests as a single session test.
  * Each test method will run a different snapshot test.
  */
-public class SnapshotTest extends WorkspaceSessionTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SnapshotTest {
 
 	/** activities */
 	static final String COMMENT_1 = "COMMENT ONE";
@@ -35,30 +38,22 @@ public class SnapshotTest extends WorkspaceSessionTest {
 	static final String PROJECT_1 = "MyProject";
 	static final String PROJECT_2 = "Project2";
 
-	public static Test suite() {
-		return new WorkspaceSessionTestSuite(PI_RESOURCES_TESTS, SnapshotTest.class);
-	}
+	@RegisterExtension
+	static SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_RESOURCES_TESTS)
+			.withCustomization(SessionTestExtension.createCustomWorkspace()).create();
 
-	private boolean skipTest() {
-		//skip on Mac due to unknown failure (bug 127752)
-		//TODO re-enable after M5 build
-		return OS.isMac();
-	}
-
+	@Test
+	@Order(1)
 	public void test1() throws CoreException {
-		if (skipTest()) {
-			return;
-		}
 		Snapshot1Test test = new Snapshot1Test();
 		test.testCreateMyProject();
 		test.testCreateProject2();
 		test.testSnapshotWorkspace();
 	}
 
+	@Test
+	@Order(2)
 	public void test2() throws CoreException {
-		if (skipTest()) {
-			return;
-		}
 		Snapshot2Test test = new Snapshot2Test();
 		test.testVerifyPreviousSession();
 		test.testChangeMyProject();
@@ -66,29 +61,26 @@ public class SnapshotTest extends WorkspaceSessionTest {
 		test.testSnapshotWorkspace();
 	}
 
+	@Test
+	@Order(3)
 	public void test3() throws CoreException {
-		if (skipTest()) {
-			return;
-		}
 		Snapshot3Test test = new Snapshot3Test();
 		test.testVerifyPreviousSession();
 		test.testSaveWorkspace();
 	}
 
+	@Test
+	@Order(4)
 	public void test4() throws CoreException {
-		if (skipTest()) {
-			return;
-		}
 		Snapshot4Test test = new Snapshot4Test();
 		test.testVerifyPreviousSession();
 		test.testChangeMyProject();
 		test.testChangeProject2();
 	}
 
+	@Test
+	@Order(5)
 	public void test5() throws CoreException {
-		if (skipTest()) {
-			return;
-		}
 		Snapshot5Test test = new Snapshot5Test();
 		test.testVerifyPreviousSession();
 	}


### PR DESCRIPTION
This migrates the SnapshotTest to JUnit 5, using the SessionTestExtension with the CustomSessionWorkspace. Also re-enables the test cases on MacOS.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903