### PR TITLE
ConsoleTests: do not wait for all Jobs

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleManagerTests.java
@@ -37,6 +37,7 @@ import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.IConsoleView;
+import org.eclipse.ui.internal.console.ConsoleManager;
 import org.eclipse.ui.part.IPageBookViewPage;
 import org.eclipse.ui.part.MessagePage;
 import org.junit.After;
@@ -85,7 +86,7 @@ public class ConsoleManagerTests extends AbstractDebugTest {
 		firstConsole = new ConsoleMock(0);
 		manager.addConsoles(new ConsoleMock[] { firstConsole });
 		manager.showConsoleView(firstConsole);
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 		TestUtil.processUIEvents(100);
 		ConsoleMock.allShownConsoles.set(0);
 	}
@@ -118,7 +119,7 @@ public class ConsoleManagerTests extends AbstractDebugTest {
 
 		// Console manager starts a job with delay, let wait for him a bit
 		System.out.println("Waiting on jobs now..."); //$NON-NLS-1$
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 
 		// Give UI a chance to proceed pending console manager jobs
 		System.out.println("Done with jobs, processing UI events again..."); //$NON-NLS-1$
@@ -161,7 +162,7 @@ public class ConsoleManagerTests extends AbstractDebugTest {
 				latch.await(1, TimeUnit.MINUTES);
 				System.out.println("Requesting to show: " + console); //$NON-NLS-1$
 				manager.showConsoleView(console);
-				TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+				TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 			} catch (InterruptedException e) {
 				e.printStackTrace();
 				Thread.interrupted();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleOutputStream;
 import org.eclipse.ui.console.MessageConsole;
+import org.eclipse.ui.internal.console.ConsoleManager;
 import org.eclipse.ui.texteditor.IWorkbenchActionDefinitionIds;
 import org.junit.Test;
 
@@ -55,21 +56,21 @@ public class ConsoleTests extends AbstractDebugTest {
 		MessageConsole console = new MessageConsole("Test Console", //$NON-NLS-1$
 				IConsoleConstants.MESSAGE_CONSOLE_TYPE, null, StandardCharsets.UTF_8.name(), true);
 		IDocument document = console.getDocument();
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 		assertEquals("Document should be empty", "", document.get()); //$NON-NLS-1$ //$NON-NLS-2$
 		try (IOConsoleOutputStream outStream = console.newOutputStream()) {
 			outStream.write(testStringBuffer, 0, 6);
 			// half of Ã¶ (\u00f6) is written so we don't expect this char in
 			// output but all previous chars can be decoded
-			TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 			assertEquals("First 4 chars should be written", testString.substring(0, 4), document.get()); //$NON-NLS-1$
 			outStream.write(testStringBuffer, 6, 6);
 			// all remaining bytes are written so we expect the whole string
 			// including the Ã¶ (\u00f6) which was at buffer boundary
-			TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 			assertEquals("whole test string should be written", testString, document.get()); //$NON-NLS-1$
 		}
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 		// after closing the stream, the document content should still be the
 		// same
 		assertEquals("closing the stream should not alter the document", testString, document.get()); //$NON-NLS-1$
@@ -83,15 +84,15 @@ public class ConsoleTests extends AbstractDebugTest {
 		MessageConsole console = new MessageConsole("Test Console 2", //$NON-NLS-1$
 				IConsoleConstants.MESSAGE_CONSOLE_TYPE, null, StandardCharsets.UTF_8.name(), true);
 		IDocument document = console.getDocument();
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 		assertEquals("Document should be empty", "", document.get()); //$NON-NLS-1$ //$NON-NLS-2$
 		try (IOConsoleOutputStream outStream = console.newOutputStream()) {
 			outStream.write(testStringBuffer);
 			// everything but pending \r should be written
-			TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 			assertEquals("First char should be written", testString.substring(0, 1), document.get()); //$NON-NLS-1$
 		}
-		TestUtil.waitForJobs(name.getMethodName(), 200, 5000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 200, 5000);
 		// after closing the stream, the document content should still be the
 		// same
 		assertEquals("closing the stream should write the pending \\r", testString, document.get()); //$NON-NLS-1$
@@ -182,7 +183,7 @@ public class ConsoleTests extends AbstractDebugTest {
 		try {
 			consoleManager.addConsoles(consoles);
 			consoleManager.showConsoleView(console);
-			TestUtil.waitForJobs(name.getMethodName(), 100, 3000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 100, 3000);
 
 			ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 			Command commandFindReplace = commandService.getCommand(IWorkbenchCommandConstants.EDIT_FIND_AND_REPLACE);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.debug.tests.console;
 
 import org.eclipse.debug.tests.TestUtil;
+import org.eclipse.ui.internal.console.ConsoleManager;
 
 /**
  * Same as {@link IOConsoleTests} but with fixed width console enabled.
@@ -29,7 +30,7 @@ public class IOConsoleFixedWidthTests extends IOConsoleTests {
 		c.getConsole().setConsoleWidth(3);
 		c.setIgnoreFixedConsole(true);
 		// console width is applied asynchronous
-		TestUtil.waitForJobs(name.getMethodName(), 50, 1000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 50, 1000);
 		return c;
 	}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.debug.internal.ui.views.console.ProcessConsoleManager;
 import org.eclipse.debug.tests.TestUtil;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -41,6 +42,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.console.IConsoleDocumentPartitioner;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleOutputStream;
+import org.eclipse.ui.internal.console.ConsoleManager;
 
 /**
  * Utility to help testing input and output in {@link IOConsole}.
@@ -237,7 +239,7 @@ public final class IOConsoleTestUtil {
 			// content the caret is updated
 			setCaretOffset(e.start + content.length());
 		}
-		TestUtil.waitForJobs(name, 0, 1000);
+		TestUtil.waitForJobs(name, ConsoleManager.CONSOLE_JOB_FAMILY, 0, 1000);
 		return this;
 	}
 
@@ -288,7 +290,7 @@ public final class IOConsoleTestUtil {
 			textPanel.notifyListeners(SWT.KeyDown, e);
 			textPanel.notifyListeners(SWT.KeyUp, e);
 		}
-		TestUtil.waitForJobs(name, 0, 1000);
+		TestUtil.waitForJobs(name, ConsoleManager.CONSOLE_JOB_FAMILY, 0, 1000);
 		return this;
 	}
 
@@ -693,7 +695,8 @@ public final class IOConsoleTestUtil {
 	 * @return this {@link IOConsoleTestUtil} to chain methods
 	 */
 	public IOConsoleTestUtil waitForScheduledJobs() {
-		TestUtil.waitForJobs(name, 25, 5 * 2000);
+		TestUtil.waitForJobs(name, ProcessConsoleManager.class, 25, 5 * 2000);
+		TestUtil.waitForJobs(name, ConsoleManager.CONSOLE_JOB_FAMILY, 25, 5 * 2000);
 		return this;
 	}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
@@ -68,6 +68,7 @@ import org.eclipse.ui.console.IConsoleDocumentPartitionerExtension;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleOutputStream;
+import org.eclipse.ui.internal.console.ConsoleManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -162,7 +163,7 @@ public class IOConsoleTests extends AbstractDebugTest {
 		});
 		final IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
 		consoleManager.addConsoles(new IConsole[] { console });
-		TestUtil.waitForJobs(name.getMethodName(), 25, 10000);
+		TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 25, 10000);
 		consoleManager.showConsoleView(console);
 		@SuppressWarnings("restriction")
 		final org.eclipse.ui.internal.console.IOConsolePage page = (org.eclipse.ui.internal.console.IOConsolePage) consoleView.getCurrentPage();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
@@ -73,7 +73,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 			launch = process.getLaunch();
 			launchManager.addLaunch(launch);
 			// do not wait on input read job
-			TestUtil.waitForJobs(name.getMethodName(), 0, 10000, ProcessConsole.class);
+			TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000, ProcessConsole.class);
 			assertThat(consoleManager.getConsoles()).as("console has been added").hasSize(1);
 		} finally {
 			mockProcess.destroy();
@@ -81,7 +81,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 
 		if (launch != null) {
 			launchManager.removeLaunch(launch);
-			TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
+			TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000);
 			assertThat(consoleManager.getConsoles()).as("console has been removed").isEmpty();
 		}
 	}
@@ -106,7 +106,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 			setPreference(DebugUIPlugin.getDefault().getPreferenceStore(), IDebugUIConstants.PREF_AUTO_REMOVE_OLD_LAUNCHES, true);
 			// Stop the JobManager to reliable trigger the tested race
 			// condition.
-			TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
+			TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000);
 			Job.getJobManager().suspend();
 			launchManager.addLaunch(process1.getLaunch());
 			launchManager.addLaunch(process2.getLaunch());
