### PR TITLE
Replace custom stream comparison assertion with library call #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.junit.Assert.assertFalse;
@@ -109,8 +109,9 @@ public class BlobStoreTest {
 			createInputStream(content).transferTo(output);
 		}
 		uuid = store.addBlob(target, true);
-		InputStream input = store.getBlob(uuid);
-		assertTrue(compareContent(createInputStream(content), input));
+		try (InputStream input = store.getBlob(uuid)) {
+			assertThat(input).hasContent(content);
+		}
 	}
 
 	@Test
@@ -127,8 +128,9 @@ public class BlobStoreTest {
 			createInputStream(content).transferTo(output);
 		}
 		uuid = store.addBlob(target, true);
-		InputStream input = store.getBlob(uuid);
-		assertTrue(compareContent(createInputStream(content), input));
+		try (InputStream input = store.getBlob(uuid)) {
+			assertThat(input).hasContent(content);
+		}
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryStoreTest.java
@@ -16,7 +16,6 @@ package org.eclipse.core.tests.internal.localstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
@@ -524,8 +523,8 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		// Now do the move
 		folder.copy(folder2.getFullPath(), true, createTestMonitor());
@@ -541,14 +540,14 @@ public class HistoryStoreTest {
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -596,8 +595,8 @@ public class HistoryStoreTest {
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
 
@@ -637,9 +636,9 @@ public class HistoryStoreTest {
 		store.copyHistory(file, file2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(3).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[1]),
+				third -> assertThat(third.getContents()).hasContent(contents[0]));
 	}
 
 	@Test
@@ -666,8 +665,8 @@ public class HistoryStoreTest {
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 		folder2.create(true, true, createTestMonitor());
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
@@ -677,9 +676,9 @@ public class HistoryStoreTest {
 		store.copyHistory(folder, folder2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(3).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[1]),
+				third -> assertThat(third.getContents()).hasContent(contents[0]));
 	}
 
 	@Test
@@ -706,8 +705,8 @@ public class HistoryStoreTest {
 
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 		folder2.create(true, true, createTestMonitor());
 		file2.create(createInputStream(contents[3]), true, createTestMonitor());
 		file2.setContents(createInputStream(contents[4]), true, true, createTestMonitor());
@@ -717,9 +716,9 @@ public class HistoryStoreTest {
 		store.copyHistory(project, project2, false);
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(3).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[1]),
+				third -> assertThat(third.getContents()).hasContent(contents[0]));
 	}
 
 	@Test
