### PR TITLE
Deprecate ARCH_X86 and WS_WPF constants and constant for ppc64le architecture in o.e.core.runtime.Platform

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -91,7 +91,8 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 public final class InternalPlatform {
 
-	private static final String[] ARCH_LIST = { Platform.ARCH_AARCH64, Platform.ARCH_X86, Platform.ARCH_X86_64 };
+	private static final String[] ARCH_LIST = { Platform.ARCH_AARCH64, Platform.ARCH_PPC64LE, Platform.ARCH_RISCV64,
+			Platform.ARCH_X86_64 };
 
 	public static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
@@ -132,7 +133,7 @@ public final class InternalPlatform {
 
 	private static final InternalPlatform singleton = new InternalPlatform();
 
-	private static final String[] WS_LIST = { Platform.WS_COCOA, Platform.WS_GTK, Platform.WS_WIN32, Platform.WS_WPF };
+	private static final String[] WS_LIST = { Platform.WS_COCOA, Platform.WS_GTK, Platform.WS_WIN32 };
 	private IPath cachedInstanceLocation; // Cache the path of the instance location
 	private ServiceTracker<Location,Location> configurationLocation = null;
 	private BundleContext context;

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -418,6 +418,14 @@ public final class Platform {
 	public static final String ARCH_AARCH64 = "aarch64";//$NON-NLS-1$
 
 	/**
+	 * Constant string (value {@code ppc64le}) indicating the platform is running on
+	 * an little-endian PowerPC 64bit based architecture.
+	 *
+	 * @since 3.32
+	 */
+	public static final String ARCH_PPC64LE = "ppc64le"; //$NON-NLS-1$
+
+	/**
 	 * Constant string (value {@code riscv64} indicating the platform is running on
 	 * an RISC-V 64bit-based architecture.
 	 *

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -353,7 +353,9 @@ public final class Platform {
 	 * </p>
 	 *
 	 * @since 3.0
+	 * @deprecated not supported anymore
 	 */
+	@Deprecated
 	public static final String ARCH_X86 = "x86";//$NON-NLS-1$
 
 	/**
@@ -548,7 +550,9 @@ public final class Platform {
 	 * machine using the WPF windowing system.
 	 *
 	 * @since 3.3
+	 * @deprecated not supported anymore
 	 */
+	@Deprecated
 	public static final String WS_WPF = "wpf";//$NON-NLS-1$
 
 	/**


### PR DESCRIPTION
As far as I can tell x86 32-bit is not supported anymore for any OS just like WPF on Windows.

Or can any tell if it's different?


Additionally show constant values in `@code` elements.

