### PR TITLE
LaunchConfigurationFilteredTree: filter with '*' in front

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationFilteredTree.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationFilteredTree.java
@@ -67,6 +67,7 @@ public final class LaunchConfigurationFilteredTree extends FilteredTree {
 		fFilters = filters;
 		fPatternFilter = filter;
 		fTreeStyle = treeStyle;
+		filter.setIncludeLeadingWildcard(true);
 	}
 
 	/**


### PR DESCRIPTION
implementation taken from
org.eclipse.pde.internal.ui.shared.FilteredCheckboxTree.getFilterString()

![image](https://github.com/eclipse-platform/eclipse.platform/assets/51790620/0414640f-7d53-4d04-84b5-25d883798c14)
