### PR TITLE
Remove unused native code and assume unicode is always supported in Win32Natives refresh provider

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/natives/make.bat
+++ b/resources/bundles/org.eclipse.core.resources/natives/make.bat
@@ -11,22 +11,20 @@
 @rem Contributors:
 @rem     IBM Corporation - initial API and implementation
 @rem ***************************************************************************
+@echo off
 REM build JNI header file
-cd ..\bin
-"C:\Program Files\Java\jdk1.8.0_65\bin\javah.exe" org.eclipse.core.internal.resources.refresh.win32.Win32Natives
-move org_eclipse_core_internal_resources_refresh_win32_Win32Natives.h ..\natives\ref2.h
+cd %~dp0\..\src
+
+"%JAVA_HOME%\bin\javac" -h . org\eclipse\core\internal\resources\refresh\win32\Win32Natives.java
+del org\eclipse\core\internal\resources\refresh\win32\Win32Natives.class
+move org_eclipse_core_internal_resources_refresh_win32_Win32Natives.h ..\natives\ref.h
 
 REM compile and link
+if "%MSVC_HOME%"=="" set MSVC_HOME=C:\Program Files\Microsoft Visual Studio\2022\Community
 cd ..\natives
-set win_include="C:\Program Files\Microsoft Visual Studio 14.0\VC\include"
-set jdk_include="C:\Program Files\Java\jdk1.8.0_65\include"
 
 set dll_name=win32refresh.dll
 
-call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64_x86
-"cl.exe" -I%win_include% -I%jdk_include% -I%jdk_include%\win32 -LD ref.c -Fe%dll_name%
-move %dll_name% ..\..\org.eclipse.core.resources.win32.x86\os\win32\x86\%dll_name%
-
-call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-"cl.exe" -I%win_include% -I%jdk_include% -I%jdk_include%\win32 -LD ref.c -Fe%dll_name%
+call "%MSVC_HOME%\VC\Auxiliary\Build\vcvarsall.bat" amd64
+"cl.exe" -I%JAVA_HOME%\include -I%JAVA_HOME%\include\win32 -LD ref.c -Fe%dll_name%
 move %dll_name% ..\..\org.eclipse.core.resources.win32.x86_64\os\win32\x86_64\%dll_name%

