### PR TITLE
Simplify and improve assertions in Ant core tests #903

### DIFF
--- a/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.tests.core; singleton:=true
-Bundle-Version: 3.7.400.qualifier
+Bundle-Version: 3.7.500.qualifier
 Bundle-ClassPath: anttestscore.jar
 Bundle-Activator: org.eclipse.ant.tests.core.testplugin.AntTestPlugin
 Bundle-Vendor: %providerName

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AbstractAntTest.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AbstractAntTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -132,20 +132,20 @@ public abstract class AbstractAntTest {
 
 	protected IFile getBuildFile(String buildFileName) {
 		IFile file = getProject().getFolder(ProjectHelper.BUILDFILES_FOLDER).getFile(buildFileName);
-		assertTrue("Could not find build file named: " + buildFileName, file.exists()); //$NON-NLS-1$
+		assertThat(file).matches(IFile::exists, "exists"); //$NON-NLS-1$
 		return file;
 	}
 
 	protected IFolder getWorkingDirectory(String workingDirectoryName) {
 		IFolder folder = getProject().getFolder(workingDirectoryName);
-		assertTrue("Could not find the working directory named: " + workingDirectoryName, folder.exists()); //$NON-NLS-1$
+		assertThat(folder).matches(IFolder::exists, "exists"); //$NON-NLS-1$
 		return folder;
 	}
 
 	protected IFile checkFileExists(String fileName) throws CoreException {
 		getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
 		IFile file = getProject().getFolder(ProjectHelper.BUILDFILES_FOLDER).getFile(fileName);
-		assertTrue("Could not find file named: " + fileName, file.exists()); //$NON-NLS-1$
+		assertThat(file).matches(IFile::exists, "exists"); //$NON-NLS-1$
 		return file;
 	}
 
@@ -177,7 +177,8 @@ public abstract class AbstractAntTest {
 		} else {
 			runner.run(buildFile, targets, args, workingDir, true);
 		}
-		assertTrue("Build starts did not equal build finishes", AntTestChecker.getDefault().getBuildsStartedCount() == AntTestChecker.getDefault().getBuildsFinishedCount()); //$NON-NLS-1$
+		assertEquals("Build starts did not equal build finishes", //$NON-NLS-1$
+				AntTestChecker.getDefault().getBuildsStartedCount(), AntTestChecker.getDefault().getBuildsFinishedCount());
 	}
 
 	protected TargetInfo[] getTargets(String buildFileName) throws CoreException {

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.ant.tests.core.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -68,7 +69,7 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("ClasspathOrdering.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertTrue("Message incorrect: " + msg, msg.equals("classpathOrdering1")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("classpathOrdering1", msg); //$NON-NLS-1$
 		assertSuccessful();
 
 		restorePreferenceDefaults();
@@ -84,7 +85,7 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("ClasspathOrdering.xml"); //$NON-NLS-1$
 		msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertTrue("Message incorrect: " + msg, msg.equals("classpathOrdering2")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("classpathOrdering2", msg); //$NON-NLS-1$
 		assertSuccessful();
 		restorePreferenceDefaults();
 	}
@@ -110,7 +111,7 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("ClasspathOrdering.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertTrue("Message incorrect: " + msg, msg.equals("classpathOrdering1")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("classpathOrdering1", msg); //$NON-NLS-1$
 		assertSuccessful();
 
 		restorePreferenceDefaults();
@@ -126,7 +127,7 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("ClasspathOrdering.xml"); //$NON-NLS-1$
 		msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertTrue("Message incorrect: " + msg, msg.equals("classpathOrdering2")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("classpathOrdering2", msg); //$NON-NLS-1$
 		assertSuccessful();
 		restorePreferenceDefaults();
 	}
@@ -160,11 +161,11 @@ public class FrameworkTests extends AbstractAntTest {
 		run("javac.xml", new String[] { "build", "refresh" }, false); // standard compiler //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
 		IFile classFile = getProject().getFolder("temp.folder").getFolder("javac.bin").getFile("AntTestTask.class"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("Class file was not generated", classFile.exists()); //$NON-NLS-1$
+		assertThat(classFile).matches(IFile::exists, "exists"); //$NON-NLS-1$
 		run("javac.xml", new String[] { "-Duse.eclipse.compiler=true", "clean", "build", "refresh" }, false); // JDTCompiler //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 		assertSuccessful();
 		classFile = getProject().getFolder("temp.folder").getFolder("javac.bin").getFile("AntTestTask.class"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("Class file was not generated", classFile.exists()); //$NON-NLS-1$
+		assertThat(classFile).matches(IFile::exists, "exists"); //$NON-NLS-1$
 	}
 
 	/**
@@ -228,9 +229,9 @@ public class FrameworkTests extends AbstractAntTest {
 		try {
 			AntCorePreferences prefs = AntCorePlugin.getPlugin().getPreferences();
 			run("echoing.xml"); //$NON-NLS-1$
-			assertTrue("ANT_HOME not set correctly", prefs.getDefaultAntHome().equals(System.getProperty("ant.home"))); //$NON-NLS-1$ //$NON-NLS-2$
+			assertEquals(prefs.getDefaultAntHome(), System.getProperty("ant.home")); //$NON-NLS-1$
 			File antLibDir = new File(prefs.getDefaultAntHome(), ProjectHelper.LIB_FOLDER);
-			assertTrue("ant.library.dir not set correctly", antLibDir.getAbsolutePath().equals(System.getProperty("ant.library.dir"))); //$NON-NLS-1$ //$NON-NLS-2$
+			assertEquals(antLibDir.getAbsolutePath(), System.getProperty("ant.library.dir")); //$NON-NLS-1$
 			prefs.setAntHome(""); //$NON-NLS-1$
 			run("echoing.xml"); //$NON-NLS-1$
 			assertTrue("ANT_HOME not set correctly", null == System.getProperty("ant.home")); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,7 +56,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testHelp() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-help" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("incorrect message number logged", 36, AntTestChecker.getDefault().getMessagesLoggedCount()); //$NON-NLS-1$
+		assertEquals(36, AntTestChecker.getDefault().getMessagesLoggedCount());
 		assertTrue("Help is incorrect", getLastMessageLogged() != null //$NON-NLS-1$
 				&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP));
 	}
@@ -66,7 +67,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testMinusH() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-h" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("incorrect message number logged", 36, AntTestChecker.getDefault().getMessagesLoggedCount()); //$NON-NLS-1$
+		assertEquals(36, AntTestChecker.getDefault().getMessagesLoggedCount());
 		assertTrue("Help is incorrect", getLastMessageLogged() != null //$NON-NLS-1$
 				&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP));
 	}
@@ -77,8 +78,8 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testVersion() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-version" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("One message should have been logged", 1, AntTestChecker.getDefault().getMessagesLoggedCount()); //$NON-NLS-1$
-		assertTrue("Version is incorrect", getLastMessageLogged().startsWith(VERSION)); //$NON-NLS-1$
+		assertEquals(1, AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertThat(getLastMessageLogged()).startsWith(VERSION);
 	}
 
 	/**
@@ -87,8 +88,8 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testProjecthelp() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-projecthelp" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("Incorrect number of messages", 4, AntTestChecker.getDefault().getMessagesLoggedCount()); //$NON-NLS-1$
-		assertTrue("Project help is incorrect", getLastMessageLogged().startsWith("Default target:")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertThat(getLastMessageLogged()).startsWith("Default target:"); //$NON-NLS-1$
 	}
 
 	/**
@@ -97,8 +98,8 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testMinusP() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-p" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("Incorrect number of messages", 4, AntTestChecker.getDefault().getMessagesLoggedCount()); //$NON-NLS-1$
-		assertTrue("Project help is incorrect", getLastMessageLogged().startsWith("Default target:")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertThat(getLastMessageLogged()).startsWith("Default target:"); //$NON-NLS-1$
 	}
 
 	/**
@@ -119,10 +120,9 @@ public class OptionTests extends AbstractAntTest {
 		CoreException ce = assertThrows("A core exception should have occurred wrappering a class cast exception", //$NON-NLS-1$
 				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-listener", "java.lang.String" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		String msg = ce.getMessage();
-		assertTrue("Message incorrect!: " //$NON-NLS-1$
-				+ msg,
-				msg.equals(
-						"java.lang.String which was specified to be a build listener is not an instance of org.apache.tools.ant.BuildListener.")); //$NON-NLS-1$
+		assertEquals(
+				"java.lang.String which was specified to be a build listener is not an instance of org.apache.tools.ant.BuildListener.", //$NON-NLS-1$
+				msg);
 	}
 
 	/**
@@ -163,7 +163,7 @@ public class OptionTests extends AbstractAntTest {
 				buffer.append(readBuffer, 0, n);
 				n = in.read(readBuffer);
 			}
-			assertTrue("File should have started with Buildfile", buffer.toString().startsWith("Buildfile")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertThat(buffer.toString()).startsWith("Buildfile"); //$NON-NLS-1$
 		}
 
 	}
@@ -213,8 +213,7 @@ public class OptionTests extends AbstractAntTest {
 		CoreException e = assertThrows("A CoreException should have occurred as the listener class will not be found", //$NON-NLS-1$
 				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-listener", "TestBuildListener" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		String message = e.getStatus().getException().getMessage();
-		assertTrue("Should be ClassNotFoundException", //$NON-NLS-1$
-				"java.lang.ClassNotFoundException: TestBuildListener".equals(message)); //$NON-NLS-1$
+		assertEquals("java.lang.ClassNotFoundException: TestBuildListener", message); //$NON-NLS-1$
 
 	}
 
@@ -225,9 +224,7 @@ public class OptionTests extends AbstractAntTest {
 	public void testListener() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-listener", ANT_TEST_BUILD_LISTENER }); //$NON-NLS-1$ //$NON-NLS-2$
 		assertSuccessful();
-		assertTrue("A listener should have been added named: " //$NON-NLS-1$
-				+ ANT_TEST_BUILD_LISTENER,
-				ANT_TEST_BUILD_LISTENER.equals(AntTestChecker.getDefault().getLastListener()));
+		assertEquals(ANT_TEST_BUILD_LISTENER, AntTestChecker.getDefault().getLastListener());
 	}
 
 	/**
@@ -252,10 +249,8 @@ public class OptionTests extends AbstractAntTest {
 		run("TestForEcho.xml", //$NON-NLS-1$
 				new String[] { "-listener", ANT_TEST_BUILD_LISTENER, "-listener", ANT_TEST_BUILD_LISTENER }); //$NON-NLS-1$ //$NON-NLS-2$
 		assertSuccessful();
-		assertTrue("A listener should have been added named: " //$NON-NLS-1$
-				+ ANT_TEST_BUILD_LISTENER,
-				ANT_TEST_BUILD_LISTENER.equals(AntTestChecker.getDefault().getLastListener()));
-		assertEquals("Two listeners should have been added", 2, AntTestChecker.getDefault().getListeners().size()); //$NON-NLS-1$
+		assertEquals(ANT_TEST_BUILD_LISTENER, AntTestChecker.getDefault().getLastListener());
+		assertThat(AntTestChecker.getDefault().getListeners()).hasSize(2);
 	}
 
 	/**
@@ -287,26 +282,24 @@ public class OptionTests extends AbstractAntTest {
 				.getAbsolutePath();
 		run("TestForEcho.xml", new String[] { "-buildfile", buildFileName }, false, "buildfiles"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-		assertEquals("Should have been 1 tasks, was: " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getTaskStartedCount(), 1,
-				AntTestChecker.getDefault().getTaskStartedCount());
+		assertEquals(1, AntTestChecker.getDefault().getTaskStartedCount());
 	}
 
 	/**
 	 * Tests specifying a target at the command line that does not exist.
-	 * 
+	 *
 	 * @since 3.6 this will not fail - the default target will be run instead
 	 * @since 3.8 this will fail as there are no more known targets
 	 */
 	@Test
 	public void testSpecifyBadTargetAsArg() throws CoreException {
 		run("TestForEcho.xml", new String[] { "echo2" }, false); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Should be an unknown target message", //$NON-NLS-1$
-				AntTestChecker.getDefault().getLoggedMessage(1).contains("Unknown target")); //$NON-NLS-1$
-		assertTrue("Should be an unknown target message", //$NON-NLS-1$
-				AntTestChecker.getDefault().getLoggedMessage(1).contains("echo2")); //$NON-NLS-1$
-		assertTrue("Should be a no known target message", //$NON-NLS-1$
-				AntTestChecker.getDefault().getLoggedMessage(0).contains("No known target specified.")); //$NON-NLS-1$
+		assertThat(AntTestChecker.getDefault().getLoggedMessage(1)).as("Should be an unknown target message") //$NON-NLS-1$
+				.contains("Unknown target"); //$NON-NLS-1$
+		assertThat(AntTestChecker.getDefault().getLoggedMessage(1)).as("Should be an unknown target message") //$NON-NLS-1$
+				.contains("echo2"); //$NON-NLS-1$
+		assertThat(AntTestChecker.getDefault().getLoggedMessage(0)).as("Should be a no known target message") //$NON-NLS-1$
+				.contains("No known target specified."); //$NON-NLS-1$
 		assertEquals("Should not have run any targets", 0, AntTestChecker.getDefault().getTargetsStartedCount()); //$NON-NLS-1$
 	}
 
@@ -317,10 +310,10 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testSpecifyBothBadAndGoodTargetsAsArg() throws CoreException {
 		run("TestForEcho.xml", new String[] { "echo2", "Test for Echo" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("Should be an unknown target message", //$NON-NLS-1$
-				AntTestChecker.getDefault().getLoggedMessage(5).contains("Unknown target")); //$NON-NLS-1$
-		assertTrue("Should be an unknown target message", //$NON-NLS-1$
-				AntTestChecker.getDefault().getLoggedMessage(5).contains("echo2")); //$NON-NLS-1$
+		assertThat(AntTestChecker.getDefault().getLoggedMessage(5)).as("Should be an unknown target message") //$NON-NLS-1$
+				.contains("Unknown target"); //$NON-NLS-1$
+		assertThat(AntTestChecker.getDefault().getLoggedMessage(5)).as("Should be an unknown target message") //$NON-NLS-1$
+				.contains("echo2"); //$NON-NLS-1$
 		assertEquals("Should have run the Test for Echo target", 5, //$NON-NLS-1$
 				AntTestChecker.getDefault().getTargetsStartedCount());
 	}
@@ -331,9 +324,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testSpecifyTargetAsArg() throws CoreException {
 		run("echoing.xml", new String[] { "echo3" }, false); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("3 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 3,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals(3, AntTestChecker.getDefault().getMessagesLoggedCount());
 		assertSuccessful();
 	}
 
@@ -343,9 +334,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testSpecifyTargetAsArgWithOtherOptions() throws CoreException {
 		run("echoing.xml", new String[] { "-logfile", "TestLogFile.txt", "echo3" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		assertEquals("4 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 4,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		// ensure that echo3 target executed and only that target
 		assertTrue("echo3 target not executed", messages.get(2).equals("echo3")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -358,9 +347,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testSpecifyTargetsAsArgWithOtherOptions() throws CoreException {
 		run("echoing.xml", new String[] { "-logfile", "TestLogFile.txt", "echo2", "echo3" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-		assertEquals("5 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 5,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals(5, AntTestChecker.getDefault().getMessagesLoggedCount());
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		// ensure that echo2 target executed
 		assertTrue("echo2 target not executed", messages.get(2).equals("echo2")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -373,9 +360,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testSpecifyTargetAsArgAndQuiet() throws CoreException {
 		run("echoing.xml", new String[] { "-logfile", "TestLogFile.txt", "echo3", "-quiet" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-		assertEquals("2 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 2,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals(2, AntTestChecker.getDefault().getMessagesLoggedCount());
 	}
 
 	/**
@@ -385,10 +370,8 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusD() throws CoreException {
 		run("echoing.xml", new String[] { "-DAntTests=testing", "-Declipse.is.cool=true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 
 	}
@@ -400,10 +383,8 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusDMinusd() throws CoreException {
 		run("echoing.xml", new String[] { "-d", "-DAntTests=testing", "-Declipse.is.cool=true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 
 	}
@@ -412,8 +393,7 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusDAndGlobalProperties() throws CoreException {
 		run("echoing.xml", new String[] { "-DAntTests=testing", "-Declipse.is.cool=true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
-		assertTrue("eclipse.running should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.running"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.running")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNotNull("eclipse.home should have been set", AntTestChecker.getDefault().getUserProperty("eclipse.home")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -424,10 +404,8 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusDEmpty() throws CoreException {
 		run("echoing.xml", new String[] { "-D=emptyStringIsMyName", "-Declipse.is.cool=true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("\"\" should have a value of emptyStringIsMyName", //$NON-NLS-1$
-				"emptyStringIsMyName".equals(AntTestChecker.getDefault().getUserProperty(""))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("emptyStringIsMyName", AntTestChecker.getDefault().getUserProperty("")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -438,10 +416,8 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusDWithSpaces() throws CoreException {
 		run("echoing.xml", new String[] { "-DAntTests= testing", "-Declipse.is.cool=    true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -452,13 +428,10 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testPropertiesWithMinusDebug() throws CoreException {
 		run("echoing.xml", new String[] { "-Debug", "-DAntTests= testing", "-Declipse.is.cool=    true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		assertTrue("\"-Debug\" should be flagged as an unknown argument", //$NON-NLS-1$
-				"Unknown argument: -Debug".equals(AntTestChecker.getDefault().getMessages().get(0))); //$NON-NLS-1$
+		assertEquals("Unknown argument: -Debug", AntTestChecker.getDefault().getMessages().get(0)); //$NON-NLS-1$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -468,8 +441,7 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testMinusDebug() throws CoreException {
 		run("echoing.xml", new String[] { "-Debug" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("\"-Debug\" should be flagged as an unknown argument", //$NON-NLS-1$
-				"Unknown argument: -Debug".equals(AntTestChecker.getDefault().getMessages().get(0))); //$NON-NLS-1$
+		assertEquals("Unknown argument: -Debug", AntTestChecker.getDefault().getMessages().get(0)); //$NON-NLS-1$
 		assertSuccessful();
 	}
 
@@ -478,8 +450,7 @@ public class OptionTests extends AbstractAntTest {
 		assertThrows("You must specify a property filename when using the -propertyfile argument", CoreException.class, //$NON-NLS-1$
 				() -> run("TestForEcho.xml", new String[] { "-propertyfile" })); //$NON-NLS-1$ //$NON-NLS-2$
 		String msg = AntTestChecker.getDefault().getMessages().get(0);
-		assertTrue("Message incorrect!: " + msg, //$NON-NLS-1$
-				msg.equals("You must specify a property filename when using the -propertyfile argument")); //$NON-NLS-1$
+		assertEquals("You must specify a property filename when using the -propertyfile argument", msg); //$NON-NLS-1$
 	}
 
 	/**
@@ -492,17 +463,15 @@ public class OptionTests extends AbstractAntTest {
 		run("TestForEcho.xml", new String[] { "-propertyfile", "qq.txt" }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
 		String msg = AntTestChecker.getDefault().getMessages().get(0);
-		assertTrue("Message incorrect!: " + msg, msg.startsWith("Could not load property file:")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThat(msg).startsWith("Could not load property file:"); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testPropertyFile() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-propertyfile", getPropertyFileName() }); //$NON-NLS-1$ //$NON-NLS-2$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as Yep", //$NON-NLS-1$
-				"Yep".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing from properties file".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Yep", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing from properties file", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -512,10 +481,8 @@ public class OptionTests extends AbstractAntTest {
 				new String[] { "-propertyfile", getPropertyFileName(), "-DAntTests=testing", "-Declipse.is.cool=true" }, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				false);
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", //$NON-NLS-1$
-				"true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("AntTests should have a value of testing", //$NON-NLS-1$
-				"testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
@@ -524,8 +491,7 @@ public class OptionTests extends AbstractAntTest {
 		CoreException ce = assertThrows("You must specify a classname when using the -inputhandler argument", //$NON-NLS-1$
 				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-inputhandler" })); //$NON-NLS-1$ //$NON-NLS-2$
 		String msg = ce.getMessage();
-		assertTrue("Message incorrect!: " + msg, //$NON-NLS-1$
-				msg.equals("You must specify a classname when using the -inputhandler argument")); //$NON-NLS-1$
+		assertEquals("You must specify a classname when using the -inputhandler argument", msg); //$NON-NLS-1$
 	}
 
 	/**
@@ -540,7 +506,7 @@ public class OptionTests extends AbstractAntTest {
 								"-inputhandler", //$NON-NLS-1$
 								"org.apache.tools.ant.input.DefaultInputHandler" })); //$NON-NLS-1$
 		String msg = ce.getMessage();
-		assertTrue("Message incorrect!: " + msg, msg.equals("Only one input handler class may be specified.")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Only one input handler class may be specified.", msg); //$NON-NLS-1$
 	}
 
 	/**
@@ -552,10 +518,9 @@ public class OptionTests extends AbstractAntTest {
 		CoreException ce = assertThrows("Incorrect inputhandler", CoreException.class, //$NON-NLS-1$
 				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "java.lang.StringBuffer" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		String msg = ce.getMessage();
-		assertTrue("Message incorrect!: " //$NON-NLS-1$
-				+ msg,
-				msg.equals(
-						"The specified input handler class java.lang.StringBuffer does not implement the org.apache.tools.ant.input.InputHandler interface")); //$NON-NLS-1$
+		assertEquals(
+				"The specified input handler class java.lang.StringBuffer does not implement the org.apache.tools.ant.input.InputHandler interface", //$NON-NLS-1$
+				msg);
 	}
 
 	/**
@@ -567,8 +532,7 @@ public class OptionTests extends AbstractAntTest {
 		CoreException ce = assertThrows("Incorrect inputhandler", CoreException.class, //$NON-NLS-1$
 				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "ja.lang.StringBuffer" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		String msg = ce.getMessage();
-		assertTrue("Message incorrect!: " + msg, //$NON-NLS-1$
-				msg.startsWith("Unable to instantiate specified input handler class ja.lang.StringBuffer")); //$NON-NLS-1$
+		assertThat(msg).startsWith("Unable to instantiate specified input handler class ja.lang.StringBuffer"); //$NON-NLS-1$
 	}
 
 	/**
@@ -580,10 +544,8 @@ public class OptionTests extends AbstractAntTest {
 		CoreException ce = assertThrows("Build should have failed", CoreException.class, //$NON-NLS-1$
 				() -> run("input.xml", new String[] { "-inputhandler", //$NON-NLS-1$ //$NON-NLS-2$
 						"org.eclipse.ant.tests.core.support.inputHandlers.AntTestInputHandler", "-noinput" })); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Message incorrect: " //$NON-NLS-1$
-				+ ce.getMessage(),
-				ce.getMessage().endsWith(
-						"Unable to respond to input request likely as a result of specifying the -noinput command")); //$NON-NLS-1$
+		assertThat(ce.getMessage()).endsWith(
+				"Unable to respond to input request likely as a result of specifying the -noinput command"); //$NON-NLS-1$
 	}
 
 	/**
@@ -593,8 +555,7 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusNoInput() {
 		CoreException ce = assertThrows("Build should have failed", CoreException.class, //$NON-NLS-1$
 				() -> run("input.xml", new String[] { "-noinput" })); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Message incorrect: " + ce.getMessage(), //$NON-NLS-1$
-				ce.getMessage().endsWith("Failed to read input from Console.")); //$NON-NLS-1$
+		assertThat(ce.getMessage()).endsWith("Failed to read input from Console."); //$NON-NLS-1$
 	}
 
 	/**
@@ -603,12 +564,11 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testInputHandler() throws CoreException {
-
 		run("input.xml", new String[] { "-inputhandler", //$NON-NLS-1$ //$NON-NLS-2$
 				"org.eclipse.ant.tests.core.support.inputHandlers.AntTestInputHandler" }); //$NON-NLS-1$
 		assertSuccessful();
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertTrue("Message incorrect: " + msg, msg.equals("testing handling input requests")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing handling input requests", msg); //$NON-NLS-1$
 
 	}
 
@@ -622,7 +582,7 @@ public class OptionTests extends AbstractAntTest {
 			run("input.xml", new String[] { "-diagnostics" }); //$NON-NLS-1$ //$NON-NLS-2$
 
 			String msg = AntTestChecker.getDefault().getMessages().get(0);
-			assertTrue("Message incorrect: " + msg, msg.equals("------- Ant diagnostics report -------")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertEquals("------- Ant diagnostics report -------", msg); //$NON-NLS-1$
 		} finally {
 			restorePreferenceDefaults();
 		}
@@ -643,25 +603,21 @@ public class OptionTests extends AbstractAntTest {
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		String msg = messages.get(17);
 		// msg depends on whether self hosting testing or build testing
-		assertTrue("Message incorrect: " + msg, checkAntHomeMessage(msg)); //$NON-NLS-1$
+		assertAntHomeMessage(msg);
 	}
 
-	private boolean checkAntHomeMessage(String message) {
-		String msg = message;
-		if (msg.endsWith("org.apache.ant")) { //$NON-NLS-1$
-			return true;
-		}
+	private void assertAntHomeMessage(String message) {
+		assertThat(message).satisfiesAnyOf( //
+				it -> assertThat(it).endsWith("org.apache.ant"), //$NON-NLS-1$
+				it -> assertThat(it).endsWith(PLUGIN_VERSION), it -> {
+					// org.apache.ant_1.7.1.v200704241635
+					int index = it.lastIndexOf('.');
+					if (index > 0) {
+						it = it.substring(0, index);
+					}
+					assertThat(it).endsWith(PLUGIN_VERSION);
 
-		if (msg.endsWith(PLUGIN_VERSION)) {
-			return true;
-		}
-
-		// org.apache.ant_1.7.1.v200704241635
-		int index = msg.lastIndexOf('.');
-		if (index > 0) {
-			msg = msg.substring(0, index);
-		}
-		return msg.endsWith(PLUGIN_VERSION);
+				});
 	}
 
 	/**
@@ -680,12 +636,8 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusKeepGoing() {
 		assertThrows("The build should have failed", CoreException.class, //$NON-NLS-1$
 				() -> run("failingTarget.xml", new String[] { "-keep-going" }, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("4 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 4,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
-		assertTrue("Incorrect message:" //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getLoggedMessage(1),
-				"Still echo on failure".equals(AntTestChecker.getDefault().getLoggedMessage(1))); //$NON-NLS-1$
+		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals("Still echo on failure", AntTestChecker.getDefault().getLoggedMessage(1)); //$NON-NLS-1$
 	}
 
 	/**
@@ -695,11 +647,7 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusK() {
 		assertThrows("The build should have failed", CoreException.class, //$NON-NLS-1$
 				() -> run("failingTarget.xml", new String[] { "-k" }, false)); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("4 messages should have been logged; was " //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getMessagesLoggedCount(), 4,
-				AntTestChecker.getDefault().getMessagesLoggedCount());
-		assertTrue("Incorrect message:" //$NON-NLS-1$
-				+ AntTestChecker.getDefault().getLoggedMessage(1),
-				"Still echo on failure".equals(AntTestChecker.getDefault().getLoggedMessage(1))); //$NON-NLS-1$
+		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
+		assertEquals("Still echo on failure", AntTestChecker.getDefault().getLoggedMessage(1)); //$NON-NLS-1$
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/PropertyTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/PropertyTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.ant.core.Property;
 import org.eclipse.ant.tests.core.AbstractAntTest;
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Tests the {@link Property} class
- * 
+ *
  * @since 3.8
  */
 public class PropertyTests extends AbstractAntTest {
@@ -31,33 +31,33 @@ public class PropertyTests extends AbstractAntTest {
 	public void testPropertyEqual() throws Exception {
 		Property p1 = new Property("one", "ONE"); //$NON-NLS-1$ //$NON-NLS-2$
 		Property p2 = new Property("one", "ONE"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("The properties should be equal", p1.equals(p2)); //$NON-NLS-1$
+		assertEquals(p1, p2);
 	}
 
 	@Test
 	public void testPropertyEqualNameOnly() throws Exception {
 		Property p1 = new Property("two", "TWO"); //$NON-NLS-1$ //$NON-NLS-2$
 		Property p2 = new Property("two", "FOUR"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("The properties should be equal", p1.equals(p2)); //$NON-NLS-1$
+		assertEquals(p1, p2);
 	}
 
 	@Test
 	public void testPropertyNotEqual() throws Exception {
 		Property p1 = new Property("three", "THREE"); //$NON-NLS-1$ //$NON-NLS-2$
 		Property p2 = new Property("four", "FOUR"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("The properties should not be equal", p1.equals(p2)); //$NON-NLS-1$
+		assertNotEquals(p1, p2);
 	}
 
 	@Test
 	public void testPropertyNotEqual2() throws Exception {
 		Property p1 = new Property("five", "FIVE"); //$NON-NLS-1$ //$NON-NLS-2$
 		Property p2 = new Property("six", "FIVE"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("The properties should not be equal", p1.equals(p2)); //$NON-NLS-1$
+		assertNotEquals(p1, p2);
 	}
 
 	@Test
 	public void testPropertyNotEqualNull() throws Exception {
 		Property p1 = new Property("seven", "SEVEN"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("The properties should not be equal", p1.equals(null)); //$NON-NLS-1$
+		assertNotEquals(p1, null);
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
@@ -58,10 +58,8 @@ public class TargetTests extends AbstractAntTest {
 		CoreException ce = assertThrows(CoreException.class, () -> getTargets("Bug42926.xml")); //$NON-NLS-1$
 		// classpathref was successful but the task is not defined
 		String message = ce.getMessage();
-		assertTrue("Core exception message not as expected: " //$NON-NLS-1$
-				+ message,
-				message.endsWith(
-						"Bug42926.xml:7: taskdef class com.foo.SomeTask cannot be found\n using the classloader AntClassLoader[]")); //$NON-NLS-1$
+		assertThat(message).endsWith(
+				"Bug42926.xml:7: taskdef class com.foo.SomeTask cannot be found\n using the classloader AntClassLoader[]"); //$NON-NLS-1$
 	}
 
 	/**
@@ -71,8 +69,8 @@ public class TargetTests extends AbstractAntTest {
 	public void testTargetNames() throws CoreException {
 		String[] targetNames = getTargetNames("TestForEcho.xml"); //$NON-NLS-1$
 		assertThat(targetNames).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
-		assertEquals("First name should be init", "init", targetNames[0]); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("Second name should be Test for Echo", "Test for Echo", targetNames[1]); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("init", targetNames[0]); //$NON-NLS-1$
+		assertEquals("Test for Echo", targetNames[1]); //$NON-NLS-1$
 	}
 
 	/**
@@ -82,8 +80,8 @@ public class TargetTests extends AbstractAntTest {
 	public void testTargetDescription() throws CoreException {
 		String[] targetDescriptions = getTargetDescriptions("TestForEcho.xml"); //$NON-NLS-1$
 		assertThat(targetDescriptions).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
-		assertNull("First description should be null", targetDescriptions[0]); //$NON-NLS-1$
-		assertEquals("Second description should be Calls other targets", "Calls other echos", targetDescriptions[1]); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(targetDescriptions[0]);
+		assertEquals("Calls other echos", targetDescriptions[1]); //$NON-NLS-1$
 	}
 
 	/**
@@ -92,7 +90,7 @@ public class TargetTests extends AbstractAntTest {
 	@Test
 	public void testTargetProject() throws CoreException {
 		String targetProject = getProjectName("TestForEcho.xml", "Test for Echo"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertEquals("Project name should be Echo Test", "Echo Test", targetProject); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Echo Test", targetProject); //$NON-NLS-1$
 	}
 
 	/**
@@ -102,7 +100,7 @@ public class TargetTests extends AbstractAntTest {
 	public void testTargetDependencies() throws CoreException {
 		String[] dependencies = getDependencies("TestForEcho.xml", "Test for Echo"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertThat(dependencies).as("number of dependencies in Test for Echo").hasSize(1); //$NON-NLS-1$
-		assertEquals("First dependency should be init", "init", dependencies[0]); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("init", dependencies[0]); //$NON-NLS-1$
 	}
 
 	/**
@@ -112,8 +110,8 @@ public class TargetTests extends AbstractAntTest {
 	public void testRunScript() throws CoreException {
 		run("TestForEcho.xml"); //$NON-NLS-1$
 		String message = AntTestChecker.getDefault().getMessages().get(0);
-		assertTrue("Build file location should be logged as the first message", message != null //$NON-NLS-1$
-				&& message.endsWith("AntTests" + File.separator + "buildfiles" + File.separator + "TestForEcho.xml")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertThat(message).as("Build file location should be logged as the first message").isNotNull() //$NON-NLS-1$
+				.endsWith("AntTests" + File.separator + "buildfiles" + File.separator + "TestForEcho.xml"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TaskTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TaskTests.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
@@ -52,7 +52,7 @@ public class TaskTests extends AbstractAntTest {
 
 		run("CustomTask.xml", new String[0], false); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertEquals("Message incorrect: " + msg, "Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 
@@ -70,7 +70,7 @@ public class TaskTests extends AbstractAntTest {
 
 		run("CustomTask.xml", new String[] { "Custom Task from Entry" }, false); //$NON-NLS-1$ //$NON-NLS-2$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertEquals("Message incorrect: " + msg, "Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 
@@ -81,8 +81,8 @@ public class TaskTests extends AbstractAntTest {
 		try {
 			CoreException ce = assertThrows("Build should have failed as task no longer defined", CoreException.class, //$NON-NLS-1$
 					() -> run("CustomTask.xml")); //$NON-NLS-1$
-			assertTrue("Exception from undefined task is incorrect", ce.getMessage().trim() //$NON-NLS-1$
-					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place.")); //$NON-NLS-1$
+			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
+					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {
 			restorePreferenceDefaults();
 		}
@@ -111,7 +111,7 @@ public class TaskTests extends AbstractAntTest {
 
 			run("CustomTask.xml", new String[0], false); //$NON-NLS-1$
 			String msg = AntTestChecker.getDefault().getMessages().get(1);
-			assertEquals("Message incorrect: " + msg, "Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$ //$NON-NLS-2$
+			assertEquals("Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$
 			assertSuccessful();
 		} finally {
 			restorePreferenceDefaults();
@@ -134,7 +134,7 @@ public class TaskTests extends AbstractAntTest {
 	public void testTaskDefinedInExtensionPoint() throws CoreException {
 		run("ExtensionPointTask.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertEquals("Message incorrect: " + msg, "Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 
@@ -144,8 +144,8 @@ public class TaskTests extends AbstractAntTest {
 		try {
 			CoreException ce = assertThrows("Build should have failed as task was not defined to run in headless", //$NON-NLS-1$
 					CoreException.class, () -> run("ExtensionPointTask.xml")); //$NON-NLS-1$
-			assertTrue("Exception from undefined task is incorrect", ce.getMessage().trim() //$NON-NLS-1$
-					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place.")); //$NON-NLS-1$
+			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
+					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {
 			AntCorePlugin.getPlugin().setRunningHeadless(false);
 		}
@@ -155,7 +155,7 @@ public class TaskTests extends AbstractAntTest {
 	public void testTaskDefinedInExtensionPointWithURI() throws CoreException {
 		run("ExtensionPointTask.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(2);
-		assertEquals("Message incorrect: " + msg, "Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Testing Ant in Eclipse with a custom task", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TypeTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TypeTests.java
@@ -42,7 +42,7 @@ public class TypeTests extends AbstractAntTest {
 
 		run("CustomType.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertEquals("Message incorrect: " + msg, "Test adding a custom type", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Test adding a custom type", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 
@@ -67,7 +67,7 @@ public class TypeTests extends AbstractAntTest {
 	public void testTypeDefinedInExtensionPoint() throws CoreException {
 		run("ExtensionPointType.xml"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(1);
-		assertEquals("Message incorrect: " + msg, "Ensure that an extension point defined type is present", msg); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Ensure that an extension point defined type is present", msg); //$NON-NLS-1$
 		assertSuccessful();
 	}
 


### PR DESCRIPTION
Simplifies and/or improves several assertions in org.eclipse.ant.core.tests
- Replace assertTrue/assertFalse with assertEquals/assertThat
- Remove obsolete assertions messages just repeating the assertions

This also prepares for a migration of assertions to JUnit 5.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903