### PR TITLE
Force qualifier to resign bundles signed with an expired certificate

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/forceQualifierUpdate.txt
+++ b/resources/tests/org.eclipse.core.tests.resources/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044