### PR TITLE
Migrate resources utils tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/FileUtilTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/FileUtilTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.EFS;
@@ -21,9 +21,9 @@ import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FileUtil} class.
@@ -31,13 +31,13 @@ import org.junit.Test;
 public class FileUtilTest {
 	private IPath baseTestDir;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		baseTestDir = FileSystemHelper.getRandomLocation();
 		baseTestDir.toFile().mkdirs();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		FileSystemHelper.clear(baseTestDir.toFile());
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/utils/ObjectMapTest.java
@@ -16,17 +16,15 @@ package org.eclipse.core.tests.internal.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.core.internal.utils.ObjectMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ObjectMapTest {
 	private static final int MAXIMUM = 100;
@@ -44,17 +42,17 @@ public class ObjectMapTest {
 		for (int i = 0; i < values.length; i++) {
 			Integer key = Integer.valueOf(i);
 			map.put(key, values[i]);
-			assertTrue("2.0." + i, map.containsKey(key));
-			assertTrue("2.1." + i, map.containsValue(values[i]));
-			assertEquals("2.2." + i, i + 1, map.size());
+			assertThat(map).containsKey(key);
+			assertThat(map).containsValue(values[i]);
+			assertThat(map).hasSize(i + 1);
 		}
 
 		// make sure they are all still there
-		assertEquals("3.0", MAXIMUM, map.size());
+		assertThat(map).hasSize(MAXIMUM);
 		for (int i = 0; i < values.length; i++) {
 			Integer key = Integer.valueOf(i);
-			assertTrue("3.1." + i, map.containsKey(key));
-			assertNotNull("3.2." + i, map.get(key));
+			assertThat(map).containsKey(key);
+			assertNotNull(map.get(key), "" + i);
 		}
 	}
 
@@ -72,18 +70,18 @@ public class ObjectMapTest {
 
 		// remove each element
 		for (int i = MAXIMUM - 1; i >= 0; i--) {
-			Object key = Integer.valueOf(i);
+			Integer key = Integer.valueOf(i);
 			map.remove(key);
-			assertTrue("2.0." + i, !map.containsKey(key));
-			assertEquals("2.1," + i, i, map.size());
+			assertThat(map).doesNotContainKey(key);
+			assertThat(map).hasSize(i);
 			// check that the others still exist
 			for (int j = 0; j < i; j++) {
-				assertTrue("2.2." + j, map.containsKey(Integer.valueOf(j)));
+				assertThat(map).containsKey(Integer.valueOf(j));
 			}
 		}
 
 		// all gone?
-		assertEquals("3.0", 0, map.size());
+		assertThat(map).isEmpty();
 	}
 
 	@Test
@@ -92,14 +90,14 @@ public class ObjectMapTest {
 		ObjectMap<Integer, Object> map = populateMap(values);
 
 		for (int i = 0; i < MAXIMUM; i++) {
-			assertTrue("2.0." + i, map.containsKey(Integer.valueOf(i)));
-			assertTrue("2.1." + i, map.containsValue(values[i]));
+			assertThat(map).containsKey(Integer.valueOf(i));
+			assertThat(map).containsValue(values[i]);
 		}
 
-		assertFalse("3.0", map.containsKey(Integer.valueOf(MAXIMUM + 1)));
-		assertFalse("3.1", map.containsKey(Integer.valueOf(-1)));
-		assertFalse("3.2", map.containsValue(null));
-		assertFalse("3.3", map.containsValue(createRandomString()));
+		assertThat(map).doesNotContainKey(Integer.valueOf(MAXIMUM + 1));
+		assertThat(map).doesNotContainKey(Integer.valueOf(-1));
+		assertThat(map).doesNotContainValue(null);
+		assertThat(map).doesNotContainValue(createRandomString());
 	}
 
 	@Test
@@ -109,7 +107,7 @@ public class ObjectMapTest {
 
 		Collection<Object> result = map.values();
 		for (int i = 0; i < MAXIMUM; i++) {
-			assertTrue("2.0." + i, result.contains(values[i]));
+			assertThat(result).contains(values[i]);
 		}
 	}
 
@@ -118,7 +116,7 @@ public class ObjectMapTest {
 		Object[] values = new Object[MAXIMUM];
 		ObjectMap<Integer, Object> map = populateMap(values);
 		Set<Integer> keys = map.keySet();
-		assertEquals("1.0", MAXIMUM, keys.size());
+		assertThat(keys).hasSize(MAXIMUM);
 	}
 
 	@Test
@@ -127,7 +125,7 @@ public class ObjectMapTest {
 		ObjectMap<Integer, Object> map = populateMap(values);
 		Set<Map.Entry<Integer, Object>> entries = map.entrySet();
 		for (int i = 0; i < MAXIMUM; i++) {
-			assertTrue("1.0." + i, contains(entries, values[i]));
+			assertTrue(contains(entries, values[i]), "" + i);
 		}
 	}
 


### PR DESCRIPTION
Migrates the tests in org.eclipse.core.tests.internal.utils to JUnit 5.
- Exchange JUnit 4 test annotations
- Replace JUnit 4 assertions with JUnit 5 or AssertJ assertions

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903