@@ -1027,7 +1026,7 @@ public class HistoryStoreTest {
 		for (int i = 0; i < stateArray.length; i++, myLong++) {
 			try (DataInputStream inFile = new DataInputStream(file.getContents(false))) {
 				try (DataInputStream inContents = new DataInputStream(historyStore.getContents(stateArray[i]))) {
-					assertTrue(i + " No match, files are not identical.", compareContent(inFile, inContents));
+					assertThat(inFile).as("match history state " + i).hasSameContentAs(inContents);
 				}
 			}
 		}
@@ -1036,7 +1035,7 @@ public class HistoryStoreTest {
 		for (int i = 0; i < stateArray.length; i++, myLong++) {
 			try (DataInputStream inFile = new DataInputStream(secondValidFile.getContents(false))) {
 				try (DataInputStream inContents = new DataInputStream(historyStore.getContents(stateArray[i]))) {
-					assertTrue(i + " No match, files are not identical.", compareContent(inFile, inContents));
+					assertThat(inFile).as("match history state " + i).hasSameContentAs(inContents);
 				}
 			}
 		}
@@ -1115,8 +1114,8 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		// Now do the move
 		folder.move(folder2.getFullPath(), true, createTestMonitor());
@@ -1132,14 +1131,14 @@ public class HistoryStoreTest {
 		// Check the local history of both files
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1181,8 +1180,8 @@ public class HistoryStoreTest {
 		file.setContents(createInputStream(contents[2]), true, true, createTestMonitor());
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		// Now do the move
 		project.move(IPath.fromOSString("SecondMoveProjectProject"), true, createTestMonitor());
@@ -1202,10 +1201,10 @@ public class HistoryStoreTest {
 		assertThat(states).isEmpty();
 		states = file2.getHistory(createTestMonitor());
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 
 		project.delete(true, createTestMonitor());
 	}
@@ -1341,16 +1340,16 @@ public class HistoryStoreTest {
 		// Check log for original file.
 		states = file.getHistory(null);
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		// Check log for copy.
 		states = copyFile.getHistory(null);
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 	}
 
 	/**
@@ -1406,16 +1405,16 @@ public class HistoryStoreTest {
 		// Check log for original file.
 		states = file.getHistory(null);
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		// Check log for moved file.
 		states = moveFile.getHistory(null);
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[3]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[3]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 	}
 
 	/**
@@ -1451,8 +1450,8 @@ public class HistoryStoreTest {
 		/* Ensure two entries are available for the file, and that content matches. */
 		IFileState[] states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(2).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[0]), second.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[0]));
 
 		/* Delete the file. Should add an entry to the store. */
 		file.delete(true, true, createTestMonitor());
@@ -1460,9 +1459,9 @@ public class HistoryStoreTest {
 		/* Ensure three entries are available for the file, and that content matches. */
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(3).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[2]),
+				second -> assertThat(second.getContents()).hasContent(contents[1]),
+				third -> assertThat(third.getContents()).hasContent(contents[0]));
 		/* Roll file back to first version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
 		// Create the file with the contents from one of the states.
@@ -1472,12 +1471,12 @@ public class HistoryStoreTest {
 		// Check history store.
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(3).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[1]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[0]), third.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[2]),
+				second -> assertThat(second.getContents()).hasContent(contents[1]),
+				third -> assertThat(third.getContents()).hasContent(contents[0]));
 
 		// Check file contents.
-		assertThat(compareContent(createInputStream(contents[2]), file.getContents(false))).isTrue();
+		assertThat(file.getContents(false)).hasContent(contents[2]);
 
 		/* Set new contents on the file. Should add an entry to the history store. */
 		file.setContents(createInputStream(contents[1]), true, true, null);
@@ -1485,10 +1484,10 @@ public class HistoryStoreTest {
 		/* Ensure four entries are available for the file, and that entries match. */
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(4).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[2]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[1]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[0]), fourth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[2]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[1]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[0]));
 
 		/* Roll file back to third version, and ensure that content matches. */
 		states = file.getHistory(createTestMonitor());
@@ -1498,14 +1497,14 @@ public class HistoryStoreTest {
 		// Check history log.
 		states = file.getHistory(createTestMonitor());
 		assertThat(states).hasSize(5).satisfiesExactly(
-				first -> assertThat(compareContent(createInputStream(contents[1]), first.getContents())).isTrue(),
-				second -> assertThat(compareContent(createInputStream(contents[2]), second.getContents())).isTrue(),
-				third -> assertThat(compareContent(createInputStream(contents[2]), third.getContents())).isTrue(),
-				fourth -> assertThat(compareContent(createInputStream(contents[1]), fourth.getContents())).isTrue(),
-				fifth -> assertThat(compareContent(createInputStream(contents[0]), fifth.getContents())).isTrue());
+				first -> assertThat(first.getContents()).hasContent(contents[1]),
+				second -> assertThat(second.getContents()).hasContent(contents[2]),
+				third -> assertThat(third.getContents()).hasContent(contents[2]),
+				fourth -> assertThat(fourth.getContents()).hasContent(contents[1]),
+				fifth -> assertThat(fifth.getContents()).hasContent(contents[0]));
 
 		// Check file contents.
-		assertThat(compareContent(createInputStream(contents[1]), file.getContents(false))).isTrue();
+		assertThat(file.getContents(false)).hasContent(contents[1]);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertFalse;
@@ -82,8 +82,9 @@ public class SafeFileInputOutputStreamTest {
 		}
 		assertTrue(target.exists());
 		assertFalse(tempFile.exists());
