### PR TITLE
IFile.write byte[] for filesystems without errorcode - fixes #1449

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1359,9 +1359,6 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 			if (append) {
 				throw e;
 			}
-			if (e.getStatus().getCode() != EFS.ERROR_WRITE) {
-				throw e;
-			}
 			IFileStore parent = store.getParent();
 			IFileInfo parentInfo = parent.fetchInfo();
 			if (parentInfo.exists()) {


### PR DESCRIPTION
fixes FileSystemResourceManagerTest.testBug440110

https://github.com/eclipse-platform/eclipse.platform/issues/1449