### PR TITLE
[FS] Copy small files using InputStream.transferTo()

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
@@ -150,10 +150,11 @@ public class LocalFile extends FileStore {
 
 	private static final CopyOption[] NO_OVERWRITE = {StandardCopyOption.COPY_ATTRIBUTES};
 	private static final CopyOption[] OVERWRITE_EXISTING = {StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING};
+	private static final int LARGE_FILE_SIZE_THRESHOLD = 1024 * 1024; // 1 MiB experimentally determined
 
 	@Override
 	protected void copyFile(IFileInfo sourceInfo, IFileStore destination, int options, IProgressMonitor monitor) throws CoreException {
-		if (destination instanceof LocalFile target) {
+		if (sourceInfo.getLength() > LARGE_FILE_SIZE_THRESHOLD && destination instanceof LocalFile target) {
 			try {
 				boolean overwrite = (options & EFS.OVERWRITE) != 0;
 				Files.copy(this.file.toPath(), target.file.toPath(), overwrite ? OVERWRITE_EXISTING : NO_OVERWRITE);


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-platform/eclipse.platform/pull/1471 to not use `java.nio.file.Files.copy()` for small files because it's slower in that case.

With https://github.com/eclipse-platform/eclipse.platform/pull/1475 `InputStream.transferTo()` is used, which is optimized from Java-17 to 21 in case a `FileInputStream` is transferred to a `FileOutputStream` to perform the copy using `FileChannel`s.
In my experiments the latter method and `Files.copy()` had approximately similar performance in the area of 1MiB large files, while `Files.copy()` became faster with further growing file-size and was significantly faster for 1GiB files.
Since Eclipse-Platform probably requires Java-21 soonish, using 1MiB as threshold seemed to be a good compromise for me.