### PR TITLE
Check 'ECLIPSE_I_BUILD_TEST' to disable 'ensureJavaxIsNotAvailable' case

### DIFF
--- a/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/InjectionOSGiTest.java
+++ b/runtime/tests/org.eclipse.e4.core.tests/src/org/eclipse/e4/core/internal/tests/di/extensions/InjectionOSGiTest.java
@@ -115,7 +115,7 @@ public class InjectionOSGiTest {
 		// However due to the way I-build tests are set up (i.e. by using a built
 		// Eclipse installation) exactly that's the case.
 		// -> Disable this for I-build tests
-		Assume.assumeFalse("org.eclipse.ant.core.antRunner".equals(System.getProperty("eclipse.application")));
+		Assume.assumeFalse(Boolean.parseBoolean(System.getenv().getOrDefault("ECLIPSE_I_BUILD_TEST", "false")));
 
 		// Ensure that the providing bundles of the following classes are absent of the
 		// test-runtime and thus the mentioned classes cannot be loaded


### PR DESCRIPTION
Check the newly introduced 'ECLIPSE_I_BUILD_TEST' environment variable to disable the InjectionOSGiTest.ensureJavaxIsNotAvailable()' test case in I-build tests.
The previous attempt to disable it failed.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1098 Requires
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2031