### PR TITLE
Move transferAttributes outside of try-with-resource-block to prevent premature file closure

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/filesystem/provider/FileStore.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/filesystem/provider/FileStore.java
@@ -164,10 +164,12 @@ public abstract class FileStore extends PlatformObject implements IFileStore {
 		}
 		String sourcePath = toString();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, NLS.bind(Messages.copying, sourcePath), 100);
-		try (InputStream in = openInputStream(EFS.NONE, subMonitor.newChild(1)); //
-				OutputStream out = destination.openOutputStream(EFS.NONE, subMonitor.newChild(1));) {
-			in.transferTo(out);
-			subMonitor.worked(93);
+		try {
+			try (InputStream in = openInputStream(EFS.NONE, subMonitor.newChild(1)); //
+					OutputStream out = destination.openOutputStream(EFS.NONE, subMonitor.newChild(1));) {
+				in.transferTo(out);
+				subMonitor.worked(93);
+			} // Close the streams to ensure the target file exists before transferring attributes
 			LocalFile.transferAttributes(sourceInfo, destination);
 			subMonitor.worked(5);
 		} catch (IOException e) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -55,6 +55,7 @@ import org.eclipse.core.internal.filesystem.local.LocalFileSystem;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
 import org.eclipse.osgi.util.NLS;
@@ -368,6 +369,23 @@ public class FileStoreTest {
 		createFile(target, content);
 		assertTrue(destination.fetchInfo().isDirectory());
 		destination.delete(EFS.NONE, null);
+	}
+
+	@Test
+	public void testFileAttributeCopyForSmallFiles() throws CoreException, IOException {
+		Path root = Files.createDirectories(randomUniqueNotExistingPath());
+		Path sourceFile = root.resolve("source.txt");
+		Files.writeString(sourceFile, "This is a test file.");
+		Path targetFile = root.resolve("target.txt");
+
+		IFileStore sourceStore = EFS.getLocalFileSystem().getStore(IPath.fromPath(sourceFile));
+		IFileStore targetStore = new OnCloseWritingFileStore(targetFile);
+
+		sourceStore.copy(targetStore, EFS.NONE, new NullProgressMonitor());
+
+		String sourceContent = Files.readString(sourceFile);
+		String targetContent = Files.readString(targetFile);
+		assertEquals(sourceContent, targetContent);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/OnCloseWritingFileStore.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/OnCloseWritingFileStore.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *  Contributors:
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.filesystem;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.provider.FileInfo;
+import org.eclipse.core.filesystem.provider.FileStore;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+class OnCloseWritingFileStore extends FileStore {
+
+	private final Path filePath;
+
+	public OnCloseWritingFileStore(Path file) {
+		this.filePath = file;
+	}
+
+	@Override
+	public OutputStream openOutputStream(int options, IProgressMonitor monitor) {
+		return new ByteArrayOutputStream() {
+			@Override
+			public void close() throws IOException {
+				Files.write(filePath, this.toByteArray());
+			}
+		};
+	}
+
+	@Override
+	public void putInfo(IFileInfo info, int options, IProgressMonitor monitor) throws CoreException {
+		if ((options & EFS.SET_LAST_MODIFIED) != 0) {
+			FileTime lastModified = FileTime.fromMillis(info.getLastModified());
+			try {
+				Files.setLastModifiedTime(filePath, lastModified);
+			} catch (IOException e) {
+				if (!Files.exists(filePath, LinkOption.NOFOLLOW_LINKS)) {
+					throw new CoreException(new Status(IStatus.ERROR, "CopyBugFileStore", "File does not exist", e));
+				}
+				throw new CoreException(new Status(IStatus.ERROR, "CopyBugFileStore", "Failed to set attribute", e));
+			}
+		}
+	}
+
+	@Override
+	public IFileInfo fetchInfo(int options, IProgressMonitor monitor) throws CoreException {
+		FileInfo info = new FileInfo();
+		try {
+			info.setLastModified(Files.getLastModifiedTime(filePath).toMillis());
+			info.setLength(Files.size(filePath));
+			info.setExists(Files.exists(filePath));
+		} catch (IOException e) {
+			throw new CoreException(new Status(IStatus.ERROR, "TestFileStore", "Failed to fetch file info", e));
+		}
+		return info;
+	}
+
+	@Override
+	public String getName() {
+		return filePath.getFileName().toString();
+	}
+
+	@Override
+	public IFileStore getParent() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String[] childNames(int options, IProgressMonitor monitor) throws CoreException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IFileStore getChild(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public InputStream openInputStream(int options, IProgressMonitor monitor) throws CoreException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public URI toURI() {
+		throw new UnsupportedOperationException();
+	}
+}


### PR DESCRIPTION
This commit refactors the code by moving the transferAttributes method call outside of the try-with-resources block. Closing the OutputStream prematurely could result in the destination FileStore not creating the file before the file attributes are transferred. Additionally, transferring attributes does not require the streams to remain open.

A TestFileStore and a matching test is provided.

This commit is an adjustment to https://github.com/eclipse-platform/eclipse.platform/pull/1475 and fixes https://github.com/eclipse-platform/eclipse.platform/issues/1524.