### PR TITLE
Build jsps to Java 17 bytecode

### DIFF
--- a/ua/org.eclipse.help.webapp/pom.xml
+++ b/ua/org.eclipse.help.webapp/pom.xml
@@ -38,8 +38,8 @@
               </jspc>
               <webAppSourceDirectory>${basedir}</webAppSourceDirectory>
               <useProvidedScope>true</useProvidedScope>
-              <sourceVersion>11</sourceVersion>
-              <targetVersion>11</targetVersion>
+              <sourceVersion>17</sourceVersion>
+              <targetVersion>17</targetVersion>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
As the webapp is already at Java 17 there is no point in targetting older bytecode for jsps.