### PR TITLE
add API for IFile.readNBytes(n)

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IFile.java
@@ -1334,6 +1334,27 @@ public interface IFile extends IResource, IEncodedStorage, IAdaptable {
 	}
 
 	/**
+	 * Reads the first bytes of the content in a byte array. Equivalent of calling
+	 * {@code getContents(true).readNBytes(maxBytes)} but also closing the stream.
+	 *
+	 * @param maxBytes The maximal length of the returned array. If maxBytes is
+	 *                 greater or equal to the file length the whole content is
+	 *                 returned. If maxBytes is smaller then the file length then
+	 *                 only the first maxBytes bytes are returned.
+	 * @return content bytes
+	 * @throws CoreException on error
+	 * @see #getContents(boolean)
+	 * @since 3.21
+	 */
+	public default byte[] readNBytes(int maxBytes) throws CoreException {
+		try (InputStream stream = getContents(true)) {
+			return stream.readNBytes(maxBytes);
+		} catch (IOException e) {
+			throw new CoreException(Status.error("Error reading " + getFullPath(), e)); //$NON-NLS-1$
+		}
+	}
+
+	/**
 	 * Reads the content as char array. Skips the UTF BOM header if any. This method
 	 * is not intended for reading in large files that do not fit in a char array.
 	 * Preferable (potentially faster) equivalent of calling

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -1053,6 +1053,39 @@ public class IFileTest {
 	}
 
 	@Test
+	public void testReadNBytes() throws IOException, CoreException {
+		IFile file = projects[0].getFile("smallfile");
+		byte[] bytes = "1234".getBytes(StandardCharsets.US_ASCII);
+		file.write(bytes, false, false, false, null);
+		try {
+			file.readNBytes(-1);
+			assertFalse(true);
+		} catch (IllegalArgumentException expected) {
+			// expected
+		}
+		byte[] nBytes0 = file.readNBytes(0);
+		assertEquals(0, nBytes0.length);
+		byte[] nBytes1 = file.readNBytes(1);
+		assertEquals(1, nBytes1.length);
+		assertEquals('1', nBytes1[0]);
+		byte[] nBytes4 = file.readNBytes(4);
+		assertEquals(4, nBytes4.length);
+		byte[] nBytes5 = file.readNBytes(5);
+		assertEquals(4, nBytes5.length);
+		byte[] nBytesMax = file.readNBytes(Integer.MAX_VALUE);
+		assertEquals(4, nBytesMax.length);
+		assertArrayEquals(bytes, nBytesMax);
+
+		IFile largefile = projects[0].getFile("largefile");
+		byte[] largeContent = new byte[50_000_000]; // only 50 MB to prevent OutOfMemoryError on jenkins
+		largefile.write(largeContent, false, false, false, null);
+		byte[] largeBytes = largefile.readNBytes(Integer.MAX_VALUE);
+		assertEquals(largeContent.length, largeBytes.length);
+		byte[] largeBytes1 = largefile.readNBytes(1);
+		assertEquals(1, largeBytes1.length);
+	}
+
+	@Test
 	public void testReadAll() throws IOException, CoreException {
 		List<Charset> charsets = List.of(StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8, StandardCharsets.UTF_16BE,
 				StandardCharsets.UTF_16LE);


### PR DESCRIPTION
A convenience method that avoids callers to care about streams and may be implemented faster