### PR TITLE
[FS] Use default local again when comparing filenames case-insensitive

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Locale;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
@@ -248,7 +247,7 @@ public class LocalFile extends FileStore {
 	@Override
 	public int hashCode() {
 		if (LocalFileSystem.MACOSX)
-			return filePath.toLowerCase(Locale.ENGLISH).hashCode();
+			return filePath.toLowerCase().hashCode();
 		return file.hashCode();
 	}
 
@@ -339,7 +338,7 @@ public class LocalFile extends FileStore {
 				return false;
 			}
 		} else {
-			if (!thatPath.toLowerCase(Locale.ENGLISH).startsWith(thisPath.toLowerCase(Locale.ENGLISH))) {
+			if (!thatPath.toLowerCase().startsWith(thisPath.toLowerCase())) {
 				return false;
 			}
 		}


### PR DESCRIPTION
The comparison of file-names in case-insensitive file-systems is non-trivial. This reverts the local to the previous state to use the default local until there is better understanding how the case-insensitive file-systems work for difficult locals a better solution can be applied.
See https://github.com/eclipse-platform/eclipse.platform/pull/1485#discussion_r1713973832.