### PR TITLE
[#1668] API types to simplify work with launch configuration attributes

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LauchAttributeIdentityRecord.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LauchAttributeIdentityRecord.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.core;
+
+/**
+ * Default implementation for {@link LaunchAttributeIdentity}
+ *
+ * @since 3.22
+ */
+public record LauchAttributeIdentityRecord(String id) implements LaunchAttributeIdentity {
+
+	/**
+	 * Convenience way to compose full qualified name for launch attribute
+	 *
+	 * @param qualifier usually corresponds to Bundle-Symbolic-Name
+	 * @param key short key to name this very attribute in the scope of
+	 *            qualifier
+	 */
+	public LauchAttributeIdentityRecord(String qualifier, String key) {
+		this(qualifier + "." + key); //$NON-NLS-1$
+	}
+
+}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeDefined.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeDefined.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.core;
+
+import org.eclipse.core.runtime.preferences.PreferenceMetadata;
+
+/**
+ *
+ * The definition of {@link ILaunchConfiguration} attribute convenience to:
+ * <ul>
+ * <li>{@link ILaunchConfiguration#getAttribute(String, String)} and similar
+ * operations</li>
+ * <li>{@link ILaunchConfigurationWorkingCopy#setAttribute(String, String)} and
+ * similar operations</li>
+ * <li>Connecting {@link ILaunchConfiguration} attributes with preferences</li>
+ * <li>Representing {@link ILaunchConfiguration} attributes in UI</li>
+ * </ul>
+ *
+ * @see LaunchAttributeRead
+ * @see LaunchAttributeWrite
+ *
+ * @since 3.22
+ */
+public interface LaunchAttributeDefined<V> {
+
+	/**
+	 *
+	 * @return identity for defined attribute
+	 */
+	LaunchAttributeIdentity identity();
+
+	/**
+	 *
+	 * @return preference metadata for defined attribute
+	 */
+	PreferenceMetadata<V> metadata();
+
+}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeIdentity.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeIdentity.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.core;
+
+/**
+ * Identifies an attribute in {@link ILaunchConfiguration}
+ *
+ * @since 3.22
+ */
+public interface LaunchAttributeIdentity {
+
+	/**
+	 * String id of {@link ILaunchConfiguration} attribute for "low-level"
+	 * operations
+	 *
+	 * @return id of attribute
+	 */
+	String id();
+
+}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeRead.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeRead.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+
+/**
+ *
+ * Reads the value of launch attribute
+ *
+ * @since 3.22
+ */
+public final class LaunchAttributeRead<V> {
+
+	private final ILaunchConfiguration configuration;
+	private final String id;
+	private final Class<V> type;
+	private final Supplier<V> value;
+
+	public LaunchAttributeRead(ILaunchConfiguration configuration, LaunchAttributeDefined<V> defined) {
+		this(configuration, defined.identity().id(), defined.metadata().valueClass(), defined.metadata()::defaultValue);
+	}
+
+	public LaunchAttributeRead(ILaunchConfiguration configuration, String id, Class<V> type, Supplier<V> value) {
+		this.configuration = Objects.requireNonNull(configuration);
+		this.id = Objects.requireNonNull(id);
+		this.type = Objects.requireNonNull(type);
+		this.value = Objects.requireNonNull(value);
+	}
+
+	public V get() throws CoreException {
+		if (String.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, String.class.cast(value.get())));
+		}
+		if (Boolean.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, Boolean.class.cast(value.get())));
+		}
+		if (Integer.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, Integer.class.cast(value.get())));
+		}
+		if (List.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, List.class.cast(value.get())));
+		}
+		if (Map.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, Map.class.cast(value.get())));
+		}
+		if (Set.class.equals(type)) {
+			return type.cast(configuration.getAttribute(id, Set.class.cast(value.get())));
+		}
+		throw new CoreException(Status.error(id, new ClassCastException()));
+	}
+
+}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeWrite.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/LaunchAttributeWrite.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.debug.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ *
+ * Writes the value of launch attribute. Useful in conjunction with UI.
+ *
+ * @since 3.22
+ */
+public final class LaunchAttributeWrite<V> implements Consumer<ILaunchConfigurationWorkingCopy> {
+
+	private final String id;
+	private final Class<V> type;
+	private final Supplier<V> value;
+
+	public LaunchAttributeWrite(LaunchAttributeDefined<V> defined) {
+		this(defined.identity().id(), defined.metadata().valueClass(), defined.metadata()::defaultValue);
+	}
+
+	public LaunchAttributeWrite(LaunchAttributeDefined<V> defined, Supplier<V> value) {
+		this(defined.identity().id(), defined.metadata().valueClass(), value);
+	}
+
+	public LaunchAttributeWrite(String id, Class<V> type, Supplier<V> value) {
+		this.id = Objects.requireNonNull(id);
+		this.type = Objects.requireNonNull(type);
+		this.value = Objects.requireNonNull(value);
+	}
+
+	@Override
+	public void accept(ILaunchConfigurationWorkingCopy working) {
+		if (String.class.equals(type)) {
+			working.setAttribute(id, String.class.cast(value.get()));
+		} else if (Integer.class.equals(type)) {
+			working.setAttribute(id, Integer.class.cast(value.get()).intValue());
+		} else if (Boolean.class.equals(type)) {
+			working.setAttribute(id, Boolean.class.cast(value.get()).booleanValue());
+		} else if (List.class.equals(type)) {
+			working.setAttribute(id, List.class.cast(value.get()));
+		} else if (Map.class.equals(type)) {
+			working.setAttribute(id, Map.class.cast(value.get()));
+		} else if (Set.class.equals(type)) {
+			working.setAttribute(id, Set.class.cast(value.get()));
+		} else {
+			working.setAttribute(id, value.get());
+		}
+	}
+
+}


### PR DESCRIPTION
* identify launch attribute
* connect it with preference metadata (to supply defaults/label/description)
* read attribute from configuration
* write attribute to configuration working copy