### PR TITLE
Add ISystemInformation.Section OSGi component property type

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.core.services;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 2.4.500.qualifier
+Bundle-Version: 2.5.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.annotation;version="[2.0.0,3.0.0)",

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/InstalledBundles.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/InstalledBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019, 2020 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,8 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 
-@Component(service = { ISystemInformation.class }, property = { AboutSections.SECTION + '=' + AboutSections.SECTION_INSTALLED_BUNDLES })
+@Component(service = ISystemInformation.class)
+@ISystemInformation.Section(AboutSections.SECTION_INSTALLED_BUNDLES)
 public class InstalledBundles implements ISystemInformation {
 
 	@Override
@@ -71,21 +72,14 @@ public class InstalledBundles implements ISystemInformation {
 	}
 
 	private String getStateName(int state) {
-		switch (state) {
-		case Bundle.INSTALLED:
-			return AboutMessages.bundleStateInstalled;
-		case Bundle.RESOLVED:
-			return AboutMessages.bundleStateResolved;
-		case Bundle.STARTING:
-			return AboutMessages.bundleStateStarting;
-		case Bundle.STOPPING:
-			return AboutMessages.bundleStateStopping;
-		case Bundle.UNINSTALLED:
-			return AboutMessages.bundleStateUninstalled;
-		case Bundle.ACTIVE:
-			return AboutMessages.bundleStateActive;
-		default:
-			return AboutMessages.bundleStateUnknown;
-		}
+		return switch (state) {
+		case Bundle.INSTALLED -> AboutMessages.bundleStateInstalled;
+		case Bundle.RESOLVED -> AboutMessages.bundleStateResolved;
+		case Bundle.STARTING -> AboutMessages.bundleStateStarting;
+		case Bundle.STOPPING -> AboutMessages.bundleStateStopping;
+		case Bundle.UNINSTALLED -> AboutMessages.bundleStateUninstalled;
+		case Bundle.ACTIVE -> AboutMessages.bundleStateActive;
+		default -> AboutMessages.bundleStateUnknown;
+		};
 	}
 }

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/InstalledFeatures.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/InstalledFeatures.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
-@Component(service = { ISystemInformation.class }, property = { AboutSections.SECTION + '=' + AboutSections.SECTION_INSTALLED_FEATURES })
+@Component(service = ISystemInformation.class)
+@ISystemInformation.Section(AboutSections.SECTION_INSTALLED_FEATURES)
 public class InstalledFeatures implements ISystemInformation {
 
 	private final List<IBundleGroupProvider> providers = new ArrayList<>();

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/SystemEnvironment.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/SystemEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,8 @@ import org.eclipse.e4.core.services.about.AboutSections;
 import org.eclipse.e4.core.services.about.ISystemInformation;
 import org.osgi.service.component.annotations.Component;
 
-@Component(service = { ISystemInformation.class }, property = { AboutSections.SECTION + '=' + AboutSections.SECTION_SYSTEM_ENVIRONMENT })
+@Component(service = ISystemInformation.class)
+@ISystemInformation.Section(AboutSections.SECTION_SYSTEM_ENVIRONMENT)
 public class SystemEnvironment extends PrintedMap {
 
 	@Override

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/SystemProperties.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/SystemProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,8 @@ import org.eclipse.e4.core.services.about.AboutSections;
 import org.eclipse.e4.core.services.about.ISystemInformation;
 import org.osgi.service.component.annotations.Component;
 
-@Component(service = { ISystemInformation.class }, property = { AboutSections.SECTION + '=' + AboutSections.SECTION_SYSTEM_PROPERTIES })
+@Component(service = ISystemInformation.class)
+@ISystemInformation.Section(AboutSections.SECTION_SYSTEM_PROPERTIES)
 public class SystemProperties extends PrintedMap {
 
 	@Override

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/UserPreferences.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/about/UserPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -28,7 +28,8 @@ import org.eclipse.osgi.util.NLS;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-@Component(service = { ISystemInformation.class }, property = { AboutSections.SECTION + '=' + AboutSections.SECTION_USER_PREFERENCES })
+@Component(service = ISystemInformation.class)
+@ISystemInformation.Section(AboutSections.SECTION_USER_PREFERENCES)
 public class UserPreferences implements ISystemInformation {
 
 	private IPreferencesService preferencesService;

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/AboutSections.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/AboutSections.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -69,7 +69,7 @@ public final class AboutSections {
 	 * @return the section filter string
 	 */
 	public static String createSectionFilter(String section) {
-		return new StringBuilder().append('(').append(SECTION).append('=').append(section).append(')').toString();
+		return '(' + SECTION + '=' + section + ')';
 	}
 
 }

--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/ISystemInformation.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/ISystemInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2019 ArSysOp and others.
+ *  Copyright (c) 2019, 2024 ArSysOp and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,9 @@
 package org.eclipse.e4.core.services.about;
 
 import java.io.PrintWriter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.osgi.service.component.annotations.ComponentPropertyType;
 
 /**
  * Collects the system information for the "about"-related functionality.
@@ -30,5 +33,18 @@ public interface ISystemInformation {
 	 *               closed by implementor
 	 */
 	void append(PrintWriter writer);
+
+	/**
+	 * An OSGi service component property type to define the information to be
+	 * related with the specified section.
+	 *
+	 * @since 2.5
+	 * @see #SECTION
+	 */
+	@ComponentPropertyType
+	@Target(ElementType.TYPE)
+	public @interface Section {
+		String value();
+	}
 
 }


### PR DESCRIPTION
This annotation simplifies the specification of the 'section' service property for ISystemInformation
implementations and makes it more robust:
```
@Component(service = ISystemInformation.class)
@ISystemInformation.Section(AboutSections.SECTION_SYSTEM_PROPERTIES)
public class ExampleInformation implements ISystemInformation {
```