### PR TITLE
Guard all the places that ant sets the security manager

### DIFF
--- a/ant/org.eclipse.ant.launching/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.launching/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.launching;singleton:=true
-Bundle-Version: 1.4.600.qualifier
+Bundle-Version: 1.4.700.qualifier
 Bundle-Activator: org.eclipse.ant.internal.launching.AntLaunching
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.12.0,4.0.0)",


### PR DESCRIPTION
- This copies the code because org.eclipse.ant.internal.launching.remote.InternalAntRunner can't see (much of) anything else define by org.eclipse.ant.

https://github.com/eclipse-platform/eclipse.platform/issues/1660