-		InputStream diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath());
-		assertTrue(compareContent(diskContents, createInputStream(contents)));
+		try (InputStream diskContents = new SafeFileInputStream(tempLocation.toOSString(), target.getAbsolutePath())) {
+			assertThat(diskContents).hasContent(contents);
+		}
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
@@ -98,8 +99,9 @@ public class SafeFileInputOutputStreamTest {
 		try (SafeFileOutputStream safeStream = createSafeStream(target)) {
 			createInputStream(contents).transferTo(safeStream);
 		}
-		InputStream diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, createInputStream(contents)));
+		try (InputStream diskContents = getContents(target)) {
+			assertThat(diskContents).hasContent(contents);
+		}
 
 		contents = createRandomString();
 		// update target contents
@@ -110,8 +112,9 @@ public class SafeFileInputOutputStreamTest {
 			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
-		diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, createInputStream(contents)));
+		try (InputStream diskContents = getContents(target)) {
+			assertThat(diskContents).hasContent(contents);
+		}
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 
@@ -134,8 +137,9 @@ public class SafeFileInputOutputStreamTest {
 			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
-		InputStream diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, createInputStream(contents)));
+		try (InputStream diskContents = getContents(target)) {
+			assertThat(diskContents).hasContent(contents);
+		}
 
 		contents = createRandomString();
 		// now we should have a temp file
@@ -145,8 +149,9 @@ public class SafeFileInputOutputStreamTest {
 			createInputStream(contents).transferTo(safeStream);
 		}
 		assertFalse(tempFile.exists());
