### PR TITLE
Fix logged NPE in ViewerUpdateMonitor constructor #1500

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelContentProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelContentProvider.java
@@ -1185,9 +1185,10 @@ public class TreeModelContentProvider implements ITreeModelContentProvider, ICon
 		Assert.isTrue( getViewer().getDisplay().getThread() == Thread.currentThread() );
 
 		Object parent = getElement(parentPath);
+		Object viewerInput = getViewer().getInput();
 		IElementContentProvider contentAdapter = ViewerAdapterService.getContentProvider(parent);
-		if (contentAdapter != null) {
-			ChildrenUpdate request = new ChildrenUpdate(this, getViewer().getInput(), parentPath, parent, modelIndex, contentAdapter);
+		if (viewerInput != null && contentAdapter != null) {
+			ChildrenUpdate request = new ChildrenUpdate(this, viewerInput, parentPath, parent, modelIndex, contentAdapter);
 			schedule(request);
 		}
 	}


### PR DESCRIPTION
There is a logged NPE in the constructor of `ViewerUpdateMonitor` when `viewerInput` is `null`. This can happen sporadically when updating tree elements during `Viewer.setInput(null)`.

This PR adds a check to avoid creating children updates when the viewer input is `null`.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1500