### PR TITLE
Migrate resources usecase tests to JUnit 5

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/ConcurrencyTest.java
@@ -15,20 +15,19 @@ package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ConcurrencyTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
-	protected void assertIsNotRunning(ConcurrentOperation01 op, String label) {
+	protected void assertIsNotRunning(ConcurrentOperation01 op) {
 		/* try more than once, "just in case" */
 		for (int i = 0; i < 3; i++) {
 			try {
@@ -36,7 +35,7 @@ public class ConcurrencyTest {
 			} catch (InterruptedException e) {
 				// ignore
 			}
-			assertTrue(label, !op.isRunning());
+			assertFalse(op.isRunning());
 		}
 	}
 
@@ -55,22 +54,22 @@ public class ConcurrencyTest {
 
 		/* start first operation */
 		new Thread(op1, "op1").start();
-		assertTrue("0.0", op1.hasStarted());
+		assertTrue(op1.hasStarted());
 		op1.returnWhenInSyncPoint();
-		assertTrue("0.1", op1.isRunning());
+		assertTrue(op1.isRunning());
 
 		/* start second operation but it should not run until the first finishes */
 		new Thread(op2, "op2").start();
-		assertTrue("1.0", op2.hasStarted());
-		assertIsNotRunning(op2, "1.1");
+		assertTrue(op2.hasStarted());
+		assertIsNotRunning(op2);
 
 		/* free operations */
 		op1.proceed();
 		op2.returnWhenInSyncPoint();
-		assertTrue("2.0", op2.isRunning());
+		assertTrue(op2.isRunning());
 		op2.proceed();
-		assertTrue("2.1", op1.getStatus().isOK());
-		assertTrue("2.2", op2.getStatus().isOK());
+		assertTrue(op1.getStatus().isOK());
+		assertTrue(op2.getStatus().isOK());
 
 		/* remove trash */
 		removeFromWorkspace(getWorkspace().getRoot());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
@@ -33,14 +33,12 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IFileTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests failure on get/set methods invoked on a nonexistent file.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
@@ -22,7 +22,7 @@ import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
@@ -32,14 +32,12 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IFolderTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Tests failure on get/set methods invoked on a nonexistent folder.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
@@ -22,7 +22,7 @@ import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Hashtable;
 import org.eclipse.core.resources.ICommand;
@@ -33,19 +33,17 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IProjectTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	public static String LOCAL_LOCATION_PATH_STRING_0;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		LOCAL_LOCATION_PATH_STRING_0 = getWorkspace().getRoot().getLocation().append("temp/location0").toOSString();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
@@ -14,8 +14,8 @@
 package org.eclipse.core.tests.resources.usecase;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -40,7 +40,7 @@ final class IResourceTestUtil {
 		/* Prefix to assertion messages. */
 		String method = "commonFailureTestsForResource(IResource," + (created ? "CREATED" : "NONEXISTENT") + "): ";
 		if (!created) {
-			assertTrue(method + "1", getWorkspace().getRoot().findMember(resource.getFullPath()) == null);
+			assertNull(getWorkspace().getRoot().findMember(resource.getFullPath()), method + "1");
 		}
 
 		/* Session properties */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IWorkspaceRunnableUseCaseTest.java
@@ -17,9 +17,10 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
@@ -28,14 +29,12 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IWorkspaceRunnableUseCaseTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	protected IWorkspaceRunnable createRunnable(final IProject project, final IWorkspaceRunnable nestedOperation, final boolean triggerBuild, final Exception exceptionToThrow) {
 		return monitor -> {
@@ -78,7 +77,7 @@ public class IWorkspaceRunnableUseCaseTest {
 			builder.reset();
 			getWorkspace().run(op3, createTestMonitor());
 			waitForBuild();
-			assertTrue("1.1", builder.wasExecuted());
+			assertTrue(builder.wasExecuted());
 		}
 
 		{
@@ -90,7 +89,7 @@ public class IWorkspaceRunnableUseCaseTest {
 			assertThrows(OperationCanceledException.class, () -> getWorkspace().run(op3, createTestMonitor()));
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
-			assertTrue("2.2", !builder.wasExecuted());
+			assertFalse(builder.wasExecuted());
 		}
 
 		{
@@ -103,7 +102,7 @@ public class IWorkspaceRunnableUseCaseTest {
 			assertEquals(Status.CANCEL_STATUS, exception.getStatus());
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
-			assertTrue("3.1", !builder.wasExecuted());
+			assertFalse(builder.wasExecuted());
 		}
 
 		{
@@ -115,7 +114,7 @@ public class IWorkspaceRunnableUseCaseTest {
 			getWorkspace().run(op3, createTestMonitor());
 			// waitForBuild(); // TODO: The test is invalid since it fails if this line is
 			// uncommented.
-			assertTrue("4.1", !builder.wasExecuted());
+			assertFalse(builder.wasExecuted());
 		}
 	}
 


### PR DESCRIPTION
Migrates the tests in org.eclipse.team.tests.core to JUnit 5.
- Exchange JUnit 4 test annotations
- Replace JUnit 4 WorkspaceTestRule with JUnit 5 WorkspaceResetExtension
- Replace JUnit 4 assertions with JUnit 5 assertions

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903