### PR TITLE
JsonReader.setStrictness(Strictness.LENIENT) instead of setLenient(true)

### DIFF
--- a/ua/org.eclipse.tips.json/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.tips.json/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
 Export-Package: org.eclipse.tips.json,
  org.eclipse.tips.json.internal;x-internal:=true
 Automatic-Module-Name: org.eclipse.tips.json
-Import-Package: com.google.gson;version="[2.8.6,3.0.0)"
+Import-Package: com.google.gson;version="[2.11.0,3.0.0)"
 Bundle-Vendor: %Bundle-Vendor

--- a/ua/org.eclipse.tips.json/src/org/eclipse/tips/json/JsonTipProvider.java
+++ b/ua/org.eclipse.tips.json/src/org/eclipse/tips/json/JsonTipProvider.java
@@ -41,6 +41,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.Strictness;
 import com.google.gson.stream.JsonReader;
 
 /**
@@ -110,7 +111,7 @@ public abstract class JsonTipProvider extends TipProvider {
 		try (InputStream stream = fJsonUrl.openStream();
 				InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
 			JsonReader jreader = new JsonReader(reader);
-			jreader.setLenient(true);
+			jreader.setStrictness(Strictness.LENIENT);
 			Object result = JsonParser.parseReader(jreader);
 			if (result instanceof JsonObject) {
 				return (JsonObject) result;


### PR DESCRIPTION
- JsonReader.setLenient latter is deprecated in 2.11.0 and setStrictness is new to 2.11.0.