### PR TITLE
Migrate builder tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -37,6 +37,7 @@ Require-Bundle: org.eclipse.core.resources,
 Import-Package: org.assertj.core.api,
  org.junit.jupiter.api,
  org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.function,
  org.junit.jupiter.api.io,
  org.junit.platform.suite.api,
  org.mockito

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildConfigurationsTest.java
@@ -20,10 +20,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.eclipse.core.resources.IBuildConfiguration;
@@ -38,29 +38,27 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.tests.internal.builders.TestBuilder.BuilderRuleCallback;
 import org.eclipse.core.tests.resources.ResourceDeltaVerifier;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * These tests exercise the project buildConfigs functionality which allows a different
  * builder to be run for different project buildConfigs.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuildConfigurationsTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	private static final String variant0 = "Variant0";
+	private static final String variant1 = "Variant1";
+	private static final String variant2 = "Variant2";
 
 	private IProject project0;
 	private IProject project1;
 	private IFile file0;
 	private IFile file1;
-	private static final String variant0 = "Variant0";
-	private static final String variant1 = "Variant1";
-	private static final String variant2 = "Variant2";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// Create resources
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -165,22 +163,22 @@ public class BuildConfigurationsTest {
 		// was last built
 		incrementalBuild(6, tempProject, variant0, true, 1, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		ConfigurationBuilder builder0 = ConfigurationBuilder.getBuilder(tempProject.getBuildConfig(variant0));
-		assertNotNull("6.10", builder0);
+		assertNotNull(builder0);
 		ResourceDeltaVerifier verifier0 = new ResourceDeltaVerifier();
 		verifier0.addExpectedChange(tempFile0, tempProject, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		verifier0.addExpectedChange(tempFile1, tempProject, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		verifier0.verifyDelta(builder0.deltaForLastBuild);
-		assertTrue("6.11: " + verifier0.getMessage(), verifier0.isDeltaValid());
+		assertTrue(verifier0.isDeltaValid(), verifier0.getMessage());
 
 		// verify variant1 - only File1 is expected to have changed since it was last
 		// built
 		incrementalBuild(7, tempProject, variant1, true, 1, IncrementalProjectBuilder.INCREMENTAL_BUILD);
 		ConfigurationBuilder builder1 = ConfigurationBuilder.getBuilder(tempProject.getBuildConfig(variant1));
-		assertNotNull("7.10", builder1);
+		assertNotNull(builder1);
 		ResourceDeltaVerifier verifier1 = new ResourceDeltaVerifier();
 		verifier1.addExpectedChange(tempFile1, tempProject, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 		verifier1.verifyDelta(builder1.deltaForLastBuild);
-		assertTrue("7.11: " + verifier1.getMessage(), verifier1.isDeltaValid());
+		assertTrue(verifier1.isDeltaValid(), verifier1.getMessage());
 
 		// verify variant2 - no changes are expected since it was last built
 		incrementalBuild(8, tempProject, variant2, false, 0, 0);
@@ -213,11 +211,11 @@ public class BuildConfigurationsTest {
 		setReferences(project0, variant0, new IBuildConfiguration[] {project0.getBuildConfig(variant1), project1.getBuildConfig(variant2), project1.getBuildConfig(variant0)});
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
-		assertEquals("1.0", 4, ConfigurationBuilder.buildOrder.size());
-		assertEquals("1.1", project0.getBuildConfig(variant1), ConfigurationBuilder.buildOrder.get(0));
-		assertEquals("1.2", project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(1));
-		assertEquals("1.3", project1.getBuildConfig(variant2), ConfigurationBuilder.buildOrder.get(2));
-		assertEquals("1.4", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(3));
+		assertEquals(4, ConfigurationBuilder.buildOrder.size());
+		assertEquals(project0.getBuildConfig(variant1), ConfigurationBuilder.buildOrder.get(0));
+		assertEquals(project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(1));
+		assertEquals(project1.getBuildConfig(variant2), ConfigurationBuilder.buildOrder.get(2));
+		assertEquals(project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(3));
 		checkBuild(2, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		checkBuild(3, project0, variant1, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 		checkBuild(4, project0, variant2, false, 0, 0);
@@ -231,9 +229,9 @@ public class BuildConfigurationsTest {
 		ConfigurationBuilder.clearBuildOrder();
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 
-		assertEquals("8.0", 2, ConfigurationBuilder.buildOrder.size());
-		assertEquals("8.1", project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
-		assertEquals("8.2", project1.getBuildConfig(variant2), ConfigurationBuilder.buildOrder.get(1));
+		assertEquals(2, ConfigurationBuilder.buildOrder.size());
+		assertEquals(project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
+		assertEquals(project1.getBuildConfig(variant2), ConfigurationBuilder.buildOrder.get(1));
 		checkBuild(9, project0, variant0, false, 1, 0);
 		checkBuild(10, project0, variant1, false, 1, 0);
 		checkBuild(11, project0, variant2, false, 0, 0);
@@ -262,16 +260,16 @@ public class BuildConfigurationsTest {
 		project1.close(createTestMonitor());
 		// should still be able to build project 0.
 		getWorkspace().build(new IBuildConfiguration[] {project0.getBuildConfig(variant0)}, IncrementalProjectBuilder.FULL_BUILD, true, createTestMonitor());
-		assertEquals("1.0", 1, ConfigurationBuilder.buildOrder.size());
-		assertEquals("1.1", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
+		assertEquals(1, ConfigurationBuilder.buildOrder.size());
+		assertEquals(project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
 		checkBuild(2, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
 		// Workspace full build should also build project 0
 		ConfigurationBuilder.clearStats();
 		ConfigurationBuilder.clearBuildOrder();
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
-		assertEquals("1.0", 1, ConfigurationBuilder.buildOrder.size());
-		assertEquals("1.1", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
+		assertEquals(1, ConfigurationBuilder.buildOrder.size());
+		assertEquals(project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
 		checkBuild(2, project0, variant0, true, 1, IncrementalProjectBuilder.FULL_BUILD);
 
 		// re-open project 1
@@ -281,9 +279,9 @@ public class BuildConfigurationsTest {
 		ConfigurationBuilder.clearBuildOrder();
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
-		assertEquals("8.0", 2, ConfigurationBuilder.buildOrder.size());
-		assertEquals("8.1", project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
-		assertEquals("8.2", project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(1));
+		assertEquals(2, ConfigurationBuilder.buildOrder.size());
+		assertEquals(project1.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(0));
+		assertEquals(project0.getBuildConfig(variant0), ConfigurationBuilder.buildOrder.get(1));
 	}
 
 	/**
@@ -321,9 +319,9 @@ public class BuildConfigurationsTest {
 	private void clean(int testId, IProject project, String variant, int expectedCount) throws CoreException {
 		project.build(project.getBuildConfig(variant), IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		ConfigurationBuilder builder = ConfigurationBuilder.getBuilder(project.getBuildConfig(variant));
-		assertNotNull(testId + ".0", builder);
-		assertEquals(testId + ".1", expectedCount, builder.buildCount);
-		assertEquals(testId + ".2", IncrementalProjectBuilder.CLEAN_BUILD, builder.triggerForLastBuild);
+		assertNotNull(builder, testId + "");
+		assertEquals(expectedCount, builder.buildCount, testId);
+		assertEquals(IncrementalProjectBuilder.CLEAN_BUILD, builder.triggerForLastBuild, testId);
 	}
 
 	/**
@@ -333,12 +331,12 @@ public class BuildConfigurationsTest {
 		project.getBuildConfig(variant);
 		ConfigurationBuilder builder = ConfigurationBuilder.getBuilder(project.getBuildConfig(variant));
 		if (builder == null) {
-			assertFalse(testId + ".1", shouldBuild);
-			assertEquals(testId + ".2", 0, expectedCount);
+			assertFalse(shouldBuild, testId + "");
+			assertEquals(0, expectedCount, testId);
 		} else {
-			assertEquals(testId + ".3", expectedCount, builder.buildCount);
+			assertEquals(expectedCount, builder.buildCount, testId);
 			if (shouldBuild) {
-				assertEquals(testId + ".4", expectedTrigger, builder.triggerForLastBuild);
+				assertEquals(expectedTrigger, builder.triggerForLastBuild, testId);
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildContextTest.java
@@ -31,27 +31,24 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * These tests exercise the build context functionality that tells a builder in what context
  * it was called.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuildContextTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	private IProject project0;
 	private IProject project1;
 	private IProject project2;
 	private static final String variant0 = "Variant0";
 	private static final String variant1 = "Variant1";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// Create resources
 		IWorkspaceRoot root = getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuildDeltaVerificationTest.java
@@ -19,9 +19,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -35,21 +35,16 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that deltas supplied to the builder are accurate
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuildDeltaVerificationTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
-	DeltaVerifierBuilder verifier;
-	/* some random resource handles */
 	protected static final String PROJECT1 = "Project1";
 	protected static final String PROJECT2 = "Project2";
 	protected static final String FOLDER1 = "Folder1";
@@ -57,6 +52,7 @@ public class BuildDeltaVerificationTest {
 	protected static final String FILE1 = "File1";
 	protected static final String FILE2 = "File2";
 	protected static final String FILE3 = "File3";
+
 	IProject project1;
 	IProject project2;
 	IFolder folder1;//below project2
@@ -65,6 +61,7 @@ public class BuildDeltaVerificationTest {
 	IFile file1;//below folder1
 	IFile file2;//below folder1
 	IFile file3;//below folder2
+	DeltaVerifierBuilder verifier;
 
 	/**
 	 * Tests that the builder is receiving an appropriate delta
@@ -73,15 +70,8 @@ public class BuildDeltaVerificationTest {
 		if (!verifier.isDeltaValid()) {
 			//		System.out.println(verifier.getMessage());
 		}
-		assertTrue("Should be an incremental build", verifier.wasIncrementalBuild());
-		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
-	}
-
-	/**
-	 * Runs code to handle a core exception
-	 */
-	protected void handleCoreException(CoreException e) {
-		assertTrue("CoreException: " + e.getMessage(), false);
+		assertTrue(verifier.wasIncrementalBuild(), "Should be an incremental build");
+		assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 	}
 
 	/**
@@ -96,7 +86,7 @@ public class BuildDeltaVerificationTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// Turn auto-building off
 		IWorkspace workspace = getWorkspace();
@@ -125,8 +115,8 @@ public class BuildDeltaVerificationTest {
 		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		verifier = DeltaVerifierBuilder.getInstance();
-		assertNotNull("Builder was not instantiated", verifier);
-		assertTrue("First build should be a batch build", verifier.wasFullBuild());
+		assertNotNull(verifier, "Builder was not instantiated");
+		assertTrue(verifier.wasFullBuild(), "First build should be a batch build");
 	}
 
 	/**
@@ -142,7 +132,7 @@ public class BuildDeltaVerificationTest {
 		if (verifier.wasFullBuild()) {
 			verifier.emptyBuild();
 		}
-		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
+		assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 	}
 
 	/**
@@ -157,7 +147,7 @@ public class BuildDeltaVerificationTest {
 		if (verifier.wasFullBuild()) {
 			verifier.emptyBuild();
 		}
-		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
+		assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 	}
 
 	/**
@@ -206,7 +196,7 @@ public class BuildDeltaVerificationTest {
 		project2.create(createTestMonitor());
 		rebuild();
 		// builder for project1 should not even be called
-		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
+		assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderCycleTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -30,20 +30,18 @@ import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests platform support for build cycles.  Namely, the ability of builders to
  * request that a rebuild occur automatically if it modifies projects that came
  * before it in the build order.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuilderCycleTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testIsBeforeThisProject() throws CoreException {
@@ -73,7 +71,7 @@ public class BuilderCycleTest {
 	}
 
 	@Test
-	@Ignore("test has been skipped for unknown reasons")
+	@Disabled("test has been skipped for unknown reasons")
 	public void testNeedRebuild() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderEventTest.java
@@ -17,37 +17,34 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the PRE_BUILD and POST_BUILD events.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuilderEventTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	private BuildEventListener listener;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		listener = new BuildEventListener();
 		int mask = IResourceChangeEvent.PRE_BUILD | IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.POST_CHANGE;
 		getWorkspace().addResourceChangeListener(listener, mask);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		getWorkspace().removeResourceChangeListener(listener);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderNatureTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -31,19 +31,17 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests relationship between natures and builders.  Builders that are owned
  * by a nature can only be run if their owning nature is defined on the project
  * being built.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuilderNatureTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	protected InputStream projectFileWithoutSnow() {
 		String contents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<projectDescription>\n" + "	<name>P1</name>\n" + "	<comment></comment>\n" + "	<projects>\n" + "	</projects>\n" + "	<buildSpec>\n" + "		<buildCommand>\n" + "			<name>org.eclipse.core.tests.resources.snowbuilder</name>\n" + "			<arguments>\n" + "				<dictionary>\n" + "					<key>BuildID</key>\n" + "					<value>SnowBuild</value>\n" + "				</dictionary>\n" + "			</arguments>\n" + "		</buildCommand>\n" + "	</buildSpec>\n" + "	<natures>\n" + "		<nature>org.eclipse.core.tests.resources.waterNature</nature>\n" + "	</natures>\n" + "</projectDescription>";
@@ -178,7 +176,7 @@ public class BuilderNatureTest {
 		project.setDescription(desc, IResource.FORCE, createTestMonitor());
 		waitForBuild();
 		builder.assertLifecycleEvents();
-		assertTrue("5.1", builder.wasDeltaNull());
+		assertTrue(builder.wasDeltaNull());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/BuilderTest.java
@@ -25,11 +25,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setBuildOrder;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -56,13 +56,13 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
 import org.junit.function.ThrowingRunnable;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class tests public API related to building and to build specifications.
@@ -71,16 +71,11 @@ import org.junit.rules.TestName;
  * IWorkspace#build IProject#build IProjectDescription#getBuildSpec
  * IProjectDescription#setBuildSpec
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuilderTest {
 
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
-	@Before
-	@After
+	@BeforeEach
+	@AfterEach
 	public void resetBuilder() throws Exception {
 		TestBuilder builder = SortBuilder.getInstance();
 		if (builder != null) {
@@ -216,30 +211,30 @@ public class BuilderTest {
 		monitor.assertUsedUp();
 
 		DeltaVerifierBuilder verifier = DeltaVerifierBuilder.getInstance();
-		assertTrue("3.2", verifier.wasCleanBuild());
+		assertTrue(verifier.wasCleanBuild());
 		// Now do an incremental build - since delta was null it should appear as a clean build
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 		monitor.assertUsedUp();
-		assertTrue("3.4", verifier.wasFullBuild());
+		assertTrue(verifier.wasFullBuild());
 		// next time it will appear as an incremental build
 		project.touch(createTestMonitor());
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 		monitor.assertUsedUp();
-		assertTrue("3.6", verifier.wasIncrementalBuild());
+		assertTrue(verifier.wasIncrementalBuild());
 
 		//do another clean
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
 		monitor.assertUsedUp();
-		assertTrue("3.8", verifier.wasCleanBuild());
+		assertTrue(verifier.wasCleanBuild());
 
 		//doing a full build should still look like a full build
 		monitor = new FussyProgressMonitor();
 		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
 		monitor.assertUsedUp();
-		assertTrue("3.10", verifier.wasFullBuild());
+		assertTrue(verifier.wasFullBuild());
 	}
 
 	/**
@@ -513,6 +508,7 @@ public class BuilderTest {
 		verifier.assertLifecycleEvents();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void extracted(final IProject proj1, final IProject proj2) throws CoreException {
 		// Create and set a build specs for project one
 		proj1.create(createTestMonitor());
@@ -531,6 +527,7 @@ public class BuilderTest {
 	 * to be built in the correct order.
 	 * This is a regression test for bug 330194.
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testChangeDynamicBuildOrderDuringPreBuild() throws Throwable {
 		IWorkspace workspace = getWorkspace();
@@ -659,7 +656,7 @@ public class BuilderTest {
 	 * but the source project does not.
 	 */
 	@Test
-	public void testCopyProject() throws CoreException {
+	public void testCopyProject(TestInfo testInfo) throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		// Create some resource handles
 		IProject proj1 = workspace.getRoot().getProject("testCopyProject" + 1);
@@ -683,7 +680,7 @@ public class BuilderTest {
 		desc.setName(proj2.getName());
 		proj1.copy(desc, IResource.NONE, createTestMonitor());
 
-		waitForEncodingRelatedJobs(testName.getMethodName());
+		waitForEncodingRelatedJobs(testInfo.getTestMethod().get().getName());
 		waitForBuild();
 		SortBuilder builder = SortBuilder.getInstance();
 		assertEquals(proj2, builder.getProject());
@@ -700,6 +697,7 @@ public class BuilderTest {
 	 * Tests an implicit workspace build order created by setting dynamic
 	 * project references.
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testDynamicBuildOrder() throws CoreException {
 		IWorkspace workspace = getWorkspace();
@@ -899,7 +897,7 @@ public class BuilderTest {
 		createInWorkspace(input, createRandomString());
 
 		waitForBuild();
-		assertTrue("1.0", output.exists());
+		assertTrue(output.exists());
 
 		//change the file and then immediately perform build
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ComputeProjectOrderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ComputeProjectOrderTest.java
@@ -13,15 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.eclipse.core.internal.resources.ComputeProjectOrder;
 import org.eclipse.core.internal.resources.ComputeProjectOrder.Digraph;
 import org.eclipse.core.internal.resources.ComputeProjectOrder.Digraph.Edge;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ComputeProjectOrderTest {
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ConfigurationBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ConfigurationBuilder.java
@@ -13,11 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
-import java.util.*;
-import org.eclipse.core.resources.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.junit.Assert;
 
 /**
  * A builder used that stores statistics, such as which target was built, per project build config.
@@ -74,7 +81,7 @@ public class ConfigurationBuilder extends TestBuilder {
 	protected void clean(IProgressMonitor monitor) throws CoreException {
 		super.clean(monitor);
 		IResourceDelta delta = getDelta(getProject());
-		Assert.assertNull(delta);
+		assertNull(delta);
 		buildCount++;
 		triggerForLastBuild = IncrementalProjectBuilder.CLEAN_BUILD;
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomBuildTriggerTest.java
@@ -19,9 +19,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -31,10 +32,10 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * These tests exercise the function added in Eclipse 3.1 to allow a builder
@@ -44,12 +45,10 @@ import org.junit.Test;
  * ICommand.setBuilding(int, boolean)
  * The "isConfigurable" attribute in the builder extension schema
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class CustomBuildTriggerTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		SortBuilder.resetSingleton();
 		CustomTriggerBuilder.resetSingleton();
@@ -81,29 +80,29 @@ public class CustomBuildTriggerTest {
 		//do an initial workspace build to get the builder instance
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("1.0", builder);
-		assertTrue("1.1", builder.triggerForLastBuild == 0);
+		assertNotNull(builder);
+		assertTrue(builder.triggerForLastBuild == 0);
 
 		//do a clean - builder should not be called
 		waitForBuild();
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
-		assertEquals("2.0", 0, builder.triggerForLastBuild);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// Ensure that Auto-build doesn't cause a FULL_BUILD
 		waitForBuild();
-		assertEquals("2.1", 0, builder.triggerForLastBuild);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// But first requested build should cause a FULL_BUILD
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertTrue("3.0", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		// But subsequent builds shouldn't
 		builder.reset();
 		builder.clearBuildTrigger();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertTrue("3.1", builder.triggerForLastBuild == 0);
+		assertTrue(builder.triggerForLastBuild == 0);
 	}
 
 	/**
@@ -131,23 +130,23 @@ public class CustomBuildTriggerTest {
 		//do an initial workspace build to get the builder instance
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("1.0", builder);
-		assertEquals("1.1", 0, builder.triggerForLastBuild);
+		assertNotNull(builder);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		//do a clean - builder should not be called
 		waitForBuild();
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
-		assertEquals("2.0", 0, builder.triggerForLastBuild);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// Ensure that Auto-build doesn't cause a FULL_BUILD
 		waitForBuild();
-		assertEquals("2.1", 0, builder.triggerForLastBuild);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// But first requested build should cause a FULL_BUILD
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertTrue("3.0", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		IFile file = project.getFile("a.txt");
 		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
@@ -156,7 +155,7 @@ public class CustomBuildTriggerTest {
 		builder.reset();
 		builder.clearBuildTrigger();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertEquals("5.0", IncrementalProjectBuilder.INCREMENTAL_BUILD, builder.triggerForLastBuild);
+		assertEquals(IncrementalProjectBuilder.INCREMENTAL_BUILD, builder.triggerForLastBuild);
 	}
 
 	/**
@@ -188,8 +187,8 @@ public class CustomBuildTriggerTest {
 		// do an initial workspace build to get the builder instance
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("1.0", builder);
-		assertTrue("1.1", builder.triggerForLastBuild == 0);
+		assertNotNull(builder);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		//do a clean - Ensure that Auto-build causes a FULL_BUILD
 		waitForBuild();
@@ -197,7 +196,7 @@ public class CustomBuildTriggerTest {
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 
 		waitForBuild();
-		assertTrue("2.1", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		// add a file in the project to trigger an auto-build - no FULL_BUILD should be triggered
 		builder.clearBuildTrigger();
@@ -207,8 +206,8 @@ public class CustomBuildTriggerTest {
 		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
-		assertTrue("6.0", !builder.wasCleanBuild());
-		assertTrue("6.1", builder.wasAutobuild());
+		assertFalse(builder.wasCleanBuild());
+		assertTrue(builder.wasAutobuild());
 	}
 
 	/**
@@ -231,23 +230,23 @@ public class CustomBuildTriggerTest {
 
 		assertThat(project.getDescription().getBuildSpec()).hasSize(1);
 		ICommand command = project.getDescription().getBuildSpec()[0];
-		assertTrue("1.0", command.isConfigurable());
+		assertTrue(command.isConfigurable());
 		//ensure that setBuilding has effect
-		assertTrue("1.1", command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, false);
-		assertTrue("1.2", !command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
+		assertFalse(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
 
-		assertTrue("1.3", command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
-		assertTrue("1.4", !command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
+		assertFalse(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
 
-		assertTrue("1.5", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, false);
-		assertTrue("1.6", !command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
+		assertFalse(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
 
-		assertTrue("1.7", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
-		assertTrue("1.8", !command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
+		assertFalse(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
 
 		// set the command back into the project for change to take effect
 		updateProjectDescription(project).removingExistingCommands().addingCommand(command).apply();
@@ -255,20 +254,20 @@ public class CustomBuildTriggerTest {
 		//ensure the builder is not called
 		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertTrue("2.0", builder == null || builder.triggerForLastBuild == 0);
+		assertTrue(builder == null || builder.triggerForLastBuild == 0);
 
 		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
-		assertTrue("2.1", builder == null || builder.triggerForLastBuild == 0);
+		assertTrue(builder == null || builder.triggerForLastBuild == 0);
 
 		project.touch(createTestMonitor());
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
-		assertTrue("3.0", builder == null || builder.triggerForLastBuild == 0);
+		assertTrue(builder == null || builder.triggerForLastBuild == 0);
 		setAutoBuilding(true);
 		project.touch(createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
-		assertTrue("4.0", builder == null || builder.triggerForLastBuild == 0);
+		assertTrue(builder == null || builder.triggerForLastBuild == 0);
 
 		//turn the builder back on and make sure it runs
 		setAutoBuilding(false);
@@ -281,14 +280,14 @@ public class CustomBuildTriggerTest {
 		//ensure the builder is called
 		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
-		assertTrue("6.1", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		builder = CustomTriggerBuilder.getInstance();
-		assertTrue("7.1", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		project.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
-		assertTrue("8.1", builder.wasCleanBuild());
+		assertTrue(builder.wasCleanBuild());
 	}
 
 	/**
@@ -310,16 +309,16 @@ public class CustomBuildTriggerTest {
 
 		assertThat(project.getDescription().getBuildSpec()).hasSize(1);
 		ICommand command = project.getDescription().getBuildSpec()[0];
-		assertTrue("1.0", !command.isConfigurable());
+		assertFalse(command.isConfigurable());
 		//ensure that setBuilding has no effect
 		command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, false);
-		assertTrue("1.1", command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
-		assertTrue("1.2", command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, false);
-		assertTrue("1.3", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD));
 		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
-		assertTrue("1.4", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD));
 
 		//set the command back into the project for change to take effect
 		updateProjectDescription(project).removingExistingCommands().addingCommand(command);
@@ -327,14 +326,14 @@ public class CustomBuildTriggerTest {
 		//ensure that builder is still called
 		project.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 		SortBuilder builder = SortBuilder.getInstance();
-		assertTrue("2.0", builder.wasBuilt());
-		assertTrue("2.1", builder.wasFullBuild());
-		assertEquals("2.2", command, builder.getCommand());
+		assertTrue(builder.wasBuilt());
+		assertTrue(builder.wasFullBuild());
+		assertEquals(command, builder.getCommand());
 
 		project.touch(createTestMonitor());
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertTrue("3.0", builder.wasBuilt());
-		assertTrue("3.1", builder.wasIncrementalBuild());
+		assertTrue(builder.wasBuilt());
+		assertTrue(builder.wasIncrementalBuild());
 	}
 
 	/**
@@ -362,15 +361,15 @@ public class CustomBuildTriggerTest {
 		// turn autobuild back on
 		setAutoBuilding(true);
 
-		assertTrue("1.0", command.isConfigurable());
+		assertTrue(command.isConfigurable());
 		//ensure that setBuilding has effect
-		assertTrue("1.1", !command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
+		assertFalse(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD));
 
 		//do an initial build to get the builder instance
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("1.3", builder);
+		assertNotNull(builder);
 		builder.clearBuildTrigger();
 
 		//add a file in the project, to trigger an autobuild
@@ -379,13 +378,13 @@ public class CustomBuildTriggerTest {
 
 		//autobuild should not call our builder
 		waitForBuild();
-		assertTrue("2.0", !builder.wasIncrementalBuild());
-		assertTrue("2.1", !builder.wasAutobuild());
+		assertFalse(builder.wasIncrementalBuild());
+		assertFalse(builder.wasAutobuild());
 
 		//but, a subsequent incremental build should call it
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
-		assertTrue("2.1", !builder.wasAutobuild());
-		assertTrue("3.0", builder.wasIncrementalBuild());
+		assertFalse(builder.wasAutobuild());
+		assertTrue(builder.wasIncrementalBuild());
 
 	}
 
@@ -418,23 +417,23 @@ public class CustomBuildTriggerTest {
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("2.0", builder);
-		assertTrue("2.1", builder.wasFullBuild());
+		assertNotNull(builder);
+		assertTrue(builder.wasFullBuild());
 
 		// do a clean - builder should not be called
 		builder.clearBuildTrigger();
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
-		assertTrue("3.0", !builder.wasCleanBuild());
-		assertTrue("3.1", !builder.wasFullBuild());
+		assertFalse(builder.wasCleanBuild());
+		assertFalse(builder.wasFullBuild());
 
 		// do an incremental build - FULL_BUILD should be triggered
 		builder.clearBuildTrigger();
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
-		assertTrue("4.0", !builder.wasCleanBuild());
-		assertTrue("4.1", builder.wasFullBuild());
+		assertFalse(builder.wasCleanBuild());
+		assertTrue(builder.wasFullBuild());
 
 		// add a file in the project before an incremental build is triggered again
 		IFile file = project.getFile("a.txt");
@@ -445,8 +444,8 @@ public class CustomBuildTriggerTest {
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
-		assertTrue("6.0", !builder.wasCleanBuild());
-		assertTrue("6.1", !builder.wasFullBuild());
+		assertFalse(builder.wasCleanBuild());
+		assertFalse(builder.wasFullBuild());
 	}
 
 	/**
@@ -474,15 +473,15 @@ public class CustomBuildTriggerTest {
 		// turn auto-building on
 		setAutoBuilding(true);
 		CustomTriggerBuilder builder = CustomTriggerBuilder.getInstance();
-		assertNotNull("1.0", builder);
-		assertEquals("1.1", 0, builder.triggerForLastBuild);
+		assertNotNull(builder);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// do a clean - builder should not be called
 		builder.clearBuildTrigger();
 		builder.reset();
 		workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
-		assertTrue("2.0", !builder.wasCleanBuild());
-		assertTrue("2.1", !builder.wasFullBuild());
+		assertFalse(builder.wasCleanBuild());
+		assertFalse(builder.wasFullBuild());
 
 		// add a file in the project to trigger an auto-build - no FULL_BUILD should be triggered
 		builder.clearBuildTrigger();
@@ -492,12 +491,12 @@ public class CustomBuildTriggerTest {
 		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
-		assertEquals("4.0", 0, builder.triggerForLastBuild);
+		assertEquals(0, builder.triggerForLastBuild);
 
 		// Build the project explicitly -- full build should be triggered
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
 		waitForBuild();
-		assertTrue("4.1", builder.wasFullBuild());
+		assertTrue(builder.wasFullBuild());
 
 		// add another file in the project to trigger an auto-build - build should NOT be triggered
 		builder.clearBuildTrigger();
@@ -507,8 +506,8 @@ public class CustomBuildTriggerTest {
 		file.create(createRandomContentsStream(), IResource.NONE, createTestMonitor());
 
 		waitForBuild();
-		assertTrue("6.0", !builder.wasCleanBuild());
-		assertTrue("6.1", !builder.wasFullBuild());
+		assertFalse(builder.wasCleanBuild());
+		assertFalse(builder.wasFullBuild());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomTriggerBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CustomTriggerBuilder.java
@@ -12,11 +12,14 @@
  ******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.junit.Assert;
 
 /**
  * A test builder that allows specification of what build triggers it responds to.
@@ -52,7 +55,7 @@ public class CustomTriggerBuilder extends TestBuilder {
 		super.clean(monitor);
 		triggerForLastBuild = IncrementalProjectBuilder.CLEAN_BUILD;
 		IResourceDelta delta = getDelta(getProject());
-		Assert.assertNull(delta);
+		assertNull(delta);
 	}
 
 	public void clearBuildTrigger() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CycleBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/CycleBuilder.java
@@ -14,13 +14,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Map;
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.junit.Assert;
 
 /**
  * Helper builder for cycle related tests.
@@ -49,12 +56,12 @@ public class CycleBuilder extends TestBuilder {
 	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
 		if (beforeProjects != null) {
 			for (IProject beforeProject : beforeProjects) {
-				Assert.assertTrue("Missing before project: " + beforeProject, hasBeenBuilt(beforeProject));
+				assertTrue(hasBeenBuilt(beforeProject), "Missing before project: " + beforeProject);
 			}
 		}
 		if (afterProjects != null) {
 			for (IProject afterProject : afterProjects) {
-				Assert.assertTrue("Missing after project: " + afterProject, !hasBeenBuilt(afterProject));
+				assertFalse(hasBeenBuilt(afterProject), "Missing after project: " + afterProject);
 			}
 		}
 		if (rebuildsToRequest > buildCount) {
@@ -63,7 +70,7 @@ public class CycleBuilder extends TestBuilder {
 		}
 		//ensure that subsequent builds are always incremental
 		if (buildCount > 0) {
-			Assert.assertTrue("Should be incremental build", kind == IncrementalProjectBuilder.INCREMENTAL_BUILD);
+			assertTrue(kind == IncrementalProjectBuilder.INCREMENTAL_BUILD, "Should be incremental build");
 		}
 		buildCount++;
 		return null;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/EmptyDeltaTest.java
@@ -21,17 +21,15 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDes
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the callOnEmptyDelta attribute of the builder extension
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class EmptyDeltaTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testBuildEvents() throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/MultiProjectBuildTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -35,21 +35,18 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.resources.TestPerformer;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class tests builds that span multiple projects.  Project builders
  * can specify what other projects they are interested in receiving deltas for,
  * and they should only be receiving deltas for exactly those projects.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class MultiProjectBuildTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	//various resource handles
 	private IProject project1;
 	private IProject project2;
@@ -63,7 +60,7 @@ public class MultiProjectBuildTest {
 	/**
 	 * Returns an array of interesting project combinations.
 	 */
-	protected IProject[][] interestingProjects() {
+	private IProject[][] interestingProjects() {
 		//mix things up, because requests from one run affect results in the next.
 		return new IProject[][] {new IProject[] {}, new IProject[] {project3}, new IProject[] {project1}, new IProject[] {project1, project2, project3}, new IProject[] {project2}, new IProject[] {project3}, new IProject[] {project4}, new IProject[] {project1, project2}, new IProject[] {project1, project3}, new IProject[] {project3}, new IProject[] {project2, project3}, new IProject[] {project1, project2, project3}, new IProject[] {project1, project2, project4}, new IProject[] {project1}, new IProject[] {project1, project3, project4}, new IProject[] {project1, project2}, new IProject[] {project2, project3, project4}, new IProject[] {project3, project4}, new IProject[] {project1, project2, project3, project4},};
 	}
@@ -71,7 +68,7 @@ public class MultiProjectBuildTest {
 	/**
 	 * Modifies any files in the given projects, all in a single operation
 	 */
-	protected void dirty(final IProject[] projects) throws CoreException {
+	private void dirty(final IProject[] projects) throws CoreException {
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			for (IProject project : projects) {
 				for (IResource member : project.members()) {
@@ -87,7 +84,7 @@ public class MultiProjectBuildTest {
 	/**
 	 * Returns an array reversed.
 	 */
-	IProject[][] reverse(IProject[][] input) {
+	private IProject[][] reverse(IProject[][] input) {
 		if (input == null) {
 			return null;
 		}
@@ -102,7 +99,7 @@ public class MultiProjectBuildTest {
 	/*
 	 * @see TestCase#setUp()
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setAutoBuilding(true);
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -131,7 +128,7 @@ public class MultiProjectBuildTest {
 		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
-		assertTrue("1.1", builder != null);
+		assertNotNull(builder);
 		//always check deltas for all projects
 		final IProject[] allProjects = new IProject[] {project1, project2, project3, project4};
 		builder.checkDeltas(allProjects);
@@ -218,7 +215,7 @@ public class MultiProjectBuildTest {
 		project1.build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
 
 		final DeltaVerifierBuilder builder = DeltaVerifierBuilder.getInstance();
-		assertTrue("1.1", builder != null);
+		assertNotNull(builder);
 		//always check deltas for all projects
 		final IProject[] allProjects = new IProject[] {project1, project2, project3, project4};
 		project2.close(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ParallelBuildChainTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.TestUtil.waitForCondition;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,18 +43,15 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.internal.builders.TimerBuilder.RuleType;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ParallelBuildChainTest {
 	private static final int TIMEOUT_IN_MILLIS = 30_000;
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static enum BuildDurationType {
 		/*
@@ -98,12 +96,12 @@ public class ParallelBuildChainTest {
 
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setAutoBuilding(false);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// Cleanup workspace first to ensure that auto-build is not started on projects
 		waitForBuild();
@@ -420,7 +418,7 @@ public class ParallelBuildChainTest {
 			TimerBuilder.abortCurrentBuilds();
 			job.cancel();
 			boolean joinSuccessful = job.join(TIMEOUT_IN_MILLIS, createTestMonitor());
-			Assert.assertTrue("timeout occurred when waiting for job that runs the build to finish", joinSuccessful);
+			assertTrue(joinSuccessful, "timeout occurred when waiting for job that runs the build to finish");
 		}
 	}
 
@@ -458,8 +456,7 @@ public class ParallelBuildChainTest {
 			TimerBuilder.abortCurrentBuilds();
 			jobGroup.cancel();
 			boolean joinSuccessful = jobGroup.join(TIMEOUT_IN_MILLIS, createTestMonitor());
-			Assert.assertTrue("timeout occurred when waiting for job group that runs the builds to finish",
-					joinSuccessful);
+			assertTrue(joinSuccessful, "timeout occurred when waiting for job group that runs the builds to finish");
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/RebuildTest.java
@@ -19,8 +19,8 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 import org.eclipse.core.internal.resources.Workspace;
@@ -28,41 +28,37 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runners.MethodSorters;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class tests builder behavior related to re-building
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ExtendWith(WorkspaceResetExtension.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class RebuildTest {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	final String builderName = RebuildingBuilder.BUILDER_NAME;
 	private int maxBuildIterations;
+	private String testName;
 
-	@Before
-	public void setUp() throws CoreException {
+	@BeforeEach
+	public void setUp(TestInfo testInfo) throws CoreException {
 		maxBuildIterations = getWorkspace().getDescription().getMaxBuildIterations();
+		testName = testInfo.getTestMethod().get().getName();
 		// Turn auto-building off
 		setAutoBuilding(false);
 		boolean earlyExitAllowed = ((Workspace) getWorkspace()).getBuildManager()
 				.isEarlyExitFromBuildLoopAllowed();
-		assertFalse("early exit shouldn't be set", earlyExitAllowed);
+		assertFalse(earlyExitAllowed, "early exit shouldn't be set");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws CoreException {
 		IWorkspaceDescription description = getWorkspace().getDescription();
 		description.setMaxBuildIterations(maxBuildIterations);
@@ -77,7 +73,7 @@ public class RebuildTest {
 	@Test
 	public void testSingleProjectPropagationAndNoOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project = getWorkspace().getRoot().getProject(testName.getMethodName());
+		IProject project = getWorkspace().getRoot().getProject(testName);
 
 		// Create and open a project
 		project.create(createTestMonitor());
@@ -208,7 +204,7 @@ public class RebuildTest {
 	@Test
 	public void testSingleProjectPropagationAndOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project = getWorkspace().getRoot().getProject(testName.getMethodName());
+		IProject project = getWorkspace().getRoot().getProject(testName);
 
 		// Create and open a project
 		project.create(createTestMonitor());
@@ -330,7 +326,7 @@ public class RebuildTest {
 	@Test
 	public void testSingleProjectNoPropagationAndProcessOtherBuilder() throws Exception {
 		// Create some resource handles
-		IProject project = getWorkspace().getRoot().getProject(testName.getMethodName());
+		IProject project = getWorkspace().getRoot().getProject(testName);
 
 		// Create and open a project
 		project.create(createTestMonitor());
@@ -456,7 +452,7 @@ public class RebuildTest {
 	@Test
 	public void testSingleProjectNoPropagationNoOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project = getWorkspace().getRoot().getProject(testName.getMethodName());
+		IProject project = getWorkspace().getRoot().getProject(testName);
 
 		// Create and open a project
 		project.create(createTestMonitor());
@@ -589,8 +585,8 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsPropagationAndNoOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -724,8 +720,8 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsPropagationAndProcessOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -865,8 +861,8 @@ public class RebuildTest {
 		allowEarlyBuildLoopExit(true);
 
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -1021,8 +1017,8 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsNoPropagationNoOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -1178,8 +1174,8 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsNoPropagationAndOtherBuilders() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -1337,8 +1333,8 @@ public class RebuildTest {
 		allowEarlyBuildLoopExit(true);
 
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -1491,9 +1487,9 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsPropagationAndNoOtherBuildersExplicitRebuild() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
-		IProject project3 = getWorkspace().getRoot().getProject(testName.getMethodName() + 3);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
+		IProject project3 = getWorkspace().getRoot().getProject(testName + 3);
 
 		// Create and open a project
 		project1.create(createTestMonitor());
@@ -1694,9 +1690,9 @@ public class RebuildTest {
 	@Test
 	public void testMultipleProjectsPropagationAndProcessOtherBuildersExplicitRebuild() throws Exception {
 		// Create some resource handles
-		IProject project1 = getWorkspace().getRoot().getProject(testName.getMethodName() + 1);
-		IProject project2 = getWorkspace().getRoot().getProject(testName.getMethodName() + 2);
-		IProject project3 = getWorkspace().getRoot().getProject(testName.getMethodName() + 3);
+		IProject project1 = getWorkspace().getRoot().getProject(testName + 1);
+		IProject project2 = getWorkspace().getRoot().getProject(testName + 2);
+		IProject project3 = getWorkspace().getRoot().getProject(testName + 3);
 
 		// Create and open a project
 		project1.create(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TestBuilder.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/TestBuilder.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.builders;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +27,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
-import org.junit.Assert;
 
 /**
  * An abstract builder that is designed to be extended for testing purposes.
@@ -103,7 +104,7 @@ public abstract class TestBuilder extends IncrementalProjectBuilder {
 	 * expected and actual events in preparation for the next test.
 	 */
 	public void assertLifecycleEvents() {
-		Assert.assertEquals(expectedEvents, actualEvents);
+		assertEquals(expectedEvents, actualEvents);
 		reset();
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/WorkspaceResetExtension.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/WorkspaceResetExtension.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.tests.resources.FreezeMonitor;
+import org.eclipse.core.tests.resources.TestUtil;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Restores a clean workspace with a default description and an empty resource
+ * tree after test execution.
+ */
+public class WorkspaceResetExtension implements AfterEachCallback, BeforeEachCallback {
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		// Wait for any pending refresh operation, in particular from startup
+		waitForRefresh();
+		TestUtil.log(IStatus.INFO, context.getDisplayName(), "setUp");
+		assertNotNull("Workspace was not set up", getWorkspace());
+		FreezeMonitor.expectCompletionInAMinute();
+		waitForRefresh();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		TestUtil.log(IStatus.INFO, context.getDisplayName(), "tearDown");
+		try {
+			restoreCleanWorkspace();
+		} finally {
+			FreezeMonitor.done();
+			assertWorkspaceFolderEmpty();
+		}
+	}
+
+	private void restoreCleanWorkspace() {
+		List<CoreException> exceptions = new ArrayList<>();
+		try {
+			restoreWorkspaceDescription();
+		} catch (CoreException e) {
+			exceptions.add(e);
+		}
+		// Wait for any build job that may still be executed
+		waitForBuild();
+		try {
+			getWorkspace().run((IWorkspaceRunnable) monitor -> {
+				getWorkspace().getRoot().delete(true, true, createTestMonitor());
+			}, null);
+		} catch (CoreException e) {
+			exceptions.add(e);
+		}
+		try {
+			getWorkspace().save(true, null);
+		} catch (CoreException e) {
+			exceptions.add(e);
+		}
+		// don't leak builder jobs, since they may affect subsequent tests
+		waitForBuild();
+		if (!exceptions.isEmpty()) {
+			IllegalStateException composedException = new IllegalStateException("Failures when cleaning up workspace");
+			exceptions.forEach(exception -> composedException.addSuppressed(exception));
+			throw composedException;
+		}
+	}
+
+	private void restoreWorkspaceDescription() throws CoreException {
+		getWorkspace().setDescription(Workspace.defaultWorkspaceDescription());
+	}
+
+	private void assertWorkspaceFolderEmpty() {
+		final String metadataDirectoryName = ".metadata";
+		File workspaceLocation = getWorkspace().getRoot().getLocation().toFile();
+		File[] remainingFilesInWorkspace = workspaceLocation
+				.listFiles(file -> !file.getName().equals(metadataDirectoryName));
+		assertThat(remainingFilesInWorkspace).as("check workspace folder is empty").isEmpty();
+	}
+
+}


### PR DESCRIPTION
This change migrates the builder tests to JUnit 5. It replaces the JUnit 4 `WorkspaceTestRule` with the newly introduced JUnit 5 `WorkspaceResetExtension` and exchanges all JUnit 4 dependencies with JUnit 5 dependencies, including assertions.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903