### PR TITLE
Migrate org.eclipse.compare.tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.resources.refresh,
  org.eclipse.core.tests.resources.regression,
  org.eclipse.core.tests.resources.session,
- org.eclipse.core.tests.resources.usecase
+ org.eclipse.core.tests.resources.usecase,
+ org.eclipse.core.tests.resources.util
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.tests.harness,
  org.junit,

--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.tests;singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Require-Bundle: org.eclipse.compare,
  org.eclipse.jface.text,
  org.eclipse.jface,

--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -3,8 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.tests;singleton:=true
 Bundle-Version: 3.8.400.qualifier
-Require-Bundle: org.junit,
- org.eclipse.compare,
+Require-Bundle: org.eclipse.compare,
  org.eclipse.jface.text,
  org.eclipse.jface,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
@@ -18,6 +17,7 @@ Require-Bundle: org.junit,
 Import-Package: org.assertj.core.api,
  org.assertj.core.api.iterable,
  org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
  org.junit.platform.suite.api
 Bundle-Activator: org.eclipse.compare.tests.CompareTestPlugin
 Bundle-ActivationPolicy: lazy

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AllCompareTests.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AllCompareTests.java
@@ -13,17 +13,15 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test some non-UI areas of the compare plug-in.
  */
-
-@RunWith(Suite.class)
 @SuppressWarnings("deprecation")
-@SuiteClasses({
+@Suite
+@SelectClasses({
 	TextMergeViewerTest.class,
 	LineReaderTest.class,
 	StreamMergerTest.class,

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AsyncExecTests.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AsyncExecTests.java
@@ -14,9 +14,9 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AsyncExecTests {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareFileRevisionEditorInputTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareFileRevisionEditorInputTest.java
@@ -21,7 +21,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.team.internal.ui.history.CompareFileRevisionEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompareFileRevisionEditorInputTest {
 	@Test

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareUIPluginTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareUIPluginTest.java
@@ -26,7 +26,7 @@ import org.eclipse.compare.internal.ViewerDescriptor;
 import org.eclipse.compare.structuremergeviewer.DiffNode;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.graphics.Image;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompareUIPluginTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ContentMergeViewerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/ContentMergeViewerTest.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.contentmergeviewer.ContentMergeViewer;
 import org.eclipse.swt.widgets.Composite;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ContentMergeViewerTest  {
 	private MyContentMergeViewer myContentMergeViewer;
@@ -91,7 +91,7 @@ public class ContentMergeViewerTest  {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp()  {
 		result = new boolean[] { false, false };
 		myContentMergeViewer = new MyContentMergeViewer();

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
@@ -23,7 +23,7 @@ import org.eclipse.compare.rangedifferencer.RangeDifferencer;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DiffTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DocLineComparatorTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DocLineComparatorTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Optional;
@@ -27,7 +27,7 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DocLineComparatorTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
@@ -44,14 +44,12 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class FileDiffResultTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String PATCH_FILE = "patchfile";
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
@@ -16,7 +16,7 @@ package org.eclipse.compare.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.compare.internal.CompareResourceFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FilterTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/LineReaderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/LineReaderTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.eclipse.compare.internal.core.patch.LineReader;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LineReaderTest  {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchBuilderTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +34,7 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PatchBuilderTest {
 	@Test
@@ -273,7 +272,7 @@ public class PatchBuilderTest {
 	public void testReadNotValidPatch() throws CoreException, IOException {
 		IStorage patch = new StringStorage("not_a_patch.txt");
 		IFilePatch[] filePatches = ApplyPatchOperation.parsePatch(patch);
-		assertArrayEquals(new IFilePatch[0], filePatches);
+		assertThat(filePatches).isEmpty();
 	}
 
 	private void assertHunkEquals(Hunk h1, Hunk h2) {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchLinesTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchLinesTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -22,7 +22,7 @@ import java.lang.reflect.Field;
 import org.eclipse.compare.internal.core.patch.FilePatch2;
 import org.eclipse.compare.internal.patch.WorkspacePatcher;
 import org.eclipse.compare.patch.IHunk;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PatchLinesTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchTest.java
@@ -14,11 +14,11 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -57,15 +57,9 @@ import org.eclipse.compare.tests.PatchUtils.StringStorage;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
-import org.junit.Test;
-
-import junit.framework.AssertionFailedError;
+import org.junit.jupiter.api.Test;
 
 public class PatchTest {
 
@@ -297,27 +291,13 @@ public class PatchTest {
 			}
 		}
 
-		if (failures.isEmpty())
-			return;
-
-		if (failures.size() == 1)
+		if (failures.size() == 1) {
 			throw failures.get(0);
-
-		StringBuilder sb = new StringBuilder(
-				"Failures occured while testing data from patchdata subfolder (Please check log for further details):");
-		for (AssertionError error : failures) {
-			log("org.eclipse.compare.tests", error);
-			sb.append("\n" + error.getMessage());
+		} else if (failures.size() > 1) {
+			AssertionError aggregatedFailure = new AssertionError("Failures occured while testing data from patchdata subfolder");
+			failures.forEach(failure -> aggregatedFailure.addSuppressed(failure));
+			throw aggregatedFailure;
 		}
-		throw new AssertionFailedError(sb.toString());
-	}
-
-	private void log(String pluginID, IStatus status) {
-		ILog.of(Platform.getBundle(pluginID)).log(status);
-	}
-
-	private void log(String pluginID, Throwable e) {
-		log(pluginID, new Status(IStatus.ERROR, pluginID, IStatus.ERROR, "Error", e)); //$NON-NLS-1$
 	}
 
 	/**

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUITest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUITest.java
@@ -14,7 +14,7 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,9 +46,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
@@ -62,7 +62,7 @@ public class PatchUITest {
 	private PatchWizardDialog wizardDialog = null;
 	private PatchWizard wizard = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 		testProject = workspaceRoot.getProject(TEST_PROJECT);
@@ -70,7 +70,7 @@ public class PatchUITest {
 		testProject.open(null);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testProject.delete(true, null);
 	}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerThreeWayDiffTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerThreeWayDiffTest.java
@@ -21,7 +21,7 @@ import org.eclipse.compare.rangedifferencer.RangeDifference;
 import org.eclipse.compare.rangedifferencer.RangeDifferencer;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RangeDifferencerThreeWayDiffTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StreamMergerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StreamMergerTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ import org.eclipse.compare.IStreamMerger;
 import org.eclipse.compare.internal.merge.TextStreamMerger;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // Tested class is deprecated
 @Deprecated

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StructureCreatorTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/StructureCreatorTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.compare.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.regex.Matcher;
@@ -33,7 +33,7 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StructureCreatorTest {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.compare.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -71,7 +71,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TextMergeViewerTest  {
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/PerformanceTestSuite.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/performance/PerformanceTestSuite.java
@@ -16,13 +16,11 @@ package org.eclipse.compare.tests.performance;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
-import junit.framework.TestSuite;
-
 /**
  * @since 3.1
  */
 @Suite
 @SelectClasses({RangeDifferencerTest.class})
-public class PerformanceTestSuite extends TestSuite {
+public class PerformanceTestSuite {
 	//
 }


### PR DESCRIPTION
Migrates the tests in org.eclipse.compare.tests to JUnit 5. This consists of a replacement of the according annotations, migration of assertions, and the replacement of the JUnit 4 WorkspaceTestRule with the JUnit 5 WorkspaceResetExtension. The org.junit dependency is removed from the test bundle.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903