### PR TITLE
Fix test LaunchTests.testProcessLaunchWithLongWorkingDirectory on Linux

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchTests.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
@@ -146,6 +147,7 @@ public class LaunchTests extends AbstractLaunchTest {
 		String[] segments = Collections.nCopies((400 - rootLength) / subPathElementsName.length(), subPathElementsName).toArray(String[]::new);
 		File workingDirectory = tempFolder.newFolder(segments);
 		assertTrue(workingDirectory.toString().length() > 300);
+		Files.createDirectories(workingDirectory.toPath());
 
 		startProcessAndAssertOutputContains(List.of("java", "--version"), workingDirectory, false, "jdk");
 		startProcessAndAssertOutputContains(List.of("java", "--version"), workingDirectory, true, "jdk");


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1488 (hopefully).

My only other solution would be to disable the test on Linux.