### PR TITLE
Make the PlatformConfigurationFactory a component

### DIFF
--- a/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.update.configurator; singleton:=true
-Bundle-Version: 3.5.500.qualifier
+Bundle-Version: 3.5.600.qualifier
 Bundle-Activator: org.eclipse.update.internal.configurator.ConfigurationActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -17,6 +17,7 @@ Import-Package: javax.xml.parsers,
  org.w3c.dom,
  org.xml.sax,
  org.xml.sax.helpers
-Service-Component:  OSGI-INF/org.eclipse.update.internal.configurator.BundleGroupComponent.xml
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.update.configurator
+Service-Component: OSGI-INF/org.eclipse.update.internal.configurator.BundleGroupComponent.xml,
+ OSGI-INF/org.eclipse.update.internal.configurator.PlatformConfigurationFactory.xml

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/ConfigurationActivator.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/ConfigurationActivator.java
@@ -13,27 +13,13 @@
  *******************************************************************************/
 package org.eclipse.update.internal.configurator;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-
-import org.eclipse.core.runtime.IBundleGroup;
-import org.eclipse.core.runtime.IBundleGroupProvider;
 import org.eclipse.osgi.framework.log.FrameworkLog;
-import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.service.debug.DebugOptions;
-import org.eclipse.osgi.util.NLS;
-import org.eclipse.update.configurator.IPlatformConfiguration;
-import org.eclipse.update.configurator.IPlatformConfiguration.IFeatureEntry;
-import org.eclipse.update.configurator.IPlatformConfigurationFactory;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
-import org.osgi.framework.ServiceRegistration;
 
