### PR TITLE
Provide API for IFile Bulk read/write of all bytes/String/chars

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.10.400.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)",

--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.20.300.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -424,11 +424,8 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 	 * are not considered.
 	 */
 	private boolean descriptionChanged(IFile descriptionFile, byte[] newContents) {
-		//buffer size: twice the description length, but maximum 8KB
-		int bufsize = newContents.length > 4096 ? 8192 : newContents.length * 2;
-		try (
-			InputStream oldStream = new BufferedInputStream(descriptionFile.getContents(true), bufsize);
-		) {
+		try {
+			InputStream oldStream = new ByteArrayInputStream(descriptionFile.readAllBytes());
 			InputStream newStream = new ByteArrayInputStream(newContents);
 			//compare streams char by char, ignoring line endings
 			int newChar = newStream.read();

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.500.qualifier
+Bundle-Version: 3.11.600.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.33.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.500-SNAPSHOT</version>
+  <version>3.11.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -24,7 +24,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertThrows;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -488,9 +487,7 @@ public class FilteredResourceTest {
 			fileInputStream.transferTo(originalContentStream);
 			String originalContent = new String(originalContentStream.toByteArray(), StandardCharsets.UTF_8);
 			String newContent = originalContent + "w";
-			ByteArrayInputStream modifiedContentStream = new ByteArrayInputStream(
-					newContent.getBytes(StandardCharsets.UTF_8));
-			file.setContents(modifiedContentStream, false, false, null);
+			file.setContents(newContent.getBytes(StandardCharsets.UTF_8), false, false, null);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import java.io.ByteArrayInputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.resources.Resource;
@@ -2550,7 +2549,7 @@ public class IProjectTest  {
 
 		// modify the file to create an entry in the history
 		monitor.prepare();
-		file.setContents(new ByteArrayInputStream(createRandomString().getBytes()), true, true, monitor);
+		file.setContents(createRandomString().getBytes(), true, true, monitor);
 		monitor.assertUsedUp();
 
 		// delete the project and check that its metadata is also deleted

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -273,7 +273,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
+		assertEquals("5.3", "contents for a file", file.readString());
 	}
 
 	/**
@@ -330,7 +330,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
+		assertEquals("5.3", "contents for a file", file.readString());
 	}
 
 	/**
@@ -509,7 +509,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertDoesNotExistInWorkspace(file);
 
 		file.createLink(variableBasedLocation, IResource.ALLOW_MISSING_LOCAL, null);
-		file.setContents(createInputStream("contents for a file"), IResource.FORCE, null);
+		file.setContents("contents for a file".getBytes(), IResource.FORCE, null);
 
 		// now the file exists in both workspace and file system
 		assertExistsInWorkspace(file);
@@ -545,7 +545,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertNotNull("5.1", file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
+		assertEquals("5.3", "contents for a file", file.readString());
 	}
 
 	/**
@@ -859,7 +859,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
+		assertEquals("5.3", "contents for a file", file.readString());
 	}
 
 	/**
@@ -925,7 +925,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertTrue("5.3", compareContent(file.getContents(true), createInputStream("contents for a file")));
+		assertEquals("5.3", "contents for a file", file.readString());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -319,7 +319,7 @@ public class WorkspaceTest {
 		assertTrue(fileTarget.exists());
 		String testString = createRandomString();
 		monitor = new FussyProgressMonitor();
-		fileTarget.setContents(createInputStream(testString), true, false, monitor);
+		fileTarget.setContents(testString.getBytes(), true, false, monitor);
 		monitor.assertUsedUp();
 		try (InputStream content = fileTarget.getContents(false)) {
 			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_303517.java
@@ -134,16 +134,14 @@ public class Bug_303517 {
 
 		// Touch on file-system
 		touchInFilesystem(f);
-		try (InputStream in = f.getContents(true)) {
-		}
+		f.readAllBytes();
 
 		// Wait for auto-refresh to happen
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 
 		// File is now in sync.
-		try (InputStream in = f.getContents()) {
-		}
+		f.readAllBytes();
 
 		// Test that getContent(true) on an out-if-sync deleted file throws a CoreException
 		// with IResourceStatus.RESOURCE_NOT_FOUND error code.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -471,9 +471,7 @@ public class IResourceTest {
 		});
 		IResourceChangeListener listener = event -> {
 			listenerInMainThreadCallback.set(() -> {
-				try (InputStream is = target.getContents(true)) {
-					assertTrue("4.0", compareContent(createInputStream(newContents), is));
-				}
+				assertEquals("4.0", newContents, target.readString());
 			});
 		};
 		try {

--- a/team/bundles/org.eclipse.compare/.settings/.api_filters
+++ b/team/bundles/org.eclipse.compare/.settings/.api_filters
@@ -8,12 +8,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="compare/org/eclipse/compare/CompareConfiguration.java" type="org.eclipse.compare.CompareConfiguration">
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.compare.CompareConfiguration"/>
-                <message_argument value="CONTENT_TYPE"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.11.0.qualifier
+Bundle-Version: 3.11.100.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Convenience methods like java.nio.file.Files.readAllBytes(Path) etc.

The new API could be used to substitute similar Util methods like org.eclipse.jdt.internal.core.util.Util.getResourceContentsAsCharArray (hotspot of jdt pasrsing)
Searching the workspace like
org.eclipse.search.internal.core.text.FileCharSequenceProvider.toShortString(IFile) is similar but not directly replaceable with this API.

Note that clients currently do have to query file.getCharset() and file.getContents() separately, possible opening the file twice to identify the UTF-BOM while the new API combines both calls, which would allow platform to open the file single time. While this PR does not implements such optimizations it is already faster to use the JDKs bulk methods instead of streaming.

Also this API avoids typical warnings of not closed Streams with the former stream api in client code.