### PR TITLE
Fix "Terminate and Relaunch" of groups that use adoptIfRunning #1318

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.21.400.qualifier
+Bundle-Version: 3.21.500.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/RuntimeProcess.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/RuntimeProcess.java
@@ -269,8 +269,12 @@ public class RuntimeProcess extends PlatformObject implements IProcess {
 				try { // (in total don't wait longer than TERMINATION_TIMEOUT)
 					long waitStart = System.currentTimeMillis();
 					if (process.waitFor(TERMINATION_TIMEOUT, TimeUnit.MILLISECONDS)) {
+						int exitValue = process.exitValue();
 						synchronized (this) {
-							fExitValue = process.exitValue();
+							fExitValue = exitValue;
+							// synchronously remember thread is terminated
+							// before later asynchronously done in terminated():
+							fTerminated = true;
 						}
 						if (waitFor(descendants, waitStart)) {
 							return;


### PR DESCRIPTION
This was a race condition:
RuntimeProcess.fTerminated was only set asynchronously, hindering relaunching the process, thinking it was already running.

Happened only for GroupLaunchElement.adoptIfRunning == true

fixes
https://github.com/eclipse-platform/eclipse.platform/issues/1318