### PR TITLE
Improve assertions in resource regression tests #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_006708.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_006708.java
@@ -13,11 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import static org.junit.Assert.assertFalse;
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -34,14 +36,14 @@ public class Bug_006708 {
 	public void testBug() throws CoreException {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject sourceProj = root.getProject("bug_6708");
-		assertFalse("Project bug_6708 exists already", sourceProj.exists());
+		assertThat(sourceProj).matches(not(IResource::exists), "does not exists already");
 		sourceProj.create(null);
 		sourceProj.open(null);
 		IFile source = sourceProj.getFile("Source.txt");
 		source.create(new ByteArrayInputStream("abcdef".getBytes()), false, null);
 
 		IProject destProj = root.getProject("bug_6708_2");
-		assertFalse("Project bug_6708_2 exists already", destProj.exists());
+		assertThat(destProj).matches(not(IResource::exists), "does not exists already");
 		destProj.create(null);
 		destProj.open(null);
 		IFile dest = destProj.getFile("Dest.txt");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -66,11 +67,11 @@ public class Bug_025457 {
 					() -> sourceFile.move(destFile.getFullPath(), IResource.NONE, createTestMonitor()));
 		}
 		//ensure source still exists and has same content
-		assertTrue("2.0", source.exists());
-		assertTrue("2.1", sourceFile.exists());
+		assertThat(source).matches(IResource::exists, "exists");
+		assertThat(sourceFile).matches(IResource::exists, "exists");
 		assertEquals(content, sourceFile.readString());
 		//ensure destination file does not exist
-		assertTrue("2.3", !destFile.exists());
+		assertThat(destFile).matches(not(IResource::exists), "not exists");
 	}
 
 	@Test
@@ -93,13 +94,13 @@ public class Bug_025457 {
 			assertThrows(CoreException.class,
 					() -> sourceFolder.move(destFolder.getFullPath(), IResource.NONE, createTestMonitor()));
 			//ensure source still exists
-			assertTrue("2.0", source.exists());
-			assertTrue("2.1", sourceFolder.exists());
-			assertTrue("2.2", sourceFile.exists());
+			assertThat(source).matches(IResource::exists, "exists");
+			assertThat(sourceFolder).matches(IResource::exists, "exists");
+			assertThat(sourceFile).matches(IResource::exists, "exists");
 
 			//ensure destination does not exist
-			assertTrue("2.3", !destFolder.exists());
-			assertTrue("2.4", !destFile.exists());
+			assertThat(destFolder).matches(not(IResource::exists), "not exists");
+			assertThat(destFile).matches(not(IResource::exists), "not exists");
 		}
 	}
 
