### PR TITLE
ProcessConsole: skip milliseconds while running.

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
@@ -337,12 +337,16 @@ public class ProcessConsole extends IOConsole implements IConsole, IDebugEventSe
 					DateFormat dateTimeFormat = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
 					Duration elapsedTime = Duration.between(launchTime != null ? launchTime.toInstant() : Instant.now(),
 							terminateTime != null ? terminateTime.toInstant() : Instant.now());
-					String elapsedString = String.format("%d:%02d:%02d.%03d", elapsedTime.toHours(), //$NON-NLS-1$
-							elapsedTime.toMinutesPart(), elapsedTime.toSecondsPart(), elapsedTime.toMillisPart());
+					String elapsedFormat = "%d:%02d:%02d.%03d"; //$NON-NLS-1$
 					if (terminateTime == null) {
+						// refresh every second:
 						DebugUIPlugin.getStandardDisplay().asyncExec(
 								() -> DebugUIPlugin.getStandardDisplay().timerExec(1000, () -> resetName(false)));
+						// pointless to update milliseconds:
+						elapsedFormat = "%d:%02d:%02d"; //$NON-NLS-1$
 					}
+					String elapsedString = String.format(elapsedFormat, elapsedTime.toHours(),
+							elapsedTime.toMinutesPart(), elapsedTime.toSecondsPart(), elapsedTime.toMillisPart());
 					if (launchTime != null && terminateTime != null) {
 						String launchTimeStr = dateTimeFormat.format(launchTime);
 						// Check if process started and terminated at same day. If so only print the


### PR DESCRIPTION
it's updating only once a second anyway
![image](https://github.com/user-attachments/assets/e314a667-0642-4fb2-9536-d9196d7f9690)
![image](https://github.com/user-attachments/assets/1c455e6e-ddb7-429a-b1a7-c6ceb34c6be9)
