### PR TITLE
clean CharsetManagerJob shutdown #1427

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetDeltaJob.java
@@ -240,6 +240,7 @@ public class CharsetDeltaJob extends Job implements IContentTypeManager.IContent
 		try {
 			// try to prevent execution of this job to avoid "already shutdown.":
 			cancel();
+			wakeUp();
 			// if job is already running wait for it to finish:
 			join(3000, null);
 		} catch (InterruptedException e) {


### PR DESCRIPTION
To prevent logging exception on shutdown at end of Junit tests: 'Workspace was not properly initialized or has already shutdown.'

https://github.com/eclipse-platform/eclipse.platform/issues/1427