### PR TITLE
Force qualifier to resign bundles signed with an expired certificate

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/forceQualifierUpdate.txt
+++ b/runtime/tests/org.eclipse.core.tests.harness/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/ua/org.eclipse.tips.feature/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.tips.feature/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Update to com.google.gson from maven central
 Update to gson 2.9.1
 Update to gson 2.10
 Update to gson 2.10.1
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/ua/org.eclipse.tips.json/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.tips.json/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044