### PR TITLE
Improve "Job found still running" message

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.jobs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.jobs; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.15.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.jobs;x-internal:=true,

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -720,16 +720,17 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 		}
 		internalWorker.cancel();
 		if (toCancel != null) {
-			for (Job element : toCancel) {
-				String jobName = printJobName(element);
+			for (Job job : toCancel) {
+				String jobName = printJobName(job) + " " + printState(job); //$NON-NLS-1$
+				if (job.getThread() instanceof Thread t) {
+					StackTraceElement[] stackTrace = t.getStackTrace();
+					for (StackTraceElement stackTraceElement : stackTrace) {
+						jobName += "\n\t at " + stackTraceElement; //$NON-NLS-1$
+					}
+				}
 				//this doesn't need to be translated because it's just being logged
 				String msg = "Job found still running after platform shutdown.  Jobs should be canceled by the plugin that scheduled them during shutdown: " + jobName; //$NON-NLS-1$
 				RuntimeLog.log(new Status(IStatus.WARNING, JobManager.PI_JOBS, JobManager.PLUGIN_ERROR, msg, null));
-
-				// TODO the RuntimeLog.log in its current implementation won't produce a log
-				// during this stage of shutdown. For now add a standard error output.
-				// One the logging story is improved, the System.err output below can be removed:
-				System.err.println(msg);
 			}
 		}
 		synchronized (lock) {


### PR DESCRIPTION
* add state and stacktrace of running job
* only log the message once