### PR TITLE
Shorten long working directories of launched processes on Windows

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Export-Package: org.eclipse.debug.core,
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
+ org.eclipse.core.filesystem;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Win32Handler.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Win32Handler.java
@@ -111,6 +111,18 @@ public class Win32Handler extends NativeHandler {
 		return FileAPIh.SetFileAttributesW(lpFileName, fileAttributes);
 	}
 
+	public static String getShortPathName(String longPath) {
+		longPath = toLongWindowsPath(longPath);
+		char[] buffer = new char[longPath.length()];
+		// https://learn.microsoft.com/de-de/windows/win32/api/fileapi/nf-fileapi-getshortpathnamew
+		int newLength = com.sun.jna.platform.win32.Kernel32.INSTANCE.GetShortPathName(longPath, buffer, buffer.length);
+		if (0 < newLength && newLength < buffer.length) { // zero means error
+			int offset = longPath.startsWith(WIN32_UNC_RAW_PATH_PREFIX) ? WIN32_UNC_RAW_PATH_PREFIX.length() : WIN32_RAW_PATH_PREFIX.length();
+			return new String(buffer, offset, newLength);
+		}
+		return null;
+	}
+
 	private static String toLongWindowsPath(String fileName) {
 		// See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 		if (fileName.startsWith("\\\\") && !fileName.startsWith(WIN32_UNC_RAW_PATH_PREFIX)) { //$NON-NLS-1$


### PR DESCRIPTION
[JDK Bug 8315405](https://bugs.openjdk.org/browse/JDK-8315405) states that there is no perfect way to circumvent the `MAX_PATH` length limit for the working directory of launched processes on Windows.

This is a work-around based on shortened MS-DOS naming convention that at least permits longer paths than currently possible. It is most effective if a path consists of only few long segments.

Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1333
