### PR TITLE
Use Win32Handler native file-system handler by default on Windows

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileNativesManager.java
@@ -28,16 +28,16 @@ import org.eclipse.core.runtime.Platform;
  * <p>Dispatches methods backed by native code to the appropriate platform specific
  * implementation depending on a library provided by a fragment. Failing this it tries
  * to use Java 7 NIO/2 API's.</p>
- * 
- * <p>Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false 
+ *
+ * <p>Use of native libraries can be disabled by adding -Declipse.filesystem.useNatives=false
  * to VM arguments.</p>
- * 
+ *
  * <p>Please notice that the native implementation is significantly faster than the non-native
- * one. The BenchFileStore test runs 3.1 times faster on Linux with the native code than 
+ * one. The BenchFileStore test runs 3.1 times faster on Linux with the native code than
  * without it.</p>
  */
 public class LocalFileNativesManager {
-	public static final boolean PROPERTY_USE_NATIVE_DEFAULT = true;
+	public static final boolean PROPERTY_USE_NATIVE_DEFAULT = Platform.OS.isWindows() ? false : true;
 	public static final String PROPERTY_USE_NATIVES = "eclipse.filesystem.useNatives"; //$NON-NLS-1$
 	private static NativeHandler HANDLER;
 
@@ -54,7 +54,7 @@ public class LocalFileNativesManager {
 
 	/**
 	 * Try to set the usage of natives to the provided value
-	 * @return <code>true</code> if natives are used as result of this call <code>false</code> otherwhise
+	 * @return <code>true</code> if natives are used as result of this call <code>false</code> otherwise
 	 */
 	public static boolean setUsingNative(boolean useNatives) {
 		boolean nativesAreUsed;

--- a/resources/tests/org.eclipse.core.tests.filesystem.feature/feature.xml
+++ b/resources/tests/org.eclipse.core.tests.filesystem.feature/feature.xml
@@ -26,12 +26,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.filesystem.win32.x86_64"
-         os="win32"
-         arch="x86_64"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.filesystem.macosx"
          os="macosx"
          version="0.0.0"/>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_530868.java
@@ -16,7 +16,6 @@ package org.eclipse.core.tests.resources.regression;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 import java.io.ByteArrayInputStream;
@@ -64,8 +63,6 @@ public class Bug_530868 {
 	public void testMillisecondResolution() throws Exception {
 		assumeFalse("not relevant on Mac, as it does not have milliseconds resolution", OS.isMac());
 		try {
-			assertTrue("can only run if native provider can be enabled", LocalFileNativesManager.setUsingNative(true));
-
 			/*
 			 * Run 3 times in case we have seconds resolution due to a bug, but by chance we
 			 * happened to modify the file in-between two seconds.


### PR DESCRIPTION
This is done in preparation for the removal of the JNI based native `LocalFileHandler` for Windows. This increases the number of users (and therefore testers) but still makes it easily possible to revert to the old implementation if regressions are found.

With https://github.com/eclipse-platform/eclipse.platform/pull/1476 I proposed to remove the JNI based `LocalFileHandler` and the associated fragment for Windows that carries the compiled native library.
But while I would like to have the Win32Handler in use for M2 to have more testers, I'm not 100% confident it can handle all corner cases well. And because M2 is soon (on Friday) and I don't want to break that mile-stone, having the old implementation still around but disabled by default seems to be a good compromise for now.

If desired, one can revert this change by specifying the VM argument `-Declipse.filesystem.useNatives=true`.

