### PR TITLE
runtime tests: throw dedicated TestException

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.21.500.qualifier
+Bundle-Version: 3.21.600.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
@@ -35,10 +35,6 @@ public class LogSerializationTest {
 
 	static class TestException extends Exception {
 		private static final long serialVersionUID = 1L;
-
-		TestException() {
-			super();
-		}
 	}
 
 	private File logFile = null;
@@ -139,7 +135,16 @@ public class LogSerializationTest {
 			interestingChildren[i] = subArray;
 		}
 		int childOff = 0;
-		return new IStatus[] {new MultiStatus("plugin-id", 1, interestingChildren[childOff++ % len], "message", null), new MultiStatus("org.foo.bar", 5, interestingChildren[childOff++ % len], "message", new NullPointerException()), new MultiStatus("plugin-id", 8, interestingChildren[childOff++ % len], "message", null), new MultiStatus("plugin-id", 0, interestingChildren[childOff++ % len], "message", new IllegalStateException()), new MultiStatus("plugin-id", 65756, interestingChildren[childOff++ % len], "message", null), new MultiStatus(".", 1, interestingChildren[childOff++ % len], "message", null), new MultiStatus("org.foo.blaz", 1, interestingChildren[childOff++ % len], "", null), new MultiStatus("plugin-id", 1, interestingChildren[childOff++ % len], "%$(% 98%(%(*^", null),
+		return new IStatus[] { new MultiStatus("plugin-id", 1, interestingChildren[childOff++ % len], "message", null),
+				new MultiStatus("org.foo.bar", 5, interestingChildren[childOff++ % len], "message",
+						new TestException()),
+				new MultiStatus("plugin-id", 8, interestingChildren[childOff++ % len], "message", null),
+				new MultiStatus("plugin-id", 0, interestingChildren[childOff++ % len], "message",
+						new TestException()),
+				new MultiStatus("plugin-id", 65756, interestingChildren[childOff++ % len], "message", null),
+				new MultiStatus(".", 1, interestingChildren[childOff++ % len], "message", null),
+				new MultiStatus("org.foo.blaz", 1, interestingChildren[childOff++ % len], "", null),
+				new MultiStatus("plugin-id", 1, interestingChildren[childOff++ % len], "%$(% 98%(%(*^", null),
 				new MultiStatus("plugin-id", 1, "message", null), new MultiStatus("..", 87326, "", null),};
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
@@ -142,6 +142,9 @@ public class PlatformTest {
 		assertEquals("4.0", initialLocation, Platform.getLogFileLocation());
 	}
 
+	static class TestException extends Exception {
+		private static final long serialVersionUID = 1L;
+	}
 	@Test
 	public void testRunnable() {
 		final List<Throwable> exceptions = new ArrayList<>();
@@ -152,7 +155,7 @@ public class PlatformTest {
 		ILogListener logListener = (status, plugin) -> collected.add(status);
 		Platform.addLogListener(logListener);
 
-		final Exception exception = new Exception("PlatformTest.testRunnable: this exception is thrown on purpose as part of the test.");
+		final Exception exception = new TestException();
 		ISafeRunnable runnable = new ISafeRunnable() {
 			@Override
 			public void handleException(Throwable t) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -443,6 +443,10 @@ public class JobTest extends AbstractJobTest {
 
 	}
 
+	static class TestException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+	}
+
 	/**
 	 * Test of an ill-behaving {@link Job#shouldRun()}.
 	 */
@@ -463,7 +467,7 @@ public class JobTest extends AbstractJobTest {
 
 			@Override
 			public boolean shouldRun() {
-				throw new RuntimeException("Exception thrown on purpose as part of a test");
+				throw new TestException();
 			}
 		}
 		ShouldRunJob j = new ShouldRunJob();
@@ -1085,7 +1089,7 @@ public class JobTest extends AbstractJobTest {
 		shortJob.addJobChangeListener(new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
-				throw new RuntimeException("This exception thrown on purpose as part of a test");
+				throw new TestException();
 			}
 		});
 		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);


### PR DESCRIPTION
To make it easier to filter test output for unintended exceptions.