### PR TITLE
Avoid session test customization instantiation in remote execution #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionConfiguration.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionConfiguration.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness.session;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import org.eclipse.core.tests.harness.session.customization.SessionCustomization;
 import org.osgi.framework.Bundle;
@@ -19,6 +20,11 @@ import org.osgi.framework.Bundle;
  * "config.ini" file with a defined set of bundles to be used.
  */
 public interface CustomSessionConfiguration extends SessionCustomization {
+
+	/**
+	 * {@return the path of the used configuration directory}
+	 */
+	public Path getConfigurationDirectory() throws IOException;
 
 	/**
 	 * Sets the given configuration directory. If not called, a temporary folder is

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
@@ -14,7 +14,9 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.tests.harness.session.customization.CustomSessionConfigurationDummy;
 import org.eclipse.core.tests.harness.session.customization.CustomSessionConfigurationImpl;
+import org.eclipse.core.tests.harness.session.customization.CustomSessionWorkspaceDummy;
 import org.eclipse.core.tests.harness.session.customization.CustomSessionWorkspaceImpl;
 import org.eclipse.core.tests.harness.session.customization.SessionCustomization;
 import org.eclipse.core.tests.harness.session.samples.SampleSessionTests;
@@ -186,6 +188,9 @@ public interface SessionTestExtension extends InvocationInterceptor {
 	 * folder to store the workspace files}
 	 */
 	public static CustomSessionWorkspace createCustomWorkspace() {
+		if (RemoteTestExecutor.isRemoteExecution()) {
+			return new CustomSessionWorkspaceDummy();
+		}
 		return new CustomSessionWorkspaceImpl();
 	}
 
@@ -194,6 +199,9 @@ public interface SessionTestExtension extends InvocationInterceptor {
 	 * temporary folder to store the configuration files}
 	 */
 	public static CustomSessionConfiguration createCustomConfiguration() {
+		if (RemoteTestExecutor.isRemoteExecution()) {
+			return new CustomSessionConfigurationDummy();
+		}
 		return new CustomSessionConfigurationImpl();
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationDummy.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationDummy.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.customization;
+
+import java.nio.file.Path;
+import org.eclipse.core.tests.harness.session.CustomSessionConfiguration;
+import org.eclipse.core.tests.session.Setup;
+import org.osgi.framework.Bundle;
+
+public class CustomSessionConfigurationDummy implements CustomSessionConfiguration {
+
+	private Path configurationDirectory;
+
+	public CustomSessionConfigurationDummy() {
+	}
+
+	@Override
+	public CustomSessionConfiguration setCascaded() {
+		return this;
+	}
+
+	@Override
+	public CustomSessionConfiguration setReadOnly() {
+		return this;
+	}
+
+	@Override
+	public Path getConfigurationDirectory() {
+		return configurationDirectory;
+	}
+
+	@Override
+	public CustomSessionConfiguration setConfigurationDirectory(Path configurationDirectory) {
+		this.configurationDirectory = configurationDirectory;
+		return this;
+	}
+
+	@Override
+	public void prepareSession(Setup setup) {
+		// Do nothing
+	}
+
+	@Override
+	public void cleanupSession(Setup setup) {
+		// Do nothing
+	}
+
+	@Override
+	public CustomSessionConfiguration addBundle(Class<?> classFromBundle) {
+		return this;
+	}
+
+	@Override
+	public CustomSessionConfiguration addBundle(Bundle bundle) {
+		return this;
+	}
+
+}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
@@ -142,7 +142,8 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 		return this;
 	}
 
-	private Path getConfigurationDirectory() throws IOException {
+	@Override
+	public Path getConfigurationDirectory() throws IOException {
 		if (configurationDirectory == null) {
 			setConfigurationDirectory(Files.createTempDirectory(TEMP_DIR_PREFIX));
 		}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceDummy.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionWorkspaceDummy.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.customization;
+
+import java.nio.file.Path;
+import org.eclipse.core.tests.harness.session.CustomSessionWorkspace;
+import org.eclipse.core.tests.session.Setup;
+
+/**
+ * A session customization to use a custom workspace directory.
+ */
+public class CustomSessionWorkspaceDummy implements CustomSessionWorkspace {
+	private Path workspaceDirectory;
+
+	public CustomSessionWorkspaceDummy() {
+		// nothing to initialize
+	}
+
+	@Override
+	public CustomSessionWorkspace setWorkspaceDirectory(Path workspaceDirectory) {
+		this.workspaceDirectory = workspaceDirectory;
+		return this;
+	}
+
+	@Override
+	public Path getWorkspaceDirectory() {
+		return workspaceDirectory;
+	}
+
+	@Override
+	public void prepareSession(Setup setup) throws Exception {
+		// do nothing
+	}
+
+	@Override
+	public void cleanupSession(Setup setup) throws Exception {
+		// do nothing
+	}
+
+}


### PR DESCRIPTION
Currently, the SessionTestExtension with all its customizations is not only instantiated in the test-executing host application but also in every remote Eclipse application that is started to run a test case in an isolated session. Even though the current implementation already considers this during execution of the extensions and accesses to the customizations, it would be preferable to even only instantiate them if required.

This change introduces dummy implementations for the session test customizations that are used during remote execution to avoid unnecessary overhead.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903