### PR TITLE
Cleanup externally set directories in session tests #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
@@ -138,13 +138,13 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 	public CustomSessionConfiguration setConfigurationDirectory(Path configurationDirectory) {
 		Objects.requireNonNull(configurationDirectory);
 		this.configurationDirectory = configurationDirectory;
+		deleteOnShutdownRecursively(configurationDirectory);
 		return this;
 	}
 
 	private Path getConfigurationDirectory() throws IOException {
 		if (configurationDirectory == null) {
-			this.configurationDirectory = Files.createTempDirectory(TEMP_DIR_PREFIX);
-			deleteOnShutdownRecursively(configurationDirectory);
+			setConfigurationDirectory(Files.createTempDirectory(TEMP_DIR_PREFIX));
 		}
 		return configurationDirectory;
 	}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceImpl.java
@@ -34,14 +34,14 @@ public class CustomSessionWorkspaceImpl implements CustomSessionWorkspace {
 	public CustomSessionWorkspace setWorkspaceDirectory(Path workspaceDirectory) {
 		Objects.requireNonNull(workspaceDirectory);
 		this.workspaceDirectory = workspaceDirectory;
+		deleteOnShutdownRecursively(workspaceDirectory);
 		return this;
 	}
 
 	@Override
 	public Path getWorkspaceDirectory() throws IOException {
 		if (workspaceDirectory == null) {
-			this.workspaceDirectory = Files.createTempDirectory(TEMP_DIR_PREFIX);
-			deleteOnShutdownRecursively(workspaceDirectory);
+			setWorkspaceDirectory(Files.createTempDirectory(TEMP_DIR_PREFIX));
 		}
 		return workspaceDirectory;
 	}


### PR DESCRIPTION
The customizations for session tests to define custom workspaces and configurations currently only cleanup the contents of the used test directories if they are created by the customization implementation on their own. When a path is passed from outside, e.g., injected via a JUnit TempDir annotation, the folder is not cleaned up, but usually the provider will not do that on its own. In particular, JUnit only removes an injected temporary directory but not its contents.

With this change, the data created by session tests in custom workspace or configuration folders is always cleaned up after the test, no matter who created the temporary directory.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903