### PR TITLE
Switch to Temurin JVM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'openjdk-jdk17-latest'
+		jdk 'temurin-jdk17-latest'
 	}
 	stages {
 		stage('Build') {


### PR DESCRIPTION
Openjdk 17 is stuck to 17.0.2 in EF infra while Temurin one is updated.