### PR TITLE
show diff in "replace with local history" dialog on selection change

### DIFF
--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.10.500.qualifier
+Bundle-Version: 3.11.0.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryPage.java
@@ -336,9 +336,7 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 		return null;
 	}
 
-	@Override
-	public void createControl(Composite parent) {
-
+	public final void createControl(Composite parent, boolean allowMultiSelection) {
 		localComposite = new Composite(parent, SWT.NONE);
 		GridLayout layout = new GridLayout();
 		layout.marginHeight = 0;
@@ -348,7 +346,7 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 		data.grabExcessVerticalSpace = true;
 		localComposite.setLayoutData(data);
 
-		treeViewer = createTree(localComposite);
+		treeViewer = createTree(localComposite, allowMultiSelection);
 
 		contributeActions();
 
@@ -360,6 +358,11 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceListener, IResourceChangeEvent.POST_CHANGE);
 
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(localComposite, IHelpContextIds.LOCAL_HISTORY_PAGE);
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		createControl(parent, true);
 	}
 
 	private void contributeActions() {
@@ -599,8 +602,12 @@ public class LocalHistoryPage extends HistoryPage implements IHistoryCompareAdap
 	 * @return the group control
 	 */
 	protected TreeViewer createTree(Composite parent) {
+		return createTree(parent, true);
+	}
+
+	protected final TreeViewer createTree(Composite parent, boolean allowMultiSelection) {
 		historyTableProvider = new LocalFileHistoryTableProvider();
-		TreeViewer viewer = historyTableProvider.createTree(parent);
+		TreeViewer viewer = historyTableProvider.createTree(parent, allowMultiSelection);
 		viewer.setContentProvider(new LocalHistoryContentProvider());
 		return viewer;
 	}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryTableProvider.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/LocalHistoryTableProvider.java
@@ -291,7 +291,15 @@ public class LocalHistoryTableProvider {
 	 * @return TableViewer
 	 */
 	public TreeViewer createTree(Composite parent) {
-		Tree tree = new Tree(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI | SWT.FULL_SELECTION);
+		return createTree(parent, true);
+	}
+
+	public TreeViewer createTree(Composite parent, boolean allowMultiSelection) {
+		int style = SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION;
+		if (allowMultiSelection) {
+			style = style | SWT.MULTI;
+		}
+		Tree tree = new Tree(parent, style);
 		tree.setHeaderVisible(true);
 		tree.setLinesVisible(false);
 

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/ReplaceLocalHistory.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/history/ReplaceLocalHistory.java
@@ -15,17 +15,29 @@ package org.eclipse.team.internal.ui.history;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.CompareUI;
+import org.eclipse.compare.CompareViewerPane;
 import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFileState;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Tree;
 import org.eclipse.team.internal.ui.TeamUIMessages;
 import org.eclipse.team.internal.ui.TeamUIPlugin;
 import org.eclipse.team.internal.ui.Utils;
 import org.eclipse.team.ui.history.HistoryPageCompareEditorInput;
 import org.eclipse.team.ui.history.IHistoryPageSource;
+import org.eclipse.ui.part.IPage;
 
 public class ReplaceLocalHistory extends ShowLocalHistory {
 
@@ -54,6 +66,40 @@ public class ReplaceLocalHistory extends ShowLocalHistory {
 				public String getOKButtonLabel() {
 					return TeamUIMessages.ReplaceLocalHistory_0;
 				}
+
+				@Override
+				protected IPage createPage(CompareViewerPane parent, IToolBarManager toolBarManager) {
+					var page = super.createPage(parent, toolBarManager, false);
+					Tree tree = getTree(page);
+					runDefaultSelectionEventOnSelectionChange(tree);
+					return page;
+				}
+
+				private void runDefaultSelectionEventOnSelectionChange(Tree tree) {
+					if (tree == null) {
+						return;
+					}
+					var handler = new NotifyDefaultSelectionOnWidgetSelectedHandler(tree);
+					tree.addSelectionListener(handler);
+					tree.addMouseListener(handler);
+				}
+
+				private Tree getTree(IPage page) {
+					Control control = page.getControl();
+					if (!(control instanceof Composite composite)) {
+						return null;
+					}
+					Control[] children = composite.getChildren();
+					if (children == null) {
+						return null;
+					}
+					for (Control child : children) {
+						if (child instanceof Tree t) {
+							return t;
+						}
+					}
+					return null;
+				}
 				@Override
 				public boolean okPressed() {
 					try {
@@ -75,5 +121,51 @@ public class ReplaceLocalHistory extends ShowLocalHistory {
 	@Override
 	protected String getPromptTitle() {
 		return TeamUIMessages.ReplaceLocalHistory_1;
+	}
+
+	private static final class NotifyDefaultSelectionOnWidgetSelectedHandler extends SelectionAdapter
+			implements MouseListener {
+		private boolean mouseDownPressed = false;
+		private Runnable runOnMouseUp;
+		private final Tree tree;
+
+		public NotifyDefaultSelectionOnWidgetSelectedHandler(Tree tree) {
+			this.tree = tree;
+		}
+		@Override
+		public void widgetSelected(SelectionEvent e) {
+			if (tree.getSelectionCount() != 1) {
+				return;
+			}
+			Runnable r = () -> {
+				Event event = new Event();
+				event.item = e.item;
+				tree.notifyListeners(SWT.DefaultSelection, event);
+			};
+			if (mouseDownPressed) {
+				// run DefaultSelection event after mouseUp
+				runOnMouseUp = r;
+				return;
+			}
+			r.run();
+		}
+
+		@Override
+		public void mouseDoubleClick(MouseEvent e) {
+		}
+
+		@Override
+		public void mouseDown(MouseEvent e) {
+			mouseDownPressed = true;
+		}
+
+		@Override
+		public void mouseUp(MouseEvent e) {
+			mouseDownPressed = false;
+			if (runOnMouseUp != null) {
+				runOnMouseUp.run();
+				runOnMouseUp = null;
+			}
+		}
 	}
 }

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/ui/history/HistoryPageCompareEditorInput.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/ui/history/HistoryPageCompareEditorInput.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.team.internal.ui.TeamUIMessages;
 import org.eclipse.team.internal.ui.Utils;
 import org.eclipse.team.internal.ui.history.DialogHistoryPageSite;
+import org.eclipse.team.internal.ui.history.LocalHistoryPage;
 import org.eclipse.team.ui.PageCompareEditorInput;
 import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.part.Page;
@@ -79,11 +80,23 @@ public class HistoryPageCompareEditorInput extends PageCompareEditorInput {
 
 	@Override
 	protected IPage createPage(CompareViewerPane parent, IToolBarManager toolBarManager) {
+		return createPage(parent, toolBarManager, true);
+	}
+
+	/**
+	 * @since 3.11
+	 */
+	protected final IPage createPage(CompareViewerPane parent, IToolBarManager toolBarManager,
+			boolean allowMultiSelection) {
 		site = new DialogHistoryPageSite(parent.getShell());
 		historyPage = (IHistoryPage)pageSource.createPage(object);
 		historyPage.setSite(site);
 		site.setToolBarManager(toolBarManager);
-		((Page) historyPage).createControl(parent);
+		if (historyPage instanceof LocalHistoryPage localHistoryPage) {
+			localHistoryPage.createControl(parent, allowMultiSelection);
+		} else {
+			((Page) historyPage).createControl(parent);
+		}
 		historyPage.setInput(object);
 		String description = historyPage.getDescription();
 		if (description == null)


### PR DESCRIPTION

The "Replace With" -> "Local History ..." option in the source editor context menu launches a dialog that allows users to revert to a previous version. Initially, this dialog displays a list of all available revisions:

![replace_with_local_history](https://github.com/user-attachments/assets/bf78a698-b535-4035-a95f-caa6f1d39012)

Previously, selecting an entry from the revision list did not trigger any action. Users had to double-click to view the differences.

This pull request enhances the behavior by displaying the differences upon a single click/selection.