### PR TITLE
TextMergeView Unhandled IndexOutOfBoundsException at lines height calc

### DIFF
--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.11.100.qualifier
+Bundle-Version: 3.11.200.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
In the TextMergeViewer the method
getHeightBetweenLines(MergeSourceViewer tp, int fromLine, int toLine) can be called with a higher toLine value than the number of lines in the TextWidget. In this case a default handling has to be used for getting the line height. This must be checked with:
https://github.com/eclipse-platform/eclipse.platform/issues/1542 which is the compare of java methods.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1536