### PR TITLE
Migrate Ant core tests to JUnit 5 #903

### DIFF
--- a/ant/org.eclipse.ant.tests.core/Ant Core Test Suite.launch
+++ b/ant/org.eclipse.ant.tests.core/Ant Core Test Suite.launch
@@ -22,7 +22,7 @@
     <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ant.tests.core.AutomatedAntSuite"/>

--- a/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
@@ -12,12 +12,14 @@ Export-Package: org.eclipse.ant.tests.core,
  org.eclipse.ant.tests.core.tests
 Require-Bundle: org.eclipse.ui.ide;resolution:=optional,
  org.apache.ant;bundle-version="1.9.4",
- org.junit,
  org.eclipse.core.resources,
  org.eclipse.ui,
  org.eclipse.ant.core,
  org.eclipse.core.runtime
-Import-Package: org.assertj.core.api
+Import-Package: org.assertj.core.api,
+ org.junit.jupiter.api,
+ org.junit.jupiter.api.function,
+ org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AbstractAntTest.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AbstractAntTest.java
@@ -7,14 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;
@@ -48,7 +48,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.progress.UIJob;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Tests for Ant core
@@ -60,7 +60,7 @@ public abstract class AbstractAntTest {
 	public static final String ANT_TEST_BUILD_LISTENER = "org.eclipse.ant.tests.core.support.testloggers.TestBuildListener"; //$NON-NLS-1$
 	private static boolean welcomeClosed = false;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		assertProject();
 		assertWelcomeScreenClosed();
@@ -68,7 +68,7 @@ public abstract class AbstractAntTest {
 
 	/**
 	 * Ensure the welcome screen is closed because in 4.x the debug perspective opens a giant fast-view causing issues
-	 * 
+	 *
 	 * @since 3.8
 	 */
 	void assertWelcomeScreenClosed() throws Exception {
@@ -98,7 +98,7 @@ public abstract class AbstractAntTest {
 
 	/**
 	 * Asserts that the test project has been created and all testing resources have been loaded each time the {@link #setUp()} method is called
-	 * 
+	 *
 	 * @since 3.5
 	 */
 	protected void assertProject() throws Exception {
@@ -123,7 +123,7 @@ public abstract class AbstractAntTest {
 
 	/**
 	 * Returns the 'AntTests' project.
-	 * 
+	 *
 	 * @return the test project
 	 */
 	protected IProject getProject() {
@@ -177,8 +177,8 @@ public abstract class AbstractAntTest {
 		} else {
 			runner.run(buildFile, targets, args, workingDir, true);
 		}
-		assertEquals("Build starts did not equal build finishes", //$NON-NLS-1$
-				AntTestChecker.getDefault().getBuildsStartedCount(), AntTestChecker.getDefault().getBuildsFinishedCount());
+		assertEquals(AntTestChecker.getDefault().getBuildsStartedCount(),
+				AntTestChecker.getDefault().getBuildsFinishedCount(), "Build starts did not equal build finishes"); //$NON-NLS-1$
 	}
 
 	protected TargetInfo[] getTargets(String buildFileName) throws CoreException {
@@ -245,7 +245,7 @@ public abstract class AbstractAntTest {
 
 	/**
 	 * Return the log message n from the last: e.g. getLoggedMessage(0) returns the most recent message
-	 * 
+	 *
 	 * @param n
 	 *              message index
 	 * @return the nth last message
@@ -261,7 +261,7 @@ public abstract class AbstractAntTest {
 	protected void assertSuccessful() {
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		String success = messages.get(messages.size() - 1);
-		assertEquals("Build was not flagged as successful: " + success, BUILD_SUCCESSFUL, success); //$NON-NLS-1$
+		assertEquals(BUILD_SUCCESSFUL, success, "Build was not flagged as successful"); //$NON-NLS-1$
 	}
 
 	protected String getPropertyFileName() {

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AutomatedAntSuite.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/AutomatedAntSuite.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -21,12 +21,12 @@ import org.eclipse.ant.tests.core.tests.PropertyTests;
 import org.eclipse.ant.tests.core.tests.TargetTests;
 import org.eclipse.ant.tests.core.tests.TaskTests;
 import org.eclipse.ant.tests.core.tests.TypeTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test the Eclipse Ant Core.
- * 
+ *
  * To run this test suite:
  * <ol>
  * <li>Create a new JUnit plugin test launch configuration</li>
@@ -35,9 +35,17 @@ import org.junit.runners.Suite;
  * <li>Run the launch configuration. Output from the tests will be displayed in a JUnit view</li>
  * </ol>
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ FrameworkTests.class, TargetTests.class, ProjectTests.class, OptionTests.class, TaskTests.class, TypeTests.class,
-		PropertyTests.class, AntSecurityManagerTest.class })
+@Suite
+@SelectClasses({ //
+		FrameworkTests.class, //
+		TargetTests.class, //
+		ProjectTests.class, //
+		OptionTests.class, //
+		TaskTests.class, //
+		TypeTests.class, //
+		PropertyTests.class, //
+		AntSecurityManagerTest.class //
+})
 public class AutomatedAntSuite {
-	// SUITE
+	//
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/AntSecurityManagerTest.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/AntSecurityManagerTest.java
@@ -1,10 +1,10 @@
 package org.eclipse.ant.tests.core.tests;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.ant.internal.core.AntSecurityManager;
 import org.eclipse.ant.tests.core.AbstractAntTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AntSecurityManagerTest extends AbstractAntTest {
 

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/FrameworkTests.java
@@ -15,11 +15,10 @@
 package org.eclipse.ant.tests.core.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -39,7 +38,7 @@ import org.eclipse.ant.tests.core.testplugin.ProjectHelper;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FrameworkTests extends AbstractAntTest {
 
@@ -181,9 +180,9 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("TestForEcho.xml", new String[] {}); //$NON-NLS-1$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as Yep", "Yep".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("AntTests should have a value of testing", "testing from properties file".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Yep", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing from properties file", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		restorePreferenceDefaults();
 	}
@@ -199,9 +198,9 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("TestForEcho.xml", new String[] {}); //$NON-NLS-1$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as Yep", "Yep".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("JUnitTests should have a value of true", "true".equals(AntTestChecker.getDefault().getUserProperty("JUnitTest"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Yep", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("JUnitTest")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		restorePreferenceDefaults();
 	}
@@ -215,9 +214,9 @@ public class FrameworkTests extends AbstractAntTest {
 
 		run("echoing.xml", new String[] { "-DAntTests=testing", "-Declipse.is.cool=true" }, false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		assertSuccessful();
-		assertTrue("eclipse.is.cool should have been set as true", "true".equals(AntTestChecker.getDefault().getUserProperty("eclipse.is.cool"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertTrue("AntTests should have a value of testing", "testing".equals(AntTestChecker.getDefault().getUserProperty("AntTests"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 		restorePreferenceDefaults();
 	}
 
@@ -234,8 +233,8 @@ public class FrameworkTests extends AbstractAntTest {
 			assertEquals(antLibDir.getAbsolutePath(), System.getProperty("ant.library.dir")); //$NON-NLS-1$
 			prefs.setAntHome(""); //$NON-NLS-1$
 			run("echoing.xml"); //$NON-NLS-1$
-			assertTrue("ANT_HOME not set correctly", null == System.getProperty("ant.home")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertTrue("ant.library.dir not set correctly", null == System.getProperty("ant.library.dir")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertNull(System.getProperty("ant.home"), "ant.home should be null"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertNull(System.getProperty("ant.library.dir"), "ant.library.dir should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		finally {
 			restorePreferenceDefaults();
@@ -290,8 +289,14 @@ public class FrameworkTests extends AbstractAntTest {
 
 		IAntClasspathEntry resultedEntries[] = prefs.getAntHomeClasspathEntries();
 		int index = resultedEntries[entries.length].getLabel().indexOf("hub"); //$NON-NLS-1$
-		assertNotSame("Missing machine details", index, -1); //$NON-NLS-1$
-		assertFalse("Incorrect classpath entry. This would have been the value before the fix", resultedEntries[entries.length].getLabel().equals(IPath.fromOSString("/home/tom/.eclipse/3.8/configuration/org.eclipse.osgi/bundles/21/2/.cp/lib/remote.jar").toOSString())); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Incorrect classpath entry", resultedEntries[entries.length].getLabel().substring(index).equals(IPath.fromOSString("hub/home/tom/.eclipse/3.8/configuration/org.eclipse.osgi/bundles/21/2/.cp/lib/remote.jar").toOSString())); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNotSame(index, -1, "Missing machine details"); //$NON-NLS-1$
+		assertNotEquals(resultedEntries[entries.length].getLabel(),
+				IPath.fromOSString(
+						"/home/tom/.eclipse/3.8/configuration/org.eclipse.osgi/bundles/21/2/.cp/lib/remote.jar") //$NON-NLS-1$
+						.toOSString());
+		assertEquals(resultedEntries[entries.length].getLabel().substring(index),
+				IPath.fromOSString(
+						"hub/home/tom/.eclipse/3.8/configuration/org.eclipse.osgi/bundles/21/2/.cp/lib/remote.jar") //$NON-NLS-1$
+						.toOSString());
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/OptionTests.java
@@ -7,19 +7,19 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -33,7 +33,7 @@ import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Version;
 
 public class OptionTests extends AbstractAntTest {
@@ -57,8 +57,9 @@ public class OptionTests extends AbstractAntTest {
 	public void testHelp() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-help" }); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals(36, AntTestChecker.getDefault().getMessagesLoggedCount());
-		assertTrue("Help is incorrect", getLastMessageLogged() != null //$NON-NLS-1$
-				&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP));
+		assertTrue(getLastMessageLogged() != null
+						&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP),
+				"Help is incorrect"); //$NON-NLS-1$
 	}
 
 	/**
@@ -68,8 +69,10 @@ public class OptionTests extends AbstractAntTest {
 	public void testMinusH() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-h" }); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals(36, AntTestChecker.getDefault().getMessagesLoggedCount());
-		assertTrue("Help is incorrect", getLastMessageLogged() != null //$NON-NLS-1$
-				&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP));
+		assertTrue(
+				getLastMessageLogged() != null
+						&& AntTestChecker.getDefault().getMessages().get(0).startsWith(START_OF_HELP),
+				"Help is incorrect"); //$NON-NLS-1$
 	}
 
 	/**
@@ -117,8 +120,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testListenerBad() {
-		CoreException ce = assertThrows("A core exception should have occurred wrappering a class cast exception", //$NON-NLS-1$
-				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-listener", "java.lang.String" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		CoreException ce = assertThrows(CoreException.class,
+				() -> run("TestForEcho.xml", new String[] { "-listener", "java.lang.String" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"A core exception should have occurred wrappering a class cast exception"); //$NON-NLS-1$
 		String msg = ce.getMessage();
 		assertEquals(
 				"java.lang.String which was specified to be a build listener is not an instance of org.apache.tools.ant.BuildListener.", //$NON-NLS-1$
@@ -131,10 +135,10 @@ public class OptionTests extends AbstractAntTest {
 	@Test
 	public void testUnknownArg() throws CoreException {
 		run("TestForEcho.xml", new String[] { "-listenr" }); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Unrecognized option message should have been logged before successful build", //$NON-NLS-1$
-				(AntTestChecker.getDefault().getMessagesLoggedCount() == 6)
-						&& (getLoggedMessage(5).startsWith(UNKNOWN_ARG))
-						&& (getLastMessageLogged().startsWith(BUILD_SUCCESSFUL)));
+		assertTrue(
+				AntTestChecker.getDefault().getMessagesLoggedCount() == 6 && getLoggedMessage(5).startsWith(UNKNOWN_ARG)
+						&& getLastMessageLogged().startsWith(BUILD_SUCCESSFUL),
+				"Unrecognized option message should have been logged before successful build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -142,8 +146,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testLogFileWithNoArg() {
-		assertThrows("You must specify a log file when using the -log argument", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-logfile" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-logfile" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a log file when using the -log argument"); //$NON-NLS-1$
 	}
 
 	/**
@@ -173,8 +177,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testLoggerWithNoArg() {
-		assertThrows("You must specify a classname when using the -logger argument", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-logger" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-logger" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a classname when using the -logger argument"); //$NON-NLS-1$
 	}
 
 	/**
@@ -183,8 +187,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testLoggerBad() {
-		assertThrows("A core exception should have occurred wrappering a class cast exception", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-logger", "java.lang.String" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-logger", "java.lang.String" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"A core exception should have occurred wrappering a class cast exception"); //$NON-NLS-1$
 	}
 
 	/**
@@ -192,8 +196,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testTwoLoggers() {
-		assertThrows("As only one logger can be specified", CoreException.class, () -> run("TestForEcho.xml", //$NON-NLS-1$ //$NON-NLS-2$
-				new String[] { "-logger", "java.lang.String", "-q", "-logger", "java.lang.String" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", //$NON-NLS-1$
+				new String[] { "-logger", "java.lang.String", "-q", "-logger", "java.lang.String" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+				"As only one logger can be specified"); //$NON-NLS-1$
 	}
 
 	/**
@@ -201,8 +206,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testListenerWithNoArg() {
-		assertThrows("You must specify a listeners when using the -listener argument ", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-listener" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-listener" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a listeners when using the -listener argument "); //$NON-NLS-1$
 	}
 
 	/**
@@ -210,8 +215,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testListenerClassNotFound() {
-		CoreException e = assertThrows("A CoreException should have occurred as the listener class will not be found", //$NON-NLS-1$
-				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-listener", "TestBuildListener" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		CoreException e = assertThrows(CoreException.class,
+				() -> run("TestForEcho.xml", new String[] { "-listener", "TestBuildListener" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"A CoreException should have occurred as the listener class will not be found"); //$NON-NLS-1$
 		String message = e.getStatus().getException().getMessage();
 		assertEquals("java.lang.ClassNotFoundException: TestBuildListener", message); //$NON-NLS-1$
 
@@ -259,9 +265,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testListenerMultipleWithBad() {
-		assertThrows("You must specify a listener for all -listener arguments ", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", //$NON-NLS-1$
-						new String[] { "-listener", ANT_TEST_BUILD_LISTENER, "-q", "-listener", "-verbose" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", //$NON-NLS-1$
+				new String[] { "-listener", ANT_TEST_BUILD_LISTENER, "-q", "-listener", "-verbose" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				"You must specify a listener for all -listener arguments"); //$NON-NLS-1$
 	}
 
 	/**
@@ -269,8 +275,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testBuildFileWithNoArg() {
-		assertThrows("You must specify a buildfile when using the -buildfile argument", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-buildfile" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-buildfile" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a buildfile when using the -buildfile argument"); //$NON-NLS-1$
 	}
 
 	/**
@@ -300,7 +306,7 @@ public class OptionTests extends AbstractAntTest {
 				.contains("echo2"); //$NON-NLS-1$
 		assertThat(AntTestChecker.getDefault().getLoggedMessage(0)).as("Should be a no known target message") //$NON-NLS-1$
 				.contains("No known target specified."); //$NON-NLS-1$
-		assertEquals("Should not have run any targets", 0, AntTestChecker.getDefault().getTargetsStartedCount()); //$NON-NLS-1$
+		assertEquals(0, AntTestChecker.getDefault().getTargetsStartedCount(), "Should not have run any targets"); //$NON-NLS-1$
 	}
 
 	/**
@@ -314,8 +320,8 @@ public class OptionTests extends AbstractAntTest {
 				.contains("Unknown target"); //$NON-NLS-1$
 		assertThat(AntTestChecker.getDefault().getLoggedMessage(5)).as("Should be an unknown target message") //$NON-NLS-1$
 				.contains("echo2"); //$NON-NLS-1$
-		assertEquals("Should have run the Test for Echo target", 5, //$NON-NLS-1$
-				AntTestChecker.getDefault().getTargetsStartedCount());
+		assertEquals(5, AntTestChecker.getDefault().getTargetsStartedCount(),
+				"Should have run the Test for Echo target"); //$NON-NLS-1$
 	}
 
 	/**
@@ -337,7 +343,7 @@ public class OptionTests extends AbstractAntTest {
 		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		// ensure that echo3 target executed and only that target
-		assertTrue("echo3 target not executed", messages.get(2).equals("echo3")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("echo3", messages.get(2), "echo3 target not executed"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertSuccessful();
 	}
 
@@ -350,7 +356,7 @@ public class OptionTests extends AbstractAntTest {
 		assertEquals(5, AntTestChecker.getDefault().getMessagesLoggedCount());
 		List<String> messages = AntTestChecker.getDefault().getMessages();
 		// ensure that echo2 target executed
-		assertTrue("echo2 target not executed", messages.get(2).equals("echo2")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("echo2", messages.get(2), "echo2 target not executed"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertSuccessful();
 	}
 
@@ -372,7 +378,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 
 	}
 
@@ -385,7 +391,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 
 	}
 
@@ -406,7 +412,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("emptyStringIsMyName", AntTestChecker.getDefault().getUserProperty("")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -418,7 +424,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -432,7 +438,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -447,8 +453,8 @@ public class OptionTests extends AbstractAntTest {
 
 	@Test
 	public void testPropertyFileWithNoArg() {
-		assertThrows("You must specify a property filename when using the -propertyfile argument", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-propertyfile" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("TestForEcho.xml", new String[] { "-propertyfile" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a property filename when using the -propertyfile argument"); //$NON-NLS-1$
 		String msg = AntTestChecker.getDefault().getMessages().get(0);
 		assertEquals("You must specify a property filename when using the -propertyfile argument", msg); //$NON-NLS-1$
 	}
@@ -472,7 +478,7 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("Yep", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing from properties file", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Test
@@ -483,13 +489,14 @@ public class OptionTests extends AbstractAntTest {
 		assertSuccessful();
 		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.is.cool")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("testing", AntTestChecker.getDefault().getUserProperty("AntTests")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNull("my.name was not set and should be null", AntTestChecker.getDefault().getUserProperty("my.name")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull(AntTestChecker.getDefault().getUserProperty("my.name"), "my.name was not set and should be null"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Test
 	public void testInputHandlerWithNoArg() {
-		CoreException ce = assertThrows("You must specify a classname when using the -inputhandler argument", //$NON-NLS-1$
-				CoreException.class, () -> run("TestForEcho.xml", new String[] { "-inputhandler" })); //$NON-NLS-1$ //$NON-NLS-2$
+		CoreException ce = assertThrows(CoreException.class,
+				() -> run("TestForEcho.xml", new String[] { "-inputhandler" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"You must specify a classname when using the -inputhandler argument"); //$NON-NLS-1$
 		String msg = ce.getMessage();
 		assertEquals("You must specify a classname when using the -inputhandler argument", msg); //$NON-NLS-1$
 	}
@@ -500,11 +507,11 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testInputHandlerMultiple() {
-		CoreException ce = assertThrows("As only one input handler can be specified", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", //$NON-NLS-1$
-						new String[] { "-inputhandler", "org.apache.tools.ant.input.DefaultInputHandler", "-q", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-								"-inputhandler", //$NON-NLS-1$
-								"org.apache.tools.ant.input.DefaultInputHandler" })); //$NON-NLS-1$
+		CoreException ce = assertThrows(CoreException.class, () -> run("TestForEcho.xml", //$NON-NLS-1$
+				new String[] { "-inputhandler", "org.apache.tools.ant.input.DefaultInputHandler", "-q", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						"-inputhandler", //$NON-NLS-1$
+						"org.apache.tools.ant.input.DefaultInputHandler" }), //$NON-NLS-1$
+				"As only one input handler can be specified"); //$NON-NLS-1$
 		String msg = ce.getMessage();
 		assertEquals("Only one input handler class may be specified.", msg); //$NON-NLS-1$
 	}
@@ -515,8 +522,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testInputHandlerBad() {
-		CoreException ce = assertThrows("Incorrect inputhandler", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "java.lang.StringBuffer" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		CoreException ce = assertThrows(CoreException.class,
+				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "java.lang.StringBuffer" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"Incorrect inputhandler"); //$NON-NLS-1$
 		String msg = ce.getMessage();
 		assertEquals(
 				"The specified input handler class java.lang.StringBuffer does not implement the org.apache.tools.ant.input.InputHandler interface", //$NON-NLS-1$
@@ -529,8 +537,9 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testInputHandlerBad2() {
-		CoreException ce = assertThrows("Incorrect inputhandler", CoreException.class, //$NON-NLS-1$
-				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "ja.lang.StringBuffer" })); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		CoreException ce = assertThrows(CoreException.class,
+				() -> run("TestForEcho.xml", new String[] { "-inputhandler", "ja.lang.StringBuffer" }), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"Incorrect inputhandler"); //$NON-NLS-1$
 		String msg = ce.getMessage();
 		assertThat(msg).startsWith("Unable to instantiate specified input handler class ja.lang.StringBuffer"); //$NON-NLS-1$
 	}
@@ -541,11 +550,11 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testInputHandlerWithMinusNoInput() {
-		CoreException ce = assertThrows("Build should have failed", CoreException.class, //$NON-NLS-1$
-				() -> run("input.xml", new String[] { "-inputhandler", //$NON-NLS-1$ //$NON-NLS-2$
-						"org.eclipse.ant.tests.core.support.inputHandlers.AntTestInputHandler", "-noinput" })); //$NON-NLS-1$ //$NON-NLS-2$
-		assertThat(ce.getMessage()).endsWith(
-				"Unable to respond to input request likely as a result of specifying the -noinput command"); //$NON-NLS-1$
+		CoreException ce = assertThrows(CoreException.class, () -> run("input.xml", new String[] { "-inputhandler", //$NON-NLS-1$ //$NON-NLS-2$
+				"org.eclipse.ant.tests.core.support.inputHandlers.AntTestInputHandler", "-noinput" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"Build should have failed"); //$NON-NLS-1$
+		assertThat(ce.getMessage())
+				.endsWith("Unable to respond to input request likely as a result of specifying the -noinput command"); //$NON-NLS-1$
 	}
 
 	/**
@@ -553,8 +562,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testMinusNoInput() {
-		CoreException ce = assertThrows("Build should have failed", CoreException.class, //$NON-NLS-1$
-				() -> run("input.xml", new String[] { "-noinput" })); //$NON-NLS-1$ //$NON-NLS-2$
+		CoreException ce = assertThrows(CoreException.class, () -> run("input.xml", new String[] { "-noinput" }), //$NON-NLS-1$ //$NON-NLS-2$
+				"Build should have failed"); //$NON-NLS-1$
 		assertThat(ce.getMessage()).endsWith("Failed to read input from Console."); //$NON-NLS-1$
 	}
 
@@ -634,8 +643,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testMinusKeepGoing() {
-		assertThrows("The build should have failed", CoreException.class, //$NON-NLS-1$
-				() -> run("failingTarget.xml", new String[] { "-keep-going" }, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("failingTarget.xml", new String[] { "-keep-going" }, false), //$NON-NLS-1$ //$NON-NLS-2$
+				"The build should have failed"); //$NON-NLS-1$
 		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
 		assertEquals("Still echo on failure", AntTestChecker.getDefault().getLoggedMessage(1)); //$NON-NLS-1$
 	}
@@ -645,8 +654,8 @@ public class OptionTests extends AbstractAntTest {
 	 */
 	@Test
 	public void testMinusK() {
-		assertThrows("The build should have failed", CoreException.class, //$NON-NLS-1$
-				() -> run("failingTarget.xml", new String[] { "-k" }, false)); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(CoreException.class, () -> run("failingTarget.xml", new String[] { "-k" }, false), //$NON-NLS-1$ //$NON-NLS-2$
+				"The build should have failed"); //$NON-NLS-1$
 		assertEquals(4, AntTestChecker.getDefault().getMessagesLoggedCount());
 		assertEquals("Still echo on failure", AntTestChecker.getDefault().getLoggedMessage(1)); //$NON-NLS-1$
 	}

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/ProjectTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/ProjectTests.java
@@ -7,22 +7,22 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.ant.core.AntCorePlugin;
 import org.eclipse.ant.tests.core.AbstractAntTest;
 import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProjectTests extends AbstractAntTest {
 
@@ -35,18 +35,22 @@ public class ProjectTests extends AbstractAntTest {
 		run(buildFileName);
 		IFile buildFile = getBuildFile(buildFileName);
 		String fullName = buildFile.getLocation().toFile().getAbsolutePath();
-		assertEquals("eclipse.running should have been set as true", "true", AntTestChecker.getDefault().getUserProperty("eclipse.running")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		assertEquals("ant.file should have been set as the build file name", fullName, AntTestChecker.getDefault().getUserProperty("ant.file")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNotNull("ant.java.version should have been set", AntTestChecker.getDefault().getUserProperty("ant.java.version")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNotNull("ant.version should have been set", AntTestChecker.getDefault().getUserProperty("ant.version")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertNotNull("eclipse.home should have been set", AntTestChecker.getDefault().getUserProperty("eclipse.home")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("eclipse.running"), //$NON-NLS-1$ //$NON-NLS-2$
+				"eclipse.running should have been set as true"); //$NON-NLS-1$
+		assertEquals(fullName, AntTestChecker.getDefault().getUserProperty("ant.file"), //$NON-NLS-1$
+				"ant.file should have been set as the build file name"); //$NON-NLS-1$
+		assertNotNull(AntTestChecker.getDefault().getUserProperty("ant.java.version"), //$NON-NLS-1$
+				"ant.java.version should have been set"); //$NON-NLS-1$
+		assertNotNull(AntTestChecker.getDefault().getUserProperty("ant.version"), "ant.version should have been set"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNotNull(AntTestChecker.getDefault().getUserProperty("eclipse.home"), "eclipse.home should have been set"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Test
 	public void testValue() throws CoreException {
 		String buildFileName = "TestForEcho.xml"; //$NON-NLS-1$
 		run(buildFileName);
-		assertEquals("property.testing should have been set as true", "true", AntTestChecker.getDefault().getUserProperty("property.testing")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals("true", AntTestChecker.getDefault().getUserProperty("property.testing"), //$NON-NLS-1$ //$NON-NLS-2$
+				"property.testing should have been set as true"); //$NON-NLS-1$
 	}
 
 	@Test
@@ -54,14 +58,16 @@ public class ProjectTests extends AbstractAntTest {
 
 		String buildFileName = "TestForEcho.xml"; //$NON-NLS-1$
 		run(buildFileName);
-		assertEquals("property.testing2 should have been set as hey", "hey", AntTestChecker.getDefault().getUserProperty("property.testing2")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals("hey", AntTestChecker.getDefault().getUserProperty("property.testing2"), //$NON-NLS-1$ //$NON-NLS-2$
+				"property.testing2 should have been set as hey"); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testClass() throws CoreException {
 		String buildFileName = "TestForEcho.xml"; //$NON-NLS-1$
 		run(buildFileName);
-		assertEquals("property.testing3 should have been set as AntTestPropertyProvider", "AntTestPropertyValueProvider", AntTestChecker.getDefault().getUserProperty("property.testing3")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals("AntTestPropertyValueProvider", AntTestChecker.getDefault().getUserProperty("property.testing3"), //$NON-NLS-1$ //$NON-NLS-2$
+				"property.testing3 should have been set as AntTestPropertyProvider"); //$NON-NLS-1$
 	}
 
 	@Test
@@ -70,7 +76,8 @@ public class ProjectTests extends AbstractAntTest {
 			AntCorePlugin.getPlugin().setRunningHeadless(true);
 			String buildFileName = "TestForEcho.xml"; //$NON-NLS-1$
 			run(buildFileName);
-			assertNull("property.headless should not have been set as AntTestPropertyProvider", AntTestChecker.getDefault().getUserProperty("property.headless")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertNull(AntTestChecker.getDefault().getUserProperty("property.headless"), //$NON-NLS-1$
+					"property.headless should not have been set as AntTestPropertyProvider"); //$NON-NLS-1$
 		}
 		finally {
 			AntCorePlugin.getPlugin().setRunningHeadless(false);
@@ -81,6 +88,7 @@ public class ProjectTests extends AbstractAntTest {
 	public void testNotHeadless() throws CoreException {
 		String buildFileName = "TestForEcho.xml"; //$NON-NLS-1$
 		run(buildFileName);
-		assertEquals("property.headless should have been set as AntTestPropertyProvider", "headless", AntTestChecker.getDefault().getUserProperty("property.headless")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals("headless", AntTestChecker.getDefault().getUserProperty("property.headless"), //$NON-NLS-1$ //$NON-NLS-2$
+				"property.headless should have been set as AntTestPropertyProvider"); //$NON-NLS-1$
 	}
 }

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/PropertyTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/PropertyTests.java
@@ -13,12 +13,13 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.ant.core.Property;
 import org.eclipse.ant.tests.core.AbstractAntTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link Property} class

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TargetTests.java
@@ -14,10 +14,10 @@
 package org.eclipse.ant.tests.core.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -25,7 +25,7 @@ import org.eclipse.ant.core.TargetInfo;
 import org.eclipse.ant.tests.core.AbstractAntTest;
 import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetTests extends AbstractAntTest {
 
@@ -36,7 +36,7 @@ public class TargetTests extends AbstractAntTest {
 	public void testDefaultTarget() throws CoreException {
 		TargetInfo[] targets = getTargets("TestForEcho.xml"); //$NON-NLS-1$
 		assertThat(targets).as("number of targets in TestForEcho.xml").hasSize(2); //$NON-NLS-1$
-		assertTrue("Test for Echo should be the default target", targets[1].isDefault()); //$NON-NLS-1$
+		assertTrue(targets[1].isDefault(), "Test for Echo should be the default target"); //$NON-NLS-1$
 	}
 
 	/**

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TaskTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TaskTests.java
@@ -14,8 +14,8 @@
 package org.eclipse.ant.tests.core.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.URL;
@@ -30,7 +30,7 @@ import org.eclipse.ant.tests.core.AbstractAntTest;
 import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.ant.tests.core.testplugin.ProjectHelper;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TaskTests extends AbstractAntTest {
 
@@ -79,8 +79,8 @@ public class TaskTests extends AbstractAntTest {
 		AntCorePreferences prefs = AntCorePlugin.getPlugin().getPreferences();
 		prefs.setCustomTasks(new Task[] {});
 		try {
-			CoreException ce = assertThrows("Build should have failed as task no longer defined", CoreException.class, //$NON-NLS-1$
-					() -> run("CustomTask.xml")); //$NON-NLS-1$
+			CoreException ce = assertThrows(CoreException.class, () -> run("CustomTask.xml"), //$NON-NLS-1$
+					"Build should have failed as task no longer defined"); //$NON-NLS-1$
 			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
 					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {
@@ -142,8 +142,8 @@ public class TaskTests extends AbstractAntTest {
 	public void testTaskDefinedInExtensionPointHeadless() {
 		AntCorePlugin.getPlugin().setRunningHeadless(true);
 		try {
-			CoreException ce = assertThrows("Build should have failed as task was not defined to run in headless", //$NON-NLS-1$
-					CoreException.class, () -> run("ExtensionPointTask.xml")); //$NON-NLS-1$
+			CoreException ce = assertThrows(CoreException.class, () -> run("ExtensionPointTask.xml"), //$NON-NLS-1$
+					"Build should have failed as task was not defined to run in headless"); //$NON-NLS-1$
 			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
 					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {

--- a/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TypeTests.java
+++ b/ant/org.eclipse.ant.tests.core/tests/org/eclipse/ant/tests/core/tests/TypeTests.java
@@ -7,15 +7,15 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.ant.tests.core.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
 
@@ -26,7 +26,7 @@ import org.eclipse.ant.internal.core.AntClasspathEntry;
 import org.eclipse.ant.tests.core.AbstractAntTest;
 import org.eclipse.ant.tests.core.testplugin.AntTestChecker;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TypeTests extends AbstractAntTest {
 
@@ -51,12 +51,10 @@ public class TypeTests extends AbstractAntTest {
 		AntCorePreferences prefs = AntCorePlugin.getPlugin().getPreferences();
 		prefs.setCustomTypes(new Type[] {});
 		try {
-			CoreException ce = assertThrows("Build should have failed as type no longer defined", CoreException.class, //$NON-NLS-1$
-					() -> run("CustomType.xml")); //$NON-NLS-1$
-			assertTrue("Exception from undefined type is incorrect: " //$NON-NLS-1$
-					+ ce.getMessage(),
-					ce.getMessage().trim()
-							.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place.")); //$NON-NLS-1$
+			CoreException ce = assertThrows(CoreException.class, () -> run("CustomType.xml"), //$NON-NLS-1$
+					"Build should have failed as type no longer defined"); //$NON-NLS-1$
+			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
+					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {
 			restorePreferenceDefaults();
 		}
@@ -75,12 +73,10 @@ public class TypeTests extends AbstractAntTest {
 	public void testTypeDefinedInExtensionPointHeadless() {
 		AntCorePlugin.getPlugin().setRunningHeadless(true);
 		try {
-			CoreException ce = assertThrows("Build should have failed as type was not defined to run in headless", //$NON-NLS-1$
-					CoreException.class, () -> run("ExtensionPointType.xml")); //$NON-NLS-1$
-			assertTrue("Exception from undefined type is incorrect: " //$NON-NLS-1$
-					+ ce.getMessage(),
-					ce.getMessage().trim()
-							.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place.")); //$NON-NLS-1$
+			CoreException ce = assertThrows(CoreException.class, () -> run("ExtensionPointType.xml"), //$NON-NLS-1$
+					"Build should have failed as type was not defined to run in headless"); //$NON-NLS-1$
+			assertThat(ce.getMessage().trim()).as("exception from undefined type") //$NON-NLS-1$
+					.endsWith("Action: Check that any <presetdef>/<macrodef> declarations have taken place."); //$NON-NLS-1$
 		} finally {
 			AntCorePlugin.getPlugin().setRunningHeadless(false);
 		}


### PR DESCRIPTION
Migrates the tests in org.eclipse.ant.tests.core to JUnit 5.
- Exchange JUnit 4 test annotations
- Replace JUnit 4 test suites with JUnit platform suites
- Replace JUnit 4 assertions with JUnit 5 assertions

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903