### PR TITLE
Provide API for IFile create(byte[], ...) and createOrReplace()

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1275,7 +1275,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 					throw new ResourceException(IResourceStatus.NOT_FOUND_LOCAL, target.getFullPath(), message, null);
 				}
 			} else {
-				if (fileInfo.exists()) {
+				if (!BitMask.isSet(updateFlags, IResource.REPLACE) && fileInfo.exists()) {
 					String message = NLS.bind(Messages.localstore_resourceExists, target.getFullPath());
 					throw new ResourceException(IResourceStatus.EXISTS_LOCAL, target.getFullPath(), message, null);
 				}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
@@ -126,7 +126,7 @@ public class File extends Resource implements IFile {
 			final ISchedulingRule rule = workspace.getRuleFactory().createRule(this);
 			try {
 				workspace.prepareOperation(rule, subMonitor.newChild(1));
-				checkCreatable();
+				checkCreatable(updateFlags);
 				workspace.beginOperation(true);
 				IFileStore store = getStore();
 				IFileInfo localInfo = create(updateFlags, subMonitor.newChild(40), store);
@@ -172,7 +172,7 @@ public class File extends Resource implements IFile {
 			final ISchedulingRule rule = workspace.getRuleFactory().createRule(this);
 			try {
 				workspace.prepareOperation(rule, subMonitor.newChild(1));
-				checkCreatable();
+				checkCreatable(updateFlags);
 				workspace.beginOperation(true);
 				IFileStore store = getStore();
 				IFileInfo localInfo = create(updateFlags, subMonitor.newChild(40), store);
@@ -202,8 +202,10 @@ public class File extends Resource implements IFile {
 		}
 	}
 
-	private void checkCreatable() throws CoreException {
-		checkDoesNotExist();
+	private void checkCreatable(int updateFlags) throws CoreException {
+		if ((updateFlags & IResource.REPLACE) == 0) {
+			checkDoesNotExist();
+		}
 		Container parent = (Container) getParent();
 		ResourceInfo info = parent.getResourceInfo(false, false);
 		parent.checkAccessible(getFlags(info));
@@ -230,7 +232,7 @@ public class File extends Resource implements IFile {
 				}
 			}
 		} else {
-			if (localInfo.exists()) {
+			if (!BitMask.isSet(updateFlags, IResource.REPLACE) && localInfo.exists()) {
 				// return an appropriate error message for case variant collisions
 				if (!Workspace.caseSensitive) {
 					String name = getLocalManager().getLocalName(store);

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -60,6 +60,7 @@ import org.eclipse.core.internal.properties.PropertyManager2;
 import org.eclipse.core.internal.refresh.RefreshManager;
 import org.eclipse.core.internal.resources.ComputeProjectOrder.Digraph;
 import org.eclipse.core.internal.resources.ComputeProjectOrder.VertexOrder;
+import org.eclipse.core.internal.utils.BitMask;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.internal.utils.StringPoolJob;
@@ -1392,7 +1393,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	 * be immediately made derived, hidden and/or team private
 	 */
 	public ResourceInfo createResource(IResource resource, int updateFlags) throws CoreException {
-		ResourceInfo info = createResource(resource, null, false, false, false);
+		ResourceInfo info = createResource(resource, null, false, BitMask.isSet(updateFlags, IResource.REPLACE), false);
 		if ((updateFlags & IResource.DERIVED) != 0)
 			info.set(M_DERIVED);
 		if ((updateFlags & IResource.TEAM_PRIVATE) != 0)

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -358,6 +358,50 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	void create(InputStream source, int updateFlags, IProgressMonitor monitor) throws CoreException;
 
 	/**
+	 * Creates the file with the given content as byte array. Same as calling
+	 * {@link #create(InputStream, int, IProgressMonitor)} with flags depending on
+	 * the boolean parameters and a {@code new ByteArrayInputStream(content)} as
+	 * {@code InputStream}. This method is preferably over the streaming API when
+	 * the content is available as byte array anyway.
+	 *
+	 * @param content the content as byte array
+	 * @param force   a flag controlling how to deal with resources that are not in
+	 *                sync with the local file system
+	 * @param derived Specifying this flag is equivalent to atomically calling
+	 *                {@link IResource#setDerived(boolean)} immediately after
+	 *                creating the resource
+	 * @param monitor a progress monitor, or <code>null</code> if progress reporting
+	 *                is not desired
+	 * @throws CoreException if this method fails or is canceled.
+	 * @since 3.21
+	 */
+	public default void create(byte[] content, boolean force, boolean derived, IProgressMonitor monitor)
+			throws CoreException {
+		int createFlags = (force ? IResource.FORCE : IResource.NONE) | (derived ? IResource.DERIVED : IResource.NONE);
+		create(content, createFlags, monitor);
+	}
+
+	/**
+	 * Creates the file with the given content as byte array. Same as calling
+	 * {@link #create(InputStream, int, IProgressMonitor)} and a
+	 * {@code new ByteArrayInputStream(content)} as {@code InputStream}. This method
+	 * is preferably over the streaming API when the content is available as byte
+	 * array anyway.
+	 *
+	 * @param content     the content as byte array
+	 * @param createFlags bit-wise or of flag constants ({@link IResource#FORCE},
+	 *                    {@link IResource#DERIVED}, and
+	 *                    {@link IResource#TEAM_PRIVATE})
+	 * @param monitor     a progress monitor, or <code>null</code> if progress
+	 *                    reporting is not desired
+	 * @throws CoreException if this method fails or is canceled.
+	 * @since 3.21
+	 */
+	public default void create(byte[] content, int createFlags, IProgressMonitor monitor) throws CoreException {
+		create(new ByteArrayInputStream(content), createFlags, monitor);
+	}
+
+	/**
 	 * Creates a new file resource as a member of this handle's parent resource.
 	 * The file's contents will be located in the file specified by the given
 	 * file system path.  The given path must be either an absolute file system

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSy
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -290,6 +291,7 @@ public class IFileTest {
 		}
 	}
 
+	@SuppressWarnings("deprecation") // org.eclipse.core.resources.IResource.isLocal(int)
 	@Test
 	public void testAppendContents2() throws Exception {
 		IFile file = projects[0].getFile("file1");
@@ -454,6 +456,29 @@ public class IFileTest {
 		monitor.assertUsedUp();
 		assertTrue("2.0", !derived.isDerived());
 		assertTrue("2.1", !derived.isTeamPrivateMember());
+	}
+	@Test
+	public void testCreateBytes() throws CoreException {
+		IFile derived = projects[0].getFile("derived.txt");
+		createInWorkspace(projects[0]);
+		removeFromWorkspace(derived);
+
+		FussyProgressMonitor monitor = new FussyProgressMonitor();
+		derived.create("derived".getBytes(), false, true, monitor);
+		monitor.assertUsedUp();
+		assertTrue(derived.isDerived());
+		assertFalse(derived.isTeamPrivateMember());
+		assertEquals("derived", derived.readString());
+
+		monitor.prepare();
+		derived.delete(false, monitor);
+		monitor.assertUsedUp();
+		monitor.prepare();
+		derived.create("notDerived".getBytes(), false, false, monitor);
+		monitor.assertUsedUp();
+		assertFalse(derived.isDerived());
+		assertFalse(derived.isTeamPrivateMember());
+		assertEquals("notDerived", derived.readString());
 	}
 
 	@Test
@@ -942,6 +967,16 @@ public class IFileTest {
 		try (InputStream content = target.getContents(false)) {
 			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
 		}
+	}
+
+	@Test
+	public void testCreateByteArray() throws IOException, CoreException {
+		IFile target = projects[0].getFile("file1");
+		String testString = createRandomString();
+		FussyProgressMonitor monitor = new FussyProgressMonitor();
+		target.create(testString.getBytes(), true, false, monitor);
+		monitor.assertUsedUp();
+		assertEquals(testString, target.readString());
 	}
 
 	@Test

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BufferedResourceNode.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BufferedResourceNode.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.compare.internal;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -73,18 +72,10 @@ public class BufferedResourceNode extends ResourceNode {
 				return;
 			}
 			IResource resource = getResource();
-			if (resource instanceof IFile) {
+			if (resource instanceof IFile file) {
 				byte[] bytes = getContent();
-				try (ByteArrayInputStream is = new ByteArrayInputStream(bytes)) {
-					IFile file = (IFile) resource;
-					if (file.exists())
-						file.setContents(is, false, true, pm);
-					else
-						file.create(is, false, pm);
-					fDirty = false;
-				} catch (IOException closeException) {
-					// Silently ignored
-				}
+				file.createOrReplace(bytes, false, false, true, pm);
+				fDirty = false;
 			}
 		}
 	}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/LocalResourceTypedElement.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/LocalResourceTypedElement.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.team.internal.ui.synchronize;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.eclipse.compare.ISharedDocumentAdapter;
@@ -93,16 +91,11 @@ public class LocalResourceTypedElement extends ResourceNode implements IAdaptabl
 				saveDocument(true, monitor);
 			} else {
 				IResource resource = getResource();
-				if (resource instanceof IFile) {
-					try (ByteArrayInputStream is = new ByteArrayInputStream(getContent())) {
-						IFile file = (IFile) resource;
-						if (file.exists())
-							file.setContents(is, false, true, monitor);
-						else
-							file.create(is, false, monitor);
+				if (resource instanceof IFile file) {
+					byte[] content = getContent();
+					try {
+						file.createOrReplace(content, false, false, true, monitor);
 						fDirty = false;
-					} catch (IOException closeException) {
-						// ignored
 					} finally {
 						fireContentChanged();
 					}

--- a/team/examples/org.eclipse.team.examples.filesystem/META-INF/MANIFEST.MF
+++ b/team/examples/org.eclipse.team.examples.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.examples.filesystem; singleton:=true
-Bundle-Version: 3.7.400.qualifier
+Bundle-Version: 3.7.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.team.examples.filesystem,

--- a/team/examples/org.eclipse.team.examples.filesystem/pom.xml
+++ b/team/examples/org.eclipse.team.examples.filesystem/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.team.examples.filesystem</artifactId>
-  <version>3.7.400-SNAPSHOT</version>
+  <version>3.7.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
   	<plugins>

--- a/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProvider.java
+++ b/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProvider.java
@@ -584,7 +584,7 @@ public class PessimisticFilesystemProvider extends RepositoryProvider  {
 		if (!prepend) {
 			buffer.append(System.getProperty("line.separator") + text);
 		}
-		file.setContents(new ByteArrayInputStream(buffer.toString().getBytes()), false, false, null);
+		file.setContents(buffer.toString().getBytes(), false, false, null);
 	}
 
 	public static String getFileContents(IFile file) throws IOException, CoreException {


### PR DESCRIPTION
A typical used pattern to replace a File content is
```
	if (file.exists()) {
			file.setContents(ByteArrayInputStream, ...);
		} else {
			file.create(ByteArrayInputStream, ...);
		}
	}
```
This can be replaced by convenience createOrReplace. For performance reasons it takes the content as byte array like
java.nio.file.Files.write(Path, byte[], OpenOption...).

An example consumer is the performance hotspot in JDT to write .class files during build:

org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.writeClassFileContents(ClassFile,
IFile, String, boolean, SourceFile)
