### PR TITLE
Various minor code clean-ups and modernizations in Resources plugin

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/CopyVisitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/CopyVisitor.java
@@ -18,10 +18,25 @@ import java.net.URI;
 import java.util.LinkedList;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.internal.resources.*;
+import org.eclipse.core.internal.resources.Container;
+import org.eclipse.core.internal.resources.File;
+import org.eclipse.core.internal.resources.FilterDescription;
+import org.eclipse.core.internal.resources.Folder;
+import org.eclipse.core.internal.resources.Project;
+import org.eclipse.core.internal.resources.Resource;
+import org.eclipse.core.internal.resources.ResourceInfo;
+import org.eclipse.core.internal.resources.ResourceStatus;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceStatus;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.osgi.util.NLS;
 
 //
@@ -135,7 +150,7 @@ public class CopyVisitor implements IUnifiedTreeVisitor {
 	 */
 	protected RefreshLocalVisitor getRefreshLocalVisitor() {
 		if (refreshLocalVisitor == null)
-			refreshLocalVisitor = new RefreshLocalVisitor(SubMonitor.convert(null));
+			refreshLocalVisitor = new RefreshLocalVisitor(null);
 		return refreshLocalVisitor;
 	}
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -722,8 +722,8 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 		}
 
 		//write the project description file (don't use API because scheduling rule might not match)
-		write(descriptionFile, newContents, fileInfo, IResource.FORCE, false, SubMonitor.convert(null));
-		workspace.getAliasManager().updateAliases(descriptionFile, getStore(descriptionFile), IResource.DEPTH_ZERO, SubMonitor.convert(null));
+		write(descriptionFile, newContents, fileInfo, IResource.FORCE, false, null);
+		workspace.getAliasManager().updateAliases(descriptionFile, getStore(descriptionFile), IResource.DEPTH_ZERO, null);
 
 		//update the timestamp on the project as well so we know when it has
 		//been changed from the outside
@@ -788,7 +788,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 					return true;
 				break;
 		}
-		IsSynchronizedVisitor visitor = new IsSynchronizedVisitor(SubMonitor.convert(null));
+		IsSynchronizedVisitor visitor = new IsSynchronizedVisitor(null);
 		UnifiedTree tree = new UnifiedTree(target);
 		try {
 			tree.accept(visitor, depth);
@@ -954,9 +954,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 		ProjectDescription description = null;
 		//hold onto any exceptions until after sync info is updated, then throw it
 		ResourceException error = null;
-		try (
-			InputStream in = new BufferedInputStream(descriptionStore.openInputStream(EFS.NONE, SubMonitor.convert(null)));
-		) {
+		try (InputStream in = new BufferedInputStream(descriptionStore.openInputStream(EFS.NONE, null));) {
 			// IFileStore#openInputStream may cancel the monitor, thus the monitor state is checked
 			description = new ProjectDescriptionReader(target).read(new InputSource(in));
 		} catch (OperationCanceledException e) {

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/AliasManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/AliasManager.java
@@ -608,8 +608,8 @@ public class AliasManager implements IManager, ILifecycleListener, IResourceChan
 	 * @param depth whether to search for aliases on all children of the given
 	 * resource.  Only depth ZERO and INFINITE are used.
 	 */
-	@SuppressWarnings({"unchecked"})
 	public void updateAliases(IResource resource, IFileStore location, int depth, IProgressMonitor monitor) throws CoreException {
+		monitor = IProgressMonitor.nullSafe(monitor);
 		if (hasNoAliases(resource))
 			return;
 		aliases.clear();
@@ -620,8 +620,7 @@ public class AliasManager implements IManager, ILifecycleListener, IResourceChan
 		if (aliases.isEmpty())
 			return;
 		FileSystemResourceManager localManager = workspace.getFileSystemManager();
-		HashSet<IResource> aliasesCopy = (HashSet<IResource>) aliases.clone();
-		for (IResource alias : aliasesCopy) {
+		for (IResource alias : new ArrayList<>(aliases)) {
 			monitor.subTask(NLS.bind(Messages.links_updatingDuplicate, alias.getFullPath()));
 			if (alias.getType() == IResource.PROJECT) {
 				if (checkDeletion((Project) alias, location))

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -2316,8 +2316,7 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 		// create root location
 		localMetaArea.locationFor(getRoot()).toFile().mkdirs();
 
-		SubMonitor subMonitor = SubMonitor.convert(null);
-		startup(subMonitor);
+		startup(new NullProgressMonitor());
 		// restart the notification manager so it is initialized with the right tree
 		notificationManager.startup(null);
 		openFlag = true;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/FileUtil.java
@@ -39,16 +39,16 @@ import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.content.IContentDescription;
-import org.eclipse.osgi.service.environment.Constants;
 import org.eclipse.osgi.util.NLS;
 
 /**
  * Static utility methods for manipulating Files and URIs.
  */
 public class FileUtil {
-	static final boolean MACOSX = Constants.OS_MACOSX.equals(getOS());
+	static final boolean MACOSX = Platform.OS.isMac();
 
 	/**
 	 * Converts a ResourceAttributes object into an IFileInfo object.
@@ -155,14 +155,6 @@ public class FileUtil {
 		}
 		// Return the original path if it's the same as the real one.
 		return realPath.equals(path) ? path : realPath;
-	}
-
-	/**
-	 * Returns the current OS.  Equivalent to Platform.getOS(), but tolerant of the platform runtime
-	 * not being present.
-	 */
-	private static String getOS() {
-		return System.getProperty("osgi.os", ""); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -67,7 +67,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.eclipse.osgi.service.environment.Constants;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -249,8 +248,8 @@ public class IFileTest {
 			if (file.getProject().exists()) {
 				file.getRawLocation().toFile().delete();
 				createInFileSystem(file);
-				if (Constants.OS_WIN32.equals(Platform.getOS())) {
-					Files.setAttribute(file.getRawLocation().toFile().toPath(), "dos:hidden", Boolean.TRUE);
+				if (Platform.OS.isWindows()) {
+					Files.setAttribute(file.getRawLocation().toPath(), "dos:hidden", Boolean.TRUE);
 				}
 			}
 			return;
@@ -263,8 +262,8 @@ public class IFileTest {
 		if (file.getName().equals(WORKSPACE_ONLY_HIDDEN)) {
 			file.getRawLocation().toFile().delete();
 			createInFileSystem(file);
-			if (Constants.OS_WIN32.equals(Platform.getOS())) {
-				Files.setAttribute(file.getRawLocation().toFile().toPath(), "dos:hidden", Boolean.TRUE);
+			if (Platform.OS.isWindows()) {
+				Files.setAttribute(file.getRawLocation().toPath(), "dos:hidden", Boolean.TRUE);
 			}
 			file.refreshLocal(1, null);
 			file.getRawLocation().toFile().delete();
@@ -284,8 +283,8 @@ public class IFileTest {
 		}
 		if (file.getName().equals(EXISTING_HIDDEN)) {
 			createInWorkspace(file);
-			if (Constants.OS_WIN32.equals(Platform.getOS())) {
-				Files.setAttribute(file.getRawLocation().toFile().toPath(), "dos:hidden", Boolean.TRUE);
+			if (Platform.OS.isWindows()) {
+				Files.setAttribute(file.getRawLocation().toPath(), "dos:hidden", Boolean.TRUE);
 			}
 			file.refreshLocal(1, null);
 			return;


### PR DESCRIPTION
- Use `Arrays.sort()` instead of custom quick-sort implementation
- Rely on monitor accepting methods that a null-monitor can be handled
- `Platform.getOS()` can now be used in non-OSGi environments