### PR TITLE
Add id_ed25519 to list of SSH private key defaults

### DIFF
--- a/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jsch.core;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.5.500.qualifier
 Bundle-Activator: org.eclipse.jsch.internal.core.JSchCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.jsch.core/src/org/eclipse/jsch/internal/core/IConstants.java
+++ b/team/bundles/org.eclipse.jsch.core/src/org/eclipse/jsch/internal/core/IConstants.java
@@ -36,7 +36,7 @@ public interface IConstants{
   public static final  String PROXY_TYPE_HTTP="HTTP"; //$NON-NLS-1$
   public static final  String HTTP_DEFAULT_PORT="80"; //$NON-NLS-1$
   public static final  String SOCKS5_DEFAULT_PORT="1080"; //$NON-NLS-1$
-  public static final  String PRIVATE_KEYS_DEFAULT="id_dsa,id_rsa"; //$NON-NLS-1$
+  public static final  String PRIVATE_KEYS_DEFAULT="id_ed25519,id_dsa,id_rsa"; //$NON-NLS-1$
 
   public static final  String DSA="DSA"; //$NON-NLS-1$
   public static final  String RSA="RSA"; //$NON-NLS-1$


### PR DESCRIPTION
For SSH I usually use `ed25519` type keys if possible. Therefore one of my first actions when using a fresh installation (without Oomph) is to add `id_ed25519` to the list of private SSH keys.

According to Stack-Exchange https://security.stackexchange.com/a/144044 ed25519 is currently the recommended key type, therefore I think it is fine to add it to the list of defaults.
Given it is the recommended type, it could even be added to the head of the list to be searched first.
Any opinions on that?