### PR TITLE
debug.tests: org.eclipse.urischeme/skipAutoRegistration #2245

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.fail;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -223,8 +222,9 @@ public class TestUtil {
 			}
 			jobs.forEach(Job::wakeUp);
 
-			if (!Collections.disjoint(runningJobs, jobs)) {
-				// There is a job which runs already quite some time, don't wait for it to avoid test timeouts
+			if (runningJobs.containsAll(jobs)) {
+				// There are only jobs which runs already quite some time, don't
+				// wait for them to avoid test timeouts
 				dumpRunningOrWaitingJobs(owner, jobs);
 				return true;
 			}

--- a/debug/org.eclipse.debug.tests/test.xml
+++ b/debug/org.eclipse.debug.tests/test.xml
@@ -37,6 +37,7 @@
   <target name="suite">
     <property name="platform-debug-folder" 
               value="${eclipse-home}/platform_debug_folder"/>
+    <property name="org.eclipse.urischeme/skipAutoRegistration" value="true"></property>
     <delete dir="${platform-debug-folder}" quiet="true"/>
     <ant target="ui-test" antfile="${library-file}" dir="${eclipse-home}">
       <property name="data-dir" value="${platform-debug-folder}"/>


### PR DESCRIPTION
IOConsoleTests complained about still running
AutoRegisterSchemeHandlersJob on macOS

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2245