### PR TITLE
Fix deletion of configuration and workspace directory for session tests

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
@@ -11,6 +11,7 @@
 package org.eclipse.core.tests.harness.session.customization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.core.tests.harness.session.customization.SessionCustomizationUtil.deleteOnShutdownRecursively;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -143,7 +144,7 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 	private Path getConfigurationDirectory() throws IOException {
 		if (configurationDirectory == null) {
 			this.configurationDirectory = Files.createTempDirectory(TEMP_DIR_PREFIX);
-			this.configurationDirectory.toFile().deleteOnExit();
+			deleteOnShutdownRecursively(configurationDirectory);
 		}
 		return configurationDirectory;
 	}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness.session.customization;
 
+import static org.eclipse.core.tests.harness.session.customization.SessionCustomizationUtil.deleteOnShutdownRecursively;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,7 +40,7 @@ public class CustomSessionWorkspaceImpl implements CustomSessionWorkspace {
 	private Path getWorkspaceDirectory() throws IOException {
 		if (workspaceDirectory == null) {
 			this.workspaceDirectory = Files.createTempDirectory(TEMP_DIR_PREFIX);
-			this.workspaceDirectory.toFile().deleteOnExit();
+			deleteOnShutdownRecursively(workspaceDirectory);
 		}
 		return workspaceDirectory;
 	}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/SessionCustomizationUtil.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/SessionCustomizationUtil.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.customization;
+
+import static java.util.Comparator.reverseOrder;
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+final class SessionCustomizationUtil {
+	private SessionCustomizationUtil() {
+	}
+
+	static void deleteOnShutdownRecursively(Path path) {
+		Runnable deleteDirectory = () -> {
+			try {
+				Files.walk(path) //
+						.sorted(reverseOrder()) //
+						.forEach(SessionCustomizationUtil::deleteSilently);
+			} catch (IOException exception) {
+				ILog.get().log(new Status(IStatus.WARNING, PI_HARNESS,
+						"Error when removing test directory: " + path, exception));
+			}
+		};
+		Runtime.getRuntime().addShutdownHook(new Thread(deleteDirectory));
+	}
+
+	private static void deleteSilently(Path path) {
+		try {
+			Files.delete(path);
+		} catch (IOException exception) {
+			ILog.get().log(new Status(IStatus.WARNING, PI_HARNESS,
+					"Test file or directory could not be removed: " + path, exception));
+		}
+	}
+
+}


### PR DESCRIPTION
The CustomSessionConfigurationImpl and CustomSessionWorkspaceImpl use `deleteOnExit()` to remove the configuration and workspaces directories on JVM shutdown. However, this does not work recursively and thus usually fails when the directory is not empty. This change corrects the cleanup by adding a shutdown hook (like used by `deleteOnExit()`) that recursively deletes all contents of the directory and only uses Java NIO instead of Java IO.