### PR TITLE
[Oomph-Setup] Add eclipse.platform configuration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Update provides Java interfaces like `IPlatformConfiguration`. `IPlatformConfigu
 
 Contributions are most welcome. There are many ways to contribute, from entering high quality bug reports, to contributing code or documentation changes.
 
-For a complete guide, see the https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md.
+For a complete guide, see the [CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) page.
 
+[![Create Eclipse Development Environment for Eclipse Platform](https://download.eclipse.org/oomph/www/setups/svg/Eclipse_Platform.svg)](
+https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/releng/org.eclipse.platform.setup/PlatformConfiguration.setup&show=true
+"Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 
 ## Issue Tracking
 

--- a/releng/org.eclipse.platform.setup/.project
+++ b/releng/org.eclipse.platform.setup/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.platform.setup</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/org.eclipse.platform.setup/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.platform.setup/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/org.eclipse.platform.setup/PlatformConfiguration.setup
+++ b/releng/org.eclipse.platform.setup/PlatformConfiguration.setup
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="Eclipse Platform">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="badgeLabel">
+      <value>Eclipse Platform</value>
+    </detail>
+  </annotation>
+  <installation
+      name="eclipse.platform.installation"
+      label="Eclipse Platform Installation">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="installation.id.default"
+        value="eclipse-platform"/>
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.applications']/@products[name='eclipse.platform.sdk']/@versions[name='latest']"/>
+    <description>The Eclipse Platform installation provides the latest tools needed to work with the project's source code.</description>
+  </installation>
+  <workspace
+      name="eclipse.platform.workspace"
+      label="Eclipse Platform Workspace">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="workspace.id.default"
+        value="eclipse-platform-ws"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+        <detail
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions">
+          <value>record</value>
+        </detail>
+      </annotation>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.oomph.setup.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions"
+            value="true"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.ui.ide">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
+            value="Eclipse Platform"/>
+      </setupTask>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="eclipse.git.authentication.style"
+        defaultValue="anonymous"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='platform']/@streams[name='master']"/>
+    <description>The Eclipse Platform workspace provides all the source code of the project.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;code>Eclipse Platform&lt;/code> configuration provisions a dedicated development environment for the complete set of projects that comprise the core of the Eclipse Platform,
+    i.e. the projects that are contained in the &lt;a href=&quot;https://github.com/eclipse-platform/eclipse.platform&quot;>eclipse.platform&lt;/a> repository.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest successful integration build of the &lt;code>Eclipse Platform SDK&lt;/code>,
+    the PDE target platform, like the installation, is also based on the latest integration build,
+    and the API baseline is based on the most recent release.
+    &lt;p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
Additionally add a styled and drag&drop-able Oomph Configuration button.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2430