### PR TITLE
Force signing of split package bundles to use new certificate

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 547066 - IBuild I20190507-1800 failed due to unresolved project dependencies
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 XML Refactoring
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 466408: Split 'org.eclipse.compare.patch' packages do not have identical cer
 Pick up new signing certificate (same as bug 466408)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/team/bundles/org.eclipse.compare/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 571840 - 4.20 I-Build: I20210310-0250 - Comparator Errors Found
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044