### PR TITLE
Version bump for 4.33 stream

### DIFF
--- a/runtime/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/runtime/features/org.eclipse.core.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.core.runtime.feature"
       label="%featureName"
-      version="1.4.400.qualifier"
+      version="1.4.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Problem reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20240616-1800/buildlogs/reporeports/reports/versionChecks.html and broke verification build for
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2138