### PR TITLE
Clean up code in findEditorLinkedDescriptors()

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -1118,12 +1118,11 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 	 */
 	Set<ViewerDescriptor> findEditorLinkedDescriptors(String fileName, IContentType contentType,
 			boolean firstIsEnough) {
-		if (fileName == null) {
-			if (contentType == null) {
-				contentType = fgContentTypeManager.findContentTypeFor(fileName);
-			} else {
-				return Collections.emptySet();
-			}
+		if (fileName == null && contentType == null) {
+			return Collections.emptySet();
+		}
+		if (contentType == null) {
+			contentType = fgContentTypeManager.findContentTypeFor(fileName);
 		}
 
 		LinkedHashSet<ViewerDescriptor> viewers = fContentMergeViewers.getAll().stream()


### PR DESCRIPTION
As noted on PR #1277, the code looks weird and I can't explain what I smoke while writing it. Fixed the code to do what actually was meant. This is mostly paranoia code, as usually input.getName() is not null.

See https://github.com/eclipse-platform/eclipse.platform/pull/1277 
See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747