### PR TITLE
AntLaunchDelegate.runInSeparateVM: wakeup waiter

### DIFF
--- a/ant/org.eclipse.ant.launching/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.launching/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.launching;singleton:=true
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Bundle-Activator: org.eclipse.ant.internal.launching.AntLaunching
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.12.0,4.0.0)",


### PR DESCRIPTION
I saw in a sampling of building the workspace, that this method slept a multiple of 50ms. Instead the waiting thread can be woken up. For example by using a CountDownLatch