### PR TITLE
[SSH] Added key size selection

### DIFF
--- a/team/bundles/org.eclipse.jsch.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.jsch.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jsch.ui;singleton:=true
-Bundle-Version: 1.5.500.qualifier
+Bundle-Version: 1.5.600.qualifier
 Bundle-Activator: org.eclipse.jsch.internal.ui.JSchUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/Messages.java
+++ b/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/Messages.java
@@ -99,6 +99,7 @@ public class Messages extends NLS{
 	public static String CVSSSH2PreferencePage_145;
 	public static String CVSSSH2PreferencePage_146;
 	public static String CVSSSH2PreferencePage_147;
+	public static String CVSSSH2PreferencePage_148;
 	public static String KeyboardInteractiveDialog_0;
 	public static String KeyboardInteractiveDialog_1;
 	public static String KeyboardInteractiveDialog_2;

--- a/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/messages.properties
+++ b/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/messages.properties
@@ -89,6 +89,7 @@ CVSSSH2PreferencePage_144=Key Exchange &Methods
 CVSSSH2PreferencePage_145=MA&C Methods
 CVSSSH2PreferencePage_146=&SSH Agent
 CVSSSH2PreferencePage_147=Select preferred SSH Agent
+CVSSSH2PreferencePage_148=Key size:
 UserInfoPrompter_0=SSH2 Message
 UserInfoPrompter_1=SSH2 Message
 KeyboardInteractiveDialog_0=Keyboard Interactive authentication for {0}: {1}

--- a/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/preference/PreferencePage.java
+++ b/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/preference/PreferencePage.java
@@ -53,6 +53,7 @@ import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.custom.TableEditor;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
@@ -66,6 +67,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -89,8 +91,11 @@ public class PreferencePage extends org.eclipse.jface.preference.PreferencePage
 		implements IWorkbenchPreferencePage{
 
 	private static final String SSH2_PREFERENCE_PAGE_CONTEXT="org.eclipse.jsch.ui.ssh2_preference_page_context"; //$NON-NLS-1$
-	private static final int RSA_KEY_SIZE = 4096;
-	private static final int DSA_KEY_SIZE = 3072;
+	private static final int RSA_MAX_KEY_SIZE = 15360;
+	private static final int DSA_MAX_KEY_SIZE = 3072;
+	private static final int INITIAL_KEY_SIZE = 4096;
+	private static final int MIN_KEY_SIZE = 2048;
+	private static final int KEY_SIZE_INCREMENT = 1024;
 
 	private Label ssh2HomeLabel;
 	private Label privateKeyLabel;
@@ -101,6 +106,7 @@ public class PreferencePage extends org.eclipse.jface.preference.PreferencePage
 	private Button ssh2HomeBrowse;
 	Button keyGenerateDSA;
 	Button keyGenerateRSA;
+	private Spinner keySizeValue;
 	private Button keyLoad;
 	private Button keyExport;
 	Button saveKeyPair;
@@ -305,6 +311,13 @@ protected Control createContents(Composite parent){
 		gd.horizontalSpan=1;
 		keyLoad.setLayoutData(gd);
 
+		final Label keySizeValueLabel = new Label(group, SWT.NONE);
+		keySizeValueLabel.setText(Messages.CVSSSH2PreferencePage_148);
+		keySizeValue = new Spinner(group, SWT.BORDER);
+		int maxKeySize = Math.max(DSA_MAX_KEY_SIZE, RSA_MAX_KEY_SIZE);
+		keySizeValue.setValues(INITIAL_KEY_SIZE, MIN_KEY_SIZE, maxKeySize, 0, KEY_SIZE_INCREMENT, KEY_SIZE_INCREMENT);
+		keySizeValue.addKeyListener(KeyListener.keyPressedAdapter(e -> e.doit = false));
+
 		publicKeylabel=new Label(group, SWT.NONE);
 		publicKeylabel.setText(Messages.CVSSSH2PreferencePage_39);
 		gd=new GridData();
@@ -485,6 +498,9 @@ protected Control createContents(Composite parent){
 					if(e.widget==keyGenerateDSA){
 						type=KeyPair.DSA;
 						_type=IConstants.DSA;
+						if (keySizeValue.getSelection() > DSA_MAX_KEY_SIZE) {
+							keySizeValue.setSelection(DSA_MAX_KEY_SIZE);
+						}
 					}
 					else if(e.widget==keyGenerateRSA){
 						type=KeyPair.RSA;
@@ -496,7 +512,7 @@ protected Control createContents(Composite parent){
 
 					final KeyPair[] _kpair=new KeyPair[1];
 					final int __type=type;
-					int keySize = type == KeyPair.RSA ? RSA_KEY_SIZE : DSA_KEY_SIZE;
+					int keySize = keySizeValue.getSelection();
 					final JSchException[] _e=new JSchException[1];
 					BusyIndicator.showWhile(getShell().getDisplay(), () -> {
 						try {


### PR DESCRIPTION
This implementation allows to select the key size of the generated key ranging from 2048-4096 bits, which is using a Spinner to increment by 1024 bits. (DSA is limited to 3072 bits)

Refer to https://github.com/eclipse-platform/eclipse.platform/issues/1464