### PR TITLE
Add ZipEntryStorage.getArchivePath() and deprecate its getArchive()

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.21.500.qualifier
+Bundle-Version: 3.22.0.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/SourceElementWorkbenchAdapter.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/SourceElementWorkbenchAdapter.java
@@ -41,7 +41,7 @@ public class SourceElementWorkbenchAdapter implements IWorkbenchAdapter {
 		}
 		return null;
 	}
-	@SuppressWarnings("resource")
+
 	@Override
 	public String getLabel(Object o) {
 		if (o instanceof LocalFileStorage) {
@@ -54,7 +54,7 @@ public class SourceElementWorkbenchAdapter implements IWorkbenchAdapter {
 			StringBuilder buffer = new StringBuilder();
 			buffer.append(storage.getZipEntry().getName());
 			buffer.append(" - "); //$NON-NLS-1$
-			buffer.append(storage.getArchive().getName());
+			buffer.append(storage.getArchivePath());
 			return buffer.toString();
 		}
 		return IInternalDebugCoreConstants.EMPTY_STRING;


### PR DESCRIPTION
This should help to prevent issues like https://github.com/eclipse-platform/eclipse.platform.ui/issues/2251.

What's your opinion regarding just deprecating `ZipEntryStorage.getArchive()` or deprecating it for removal?
We could keep it as deprecated as back-up for cases were another solution doesn't exist. But we could also use the deprecation time to work on alternatives if necessary.

The only caller in the SDK is in JDT and would be satisfied with the new method that could be applied with
https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/486