### PR TITLE
Add Ant test.xml for org.eclipse.core.tests.resources.saveparticipant

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/build.properties
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/build.properties
@@ -16,7 +16,8 @@ source.. = src/
 output.. = bin/
 bin.includes = .,\
                META-INF/,\
-               about.html
+               about.html,\
+               test.xml
 src.includes = about.html
 
 pom.model.packaging = eclipse-test-plugin

--- a/resources/tests/org.eclipse.core.tests.resources.saveparticipant/test.xml
+++ b/resources/tests/org.eclipse.core.tests.resources.saveparticipant/test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<project name="Core Resources Save Participant Automated Tests" default="run" basedir=".">
+
+  <!-- The property ${eclipse-home} should be passed into this script -->
+  <!-- sets the properties eclipse-home, and library-file -->
+  <property name="eclipse-home" value="${basedir}/../../"/>
+  <property name="library-file" value="${eclipse-home}/plugins/org.eclipse.test/library.xml"/>
+  <property name="saveparticipant_location" value="${eclipse-home}/core_resources_saveparticipant_sniff_folder"/>
+  <property name="plugin-name" value="org.eclipse.core.tests.resources.saveparticipant"/>
+
+  <!-- This target holds all initialization code that needs to be done for -->
+  <!-- all tests that are to be run. Initialization for individual tests -->
+  <!-- should be done within the body of the suite target. -->
+  <target name="init">
+    <tstamp/>
+  </target>
+
+  <!-- This target holds code to cleanup the testing environment after the tests -->
+  <!-- have been run. You can use this to delete temporary files that are created. -->
+  <target name="cleanup">
+    <delete dir="${saveparticipant_location}" quiet="true"/>
+  </target>
+
+  <!-- This target runs the test suite. Any actions that need to happen after all -->
+  <!-- the tests have been run should go here. -->
+  <target name="run" depends="init,suite,cleanup">
+    <ant target="collect" antfile="${library-file}" dir="${eclipse-home}">
+      <property name="includes" value="org*.xml"/>
+      <property name="output-file" value="${plugin-name}.xml"/>
+    </ant>
+  </target>
+  
+  <target name="SaveParticipantTests" depends="init,cleanup">
+    <ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
+      <property name="data-dir" value="${saveparticipant_location}"/>
+      <property name="plugin-name" value="${plugin-name}"/>
+      <property name="classname" value="org.eclipse.core.tests.resources.saveparticipant.SaveManagerTest"/>
+    </ant>
+  </target>
+    
+  <!-- This target defines the tests that need to be run. -->
+  <target name="suite" depends="SaveParticipantTests"/>  
+  
+ </project>


### PR DESCRIPTION
This adds a test.xml for Ant-based execution of tests in org.eclipse.core.tests.resources.saveparticipant. It is a follow-up to the addition of these tests to the Maven build.