### PR TITLE
Revert IFile.create(...REPLACE) - fixes #1433

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1286,15 +1286,11 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 				}
 			}
 		}
-		if (BitMask.isSet(updateFlags, IResource.REPLACE)) {
-			// forced update of derived flag during IFile.write:
+		if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
+			// update of derived flag during IFile.write:
 			Resource resource = (Resource) target;
 			ResourceInfo info = resource.getResourceInfo(false, false);
-			if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
-				info.set(ICoreConstants.M_DERIVED);
-			} else {
-				info.clear(ICoreConstants.M_DERIVED);
-			}
+			info.set(ICoreConstants.M_DERIVED);
 		}
 		// add entry to History Store.
 		if (BitMask.isSet(updateFlags, IResource.KEEP_HISTORY) && fileInfo.exists()

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1286,6 +1286,16 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 				}
 			}
 		}
+		if (BitMask.isSet(updateFlags, IResource.REPLACE)) {
+			// forced update of derived flag during IFile.write:
+			Resource resource = (Resource) target;
+			ResourceInfo info = resource.getResourceInfo(false, false);
+			if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
+				info.set(ICoreConstants.M_DERIVED);
+			} else {
+				info.clear(ICoreConstants.M_DERIVED);
+			}
+		}
 		// add entry to History Store.
 		if (BitMask.isSet(updateFlags, IResource.KEEP_HISTORY) && fileInfo.exists()
 				&& FileSystemResourceManager.storeHistory(target))

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1275,7 +1275,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 					throw new ResourceException(IResourceStatus.NOT_FOUND_LOCAL, target.getFullPath(), message, null);
 				}
 			} else {
-				if (!BitMask.isSet(updateFlags, IResource.REPLACE) && fileInfo.exists()) {
+				if (fileInfo.exists()) {
 					String message = NLS.bind(Messages.localstore_resourceExists, target.getFullPath());
 					throw new ResourceException(IResourceStatus.EXISTS_LOCAL, target.getFullPath(), message, null);
 				}
@@ -1285,12 +1285,6 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 							null);
 				}
 			}
