### PR TITLE
[FS] Treat ERROR_PATH_NOT_FOUND in Win32Handler as file does not exist

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Win32Handler.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/Win32Handler.java
@@ -68,7 +68,8 @@ public class Win32Handler extends NativeHandler {
 			long handle = FileAPIh.FindFirstFileW(new WString(target), mem);
 			if (handle == FileAPIh.INVALID_HANDLE_VALUE) {
 				int error = Native.getLastError();
-				if (error != WinError.ERROR_FILE_NOT_FOUND) {
+				if (!(error == WinError.ERROR_FILE_NOT_FOUND // file not found in existing parent directory
+						|| error == WinError.ERROR_PATH_NOT_FOUND)) { // Not even the parent directory exists
 					fileInfo.setError(IFileInfo.IO_ERROR);
 				}
 				return fileInfo;


### PR DESCRIPTION
If it is attempted to fetch the file-info of a file, whose parent directory does not exist the error code is `ERROR_PATH_NOT_FOUND` instead of `ERROR_FILE_NOT_FOUND`. The latter is only returned if a file does not exist in an existing parent directory.

Therefore in case of `ERROR_FILE_NOT_FOUND` the file should just be treated as not existing without setting an IO_ERROR.

The JDK's java.nio file-system implementation for Windows also considers a file as absent (i.e. throws a `NoSuchFileException`) for both error codes `ERROR_FILE_NOT_FOUND` and `ERROR_PATH_NOT_FOUND`:
https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/src/java.base/windows/classes/sun/nio/fs/WindowsException.java#L84-L85

In the JNI based native `LocalFileHandler` on the other hand only `ERROR_FILE_NOT_FOUND` is considered:
https://github.com/eclipse-platform/eclipse.platform/blob/cbfee1844b9a9df60424b56c5074378f869fbdfd/resources/bundles/org.eclipse.core.filesystem/natives/win32/localfile.c#L303-L303

This issue was revealed by https://github.com/eclipse-platform/eclipse.platform/pull/1476, but I'm currently investigating why the `LocalFileHandler` works despite this difference.

This is a follow-up on https://github.com/eclipse-platform/eclipse.platform/pull/1422.