### PR TITLE
[ANT] Only attempt to set security-manager when it is supported

### DIFF
--- a/ant/org.eclipse.ant.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.core; singleton:=true
-Bundle-Version: 3.7.500.qualifier
+Bundle-Version: 3.7.600.qualifier
 Bundle-Activator: org.eclipse.ant.core.AntCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.tests.core; singleton:=true
-Bundle-Version: 3.7.500.qualifier
+Bundle-Version: 3.7.600.qualifier
 Bundle-ClassPath: anttestscore.jar
 Bundle-Activator: org.eclipse.ant.tests.core.testplugin.AntTestPlugin
 Bundle-Vendor: %providerName

--- a/ant/org.eclipse.ant.tests.core/test plugin/org/eclipse/ant/tests/core/testplugin/AntTestChecker.java
+++ b/ant/org.eclipse.ant.tests.core/test plugin/org/eclipse/ant/tests/core/testplugin/AntTestChecker.java
@@ -14,6 +14,7 @@
 package org.eclipse.ant.tests.core.testplugin;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -219,7 +220,7 @@ public class AntTestChecker {
 	}
 
 	public List<String> getMessages() {
-		return messages;
+		return Collections.unmodifiableList(messages);
 	}
 
 	public List<String> getListeners() {


### PR DESCRIPTION
This avoids trowing+catching an UnsupportedOperationException and additional (error) logs if setting a SecurityManager is disallowed. The latter breaks ant-tests that check the log output.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2623