@@ -121,12 +122,12 @@ public class Bug_025457 {
 					() -> source.move(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 
 			//ensure source does not exist
-			assertTrue("2.0", !source.exists());
-			assertTrue("2.1", !sourceFile.exists());
+			assertThat(source).matches(not(IResource::exists), "not exists");
+			assertThat(sourceFile).matches(not(IResource::exists), "not exists");
 
 			//ensure destination does not exist
-			assertTrue("2.2", destination.exists());
-			assertTrue("2.3", destFile.exists());
+			assertThat(destination).matches(IResource::exists, "exists");
+			assertThat(destFile).matches(IResource::exists, "exists");
 		}
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.resources.IPathVariableManager;
@@ -81,7 +81,7 @@ public class Bug_027271 {
 		//sets invalid value (invalid path)
 		IPath invalidPath = IPath.fromOSString("c:\\a\\:\\b");
 		prefs.setValue(VARIABLE_PREFIX + "ANOTHER_INVALID_VAR", invalidPath.toPortableString());
-		assertTrue("3.0", !IPath.EMPTY.isValidPath(invalidPath.toPortableString()));
+		assertFalse(IPath.EMPTY.isValidPath(invalidPath.toPortableString()));
 		assertThat(pvm.getPathVariableNames()).containsExactly("VALID_VAR");
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_029671.java
@@ -13,16 +13,18 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ISynchronizer;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
@@ -61,14 +63,14 @@ public class Bug_029671 {
 			IFile targetFile = targetFolder.getFile(file.getName());
 
 			folder.move(targetFolder.getFullPath(), false, false, createTestMonitor());
-			assertTrue("3.0", folder.isPhantom());
-			assertTrue("4.0", file.isPhantom());
+			assertThat(folder).matches(IResource::isPhantom, "is phantom");
+			assertThat(file).matches(IResource::isPhantom, "is phantom");
 
 			assertExistsInWorkspace(targetFolder);
-			assertTrue("5.1", !targetFolder.isPhantom());
+			assertThat(targetFolder).matches(not(IResource::isPhantom), "is not phantom");
 
 			assertExistsInWorkspace(targetFile);
-			assertTrue("6.1", !targetFile.isPhantom());
+			assertThat(targetFile).matches(not(IResource::isPhantom), "is not phantom");
 		} finally {
 			synchronizer.remove(partner);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_044106.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
@@ -21,10 +22,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -45,6 +46,8 @@ import org.junit.Test;
  */
 public class Bug_044106 {
 
+	private static final Predicate<IFileStore> exists = store -> store.fetchInfo().exists();
+
 	@Rule
 	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
@@ -61,7 +64,7 @@ public class Bug_044106 {
 		// create the file/folder that we are going to link to
 		IFileStore linkDestFile = workspaceRule.getTempStore();
 		createInFileSystem(linkDestFile);
-		assertTrue("0.1", linkDestFile.fetchInfo().exists());
+		assertThat(linkDestFile).matches(exists, "exists");
 
 		// create some resources in the workspace
 		IProject project = getWorkspace().getRoot().getProject(createUniqueString());
@@ -83,7 +86,7 @@ public class Bug_044106 {
 
 		// ensure that the folder and file weren't deleted in the filesystem
 		assertDoesNotExistInWorkspace(linkedFile);
-		assertTrue("4.1", linkDestFile.fetchInfo().exists());
+		assertThat(linkDestFile).matches(exists, "exists");
 	}
 
 	/**
@@ -99,8 +102,8 @@ public class Bug_044106 {
 		IFileStore linkDestLocation = workspaceRule.getTempStore();
 		IFileStore linkDestFile = linkDestLocation.getChild(createUniqueString());
 		createInFileSystem(linkDestFile);
-		assertTrue("0.1", linkDestLocation.fetchInfo().exists());
-		assertTrue("0.2", linkDestFile.fetchInfo().exists());
+		assertThat(linkDestLocation).matches(exists, "exists");
+		assertThat(linkDestFile).matches(exists, "exists");
 
 		// create some resources in the workspace
 		createInWorkspace(linkedFolder.getParent());
@@ -128,8 +131,8 @@ public class Bug_044106 {
 		// ensure that the folder and file weren't deleted in the filesystem
 		assertDoesNotExistInWorkspace(linkedFolder);
 		assertDoesNotExistInWorkspace(linkedFile);
-		assertTrue("4.2", linkDestLocation.fetchInfo().exists());
-		assertTrue("4.3", linkDestFile.fetchInfo().exists());
+		assertThat(linkDestLocation).matches(exists, "exists");
+		assertThat(linkDestFile).matches(exists, "exists");
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.filesystem.EFS;
@@ -39,8 +39,8 @@ public class Bug_092108 {
 
 		IFileStore root = EFS.getStore(new java.io.File("c:\\").toURI());
 		IFileInfo info = root.fetchInfo();
-		assertTrue("1.0", info.exists());
-		assertTrue("1.1", info.isDirectory());
+		assertThat(info).matches(IFileInfo::exists, "exists");
+		assertThat(info).matches(IFileInfo::isDirectory, "is directory");
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_126104.java
@@ -13,11 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -48,14 +49,14 @@ public class Bug_126104 {
 		link.createLink(location.toURI(), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 		IFile destination = link.getFile(source.getName());
 		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
-		assertTrue("1.0", destination.exists());
+		assertThat(destination).matches(IResource::exists, "exists");
 
 		//try the same thing with move
 		removeFromWorkspace(destination);
 		location.delete(EFS.NONE, createTestMonitor());
 		source.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
-		assertTrue("3.0", !source.exists());
-		assertTrue("3.1", destination.exists());
+		assertThat(source).matches(not(IResource::exists), "not exists");
+		assertThat(destination).matches(IResource::exists, "exists");
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_147232.java
@@ -90,7 +90,7 @@ public class Bug_147232 implements IResourceChangeListener {
 		//create a file in the project to trigger a build
 		createInWorkspace(file);
 		waitForBuild();
-		assertEquals("2.0", 1, deltaSeenCount);
+		assertEquals(1, deltaSeenCount);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_160251.java
@@ -13,13 +13,16 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.util.function.Predicate;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.URIUtil;
@@ -38,6 +41,9 @@ import org.junit.Test;
  * the destination directory is empty.
  */
 public class Bug_160251 {
+
+	private static final Predicate<IResource> isSynchronizedDepthInfinite = resource -> resource
+			.isSynchronized(IResource.DEPTH_INFINITE);
 
 	@Rule
 	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
@@ -60,11 +66,11 @@ public class Bug_160251 {
 		source.move(description, IResource.NONE, createTestMonitor());
 
 		//ensure project still exists
-		assertTrue("2.0", source.exists());
-		assertTrue("2.1", sourceFile.exists());
-		assertTrue("2.2", source.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("2.3", URIUtil.equals(source.getLocationURI(), destination.toURI()));
-		assertTrue("2.4", URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
+		assertThat(source).matches(IResource::exists, "exists");
+		assertThat(sourceFile).matches(IResource::exists, "exists");
+		assertThat(source).matches(isSynchronizedDepthInfinite, "is synchronized");
+		assertTrue(URIUtil.equals(source.getLocationURI(), destination.toURI()));
+		assertTrue(URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
 	}
 
 	/**
@@ -86,11 +92,11 @@ public class Bug_160251 {
 		source.move(description, IResource.NONE, createTestMonitor());
 
 		//ensure project still exists
-		assertTrue("2.0", source.exists());
-		assertTrue("2.1", sourceFile.exists());
-		assertTrue("2.2", source.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("2.3", URIUtil.equals(source.getLocationURI(), destination.toURI()));
-		assertTrue("2.4", URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
+		assertThat(source).matches(IResource::exists, "exists");
+		assertThat(sourceFile).matches(IResource::exists, "exists");
+		assertThat(source).matches(isSynchronizedDepthInfinite, "is synchronized");
+		assertTrue(URIUtil.equals(source.getLocationURI(), destination.toURI()));
+		assertTrue(URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
 	}
 
 	/**
@@ -113,11 +119,11 @@ public class Bug_160251 {
 		assertThrows(CoreException.class, () -> source.move(description, IResource.NONE, createTestMonitor()));
 
 		//ensure project still exists in old location
-		assertTrue("2.0", source.exists());
-		assertTrue("2.1", sourceFile.exists());
-		assertTrue("2.2", source.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("2.3", !URIUtil.equals(source.getLocationURI(), destination.toURI()));
-		assertTrue("2.4", !URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
+		assertThat(source).matches(IResource::exists, "exists");
+		assertThat(sourceFile).matches(IResource::exists, "exists");
+		assertThat(source).matches(isSynchronizedDepthInfinite, "is synchronized");
+		assertFalse(URIUtil.equals(source.getLocationURI(), destination.toURI()));
+		assertFalse(URIUtil.equals(sourceFile.getLocationURI(), destinationFile.toURI()));
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_165892.java
@@ -61,16 +61,16 @@ public class Bug_165892 {
 		sourceFile.copy(destinationFile.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
-		assertEquals("2.0", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("2.1", sourceValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(sourceValue, destinationFile.getPersistentProperty(name));
 
 		//change the values of the persistent property on the copied resource
 		final String destinationValue = "DestinationValue";
 		destinationFile.setPersistentProperty(name, destinationValue);
 
 		//make sure the persistent property values are correct
-		assertEquals("3.0", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("3.1", destinationValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(destinationValue, destinationFile.getPersistentProperty(name));
 	}
 
 	/**
@@ -127,11 +127,11 @@ public class Bug_165892 {
 		sourceFolder.copy(destinationFolder.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
-		assertEquals("2.0", sourceValue, source.getPersistentProperty(name));
-		assertEquals("2.1", sourceValue, sourceFolder.getPersistentProperty(name));
-		assertEquals("2.2", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("2.3", sourceValue, destinationFolder.getPersistentProperty(name));
-		assertEquals("2.4", sourceValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, source.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(sourceValue, destinationFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, destinationFile.getPersistentProperty(name));
 
 		//change the values of the persistent property on the copied resource
 		final String destinationValue = "DestinationValue";
@@ -139,11 +139,11 @@ public class Bug_165892 {
 		destinationFile.setPersistentProperty(name, destinationValue);
 
 		//make sure the persistent property values are correct
-		assertEquals("3.0", sourceValue, source.getPersistentProperty(name));
-		assertEquals("3.1", sourceValue, sourceFolder.getPersistentProperty(name));
-		assertEquals("3.2", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("3.3", destinationValue, destinationFolder.getPersistentProperty(name));
-		assertEquals("3.4", destinationValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, source.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(destinationValue, destinationFolder.getPersistentProperty(name));
+		assertEquals(destinationValue, destinationFile.getPersistentProperty(name));
 	}
 
 	/**
@@ -170,12 +170,12 @@ public class Bug_165892 {
 		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
 
 		//make sure the persistent properties were copied
-		assertEquals("2.0", sourceValue, source.getPersistentProperty(name));
-		assertEquals("2.1", sourceValue, sourceFolder.getPersistentProperty(name));
-		assertEquals("2.2", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("2.3", sourceValue, destination.getPersistentProperty(name));
-		assertEquals("2.4", sourceValue, destinationFolder.getPersistentProperty(name));
-		assertEquals("2.5", sourceValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, source.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(sourceValue, destination.getPersistentProperty(name));
+		assertEquals(sourceValue, destinationFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, destinationFile.getPersistentProperty(name));
 
 		//change the values of the persistent property on the copied resource
 		final String destinationValue = "DestinationValue";
@@ -184,11 +184,11 @@ public class Bug_165892 {
 		destinationFile.setPersistentProperty(name, destinationValue);
 
 		//make sure the persistent property values are correct
-		assertEquals("3.0", sourceValue, source.getPersistentProperty(name));
-		assertEquals("3.1", sourceValue, sourceFolder.getPersistentProperty(name));
-		assertEquals("3.2", sourceValue, sourceFile.getPersistentProperty(name));
-		assertEquals("3.3", destinationValue, destination.getPersistentProperty(name));
-		assertEquals("3.4", destinationValue, destinationFolder.getPersistentProperty(name));
-		assertEquals("3.5", destinationValue, destinationFile.getPersistentProperty(name));
+		assertEquals(sourceValue, source.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFolder.getPersistentProperty(name));
+		assertEquals(sourceValue, sourceFile.getPersistentProperty(name));
+		assertEquals(destinationValue, destination.getPersistentProperty(name));
+		assertEquals(destinationValue, destinationFolder.getPersistentProperty(name));
+		assertEquals(destinationValue, destinationFile.getPersistentProperty(name));
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_192631.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -101,14 +101,14 @@ public class Bug_192631 {
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectA.accept(visitor);
-		assertTrue("1.1", toVisit.isEmpty());
-		assertEquals("1.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectB.getLocationURI(), commonB, folderB, projectB.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectB.accept(visitor);
-		assertTrue("2.1", toVisit.isEmpty());
-		assertEquals("2.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		projectA.delete(true, createTestMonitor());
 		projectB.delete(true, createTestMonitor());
@@ -147,14 +147,14 @@ public class Bug_192631 {
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectA.accept(visitor);
-		assertTrue("1.1", toVisit.isEmpty());
-		assertEquals("1.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectB.getLocationURI(), commonB, folderB, projectB.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectB.accept(visitor);
-		assertTrue("2.1", toVisit.isEmpty());
-		assertEquals("2.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		projectA.delete(true, createTestMonitor());
 		projectB.delete(true, createTestMonitor());
@@ -193,14 +193,14 @@ public class Bug_192631 {
 		toVisit.addAll(Arrays.asList(new URI[] {projectA.getLocationURI(), commonA, folderA, projectA.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectA.accept(visitor);
-		assertTrue("1.1", toVisit.isEmpty());
-		assertEquals("1.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		toVisit.addAll(Arrays.asList(new URI[] {projectB.getLocationURI(), commonB, folderB, projectB.getFile(".project").getLocationURI()}));
 		toVisitCount[0] = 6;
 		projectB.accept(visitor);
-		assertTrue("2.1", toVisit.isEmpty());
-		assertEquals("2.2", 0, toVisitCount[0]);
+		assertThat(toVisit).isEmpty();
+		assertEquals(0, toVisitCount[0]);
 
 		projectA.delete(true, createTestMonitor());
 		projectB.delete(true, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_226264.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -78,7 +78,7 @@ public class Bug_226264 {
 			workspace.removeResourceChangeListener(projectDeletingChangeListener);
 		}
 
-		assertTrue("2.0: " + job.getResult(), job.getResult().isOK());
+		assertThat(job.getResult()).matches(IStatus::isOK, "is okay");
 
 		assertDoesNotExistInWorkspace(project1);
 		assertDoesNotExistInWorkspace(project2);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_231301.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertTrue;
 
+import java.util.function.Predicate;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -78,9 +79,9 @@ public class Bug_231301 {
 			workspace.removeResourceChangeListener(projectClosingChangeListener);
 		}
 
-		assertTrue("2.0: " + job.getResult(), job.getResult().isOK());
-		assertTrue("3.0", !project1.isOpen());
-		assertTrue("4.0", !project2.isOpen());
+		assertThat(job.getResult().isOK()).withFailMessage(job.getResult().toString()).isTrue();
+		assertThat(project1).matches(Predicate.not(IProject::isOpen), "is not open");
+		assertThat(project2).matches(Predicate.not(IProject::isOpen), "is not open");
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_233939.java
@@ -22,7 +22,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
@@ -63,7 +62,7 @@ public class Bug_233939 {
 		container.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		IResource theLink = container.findMember(linkName);
 		assertExistsInWorkspace(theLink);
-		assertTrue(theLink.getResourceAttributes().isSymbolicLink());
+		assertThat(theLink).matches(it -> it.getResourceAttributes().isSymbolicLink(), "is symbolic link");
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_265810.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
@@ -108,9 +109,9 @@ public class Bug_265810 {
 			// restore .project [1]
 			restoreDotProject(project, dotProject1);
 
-			assertEquals("9.0", 1, resourceDeltas.size());
-			assertEquals("9.1", newFile, resourceDeltas.get(0).getResource());
-			assertEquals("9.2", IResourceDelta.REMOVED, resourceDeltas.get(0).getKind());
+			assertThat(resourceDeltas).hasSize(1);
+			assertEquals(newFile, resourceDeltas.get(0).getResource());
+			assertEquals(IResourceDelta.REMOVED, resourceDeltas.get(0).getKind());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -127,9 +128,9 @@ public class Bug_265810 {
 			// restore .project [2]
 			restoreDotProject(project, dotProject2);
 
-			assertEquals("11.0", 1, resourceDeltas.size());
-			assertEquals("11.1", newFile, resourceDeltas.get(0).getResource());
-			assertEquals("11.2", IResourceDelta.REPLACED, resourceDeltas.get(0).getFlags() & IResourceDelta.REPLACED);
+			assertThat(resourceDeltas).hasSize(1);
+			assertEquals(newFile, resourceDeltas.get(0).getResource());
+			assertEquals(IResourceDelta.REPLACED, resourceDeltas.get(0).getFlags() & IResourceDelta.REPLACED);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_329836.java
@@ -14,12 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import org.eclipse.core.filesystem.EFS;
@@ -54,9 +53,9 @@ public class Bug_329836 {
 		info = fileStore.fetchInfo();
 
 		// check that attributes are really set
-		assertTrue("2.0", info.getAttribute(EFS.ATTRIBUTE_READ_ONLY));
+		assertThat(info).matches(it -> it.getAttribute(EFS.ATTRIBUTE_READ_ONLY), "is read only");
 		if (isAttributeSupported(EFS.ATTRIBUTE_IMMUTABLE)) {
-			assertTrue("3.0", info.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
+			assertThat(info).matches(it -> it.getAttribute(EFS.ATTRIBUTE_IMMUTABLE), "is immutable");
 		}
 
 		// unset EFS.ATTRIBUTE_READ_ONLY which also unsets EFS.IMMUTABLE on Mac
@@ -68,9 +67,9 @@ public class Bug_329836 {
 		info = fileStore.fetchInfo();
 
 		// check that attributes are really unset
-		assertFalse("5.0", info.getAttribute(EFS.ATTRIBUTE_READ_ONLY));
+		assertThat(info).matches(it -> !it.getAttribute(EFS.ATTRIBUTE_READ_ONLY), "is not read only");
 		if (isAttributeSupported(EFS.ATTRIBUTE_IMMUTABLE)) {
-			assertFalse("6.0", info.getAttribute(EFS.ATTRIBUTE_IMMUTABLE));
+			assertThat(info).matches(it -> !it.getAttribute(EFS.ATTRIBUTE_IMMUTABLE), "is not immutable");
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_331445.java
@@ -53,10 +53,10 @@ public class Bug_331445 {
 		project.getPathVariableManager().setURIValue(variableName, new URI(variablePath));
 		IFolder folder = project.getFolder(createUniqueString());
 		folder.createLink(IPath.fromOSString(rawLinkFolderLocation), IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		assertNull("3.0", folder.getLocation());
-		assertEquals("4.0", IPath.fromOSString(rawLinkFolderLocation), folder.getRawLocation());
-		assertEquals("5.0", new URI(linkFolderLocation), folder.getLocationURI());
-		assertEquals("6.0", new URI(rawLinkFolderLocation), folder.getRawLocationURI());
+		assertNull(folder.getLocation());
+		assertEquals(IPath.fromOSString(rawLinkFolderLocation), folder.getRawLocation());
+		assertEquals(new URI(linkFolderLocation), folder.getLocationURI());
+		assertEquals(new URI(rawLinkFolderLocation), folder.getRawLocationURI());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_378156.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
@@ -20,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import org.eclipse.core.resources.IFile;
@@ -123,7 +123,7 @@ public class Bug_378156 {
 		waitForBuild();
 
 		//the builder should have run if the bug is fixed
-		assertTrue("1.0", builder.wasExecuted());
+		assertThat(builder).matches(SignaledBuilder::wasExecuted, "was executed");
 	}
 
 	@Test
@@ -156,7 +156,7 @@ public class Bug_378156 {
 		}, null);
 		waitForBuild();
 		//the builder should have run if the bug is fixed
-		assertTrue("1.0", builder.wasExecuted());
+		assertThat(builder).matches(SignaledBuilder::wasExecuted, "was executed");
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_380386.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_380386.java
@@ -58,11 +58,11 @@ public class Bug_380386 {
 			}
 		}
 
-		assertNotNull("1.0", statusName);
-		assertNotNull("2.0", statusValue);
+		assertNotNull(statusName);
+		assertNotNull(statusValue);
 
-		assertTrue("3.0", statusName.isOK());
-		assertNotNull("4.0", statusValue.isOK());
+		assertTrue(statusName.isOK());
+		assertNotNull(statusValue.isOK());
 
 		pathManager.setURIValue(name, value);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -20,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -64,7 +64,7 @@ public class IFileTest {
 
 		try {
 			folder.setReadOnly(true);
-			assertTrue(folder.isReadOnly());
+			assertThat(folder).matches(IResource::isReadOnly, "is read only");
 			CoreException exception = assertThrows(CoreException.class,
 					() -> file.create(createRandomContentsStream(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.FAILED_WRITE_LOCAL, exception.getStatus().getCode());
@@ -96,7 +96,7 @@ public class IFileTest {
 
 		try {
 			folder.setReadOnly(true);
-			assertTrue(folder.isReadOnly());
+			assertThat(folder).matches(IResource::isReadOnly, "is read only");
 			CoreException exception = assertThrows(CoreException.class,
 					() -> file.create(createRandomContentsStream(), true, createTestMonitor()));
 			assertEquals(IResourceStatus.PARENT_READ_ONLY, exception.getStatus().getCode());
@@ -113,7 +113,7 @@ public class IFileTest {
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		createInWorkspace(project);
-		assertTrue("1.0", descFile.exists());
+		assertThat(descFile).matches(IResource::exists, "exists");
 
 		IProjectDescription desc = project.getDescription();
 
@@ -121,7 +121,7 @@ public class IFileTest {
 		long newTime = System.currentTimeMillis() + 10000;
 		descFile.setLocalTimeStamp(newTime);
 
-		assertTrue("2.0", descFile.isSynchronized(IResource.DEPTH_ZERO));
+		assertThat(descFile).matches(it -> it.isSynchronized(IResource.DEPTH_ZERO), "is synchronized");
 
 		// try setting the description -- shouldn't fail
 		project.setDescription(desc, createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
@@ -22,7 +24,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.touchInFilesystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
@@ -126,23 +127,23 @@ public class IProjectTest {
 		projectTWObuilder.reset();
 		projectONE.build(IncrementalProjectBuilder.FULL_BUILD, null);
 		waitForBuild();
-		assertTrue("1.1", projectONEbuilder.wasExecuted());
-		assertTrue("1.2", !projectTWObuilder.wasExecuted());
+		assertThat(projectONEbuilder).matches(SignaledBuilder::wasExecuted, "was executed");
+		assertThat(projectTWObuilder).matches(not(SignaledBuilder::wasExecuted), "was not executed");
 
 		projectONEbuilder.reset();
 		projectTWObuilder.reset();
 		projectTWO.build(IncrementalProjectBuilder.FULL_BUILD, SignaledBuilder.BUILDER_ID, null, null);
 		waitForBuild();
-		assertTrue("2.1", !projectONEbuilder.wasExecuted());
-		assertTrue("2.2", projectTWObuilder.wasExecuted());
+		assertThat(projectONEbuilder).matches(not(SignaledBuilder::wasExecuted), "was not executed");
+		assertThat(projectTWObuilder).matches(SignaledBuilder::wasExecuted, "was executed");
 
 		projectONEbuilder.reset();
 		projectTWObuilder.reset();
 		projectTWO.touch(null);
 		waitForBuild();
 		//project one won't be executed because project didn't change.
-		assertTrue("3.1", !projectONEbuilder.wasExecuted());
-		assertTrue("3.2", projectTWObuilder.wasExecuted());
+		assertThat(projectONEbuilder).matches(not(SignaledBuilder::wasExecuted), "was not executed");
+		assertThat(projectTWObuilder).matches(SignaledBuilder::wasExecuted, "was executed");
 	}
 
 	/*
@@ -170,10 +171,10 @@ public class IProjectTest {
 		project.open(createTestMonitor());
 
 		// verify discovery
-		assertTrue("2.0", project.isAccessible());
-		assertTrue("2.1", folder.exists());
-		assertTrue("2.2", file1.exists());
-		assertTrue("2.3", file2.exists());
+		assertThat(project).matches(IProject::isAccessible, "is accessible");
+		assertThat(folder).matches(IFolder::exists, "exists");
+		assertThat(file1).matches(IFile::exists, "exists");
+		assertThat(file2).matches(IFile::exists, "exists");
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/LocalStoreRegressionTests.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.regression;
 
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -54,9 +55,9 @@ public class LocalStoreRegressionTests {
 		/* */
 		IFile file = project.getFile("file");
 		createInFileSystem(file);
-		assertTrue("1.0", !file.exists());
+		assertThat(file).matches(not(IFile::exists), "not exists");
 		file.refreshLocal(IResource.DEPTH_ZERO, null);
-		assertTrue("1.1", file.exists());
+		assertThat(file).matches(IFile::exists, "exists");
 	}
 
 	/**
@@ -72,8 +73,8 @@ public class LocalStoreRegressionTests {
 		createInFileSystem(folder);
 		createInFileSystem(file);
 		file.refreshLocal(IResource.DEPTH_INFINITE, null);
-		assertTrue("1.1", folder.exists());
-		assertTrue("1.2", file.exists());
+		assertThat(folder).matches(IFolder::exists, "exists");
+		assertThat(file).matches(IFile::exists, "exists");
 		removeFromWorkspace(folder);
 		removeFromFileSystem(folder);
 	}
@@ -91,7 +92,7 @@ public class LocalStoreRegressionTests {
 
 		File target = new File(temp, "target");
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue("1.0", !target.exists());
+		assertThat(target).matches(not(File::exists), "not exists");
 
 		// write chunks
 		try (SafeChunkyOutputStream output = new SafeChunkyOutputStream(target);
@@ -103,7 +104,7 @@ public class LocalStoreRegressionTests {
 		// read chunks
 		try (SafeChunkyInputStream input = new SafeChunkyInputStream(target);
 				DataInputStream dis = new DataInputStream(input)) {
-				assertEquals("3.0", dis.readLong(), 1234567890l);
+			assertEquals(dis.readLong(), 1234567890l);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GEAB3C_Test.java
@@ -45,17 +45,6 @@ public class PR_1GEAB3C_Test {
 
 	protected static final String VERIFIER_NAME = "TestListener";
 
-	public void assertDelta() {
-		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
-	}
-
-	/**
-	 * Runs code to handle a core exception
-	 */
-	protected void handleCoreException(CoreException e) {
-		assertTrue("CoreException: " + e.getMessage(), false);
-	}
-
 	/**
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
@@ -102,7 +91,7 @@ public class PR_1GEAB3C_Test {
 			}
 		};
 		getWorkspace().run(body, createTestMonitor());
-		assertDelta();
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/PR_1GH2B0N_Test.java
@@ -47,7 +47,7 @@ public class PR_1GH2B0N_Test {
 		IStatus status = getWorkspace().validateProjectLocation(project2, project.getLocation().append(project2.getName()));
 		//Note this is not the original error case -
 		//since Eclipse 3.2 a project is allowed to be nested in another project
-		assertTrue("2.0", status.isOK());
+		assertTrue(status.isOK());
 	}
 
 }


### PR DESCRIPTION
This change removes non-useful messages from assertions in org.eclipse.core.tests.resources.regression. In cases where multiple assertions without proper messages are placed in subsequent lines of code, assertions are improved to provide better messages and help identifying the failing line of code. This particularly affects assertTrue/assertFalse statements that are replaced with assertThat().matches().

This also prepares for a migration of assertions to JUnit 5, which would otherwise require swapping of parameters, as the message parameter has been moved to the end of the parameter list.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903