-		}
-		if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
-			// update of derived flag during IFile.write:
-			Resource resource = (Resource) target;
-			ResourceInfo info = resource.getResourceInfo(false, false);
-			info.set(ICoreConstants.M_DERIVED);
 		}
 		// add entry to History Store.
 		if (BitMask.isSet(updateFlags, IResource.KEEP_HISTORY) && fileInfo.exists()

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
@@ -126,7 +126,7 @@ public class File extends Resource implements IFile {
 			final ISchedulingRule rule = workspace.getRuleFactory().createRule(this);
 			try {
 				workspace.prepareOperation(rule, subMonitor.newChild(1));
-				checkCreatable(updateFlags);
+				checkCreatable();
 				workspace.beginOperation(true);
 				IFileStore store = getStore();
 				IFileInfo localInfo = create(updateFlags, subMonitor.newChild(40), store);
@@ -172,7 +172,7 @@ public class File extends Resource implements IFile {
 			final ISchedulingRule rule = workspace.getRuleFactory().createRule(this);
 			try {
 				workspace.prepareOperation(rule, subMonitor.newChild(1));
-				checkCreatable(updateFlags);
+				checkCreatable();
 				workspace.beginOperation(true);
 				IFileStore store = getStore();
 				IFileInfo localInfo = create(updateFlags, subMonitor.newChild(40), store);
@@ -202,10 +202,8 @@ public class File extends Resource implements IFile {
 		}
 	}
 
-	private void checkCreatable(int updateFlags) throws CoreException {
-		if ((updateFlags & IResource.REPLACE) == 0) {
-			checkDoesNotExist();
-		}
+	private void checkCreatable() throws CoreException {
+		checkDoesNotExist();
 		Container parent = (Container) getParent();
 		ResourceInfo info = parent.getResourceInfo(false, false);
 		parent.checkAccessible(getFlags(info));
@@ -232,7 +230,7 @@ public class File extends Resource implements IFile {
 				}
 			}
 		} else {
-			if (!BitMask.isSet(updateFlags, IResource.REPLACE) && localInfo.exists()) {
+			if (localInfo.exists()) {
 				// return an appropriate error message for case variant collisions
 				if (!Workspace.caseSensitive) {
 					String name = getLocalManager().getLocalName(store);

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/File.java
@@ -431,6 +431,10 @@ public class File extends Resource implements IFile {
 				checkAccessible(getFlags(info));
 				workspace.beginOperation(true);
 				IFileInfo fileInfo = getStore().fetchInfo();
+				if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
+					// update of derived flag during IFile.write:
+					info.set(ICoreConstants.M_DERIVED);
+				}
 				internalSetContents(content, fileInfo, updateFlags, false, subMonitor.newChild(99));
 			} catch (OperationCanceledException e) {
 				workspace.getWorkManager().operationCanceled();
@@ -459,6 +463,10 @@ public class File extends Resource implements IFile {
 				checkAccessible(getFlags(info));
 				workspace.beginOperation(true);
 				IFileInfo fileInfo = getStore().fetchInfo();
+				if (BitMask.isSet(updateFlags, IResource.DERIVED)) {
+					// update of derived flag during IFile.write:
+					info.set(ICoreConstants.M_DERIVED);
+				}
 				internalSetContents(content, fileInfo, updateFlags, false, subMonitor.newChild(99));
 			} catch (OperationCanceledException e) {
 				workspace.getWorkManager().operationCanceled();

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -414,7 +414,7 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 *                    in sync with the local file system
 	 * @param derived     Specifying this flag is equivalent to atomically calling
 	 *                    {@link IResource#setDerived(boolean)} immediately after
-	 *                    creating the resource or non-atomically setting the
+	 *                    creating the resource or atomically setting the
 	 *                    derived flag before setting the content of an already
 	 *                    existing file
 	 * @param keepHistory a flag indicating whether or not store the current
@@ -429,10 +429,11 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 			IProgressMonitor monitor) throws CoreException {
 		Objects.requireNonNull(content);
 		if (exists()) {
-			if (derived != isDerived()) {
-				setDerived(derived, null);
-			}
-			setContents(content, force, keepHistory, monitor);
+			int updateFlags = (derived ? IResource.DERIVED : IResource.NONE)
+					| REPLACE // REPLACE used to force update derived flag
+					| (force ? IResource.FORCE : IResource.NONE)
+					| (keepHistory ? IResource.KEEP_HISTORY : IResource.NONE);
+			setContents(content, updateFlags, monitor);
 		} else {
 			create(content, force, derived, monitor);
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -304,13 +304,6 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 * with a value of <code>true</code> immediately after creating the resource.
 	 * </p>
 	 * <p>
-	 * The {@link IResource#KEEP_HISTORY} update flag indicates that the history of this file is kept if any
-	 * </p>
-	 * <p>
-	 * The {@link IResource#REPLACE} update flag indicates that this resource is overridden if already existing.
-	 *
-	 * </p>
-	 * <p>
 	 * The {@link IResource#TEAM_PRIVATE} update flag indicates that this resource
 	 * should immediately be set as a team private resource.  Specifying this flag
 	 * is equivalent to atomically calling {@link IResource#setTeamPrivateMember(boolean)}
@@ -338,9 +331,7 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 * @param source an input stream containing the initial contents of the file,
 	 *    or <code>null</code> if the file should be marked as not local
 	 * @param updateFlags bit-wise or of update flag constants
-	 *   ({@link IResource#FORCE}, {@link IResource#DERIVED},
-	 *    {@link IResource#KEEP_HISTORY}, {@link IResource#REPLACE},
-	 *    and {@link IResource#TEAM_PRIVATE})
+	 *   ({@link IResource#FORCE}, {@link IResource#DERIVED}, and {@link IResource#TEAM_PRIVATE})
 	 * @param monitor a progress monitor, or <code>null</code> if progress
 	 *    reporting is not desired
 	 * @exception CoreException if this method fails. Reasons include:
@@ -400,9 +391,7 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 *
 	 * @param content     the content as byte array
 	 * @param createFlags bit-wise or of flag constants ({@link IResource#FORCE},
-	 *                    {@link IResource#DERIVED},
-	 *                    {@link IResource#KEEP_HISTORY},
-	 *                    {@link IResource#REPLACE}, and
+	 *                    {@link IResource#DERIVED}, and
 	 *                    {@link IResource#TEAM_PRIVATE})
 	 * @param monitor     a progress monitor, or <code>null</code> if progress
 	 *                    reporting is not desired
@@ -416,8 +405,9 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	/**
 	 * Creates the file and sets the file content. If the file already exists in
 	 * workspace its content is replaced. Shortcut for calling
-	 * {@link #create(byte[], int, IProgressMonitor)} with flags depending on the
-	 * boolean parameters given and {@link IResource#REPLACE}.
+	 * {@link #setContents(byte[], boolean, boolean, IProgressMonitor)} or
+	 * {@link #create(byte[], boolean, boolean, IProgressMonitor)} if the file does
+	 * not {@link #exists()}.
 	 *
 	 * @param content     the new content bytes. Must not be null.
 	 * @param force       a flag controlling how to deal with resources that are not
@@ -438,8 +428,14 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	public default void write(byte[] content, boolean force, boolean derived, boolean keepHistory,
 			IProgressMonitor monitor) throws CoreException {
 		Objects.requireNonNull(content);
-		create(content, (force ? IResource.FORCE : 0) | (derived ? IResource.DERIVED : 0)
-				| (keepHistory ? IResource.KEEP_HISTORY : 0) | IResource.REPLACE, monitor);
+		if (exists()) {
+			if (derived != isDerived()) {
+				setDerived(derived, null);
+			}
+			setContents(content, force, keepHistory, monitor);
+		} else {
+			create(content, force, derived, monitor);
+		}
 	}
 
 	/**

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -414,9 +414,10 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	 *                    in sync with the local file system
 	 * @param derived     Specifying this flag is equivalent to atomically calling
 	 *                    {@link IResource#setDerived(boolean)} immediately after
-	 *                    creating the resource or atomically setting the
-	 *                    derived flag before setting the content of an already
-	 *                    existing file
+	 *                    creating the resource or atomically setting the derived
+	 *                    flag before setting the content of an already existing
+	 *                    file if derived==true. A value of false will not update
+	 *                    the derived flag of an existing file.
 	 * @param keepHistory a flag indicating whether or not store the current
 	 *                    contents in the local history if the file did already
 	 *                    exist
@@ -430,7 +431,6 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 		Objects.requireNonNull(content);
 		if (exists()) {
 			int updateFlags = (derived ? IResource.DERIVED : IResource.NONE)
-					| REPLACE // REPLACE used to force update derived flag
 					| (force ? IResource.FORCE : IResource.NONE)
 					| (keepHistory ? IResource.KEEP_HISTORY : IResource.NONE);
 			setContents(content, updateFlags, monitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -500,8 +500,11 @@ public class IFileTest {
 			boolean setDerived = i % 2 == 0;
 			boolean deleteBefore = (i >> 1) % 2 == 0;
 			boolean keepHistory = (i >> 2) % 2 == 0;
+			boolean oldDerived1 = false;
 			if (deleteBefore) {
 				derived.delete(false, null);
+			} else {
+				oldDerived1 = derived.isDerived();
 			}
 			assertEquals(!deleteBefore, derived.exists());
 			FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -510,16 +513,22 @@ public class IFileTest {
 			derived.write(("updateOrCreate" + i).getBytes(), false, setDerived, keepHistory, monitor);
 			assertEquals("not atomic", 1, changeCount.get());
 			monitor.assertUsedUp();
-			assertEquals(setDerived, derived.isDerived());
+			if (deleteBefore) {
+				assertEquals(setDerived, derived.isDerived());
+			} else {
+				assertEquals(oldDerived1 || setDerived, derived.isDerived());
+			}
 			assertFalse(derived.isTeamPrivateMember());
 			assertTrue(derived.exists());
 
 			IFileState[] history1 = derived.getHistory(null);
 			changeCount.set(0);
 			derived.write(("update" + i).getBytes(), false, false, keepHistory, null);
+			boolean oldDerived2 = derived.isDerived();
+			assertEquals(oldDerived2, derived.isDerived());
 			assertEquals("not atomic", 1, changeCount.get());
 			IFileState[] history2 = derived.getHistory(null);
-			assertEquals(keepHistory ? 1 : 0, history2.length - history1.length);
+			assertEquals((keepHistory && !oldDerived2) ? 1 : 0, history2.length - history1.length);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -53,7 +53,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -514,6 +516,24 @@ public class IFileTest {
 			assertEquals(keepHistory ? 1 : 0, history2.length - history1.length);
 		}
 	}
+
+	@Test
+	public void testWriteRule() throws CoreException {
+		IFile resource = projects[0].getFile("derived.txt");
+		createInWorkspace(projects[0]);
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		resource.delete(false, null);
+		workspace.run(pm -> {
+			resource.write(("create").getBytes(), false, false, false, null);
+		}, workspace.getRuleFactory().createRule(resource), IWorkspace.AVOID_UPDATE, null);
+		assertTrue(resource.exists());
+		// test that modifyRule can be used for IFile.write() if the file already exits:
+		workspace.run(pm -> {
+			resource.write(("replace").getBytes(), false, false, false, null);
+		}, workspace.getRuleFactory().modifyRule(resource), IWorkspace.AVOID_UPDATE, null);
+		assertTrue(resource.exists());
+	}
+
 	@Test
 	public void testDeltaOnCreateDerived() throws CoreException {
 		IFile derived = projects[0].getFile("derived.txt");


### PR DESCRIPTION
Allows to use modifyRule for IFile.write() if the file already exits, so that every IFILE.setContents() can be replaced with IFile.create().

https://github.com/eclipse-platform/eclipse.platform/issues/1433