### PR TITLE
Use RetentionPolicy CLASS in new 'ServiceContextKey' OSGi property type

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IContextFunction.java
+++ b/runtime/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/contexts/IContextFunction.java
@@ -15,8 +15,10 @@
 
 package org.eclipse.e4.core.contexts;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.ComponentPropertyType;
 
@@ -74,7 +76,8 @@ public interface IContextFunction {
 	 * @see #SERVICE_CONTEXT_KEY
 	 */
 	@ComponentPropertyType
-	@Retention(RetentionPolicy.SOURCE)
+	@Retention(RetentionPolicy.CLASS)
+	@Target(ElementType.TYPE)
 	public @interface ServiceContextKey {
 		Class<?> value();
 	}


### PR DESCRIPTION
And permit only types as target.

If the `RetentionPolicy` is only `SOURCE` Tycho does not recognize the annotation because the underlying BND library only operates on compiled classes and not on sources.

`RetentionPolicy.CLASS` is the default, but I still declared it to be specific in this case.