--- a/resources/bundles/org.eclipse.core.resources/natives/ref.c
+++ b/resources/bundles/org.eclipse.core.resources/natives/ref.c
@@ -54,34 +54,6 @@ JNIEXPORT jlong JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_W
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FindFirstChangeNotificationA
- * Signature: ([BZI)J
- */
-JNIEXPORT jlong JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FindFirstChangeNotificationA
-(JNIEnv * env, jclass this, jbyteArray lpPathName, jboolean bWatchSubtree, jint dwNotifyFilter) {
-	jlong result;
-	jsize numberOfChars;
-	jbyte *path, *temp;
-	
-	// create a new byte array to hold the null terminated path
-	numberOfChars = (*env)->GetArrayLength(env, lpPathName);
-	path = malloc((numberOfChars + 1) * sizeof(jbyte));
-
-	// get the path bytes from the vm, copy them, and release them
-	temp = (*env)->GetByteArrayElements(env, lpPathName, 0);
-	memcpy(path, temp, numberOfChars * sizeof(jbyte));
-	(*env)->ReleaseByteArrayElements(env, lpPathName, temp, 0);
-
-	// null terminate the path, make the request, and release the path memory
-	path[numberOfChars] = '\0';
-	result = (jlong) FindFirstChangeNotificationA(path, bWatchSubtree, dwNotifyFilter);
-	free(path);
-
-	return result;
-}
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    FindCloseChangeNotification
  * Signature: (J)Z
  */
@@ -124,23 +96,6 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    IsUnicode
- * Signature: ()Z
- */
-JNIEXPORT jboolean JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_IsUnicode
-  (JNIEnv *env, jclass this) {
-  	OSVERSIONINFO osvi;
-  	memset(&osvi, 0, sizeof(OSVERSIONINFO));
-  	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-  	if (! GetVersionEx (&osvi) ) 
-    	return JNI_FALSE;
-    if (osvi.dwMajorVersion >= 5)
-    	return JNI_TRUE;
-    return JNI_FALSE;
-}
-  
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    GetLastError
  * Signature: ()I
  */
@@ -171,16 +126,6 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FILE_NOTIFY_CHANGE_ATTRIBUTES
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FILE_1NOTIFY_1CHANGE_1ATTRIBUTES
-(JNIEnv *env, jclass this) {
-	return FILE_NOTIFY_CHANGE_ATTRIBUTES;
-}
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    FILE_NOTIFY_CHANGE_SIZE
  * Signature: ()I
  */
@@ -202,42 +147,12 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FILE_NOTIFY_CHANGE_SECURITY
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FILE_1NOTIFY_1CHANGE_1SECURITY
-(JNIEnv *env, jclass this) {
-	return FILE_NOTIFY_CHANGE_SECURITY;
-}
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    MAXIMUM_WAIT_OBJECTS
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_MAXIMUM_1WAIT_1OBJECTS
 (JNIEnv *env, jclass this) {
 	return MAXIMUM_WAIT_OBJECTS;
-}
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    MAX_PATH
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_MAX_1PATH
-(JNIEnv *env, jclass this) {
-	return MAX_PATH;
-}
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    INFINITE
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_INFINITE
-(JNIEnv *env, jclass this) {
-	return INFINITE;
 }
 
 /*

--- a/resources/bundles/org.eclipse.core.resources/natives/ref.h
+++ b/resources/bundles/org.eclipse.core.resources/natives/ref.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016 IBM Corporation and others.
+ * Copyright (c) 2004, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,23 +17,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* Inaccessible static: INVALID_HANDLE_VALUE */
-/* Inaccessible static: ERROR_SUCCESS */
-/* Inaccessible static: ERROR_INVALID_HANDLE */
-/* Inaccessible static: FILE_NOTIFY_ALL */
-/* Inaccessible static: MAXIMUM_WAIT_OBJECTS */
-/* Inaccessible static: MAX_PATH */
-/* Inaccessible static: INFINITE */
-/* Inaccessible static: WAIT_TIMEOUT */
-/* Inaccessible static: WAIT_OBJECT_0 */
-/* Inaccessible static: WAIT_FAILED */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_FILE_NAME */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_DIR_NAME */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_ATTRIBUTES */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_SIZE */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_LAST_WRITE */
-/* Inaccessible static: FILE_NOTIFY_CHANGE_SECURITY */
-/* Inaccessible static: UNICODE */
+#undef org_eclipse_core_internal_resources_refresh_win32_Win32Natives_ERROR_ACCESS_DENIED
+#define org_eclipse_core_internal_resources_refresh_win32_Win32Natives_ERROR_ACCESS_DENIED 5L
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    FindFirstChangeNotificationW
@@ -41,14 +26,6 @@ extern "C" {
  */
 JNIEXPORT jlong JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FindFirstChangeNotificationW
   (JNIEnv *, jclass, jstring, jboolean, jint);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FindFirstChangeNotificationA
- * Signature: ([BZI)J
- */
-JNIEXPORT jlong JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FindFirstChangeNotificationA
-  (JNIEnv *, jclass, jbyteArray, jboolean, jint);
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
@@ -76,14 +53,6 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    IsUnicode
- * Signature: ()Z
- */
-JNIEXPORT jboolean JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_IsUnicode
-  (JNIEnv *, jclass);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    GetLastError
  * Signature: ()I
  */
@@ -108,14 +77,6 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FILE_NOTIFY_CHANGE_ATTRIBUTES
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FILE_1NOTIFY_1CHANGE_1ATTRIBUTES
-  (JNIEnv *, jclass);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    FILE_NOTIFY_CHANGE_SIZE
  * Signature: ()I
  */
@@ -132,34 +93,10 @@ JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Wi
 
 /*
  * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    FILE_NOTIFY_CHANGE_SECURITY
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_FILE_1NOTIFY_1CHANGE_1SECURITY
-  (JNIEnv *, jclass);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
  * Method:    MAXIMUM_WAIT_OBJECTS
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_MAXIMUM_1WAIT_1OBJECTS
-  (JNIEnv *, jclass);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    MAX_PATH
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_MAX_1PATH
-  (JNIEnv *, jclass);
-
-/*
- * Class:     org_eclipse_core_internal_resources_refresh_win32_Win32Natives
- * Method:    INFINITE
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_org_eclipse_core_internal_resources_refresh_win32_Win32Natives_INFINITE
   (JNIEnv *, jclass);
 
 /*

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
@@ -37,23 +37,12 @@ public class Win32Natives {
 
 	/** Access is denied. */
 	public static final int ERROR_ACCESS_DENIED = 5;
-	/**
-	 * The combination of all of the error constants.
-	 */
-	public static int FILE_NOTIFY_ALL;
+
 	/**
 	 * A constant which indicates the maximum number of objects
 	 * that can be passed into WaitForMultipleObjects.
 	 */
 	public static final int MAXIMUM_WAIT_OBJECTS;
-	/**
-	 * A constant which indicates the maximum length of a pathname.
-	 */
-	public static final int MAX_PATH;
-	/**
-	 * A constant which expresses the concept of the infinite.
-	 */
-	public static final int INFINITE;
 
 	/* wait return values */
 	/**
@@ -87,10 +76,6 @@ public class Win32Natives {
 	 */
 	public static final int FILE_NOTIFY_CHANGE_DIR_NAME;
 	/**
-	 * Change filter for monitoring file/directory attribute changes.
-	 */
-	public static final int FILE_NOTIFY_CHANGE_ATTRIBUTES;
-	/**
 	 * Change filter for monitoring file size changes.
 	 */
 	public static final int FILE_NOTIFY_CHANGE_SIZE;
@@ -98,29 +83,17 @@ public class Win32Natives {
 	 * Change filter for monitoring the file write timestamp
 	 */
 	public static final int FILE_NOTIFY_CHANGE_LAST_WRITE;
-	/**
-	 * Change filter for monitoring the security descriptors
-	 * of files.
-	 */
-	public static final int FILE_NOTIFY_CHANGE_SECURITY;
 
-	/**
-	 * Flag indicating whether or not the OS supports unicode calls.
-	 */
-	public static final boolean UNICODE;
 	/*
 	 * Make requests to set the constants.
 	 */
 	static {
 		System.loadLibrary("win32refresh"); //$NON-NLS-1$
-		UNICODE = IsUnicode();
 		INVALID_HANDLE_VALUE = INVALID_HANDLE_VALUE();
 		ERROR_SUCCESS = ERROR_SUCCESS();
 		ERROR_INVALID_HANDLE = ERROR_INVALID_HANDLE();
 
 		MAXIMUM_WAIT_OBJECTS = MAXIMUM_WAIT_OBJECTS();
-		MAX_PATH = MAX_PATH();
-		INFINITE = INFINITE();
 
 		WAIT_TIMEOUT = WAIT_TIMEOUT();
 		WAIT_OBJECT_0 = WAIT_OBJECT_0();
@@ -129,11 +102,8 @@ public class Win32Natives {
 
 		FILE_NOTIFY_CHANGE_FILE_NAME = FILE_NOTIFY_CHANGE_FILE_NAME();
 		FILE_NOTIFY_CHANGE_DIR_NAME = FILE_NOTIFY_CHANGE_DIR_NAME();
-		FILE_NOTIFY_CHANGE_ATTRIBUTES = FILE_NOTIFY_CHANGE_ATTRIBUTES();
 		FILE_NOTIFY_CHANGE_SIZE = FILE_NOTIFY_CHANGE_SIZE();
 		FILE_NOTIFY_CHANGE_LAST_WRITE = FILE_NOTIFY_CHANGE_LAST_WRITE();
-		FILE_NOTIFY_CHANGE_SECURITY = FILE_NOTIFY_CHANGE_SECURITY();
-		FILE_NOTIFY_ALL = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SECURITY;
 	}
 
 	/**
@@ -142,11 +112,10 @@ public class Win32Natives {
 	 * subtree under the directory using FindNextChangeNotification or
 	 * WaitForMultipleObjects.
 	 * <p>
-	 * If the OS supports unicode the path must be no longer than 2^15 - 1 characters.
-	 * Otherwise, the path cannot be longer than MAX_PATH. In either case, if the given
-	 * path is too long ERROR_INVALID_HANDLE is returned.
+	 * The path must be no longer than 2^15 - 1 characters, if the given path is too
+	 * long {@link #ERROR_INVALID_HANDLE} is returned.
 	 *
-	 * @param lpPathName The path of the file.
+	 * @param lpPathName The path to the directory to be monitored.
 	 * @param bWatchSubtree If <code>true</code>, specifies that the entire
 	 * 	tree under the given path should be monitored. If <code>false</code>
 	 *  specifies that just the named path should be monitored.
@@ -158,9 +127,7 @@ public class Win32Natives {
 	 *  ERROR_INVALID_HANDLE  if the attempt fails.
 	 */
 	public static long FindFirstChangeNotification(String lpPathName, boolean bWatchSubtree, int dwNotifyFilter) {
-		if (UNICODE)
-			return FindFirstChangeNotificationW(lpPathName, bWatchSubtree, dwNotifyFilter);
-		return FindFirstChangeNotificationA(Convert.toPlatformBytes(lpPathName), bWatchSubtree, dwNotifyFilter);
+		return FindFirstChangeNotificationW(lpPathName, bWatchSubtree, dwNotifyFilter);
 	}
 
 	/**
@@ -182,27 +149,6 @@ public class Win32Natives {
 	 *  ERROR_INVALID_HANDLE  if the attempt fails.
 	 */
 	private static native long FindFirstChangeNotificationW(String lpPathName, boolean bWatchSubtree, int dwNotifyFilter);
-
-	/**
-	 * Creates a change notification object for the given path. This notification object
-	 * allows the client to monitor changes to the directory and the subtree
-	 * under the directory using FindNextChangeNotification or
-	 * WaitForMultipleObjects.
-	 *
-	 * @param lpPathName The path to the directory to be monitored,  cannot be <code>null</code>,
-	 *  or  be longer
-	 *  than MAX_PATH.  This path must be in platform bytes converted.
-	 * @param bWatchSubtree If <code>true</code>, specifies that the entire
-	 * 	tree under the given path should be monitored. If <code>false</code>
-	 *  specifies that just the named path should be monitored.
-	 * @param dwNotifyFilter Any combination of FILE_NOTIFY_CHANGE_FILE_NAME,
-	 *  FILE_NOTIFY_CHANGE_DIR_NAME,   FILE_NOTIFY_CHANGE_ATTRIBUTES,
-	 *  FILE_NOTIFY_CHANGE_SIZE,  FILE_NOTIFY_CHANGE_LAST_WRITE, or
-	 *  FILE_NOTIFY_CHANGE_SECURITY.
-	 * @return long The handle to the find change notification object or
-	 *  ERROR_INVALID_HANDLE  if the attempt fails.
-	 */
-	private static native long FindFirstChangeNotificationA(byte[] lpPathName, boolean bWatchSubtree, int dwNotifyFilter);
 
 	/**
 	 * Stops and disposes of the change notification object that corresponds to the given
@@ -248,14 +194,6 @@ public class Win32Natives {
 	public static native int WaitForMultipleObjects(int nCount, long[] lpHandles, boolean bWaitAll, int dwMilliseconds);
 
 	/**
-	 * Answers <code>true</code> if the operating system supports
-	 * long filenames.
-	 * @return boolean <code>true</code> if the operating system supports
-	 * long filenames, <code>false</code> otherwise.
-	 */
-	private static native boolean IsUnicode();
-
-	/**
 	 * Answers the last error set in the current thread.
 	 * @return int the last error
 	 */
@@ -274,12 +212,6 @@ public class Win32Natives {
 	private static native int FILE_NOTIFY_CHANGE_DIR_NAME();
 
 	/**
-	 * Returns the constant FILE_NOTIFY_CHANGE_ATTRIBUTES.
-	 * @return int
-	 */
-	private static native int FILE_NOTIFY_CHANGE_ATTRIBUTES();
-
-	/**
 	 * Returns the constant FILE_NOTIFY_CHANGE_SIZE.
 	 * @return int
 	 */
@@ -292,28 +224,10 @@ public class Win32Natives {
 	private static native int FILE_NOTIFY_CHANGE_FILE_NAME();
 
 	/**
-	 * Returns the constant FILE_NOTIFY_CHANGE_SECURITY.
-	 * @return int
-	 */
-	private static native int FILE_NOTIFY_CHANGE_SECURITY();
-
-	/**
 	 * Returns the constant MAXIMUM_WAIT_OBJECTS.
 	 * @return int
 	 */
 	private static native int MAXIMUM_WAIT_OBJECTS();
-
-	/**
-	 * Returns the constant MAX_PATH.
-	 * @return int
-	 */
-	private static native int MAX_PATH();
-
-	/**
-	 * Returns the constant INFINITE.
-	 * @return int
-	 */
-	private static native int INFINITE();
 
 	/**
 	 * Returns the constant WAIT_OBJECT_0.


### PR DESCRIPTION
Unicode support is assumed to be present if the Windows-OS version is greater or equal five, which corresponds to Windows 2000 or later: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfow

For example the JDK binaries provided by Temurin and Oracle require at least Windows-8 for a JDK-17:
- https://www.oracle.com/java/technologies/javase/products-doc-jdk17certconfig.html
- https://adoptium.net/de/supported-platforms/

and given that even Windows-10 will be EOL in about a year I think we can confidently remove that support for pre Windows 2000 versions.

This was originally part of https://github.com/eclipse-platform/eclipse.platform/pull/1394.