### PR TITLE
remove unnecessary casts

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntLaunchShortcut.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntLaunchShortcut.java
@@ -546,7 +546,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 						}
 					}
 					if (resource != null) {
-						IPath location = ((IFile) resource).getLocation();
+						IPath location = resource.getLocation();
 						if (location != null) {
 							List<ILaunchConfiguration> list = collectConfigurations(location);
 							return list.toArray(new ILaunchConfiguration[list.size()]);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
@@ -689,8 +689,8 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	private void updateControlsForProblemReporting(boolean reportProblems) {
 		for (int i = fComboBoxes.size() - 1; i >= 0; i--) {
-			((Control) fComboBoxes.get(i)).setEnabled(reportProblems);
-			((Control) fProblemLabels.get(i)).setEnabled(reportProblems);
+			fComboBoxes.get(i).setEnabled(reportProblems);
+			fProblemLabels.get(i).setEnabled(reportProblems);
 		}
 		fSeverityLabel.setEnabled(reportProblems);
 		fBuildFilesToIgnoreProblems.setEnabled(reportProblems);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/RunTargetAction.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/RunTargetAction.java
@@ -100,17 +100,17 @@ public class RunTargetAction extends Action implements IUpdate {
 		AntElementNode selection = getSelectedElement();
 		boolean enabled = false;
 		if (selection instanceof AntTargetNode) {
-			if (!((AntTargetNode) selection).isErrorNode()) {
+			if (!selection.isErrorNode()) {
 				setToolTipText(AntViewActionMessages.RunTargetAction_4);
 				enabled = true;
 			}
 		} else if (selection instanceof AntProjectNode) {
-			if (!((AntProjectNode) selection).isErrorNode()) {
+			if (!selection.isErrorNode()) {
 				enabled = true;
 				setToolTipText(AntViewActionMessages.RunTargetAction_3);
 			}
 		} else if (selection instanceof AntTaskNode) {
-			if (!((AntTaskNode) selection).isErrorNode()) {
+			if (!selection.isErrorNode()) {
 				enabled = true;
 				setToolTipText(AntViewActionMessages.RunTargetAction_0);
 			}

--- a/ant/org.eclipse.ant.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.ui; singleton:=true
-Bundle-Version: 3.9.400.qualifier
+Bundle-Version: 3.9.500.qualifier
 Bundle-Activator: org.eclipse.ant.internal.ui.AntUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.tests;singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ContentTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ContentTests.java
@@ -172,7 +172,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 
 		// Complete the second set of children updates
 		for (int i = 0; i < model.fCapturedUpdates.size(); i++) {
-			((ILabelUpdate)model.fCapturedUpdates.get(i)).done();
+			model.fCapturedUpdates.get(i).done();
 		}
 
 		// Then complete the first set.
@@ -229,7 +229,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 
 		// Complete the second set of children updates
 		for (int i = 0; i < model.fCapturedUpdates.size(); i++) {
-			((ILabelUpdate)model.fCapturedUpdates.get(i)).done();
+			model.fCapturedUpdates.get(i).done();
 		}
 
 		// Then complete the first set.
@@ -281,7 +281,7 @@ abstract public class ContentTests extends AbstractViewerModelTest implements IT
 
 		// Complete the second set of children updates
 		for (int i = 0; i < model.fCapturedUpdates.size(); i++) {
-			((IChildrenUpdate)model.fCapturedUpdates.get(i)).done();
+			model.fCapturedUpdates.get(i).done();
 		}
 
 		// Then complete the first set.

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/FolderSourceContainerBrowser.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/FolderSourceContainerBrowser.java
@@ -22,7 +22,6 @@ import org.eclipse.debug.core.sourcelookup.containers.FolderSourceContainer;
 import org.eclipse.debug.ui.sourcelookup.AbstractSourceContainerBrowser;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 
@@ -38,7 +37,7 @@ public class FolderSourceContainerBrowser extends AbstractSourceContainerBrowser
 		FolderSourceContainerDialog dialog = new FolderSourceContainerDialog(shell,  new WorkbenchLabelProvider(), new WorkbenchContentProvider());
 
 		if (dialog.open() == Window.OK) {
-			Object[] selection= ((ElementTreeSelectionDialog)dialog).getResult();
+			Object[] selection= dialog.getResult();
 			ArrayList<ISourceContainer> containers = new ArrayList<>();
 			for (Object f : selection) {
 				if (f instanceof IFolder) {
@@ -63,7 +62,7 @@ public class FolderSourceContainerBrowser extends AbstractSourceContainerBrowser
 		dialog.setInitialSelection(container.getContainer());
 		if (dialog.open() == Window.OK) {
 			container.dispose();
-			Object[] selection= ((ElementTreeSelectionDialog)dialog).getResult();
+			Object[] selection= dialog.getResult();
 			ArrayList<ISourceContainer> list = new ArrayList<>();
 			for (Object f : selection) {
 				if (f instanceof IFolder) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SortBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/SortBuilder.java
@@ -222,7 +222,7 @@ public class SortBuilder extends TestBuilder {
 			}
 			folder.delete(true, null);
 		} else if (type == IResource.FILE) {
-			((IFile) resource).delete(true, null);
+			resource.delete(true, null);
 		} else {
 			throw new ResourceException(IResourceStatus.RESOURCE_WRONG_TYPE, null, "Wrong resource type", null);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -111,11 +110,11 @@ public class CopyTest {
 				() -> folder.copy(destinationFolder.getFullPath(), false, null));
 		assertThat(exception.getStatus().getChildren()).hasSize(2);
 		assertTrue(destinationFolder.exists());
-		assertTrue(((IContainer) destinationFolder).getFile(IPath.fromOSString(file.getName())).exists());
-		assertFalse(((IContainer) destinationFolder).getFolder(IPath.fromOSString(subfolder.getName())).exists());
-		assertFalse(((IContainer) destinationFolder).getFile(IPath.fromOSString(anotherFile.getName())).exists());
+		assertTrue(destinationFolder.getFile(IPath.fromOSString(file.getName())).exists());
+		assertFalse(destinationFolder.getFolder(IPath.fromOSString(subfolder.getName())).exists());
+		assertFalse(destinationFolder.getFile(IPath.fromOSString(anotherFile.getName())).exists());
 		/* assert properties were properly copied */
-		IResource target = ((IContainer) destinationFolder).getFile(IPath.fromOSString(file.getName()));
+		IResource target = destinationFolder.getFile(IPath.fromOSString(file.getName()));
 		for (int i = 0; i < NUMBER_OF_PROPERTIES; i++) {
 			String persistentValue = target.getPersistentProperty(propNames[i]);
 			Object sessionValue = target.getSessionProperty(propNames[i]);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -36,7 +36,6 @@ import org.eclipse.core.internal.resources.File;
 import org.eclipse.core.internal.resources.Resource;
 import org.eclipse.core.internal.resources.ResourceInfo;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -464,7 +463,7 @@ public class MoveTest {
 		assertTrue(folder.exists());
 		// FIXME: should #move be a best effort operation?
 		// its ok for the root to be moved but ensure the destination child wasn't moved
-		IResource destChild = ((IContainer) folderDestination).getFile(IPath.fromOSString(anotherFile.getName()));
+		IResource destChild = folderDestination.getFile(IPath.fromOSString(anotherFile.getName()));
 		assertFalse(folderDestination.exists());
 		assertFalse(destChild.exists());
 		// cleanup and delete the destination

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -406,7 +406,7 @@ public class IProjectTest  {
 		sourceChild = resources[1];
 		sourceChild.setPersistentProperty(qname, value);
 		monitor.prepare();
-		((IProject) source).copy(description, false, monitor);
+		source.copy(description, false, monitor);
 		monitor.assertUsedUp();
 		assertExistsInWorkspace(project);
 		assertExistsInWorkspace(resources);

--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.21.400.qualifier
+Bundle-Version: 3.21.500.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
@@ -114,11 +114,11 @@ public class DeadlockDetectionTest {
 		// join all threads:
 		for (int i = 0; i < allRunnables.size(); i++) {
 			try {
-				((Thread) allRunnables.get(i)).join(100000);
+				allRunnables.get(i).join(100000);
 			} catch (InterruptedException e1) {
 				//ignore
 			}
-			assertTrue("1." + i, !((Thread) allRunnables.get(i)).isAlive());
+			assertTrue("1." + i, !allRunnables.get(i).isAlive());
 		}
 		//the underlying array has to be empty
 		assertTrue("Locks not removed from graph.", lockManager.isEmpty());

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -5155,7 +5155,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 		Control center= getCenterControl();
 		if (center instanceof Canvas)
-			((Canvas) center).redraw();
+			center.redraw();
 
 		if (fRightCanvas != null)
 			fRightCanvas.redraw();

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/MergeSourceViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/MergeSourceViewer.java
@@ -933,7 +933,7 @@ public class MergeSourceViewer implements ISelectionChangedListener,
 	 */
 	public void setBounds (int x, int y, int width, int height) {
 		if(getSourceViewer().getControl() instanceof Composite){
-			((Composite)getSourceViewer().getControl()).setBounds(x, y, width, height);
+			getSourceViewer().getControl().setBounds(x, y, width, height);
 		} else {
 			getSourceViewer().getTextWidget().setBounds(x, y, width, height);
 		}

--- a/team/bundles/org.eclipse.team.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.core; singleton:=true
-Bundle-Version: 3.10.400.qualifier
+Bundle-Version: 3.10.500.qualifier
 Bundle-Activator: org.eclipse.team.internal.core.TeamPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/mapping/provider/MergeContext.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/mapping/provider/MergeContext.java
@@ -141,7 +141,7 @@ public abstract class MergeContext extends SynchronizationContext implements IMe
 						&& twd.getDirection() == IThreeWayDiff.OUTGOING
 						&& ((IFolder)resource).members().length == 0) {
 					// Delete the local folder addition
-					((IFolder)resource).delete(false, monitor);
+					resource.delete(false, monitor);
 				} else if (resource.getType() == IResource.FOLDER
 						&& !resource.exists()
 						&& twd.getKind() == IDiff.ADD

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/AbstractSynchronizeModelProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/AbstractSynchronizeModelProvider.java
@@ -129,7 +129,7 @@ public abstract class AbstractSynchronizeModelProvider implements ISynchronizeMo
 	}
 
 	private Tree getTree() {
-		return ((Tree)((AbstractTreeViewer)getViewer()).getControl());
+		return ((Tree)getViewer().getControl());
 	}
 
 	/**

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelElement.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/SynchronizeModelElement.java
@@ -134,7 +134,7 @@ public abstract class SynchronizeModelElement extends DiffNode implements IAdapt
 	public ImageDescriptor getImageDescriptor(Object object) {
 		IResource resource = getResource();
 		if(resource != null) {
-			IWorkbenchAdapter adapter = ((IAdaptable) resource).getAdapter(IWorkbenchAdapter.class);
+			IWorkbenchAdapter adapter = resource.getAdapter(IWorkbenchAdapter.class);
 			return adapter.getImageDescriptor(resource);
 		}
 		return null;

--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.7.0.qualifier
+Bundle-Version: 4.7.100.qualifier
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ComboPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/ComboPart.java
@@ -47,9 +47,9 @@ public class ComboPart {
 
 	public void addKeyListener(KeyListener listener) {
 		if (combo instanceof Combo)
-			((Combo) combo).addKeyListener(listener);
+			combo.addKeyListener(listener);
 		else
-			((CCombo) combo).addKeyListener(listener);
+			combo.addKeyListener(listener);
 	}
 
 	public void createControl(Composite parent, FormToolkit toolkit, int style) {

--- a/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.eclipse.ui.cheatsheets; singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.cheatsheets.CheatSheetPlugin
 Bundle-Vendor: %PROVIDER_NAME
 Bundle-Localization: plugin

--- a/ua/org.eclipse.ui.cheatsheets/pom.xml
+++ b/ua/org.eclipse.ui.cheatsheets/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.cheatsheets</artifactId>
-  <version>3.8.400-SNAPSHOT</version>
+  <version>3.8.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
@@ -792,7 +792,7 @@ public class CheatSheetViewer implements ICheatSheetViewer, IMenuContributor {
 		if (!inDialog && isInDialogItem() && (Platform.getBundle("org.eclipse.help.ui") != null)) { //$NON-NLS-1$
 			listener = event -> {
 				if (isTrayDialog(event.widget)) {
-					dialogOpened((TrayDialog) ((Shell) event.widget).getData());
+					dialogOpened((TrayDialog) event.widget.getData());
 				}
 			};
 			Display.getCurrent().addFilter(SWT.Show, listener);
@@ -986,7 +986,7 @@ public class CheatSheetViewer implements ICheatSheetViewer, IMenuContributor {
 	 * @return whether or not the widget is a TrayDialog
 	 */
 	private boolean isTrayDialog(Widget widget) {
-		return (widget instanceof Shell && ((Shell)widget).getData() instanceof TrayDialog);
+		return (widget instanceof Shell && widget.getData() instanceof TrayDialog);
 	}
 
 	/**


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new errors/warnings will show up in the build.