### PR TITLE
Latest jarsign service produces CODESIGN.SF/RSA not ECLIPSE_.SF/RSA

### DIFF
--- a/ua/org.eclipse.help.webapp/pom.xml
+++ b/ua/org.eclipse.help.webapp/pom.xml
@@ -53,6 +53,8 @@
           <ignoredPatterns>
             <pattern>META-INF/ECLIPSE_.RSA</pattern>
             <pattern>META-INF/ECLIPSE_.SF</pattern>
+            <pattern>META-INF/CODESIGN.RSA</pattern>
+            <pattern>META-INF/CODESIGN.SF</pattern>
           </ignoredPatterns>
         </configuration>
       </plugin>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2193