### PR TITLE
Reduce number of parallel builds in ParallelBuildChainTest #825

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -144,7 +144,7 @@ public class ParallelBuildChainTest {
 
 	@Test
 	public void testIndividualProjectBuilds_WithManyProjects_ProjectRelaxedRule() throws Exception {
-		int numberOfParallelBuilds = 30;
+		int numberOfParallelBuilds = 15;
 		var longRunningProjects = createMultipleTestProjects(numberOfParallelBuilds, BuildDurationType.LONG_RUNNING,
 				RuleType.CURRENT_PROJECT_RELAXED);
 		executeIndividualFullProjectBuilds(numberOfParallelBuilds, () -> {


### PR DESCRIPTION
The test case testIndividualProjectBuilds_WithManyProjects_ProjectRelaxedRule() in ParallelBuildChainTest fails randomly (in I-Builds) because not all jobs that are supposed to run build operations are scheduled and started in time. Since the test is not supposed to validate that a specific number of jobs can be started, the number of jobs/builds to be spawned must actually not be as high as currently defined. This change reduces the number of projects in the test case to avoid random test failures while keeping expressiveness of the test case.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/825