### PR TITLE
Add constant for riscv64 architecture in Platform class

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.31.100.qualifier
+Bundle-Version: 3.32.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -410,6 +410,15 @@ public final class Platform {
 	public static final String ARCH_AARCH64 = "aarch64";//$NON-NLS-1$
 
 	/**
+	 * Constant string (value {@code aarch64} indicating the platform is running on
+	 * an RISC-V 64bit-based architecture.
+	 *
+	 * @since 3.32
+	 *
+	 */
+	public static final String ARCH_RISCV64 = "riscv64";//$NON-NLS-1$
+
+	/**
 	 * Constant string (value "amd64") indicating the platform is running on an
 	 * AMD64-based architecture.
 	 *


### PR DESCRIPTION
As @merks pointed out, we should add a `riscv64` constant in the Platform class, that that this architecture is now supported on Linux.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2310
@yuzibo FYI