@@ -114,7 +114,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 			Job.getJobManager().resume();
 		}
 
-		TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
+		TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000);
 		ProcessConsoleManager processConsoleManager = DebugUIPlugin.getDefault().getProcessConsoleManager();
 		ILaunch[] launches = launchManager.getLaunches();
 		Set<IConsole> openConsoles = new HashSet<>();
@@ -135,7 +135,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 			assertThat(removeAction).matches(ConsoleRemoveAllTerminatedAction::isEnabled, "is enabled");
 		}
 		removeAction.run();
-		TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
+		TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000);
 		assertNull("First console not removed.", processConsoleManager.getConsole(process1));
 		assertNull("Second console not removed.", processConsoleManager.getConsole(process1));
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -53,6 +53,7 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.Launch;
 import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.views.console.ProcessConsole;
 import org.eclipse.debug.tests.AbstractDebugTest;
 import org.eclipse.debug.tests.TestUtil;
 import org.eclipse.debug.tests.launching.LaunchConfigurationTests;
@@ -67,6 +68,7 @@ import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleInputStream;
+import org.eclipse.ui.internal.console.ConsoleManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -229,7 +231,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				final Class<?> jobFamily = org.eclipse.debug.internal.ui.views.console.ProcessConsole.class;
 				assertThat(Job.getJobManager().find(jobFamily)).as("check input read job started").hasSizeGreaterThan(0);
 				Job.getJobManager().cancel(jobFamily);
