### PR TITLE
Mark IPlatformConfiguration/Factory for removal

### DIFF
--- a/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.update.configurator; singleton:=true
-Bundle-Version: 3.5.600.qualifier
+Bundle-Version: 3.5.700.qualifier
 Bundle-Activator: org.eclipse.update.internal.configurator.ConfigurationActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/configurator/IPlatformConfiguration.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/configurator/IPlatformConfiguration.java
@@ -36,7 +36,7 @@ import java.net.URL;
  * @deprecated The org.eclipse.update component has been replaced by Equinox p2.
  * This API will be deleted in a future release. See bug 311590 for details.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2025-03")
 public interface IPlatformConfiguration {
 
 	/**

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/configurator/IPlatformConfigurationFactory.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/configurator/IPlatformConfigurationFactory.java
@@ -27,7 +27,7 @@ import java.net.URL;
  * @deprecated The org.eclipse.update component has been replaced by Equinox p2.
  * This API will be deleted in a future release. See bug 311590 for details.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2025-03")
 public interface IPlatformConfigurationFactory {
 	/**
 	 * Returns the current platform configuration.


### PR DESCRIPTION
These interfaces are currently only used by ConfiguratorUtils that is already marked for removal on 2024-03

See
- https://github.com/eclipse-platform/eclipse.platform/issues/1572