### PR TITLE
Add ResourcesPlugin.FAMILY_SNAPSHOT API for DelayedSnapshotJob

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/DelayedSnapshotJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/DelayedSnapshotJob.java
@@ -17,11 +17,15 @@ package org.eclipse.core.internal.resources;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.resources.ISaveContext;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 
 /**
- * Performs periodic saving (snapshot) of the workspace.
+ * Performs on demand or periodic saving (snapshot) of the workspace.
  */
 public class DelayedSnapshotJob extends Job {
 
@@ -37,9 +41,6 @@ public class DelayedSnapshotJob extends Job {
 		setSystem(true);
 	}
 
-	/*
-	 * @see Job#run()
-	 */
 	@Override
 	public IStatus run(IProgressMonitor monitor) {
 		if (monitor.isCanceled())
@@ -55,5 +56,10 @@ public class DelayedSnapshotJob extends Job {
 			saveManager.operationCount = 0;
 			saveManager.snapshotRequested = false;
 		}
+	}
+
+	@Override
+	public boolean belongsTo(Object family) {
+		return DelayedSnapshotJob.class == family || ResourcesPlugin.FAMILY_SNAPSHOT == family;
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ResourcesPlugin.java
@@ -27,13 +27,21 @@ import java.util.List;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
-import org.osgi.framework.*;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
@@ -168,6 +176,18 @@ public final class ResourcesPlugin extends Plugin {
 	 * @since 3.4
 	 */
 	public static final Object FAMILY_MANUAL_REFRESH = new Object();
+
+	/**
+	 * Constant identifying the job family identifier for a background workspace
+	 * snapshot job. All clients that schedule background jobs for performing
+	 * background workspace snapshots should include this job family in their
+	 * implementation of <code>belongsTo</code>.
+	 *
+	 * @see IJobManager#join(Object, IProgressMonitor)
+	 * @see Job#belongsTo(Object)
+	 * @since 3.21
+	 */
+	public static final Object FAMILY_SNAPSHOT = new Object();
 
 	/**
 	 * Name of a preference indicating the encoding to use when reading text files


### PR DESCRIPTION
DelayedSnapshotJob may in parallel to any other workspace job and triggers resource changes. Clients that rely on resource change events (like JDT core) should have a chance to wait for possible pending resource changes coming from this job.

Added a family to the job & a constant in the ResourcesPlugin.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2716#issuecomment-2268875660