### PR TITLE
[FS] Always copy file-attributes using Eclipse's Native(File)Handler

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/filesystem/provider/FileStore.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/filesystem/provider/FileStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ import org.eclipse.core.filesystem.IFileSystem;
 import org.eclipse.core.internal.filesystem.FileCache;
 import org.eclipse.core.internal.filesystem.Messages;
 import org.eclipse.core.internal.filesystem.Policy;
+import org.eclipse.core.internal.filesystem.local.LocalFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -129,7 +130,7 @@ public abstract class FileStore extends PlatformObject implements IFileStore {
 		// create directory
 		destination.mkdir(EFS.NONE, subMonitor.newChild(1));
 		// copy attributes
-		transferAttributes(sourceInfo, destination);
+		LocalFile.transferAttributes(sourceInfo, destination);
 
 		if (children == null)
 			return;
@@ -167,7 +168,7 @@ public abstract class FileStore extends PlatformObject implements IFileStore {
 				OutputStream out = destination.openOutputStream(EFS.NONE, subMonitor.newChild(1));) {
 			in.transferTo(out);
 			subMonitor.worked(93);
-			transferAttributes(sourceInfo, destination);
+			LocalFile.transferAttributes(sourceInfo, destination);
 			subMonitor.worked(5);
 		} catch (IOException e) {
 			Policy.error(EFS.ERROR_WRITE, NLS.bind(Messages.failedCopy, sourcePath), e);
@@ -429,8 +430,4 @@ public abstract class FileStore extends PlatformObject implements IFileStore {
 	@Override
 	public abstract URI toURI();
 
-	private void transferAttributes(IFileInfo sourceInfo, IFileStore destination) throws CoreException {
-		int options = EFS.SET_ATTRIBUTES | EFS.SET_LAST_MODIFIED;
-		destination.putInfo(sourceInfo, options, null);
-	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -40,6 +40,8 @@ Import-Package: org.assertj.core.api,
  org.junit.jupiter.api.extension,
  org.junit.jupiter.api.function,
  org.junit.jupiter.api.io,
+ org.junit.jupiter.params,
+ org.junit.jupiter.params.provider,
  org.junit.platform.suite.api,
  org.mockito
 Bundle-ActivationPolicy: lazy

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalStoreTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,33 +13,31 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
-
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.resources.ResourceTestUtil;
 
 public final class LocalStoreTestUtil {
 
 	public static void createTree(IFileStore[] tree) throws CoreException, IOException {
+		createTree(tree, 20);
+	}
+
+	public static void createTree(IFileStore[] tree, int fileSize) throws CoreException, IOException {
 		for (IFileStore element : tree) {
-			createNode(element);
+			createNode(element, fileSize);
 		}
 	}
 
-	private static void createNode(IFileStore node) throws CoreException, IOException {
+	private static void createNode(IFileStore node, int fileSize) throws CoreException, IOException {
 		char type = node.getName().charAt(0);
 		if (type == 'd') {
 			node.mkdir(EFS.NONE, null);
 		} else {
-			InputStream input = createRandomContentsStream();
-			try (OutputStream output = node.openOutputStream(EFS.NONE, null)) {
-				input.transferTo(output);
-			}
+			ResourceTestUtil.createInFileSystem(node, fileSize);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2024 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -116,10 +117,19 @@ public final class ResourceTestUtil {
 	 * contents.
 	 */
 	public static void createInFileSystem(IFileStore file) throws CoreException, IOException {
+		createInFileSystem(file, 20);
+	}
+
+	/**
+	 * Create the given file and its parents in the local store with random contents
+	 * of the specified size
+	 */
+	public static void createInFileSystem(IFileStore file, int fileSizeInBytes) throws CoreException, IOException {
 		file.getParent().mkdir(EFS.NONE, null);
-		try (InputStream input = createRandomContentsStream();
-				OutputStream output = file.openOutputStream(EFS.NONE, null)) {
-			input.transferTo(output);
+		try (OutputStream output = new BufferedOutputStream(file.openOutputStream(EFS.NONE, null))) {
+			for (int size = 0; size < fileSizeInBytes; size++) {
+				output.write(RANDOM.nextInt(Byte.SIZE));
+			}
 		}
 	}
 


### PR DESCRIPTION
Files.copy seems to copy file-attributes differently than Eclipse NativeHandler (for files) do on Mac. In order to stay consistent always use the Eclipse way.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1504 (hopefully).

Can someone with access to a Mac verify this in advance together with https://github.com/eclipse-platform/eclipse.platform/pull/1502 reverted locally (otherwise one needs a file larger than 1MiB?