### PR TITLE
Relax dependencies on lucene to include 10.x

### DIFF
--- a/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -43,9 +43,9 @@ Require-Bundle: org.eclipse.ant.core;bundle-version="[3.2.200,4.0.0)";resolution
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.net;bundle-version="[1.2.200,2.0.0)",
- org.apache.lucene.analysis-common;bundle-version="[9.5.0,10.0.0)",
- org.apache.lucene.core;bundle-version="[9.5.0,10.0.0)",
- org.apache.lucene.analysis-smartcn;bundle-version="[9.5.0,10.0.0)"
+ org.apache.lucene.analysis-common;bundle-version="[9.5.0,11.0.0)",
+ org.apache.lucene.core;bundle-version="[9.5.0,11.0.0)",
+ org.apache.lucene.analysis-smartcn;bundle-version="[9.5.0,11.0.0)"
 Import-Package: org.eclipse.equinox.http.jetty;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: User Assistance Test
 Bundle-SymbolicName: org.eclipse.ua.tests;singleton:=true
-Bundle-Version: 3.6.400.qualifier
+Bundle-Version: 3.6.500.qualifier
 Require-Bundle: org.eclipse.help.ui,
  org.eclipse.help.webapp,
  org.eclipse.test.performance,

--- a/ua/org.eclipse.ua.tests/pom.xml
+++ b/ua/org.eclipse.ua.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ua</groupId>
   <artifactId>org.eclipse.ua.tests</artifactId>
-  <version>3.6.400-SNAPSHOT</version>
+  <version>3.6.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
- Update PrebuiltIndexCompatibility.checkReadable so that it compiles for both 9.x and 10.x and passes the tests in both case.
- This prepares for updating the target platform to use lucene 10.x, which requires Java 21.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2654