### PR TITLE
Increase lower bound to re-exported Equinox Common

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.32.100.qualifier
+Bundle-Version: 3.33.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator
@@ -10,7 +10,7 @@ Export-Package: org.eclipse.core.internal.preferences.legacy;x-internal:=true,
  org.eclipse.core.internal.runtime;x-internal:=true,
  org.eclipse.core.runtime;version="3.7.0"
 Require-Bundle: org.eclipse.osgi;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
- org.eclipse.equinox.common;bundle-version="[3.19.0,4.0.0)";visibility:=reexport,
+ org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.jobs;bundle-version="[3.15.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.registry;bundle-version="[3.12.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.preferences;bundle-version="[3.11.0,4.0.0)";visibility:=reexport,


### PR DESCRIPTION
New API has been added to the StringMatcher, which is going to be used in the Platform UI bundles.

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/2672