### PR TITLE
Fix java-doc link to AboutSections#SECTION in ISystemInformation

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/ISystemInformation.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/ISystemInformation.java
@@ -39,7 +39,7 @@ public interface ISystemInformation {
 	 * related with the specified section.
 	 *
 	 * @since 2.5
-	 * @see #SECTION
+	 * @see AboutSections#SECTION
 	 */
 	@ComponentPropertyType
 	@Target(ElementType.TYPE)


### PR DESCRIPTION
The latest I-build failed because of this invalid link 

```
 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.10.1:javadoc (attach-javadocs) on project org.eclipse.platform.doc.isv: An error has occurred in Javadoc report generation: 
 [ERROR] Exit code: 1
 [ERROR] /home/jenkins/agent/workspace/Builds/I-build-4.34/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/gitCache/eclipse.platform.releng.aggregator/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/../../../eclipse.platform/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/about/ISystemInformation.java:42: error: reference not found
 [ERROR] 	 * @see #SECTION
 [ERROR] 	        ^
 [ERROR] Note: Custom tags that could override future standard tags:  @Immutable, @provisional, @implSpec, @TrackedGetter, @noextend, @issue, @ThreadSafe, @implNote, @jniclass, @noreference, @noinstantiate, @noimplement, @nooverride, @category. To avoid potential overrides, use at least one period character (.) in custom tag names.
 [ERROR] Note: Custom tags that were not seen:  @Immutable, @provisional, @issue, @category
```