### PR TITLE
Fix for RejectedExecutionException during delete operations

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
@@ -287,7 +287,8 @@ public class LocalFile extends FileStore {
 				/* asyncMode */ false, // Last-In-First-Out is important to delete child before parent folders
 				/* corePoolSize */ 0, //
 				/* maximumPoolSize */ threadCount, //
-				/* minimumRunnable */ 0, null, // delete algorithm does not need any
+				/* minimumRunnable */ 0, //
+				pool -> true, // if maximumPoolSize would be exceeded, don't throw RejectedExecutionException
 				/* keepAliveTime */ 1, TimeUnit.MINUTES); // pool terminates 1 thread per
 	}
 


### PR DESCRIPTION
If the tasks scheduled by ForkJoinPool are all busy and new task is added, the pool would throw RejectedExecutionException if the "saturate" Predicate is not specified.

To avoid that, supply Predicate that is always true - with that, no exception will be thrown on busy pool and we would not reject new delete operations.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1592