### PR TITLE
Bump version of org.eclipse.help.webapp

### DIFF
--- a/ua/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_webapp_plugin_name
 Bundle-SymbolicName: org.eclipse.help.webapp;singleton:=true
-Bundle-Version: 3.11.400.qualifier
+Bundle-Version: 3.11.500.qualifier
 Bundle-Activator: org.eclipse.help.internal.webapp.HelpWebappPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.webapp/pom.xml
+++ b/ua/org.eclipse.help.webapp/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.help</groupId>
   <artifactId>org.eclipse.help.webapp</artifactId>
-  <version>3.11.400-SNAPSHOT</version>
+  <version>3.11.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>


### PR DESCRIPTION
- The recent update to jetty-jspc to 20.0.20 likely produces different content.