-		diskContents = getContents(target);
-		assertTrue(compareContent(diskContents, createInputStream(contents)));
+		try (InputStream diskContents = getContents(target)) {
+			assertThat(diskContents).hasContent(contents);
+		}
 		Workspace.clear(target); // make sure there was nothing here before
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -15,12 +15,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
@@ -679,9 +679,10 @@ public class IFileTest {
 		monitor.assertUsedUp();
 		assertTrue("2.2", emptyFile.exists());
 		try (InputStream stream = emptyFile.getContents(false)) {
-			assertTrue("2.4", stream.available() == 0);
+			assertEquals(0, stream.available());
+			assertThat(stream).hasContent(contents);
+
 		}
-		assertTrue("2.6", compareContent(emptyFile.getContents(false), createInputStream(contents)));
 
 		// creation with random content
 		IFile fileWithRandomContent = projects[0].getFile("file3");
@@ -691,7 +692,9 @@ public class IFileTest {
 		fileWithRandomContent.create(createInputStream(contents), true, monitor);
 		monitor.assertUsedUp();
 		assertTrue("3.2", fileWithRandomContent.exists());
-		assertTrue("3.2", compareContent(fileWithRandomContent.getContents(false), createInputStream(contents)));
+		try (InputStream fileInput = fileWithRandomContent.getContents(false)) {
+			assertThat(fileInput).hasContent(contents);
+		}
 
 		// try to create a file over a folder that exists
 		IFolder folder = projects[0].getFolder("folder1");
@@ -1082,7 +1085,7 @@ public class IFileTest {
 		monitor.assertUsedUp();
 
 		try (InputStream content = target.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
+			assertThat(content).hasContent(testString);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -247,7 +248,9 @@ public class IFolderTest {
 		assertDoesNotExistInWorkspace(before);
 		assertExistsInWorkspace(after);
 		file = project.getFile(IPath.fromOSString("a/b/z"));
-		assertTrue("2.1", compareContent(createInputStream(content), file.getContents(false)));
+		try (InputStream fileInput = file.getContents(false)) {
+			assertThat(fileInput).hasContent(content);
+		}
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -21,7 +21,6 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExi
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
@@ -848,7 +847,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		assertTrue("4.3", compareContent(file.getContents(), createInputStream("contents in different location")));
+		assertEquals("contents in different location", file.readString());
 
 		// clean-up
 		removeFromFileSystem(file);
@@ -914,7 +913,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertEquals("4.2", expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
-		assertTrue("4.3", compareContent(file.getContents(), createInputStream("contents in different location")));
+		assertEquals("contents in different location", file.readString());
 
 		// clean-up
 		removeFromFileSystem(file);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -546,26 +546,6 @@ public final class ResourceTestUtil {
 	}
 
 	/**
-	 * Returns a boolean value indicating whether or not the contents
-	 * of the given streams are considered to be equal. Closes both input streams.
-	 */
-	public static boolean compareContent(InputStream a, InputStream b) throws IOException {
-		int c, d;
-		if (a == null && b == null) {
-			return true;
-		}
-		try (a; b) {
-			if (a == null || b == null) {
-				return false;
-			}
-			while ((c = a.read()) == (d = b.read()) && (c != -1 && d != -1)) {
-				// body not needed
-			}
-		}
-		return (c == -1 && d == -1);
-	}
-
-	/**
 	 * Enables or disables workspace autobuild. Waits for the build to be finished,
 	 * even if the autobuild value did not change and a previous build is still
 	 * running.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -14,14 +14,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,8 +114,9 @@ public class ResourceURLTest {
 		IFile file = project.getFile("a.txt");
 		createInWorkspace(file, CONTENT);
 		URL url = new URL(PlatformURLResourceConnection.RESOURCE_URL_STRING + "My%20Project/a.txt");
-		InputStream stream = url.openStream();
-		assertTrue("1.0", compareContent(stream, createInputStream(CONTENT)));
+		try (InputStream stream = url.openStream()) {
+			assertThat(stream).hasContent(CONTENT);
+		}
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -23,7 +23,6 @@ import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertDoesNotExistInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -181,7 +180,9 @@ public class WorkspaceTest {
 		assertDoesNotExistInWorkspace(before);
 		assertExistsInWorkspace(after);
 		file = project.getFile(IPath.fromOSString("a/b/z"));
-		assertTrue("get not equal set", compareContent(createInputStream(content), file.getContents(false)));
+		try (InputStream fileContents = file.getContents(false)) {
+			assertThat(fileContents).hasContent(content);
+		}
 	}
 
 	@Test
@@ -322,7 +323,7 @@ public class WorkspaceTest {
 		fileTarget.setContents(testString.getBytes(), true, false, monitor);
 		monitor.assertUsedUp();
 		try (InputStream content = fileTarget.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
+			assertThat(content).hasContent(testString);
 		}
 	}
 
@@ -405,7 +406,7 @@ public class WorkspaceTest {
 		target.setContents(createInputStream(testString), true, false, monitor);
 		monitor.assertUsedUp();
 		try (InputStream content = target.getContents(false)) {
-			assertTrue("get not equal set", compareContent(content, createInputStream(testString)));
+			assertThat(content).hasContent(testString);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_025457.java
@@ -14,7 +14,6 @@
 package org.eclipse.core.tests.resources.regression;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
@@ -22,8 +21,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySuppor
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
@@ -69,9 +68,7 @@ public class Bug_025457 {
 		//ensure source still exists and has same content
 		assertTrue("2.0", source.exists());
 		assertTrue("2.1", sourceFile.exists());
-		try (InputStream stream = sourceFile.getContents()) {
-			assertTrue("2.2", compareContent(stream, new ByteArrayInputStream(content.getBytes())));
-		}
+		assertEquals(content, sourceFile.readString());
 		//ensure destination file does not exist
 		assertTrue("2.3", !destFile.exists());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -16,7 +16,6 @@ package org.eclipse.core.tests.resources.regression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
@@ -82,8 +81,9 @@ public class IResourceTest {
 		target.create(createInputStream("abc"), false, null);
 		target.appendContents(createInputStream("def"), false, true, null);
 
-		InputStream content = target.getContents(false);
-		assertTrue("3.0", compareContent(content, createInputStream("abcdef")));
+		try (InputStream content = target.getContents(false)) {
+			assertThat(content).hasContent("abcdef");
+		}
 	}
 
 	/**
@@ -458,7 +458,7 @@ public class IResourceTest {
 		target.create(createInputStream(contents), false, null);
 
 		try (InputStream is = target.getContents(false)) {
-			assertTrue("2.0", compareContent(createInputStream(contents), is));
+			assertThat(is).hasContent(contents);
 		}
 
 		final String newContents = "some other contents";
@@ -490,7 +490,7 @@ public class IResourceTest {
 		assertEquals("5.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		try (InputStream is = target.getContents(true)) {
-			assertTrue("6.0", compareContent(createInputStream(newContents), is));
+			assertThat(is).hasContent(newContents);
 		}
 	}
 

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FileDiffResultTest.java
@@ -16,7 +16,6 @@ package org.eclipse.compare.tests;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
@@ -115,9 +114,14 @@ public class FileDiffResultTest {
 		assertThat(filePatchResult.getOriginalContents()).isNotNull();
 		assertThat(filePatchResult.getPatchedContents()).isNotNull();
 
-		compareContent(new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile()),
-				filePatchResult.getOriginalContents());
-		compareContent(filePatchResult.getOriginalContents(), filePatchResult.getPatchedContents());
+		try (InputStream fileInput = new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile());
+				InputStream originalContents = filePatchResult.getOriginalContents()) {
+			assertThat(fileInput).hasSameContentAs(originalContents);
+		}
+		try (InputStream filePatched = filePatchResult.getPatchedContents();
+				InputStream originalContents = filePatchResult.getOriginalContents()) {
+			assertThat(filePatched).hasSameContentAs(originalContents);
+		}
 	}
 
 	/**
@@ -149,10 +153,15 @@ public class FileDiffResultTest {
 		assertThat(filePatchResult.getOriginalContents()).isNotNull();
 		assertThat(filePatchResult.getPatchedContents()).isNotNull();
 
-		compareContent(new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile()),
-				filePatchResult.getOriginalContents());
+		try (InputStream fileInput = new FileInputStream(project.getFile(NEW_FILENAME).getLocation().toFile());
+				InputStream originalContents = filePatchResult.getOriginalContents()) {
+			assertThat(fileInput).hasSameContentAs(originalContents);
+		}
 		assertThat(getStringFromStream(filePatchResult.getOriginalContents())).isEqualTo("I'm a different content");
-		compareContent(filePatchResult.getOriginalContents(), filePatchResult.getPatchedContents());
+		try (InputStream filePatched = filePatchResult.getPatchedContents();
+				InputStream originalContents = filePatchResult.getOriginalContents()) {
+			assertThat(filePatched).hasSameContentAs(originalContents);
+		}
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=185379

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/SaveableCompareEditorInputTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/SaveableCompareEditorInputTest.java
@@ -16,9 +16,9 @@ package org.eclipse.team.tests.ui;
 import static java.util.Collections.synchronizedList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.compareContent;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -279,10 +279,7 @@ public class SaveableCompareEditorInputTest {
 		verifyDirtyStateChanges(compareEditorInput);
 
 		// check whether file was saved
-
-		assertTrue(compareContent(new ByteArrayInputStream(
-				(fileContents1 + appendFileContents).getBytes()),
-				file1.getContents()));
+		assertEquals(fileContents1 + appendFileContents, file1.readString());
 	}
 
 	@Test
@@ -333,10 +330,7 @@ public class SaveableCompareEditorInputTest {
 		verifyDirtyStateChanges(compareEditorInput);
 
 		// check whether file was saved
-
-		assertTrue(compareContent(new ByteArrayInputStream(
-				(fileContents1 + appendFileContents).getBytes()),
-				file1.getContents()));
+		assertEquals(fileContents1 + appendFileContents, file1.readString());
 	}
 
 	@Test
@@ -415,12 +409,8 @@ public class SaveableCompareEditorInputTest {
 				.closeEditor(editor, false);
 
 		// validate if both sides where saved
-		assertTrue(compareContent(new ByteArrayInputStream(
-				(fileContents1 + appendFileContents).getBytes()),
-				file1.getContents()));
-		assertTrue(compareContent(new ByteArrayInputStream(
-				(fileContents2 + appendFileContents).getBytes()),
-				file2.getContents()));
+		assertEquals(fileContents1 + appendFileContents, file1.readString());
+		assertEquals(fileContents2 + appendFileContents, file2.readString());
 	}
 
 	@Test


### PR DESCRIPTION
The ResourceTestUtil provides a compareContents() method for comparing the contents of two streams. This method is used in assertTrue() statements to check for equality of contents of two stream. Modern assertion frameworks already provide that functionality and, in addition, also provide proper error messages when the comparison yields differences.

This change removes the compareContents() method and replaces all calls with either direct string comparison if the indirection over a stream became unnecesary or using assertThat().hasContent() or assertThat().hasSameContentAs().

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903