### PR TITLE
Revert tycho-packaging-plugin config in help.base

### DIFF
--- a/ua/org.eclipse.help.base/pom.xml
+++ b/ua/org.eclipse.help.base/pom.xml
@@ -23,4 +23,15 @@
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <configuration>
+          <format>'v${buildTimestamp}'</format>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
It looks unneeded but might be what causes about.mappings comparator issues. Weirdly enough this is not handled by tycho but instead is manual maven-resources-plugin call in eclipse-platform-parent.