### PR TITLE
ElementTree#includes: relax synchronized access

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
lookupCache is declared volatile and it's type DataTreeLookup has all fields final, so they can be used outside the synchronized block. Sadly same pattern does not work for getElementData() as the returned Object is not guaranteed to be thread-safe but some checks can be moved outside the synchronized block.

ElementTree.includes() is heavily used for example during file search.