### PR TITLE
Fix buildExtraJAR.xml to jar the bin_ant content into resource-ant.jar

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.20.300.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/scripts/buildExtraJAR.xml
+++ b/resources/bundles/org.eclipse.core.resources/scripts/buildExtraJAR.xml
@@ -32,38 +32,14 @@
 
 	<target name="ant_tasks/resources-ant.jar" depends="init" unless="ant_tasks/resources-ant.jar">
 		<property name="destdir" value="${temp.folder}/ant_tasks/resources-ant.jar.bin"/>
-		<delete dir="${temp.folder}/ant_tasks/resources-ant.jar.bin"/>
-		<mkdir dir="${temp.folder}/ant_tasks/resources-ant.jar.bin"/>
-		<!-- compile the source code -->
-		<javac destdir="${temp.folder}/ant_tasks/resources-ant.jar.bin" failonerror="true" verbose="true" debug="on" target="11" source="11">
-			<compilerarg value="-warn:-unavoidableGenericProblems"/>
-			<classpath>
-				<dirset dir="${basedir}/..">
-					<include name="org.eclipse.core.resources/bin"/>
-					<include name="org.eclipse.core.runtime/bin"/>
-					<include name="org.eclipse.equinox.common/bin"/>
-					<include name="org.eclipse.core.jobs/bin"/>
-					<include name="org.eclipse.osgi/bin"/>
-					<include name="org.eclipse.ant.core/bin"/>
-				</dirset>
-				<fileset dir="${eclipse.home}">
-					<include name="plugins/org.eclipse.core.resources*.jar"/>
-					<include name="plugins/org.eclipse.core.runtime*.jar"/>
-					<include name="plugins/org.eclipse.equinox.common*.jar"/>
-					<include name="plugins/org.eclipse.core.jobs*.jar"/>
-					<include name="plugins/org.eclipse.osgi*.jar"/>
-					<include name="plugins/org.eclipse.ant.core*.jar"/>
-				</fileset>
-			</classpath>
-			<src path="src_ant/"/>
-		</javac>
+		<delete dir="${destdir}"/>
+		<mkdir dir="${destdir}"/>
 		<!-- copy necessary resources -->
-		<copy todir="${temp.folder}/ant_tasks/resources-ant.jar.bin">
-			<fileset dir="src_ant/" excludes="**/*.java"/>
+		<copy todir="${destdir}">
+			<fileset dir="${basedir}/bin_ant/"/>
 		</copy>
 		<mkdir dir="${build.result.folder}"/>
-		<jar jarfile="${build.result.folder}/resources-ant.jar" basedir="${temp.folder}/ant_tasks/resources-ant.jar.bin"/>
-		<delete dir="${temp.folder}/ant_tasks/resources-ant.jar.bin"/>
+		<jar jarfile="${build.result.folder}/resources-ant.jar" basedir="${destdir}"/>
 		<delete dir="${temp.folder}"/>
 	</target>
 


### PR DESCRIPTION
- Remove the tasks that try to compile/copy the src_ant because the build.properties already properly populates the bin_ant folder with the contents needed in resource-ant.jar.

https://github.com/eclipse-platform/eclipse.platform/issues/1390