### PR TITLE
Update of the FAQ Open Source projects based on Eclipse

### DIFF
--- a/docs/FAQ/FAQ_What_open_source_projects_are_based_on_Eclipse.md
+++ b/docs/FAQ/FAQ_What_open_source_projects_are_based_on_Eclipse.md
@@ -1,17 +1,11 @@
-
-
 FAQ What open source projects are based on Eclipse?
 ===================================================
 
-Thousands of projects of various sizes are based on Eclipse. A small number are directly supported by the Eclipse Foundation as official Eclipse projects but a far greater number can be found elsewhere on the Web. Many are hosted at such sites as Source Forge or can be found in the various Eclipse plug-in listings floating around the Web. The following are the best-known portals for finding Eclipse-based plug-ins:
-
-*   [_Eclipse Community_](https://www.eclipse.org/community) Acknowledging the losing battle of trying to track the growing list of Eclipse plug-ins, this page lists other Eclipse information sites that have lists of plug-ins.
-
-*   [_Eclipse-Plugins.info_](http://www.eclipse-plugins.info) This site is probably the longest running Eclipse information portal, best known for its exhaustive catalog of known open source Eclipse plug-ins. If you have a plug-in that you want the world to know about, get it listed here!
+Thousands of projects of various sizes are based on Eclipse. A small number are directly supported by the Eclipse Foundation as official Eclipse projects but a far greater number can be found elsewhere on the Web. Many are hosted at such sites as Source Forge or GitHub or can be found floating around the Web.
 
 See Also:
 ---------
 
 *   [FAQ What are Eclipse projects and technologies?](./FAQ_What_are_Eclipse_projects_and_technologies.md "FAQ What are Eclipse projects and technologies?")
-*   [The Eclipse community Web site](https://eclipse.org/community)
-
+*   [The Eclipse Foundation Collaborations Web site](https://www.eclipse.org/collaborations/)
+*   [The Eclipse Marketplace](https://marketplace.eclipse.org/)


### PR DESCRIPTION
The plug-in listings links are dead or link to unrelated pages now. This was removed, but the marketplace was added as a reference despite not directly providing plug-in maintainers with a link to the repository configurable.

I didn't want to link to Wikipedia as most of the references are outdated or closed source and even the [GitHub Explore topic about Eclipse](https://github.com/topics/eclipse) is only partly useful to find plug-ins.
It seems that the official website about the Eclipse IDE also doesn't feature a curated list of plug-ins anymore and only has some listed [HERE](https://eclipseide.org/getting-started/).