-public class ConfigurationActivator implements BundleActivator, IBundleGroupProvider, IConfigurationConstants {
+public class ConfigurationActivator implements BundleActivator, IConfigurationConstants {
 
 	public static String PI_CONFIGURATOR = "org.eclipse.update.configurator"; //$NON-NLS-1$
 	public static final String LAST_CONFIG_STAMP = "last.config.stamp"; //$NON-NLS-1$
@@ -46,91 +32,22 @@ public class ConfigurationActivator implements BundleActivator, IBundleGroupProv
 	public static boolean DEBUG = false;
 
 	private static BundleContext context;
-	private ServiceRegistration<IPlatformConfigurationFactory> configurationFactorySR;
-	ServiceRegistration<?> bundleGroupProviderSR;
-	private PlatformConfiguration configuration;
-
-	// Location of the configuration data
-	private Location configLocation;
-
-	// Singleton
-	private static ConfigurationActivator configurator;
-
-	public ConfigurationActivator() {
-		configurator = this;
-	}
 
 	@Override
 	public void start(BundleContext ctx) throws Exception {
 		context = ctx;
 		loadOptions();
 		acquireFrameworkLogService();
-		try {
-			initialize();
-		} catch (Exception e) {
-			//we failed to start, so make sure Utils closes its service trackers
-			Utils.shutdown();
-			throw e;
-		}
-
 		Utils.debug("Starting update configurator..."); //$NON-NLS-1$
-	}
-	
-	private void initialize() throws Exception {
-
-		configLocation = Utils.getConfigurationLocation();
-		// create the name space directory for update (configuration/org.eclipse.update)
-		if (!configLocation.isReadOnly()) {
-			try {
-				URL privateURL = new URL(configLocation.getURL(), NAME_SPACE);
-				File f = new File(privateURL.getFile());
-				if (!f.exists())
-					f.mkdirs();
-			} catch (MalformedURLException e1) {
-				// ignore
-			}
-		}
-		configurationFactorySR = context.registerService(IPlatformConfigurationFactory.class, new PlatformConfigurationFactory(), null);
-		configuration = getPlatformConfiguration(Utils.getInstallURL(), configLocation);
-		if (configuration == null)
-			throw Utils.newCoreException(NLS.bind(Messages.ConfigurationActivator_createConfig, (new String[] {configLocation.getURL().toExternalForm()})), null);
-
 	}
 
 	@Override
 	public void stop(BundleContext ctx) throws Exception {
-		// quick fix (hack) for bug 47861
-		try {
-			PlatformConfiguration.shutdown();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		configurationFactorySR.unregister();
-		if (bundleGroupProviderSR != null)
-			bundleGroupProviderSR.unregister();
 		Utils.shutdown();
 	}
 
-	/**
-	 * Creates and starts the platform configuration.
-	 * @return the just started platform configuration
-	 */
-	private PlatformConfiguration getPlatformConfiguration(URL installURL, Location configLocation) {
-		try {
-			PlatformConfiguration.startup(installURL, configLocation);
-		} catch (Exception e) {
-			String message = e.getMessage();
-			if (message == null)
-				message = ""; //$NON-NLS-1$
-			Utils.log(Utils.newStatus(message, e));
-		}
-		return PlatformConfiguration.getCurrent();
-
-	}
-
 	private void loadOptions() {
-		// all this is only to get the application args		
+		// all this is only to get the application args
 		DebugOptions service = null;
 		ServiceReference<DebugOptions> reference = context.getServiceReference(DebugOptions.class);
 		if (reference != null)
@@ -147,29 +64,6 @@ public class ConfigurationActivator implements BundleActivator, IBundleGroupProv
 
 	public static BundleContext getBundleContext() {
 		return context;
-	}
-
-	@Override
-	public String getName() {
-		return Messages.BundleGroupProvider;
-	}
-
-	@Override
-	public IBundleGroup[] getBundleGroups() {
-		if (configuration == null)
-			return new IBundleGroup[0];
-
-		IPlatformConfiguration.IFeatureEntry[] features = configuration.getConfiguredFeatureEntries();
-		ArrayList<IBundleGroup> bundleGroups = new ArrayList<>(features.length);
-		for (IFeatureEntry feature : features) {
-			if (feature instanceof FeatureEntry && ((FeatureEntry) feature).hasBranding())
-				bundleGroups.add((IBundleGroup) feature);
-		}
-		return bundleGroups.toArray(new IBundleGroup[bundleGroups.size()]);
-	}
-
-	public static ConfigurationActivator getConfigurator() {
-		return configurator;
 	}
 
 	private void acquireFrameworkLogService() {

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/PlatformConfigurationFactory.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/PlatformConfigurationFactory.java
@@ -13,18 +13,36 @@
  *******************************************************************************/
 package org.eclipse.update.internal.configurator;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.update.configurator.IPlatformConfiguration;
 import org.eclipse.update.configurator.IPlatformConfigurationFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 
+@SuppressWarnings("deprecation")
+@Component(service = IPlatformConfigurationFactory.class)
 public class PlatformConfigurationFactory implements IPlatformConfigurationFactory {
+	private Location configLocation;
+
 	@Override
 	public IPlatformConfiguration getCurrentPlatformConfiguration() {
+		try {
+			PlatformConfiguration.startup(configLocation);
+		} catch (Exception e) {
+			String message = e.getMessage();
+			if (message == null)
+				message = ""; //$NON-NLS-1$
+			Utils.log(Utils.newStatus(message, e));
+		}
 		return PlatformConfiguration.getCurrent();
 	}
-	
+
 	@Override
 	public IPlatformConfiguration getPlatformConfiguration(URL url)	throws IOException {
 		try {
@@ -35,7 +53,7 @@ public class PlatformConfigurationFactory implements IPlatformConfigurationFacto
 			throw new IOException(e.getMessage());
 		}
 	}
-	
+
 	@Override
 	public IPlatformConfiguration getPlatformConfiguration(URL url, URL loc) throws IOException {
 		try {
@@ -46,5 +64,29 @@ public class PlatformConfigurationFactory implements IPlatformConfigurationFacto
 			throw new IOException(e.getMessage());
 		}
 	}
-	
+
+	@Activate
+	public void startup() {
+		configLocation = Utils.getConfigurationLocation();
+		// create the name space directory for update (configuration/org.eclipse.update)
+		if (!configLocation.isReadOnly()) {
+			try {
+				URL privateURL = new URL(configLocation.getURL(), ConfigurationActivator.NAME_SPACE);
+				File f = new File(privateURL.getFile());
+				if (!f.exists())
+					f.mkdirs();
+			} catch (MalformedURLException e1) {
+				// ignore
+			}
+		}
+	}
+
+	@Deactivate
+	public void shutdown() {
+		try {
+			PlatformConfiguration.shutdown();
+		} catch (IOException e) {
+		}
+	}
+
 }


### PR DESCRIPTION
Currently the activator created the factory (but only register it as a plain service) and on the other hand the BundleGroupComponent then access the activator in a static way.

This now decouples the Factory and BundleGroupComponent from the activator by making them components.

Due to
- https://github.com/eclipse-platform/eclipse.platform/issues/1652#issuecomment-2543480890

one can only see if it really works in a deployed product, so beside checking the basic things this also needs to be validated after the next I-build.

Relates to
- https://github.com/eclipse-platform/eclipse.platform/issues/1572