### PR TITLE
Add IContextFunction.ServiceContextKey OSGi component property type

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.core.contexts
-Bundle-Version: 1.12.600.qualifier
+Bundle-Version: 1.13.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IContextFunction.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IContextFunction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,11 +10,15 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add IContextFunction.ServiceContextKey OSGi component property type
  *******************************************************************************/
 
 package org.eclipse.e4.core.contexts;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.ComponentPropertyType;
 
 /**
  * A context function encapsulates evaluation of some code within an
@@ -58,8 +62,22 @@ public interface IContextFunction {
 	 * should be registered in.
 	 *
 	 * @see BundleContext#getServiceReference(String)
+	 * @see ServiceContextKey
 	 */
 	String SERVICE_CONTEXT_KEY = "service.context.key"; //$NON-NLS-1$
+
+	/**
+	 * An OSGi service component property type used to indicate the context key this
+	 * function should be registered in.
+	 *
+	 * @since 1.13
+	 * @see #SERVICE_CONTEXT_KEY
+	 */
+	@ComponentPropertyType
+	@Retention(RetentionPolicy.SOURCE)
+	public @interface ServiceContextKey {
+		Class<?> value();
+	}
 
 	/**
 	 * Evaluates the function based on the provided arguments and context to


### PR DESCRIPTION
This annotation simplifies the specification of the 'service.context.key' service property for IContextFunction implementations and makes it type-safe and more robust:
```
@Component(service = IContextFunction.class)
@IContextFunction.ServiceContextKey(IProgressService.class)
public class ProgressServiceCreationFunction extends ContextFunction {
...
```