-				TestUtil.waitForJobs(name.getMethodName(), 0, 1000);
+				TestUtil.waitForJobs(name.getMethodName(), ProcessConsole.class, 0, 1000);
 				assertThat(Job.getJobManager().find(jobFamily)).as("check input read job is canceled").isEmpty();
 			} finally {
 				console.destroy();
@@ -301,7 +303,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			waitWhile(__ -> !terminationSignaled.get(), 10_000, __ -> "No console complete notification received.");
 		} finally {
 			consoleManager.removeConsoles(new IConsole[] { console });
-			TestUtil.waitForJobs(name.getMethodName(), 0, 10000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 0, 10000);
 		}
 	}
 
@@ -422,7 +424,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				process.terminate();
 			}
 			consoleManager.removeConsoles(new IConsole[] { console });
-			TestUtil.waitForJobs(name.getMethodName(), 0, 1000);
+			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 0, 1000);
 		}
 	}
 

--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleManager.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleManager.java
@@ -57,6 +57,7 @@ import org.eclipse.ui.progress.WorkbenchJob;
  * @since 3.0
  */
 public class ConsoleManager implements IConsoleManager {
+	public static final String CONSOLE_JOB_FAMILY = "CONSOLE_JOB_FAMILY"; //$NON-NLS-1$
 
 	/**
 	 * Console listeners
@@ -91,6 +92,11 @@ public class ConsoleManager implements IConsoleManager {
 		public RepaintJob() {
 			super("schedule redraw() of viewers"); //$NON-NLS-1$
 			setSystem(true);
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == ConsoleManager.CONSOLE_JOB_FAMILY;
 		}
 
 		void addConsole(IConsole console) {
@@ -260,6 +266,11 @@ public class ConsoleManager implements IConsoleManager {
 			setPriority(Job.SHORT);
 		}
 
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == ConsoleManager.CONSOLE_JOB_FAMILY;
+		}
+
 		void addConsole(IConsole console) {
 			synchronized (queue) {
 				queue.add(console);
@@ -359,6 +370,11 @@ public class ConsoleManager implements IConsoleManager {
 		if (!fWarnQueued) {
 			fWarnQueued = true;
 			Job job = new UIJob(ConsolePlugin.getStandardDisplay(), ConsoleMessages.ConsoleManager_consoleContentChangeJob) {
+				@Override
+				public boolean belongsTo(Object family) {
+					return family == ConsoleManager.CONSOLE_JOB_FAMILY;
+				}
+
 				@Override
 				public IStatus runInUIThread(IProgressMonitor monitor) {
 					IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePartitioner.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePartitioner.java
@@ -754,6 +754,11 @@ public class IOConsolePartitioner
 		}
 
 		@Override
+		public boolean belongsTo(Object family) {
+			return family == ConsoleManager.CONSOLE_JOB_FAMILY;
+		}
+
+		@Override
 		public IStatus runInUIThread(IProgressMonitor monitor) {
 			processPendingPartitions();
 			if (ASSERT) {


### PR DESCRIPTION
defines a Jobfamily CONSOLE_JOB_FAMILY and only wait for that to fix unrelated "AutoRegisterSchemeHandlersJob still running" error on MacOs during I-Build

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2245