### PR TITLE
Correct required Apache Lucene bundles version ranges

### DIFF
--- a/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -43,9 +43,9 @@ Require-Bundle: org.eclipse.ant.core;bundle-version="[3.2.200,4.0.0)";resolution
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.net;bundle-version="[1.2.200,2.0.0)",
- org.apache.lucene.analysis-common;bundle-version="[9.4.2,10.0.0)",
- org.apache.lucene.core;bundle-version="[9.4.2,10.0.0)",
- org.apache.lucene.analysis-smartcn;bundle-version="[9.4.2,10.0.0)"
+ org.apache.lucene.analysis-common;bundle-version="[9.5.0,10.0.0)",
+ org.apache.lucene.core;bundle-version="[9.5.0,10.0.0)",
+ org.apache.lucene.analysis-smartcn;bundle-version="[9.5.0,10.0.0)"
 Import-Package: org.eclipse.equinox.http.jetty;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Since https://github.com/eclipse-platform/eclipse.platform/commit/5f4a41c1d32159416f32f352d2fcb3bcfdc8eeae the class `org.apache.lucene.index.StoredFields` is used which [does not exist in Apache Lucene 9.4.2](https://lucene.apache.org/core/9_4_2/core/org/apache/lucene/index/package-summary.html), but [only since Apache Lucene 9.5.0](
https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/index/StoredFields.html#document%28int%29)

So the minimal Apache Lucene version has to be 9.5.0, not 9.4.2.