### PR TITLE
Fix warnings due Java 21 deprecations in o.e.debug.tests

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsPlugin.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 Wind River Systems and others.
+ * Copyright (c) 2009, 2025 Wind River Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.IPath;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -38,15 +37,17 @@ public class TestsPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.debug.tests"; //$NON-NLS-1$
 
 	/**
-	 * Returns the file corresponding to the specified path from within this bundle
-	 * @return the file corresponding to the specified path from within this bundle, or
-	 * <code>null</code> if not found
+	 * Returns the file corresponding to the specified path from within this
+	 * bundle
+	 *
+	 * @return the file corresponding to the specified path from within this
+	 *         bundle, or <code>null</code> if not found
 	 */
-	public static File getFileInPlugin(IPath path) {
+	public static File getFileInPlugin(String path) {
 		try {
 			Bundle bundle = FrameworkUtil.getBundle(TestsPlugin.class);
-			URL installURL = new URL(bundle.getEntry("/"), path.toString()); //$NON-NLS-1$
-			URL localURL= FileLocator.toFileURL(installURL);//Platform.asLocalURL(installURL);
+			URL installURL = bundle.getEntry("/" + path); //$NON-NLS-1$
+			URL localURL = FileLocator.toFileURL(installURL);
 			return new File(localURL.getFile());
 		} catch (IOException e) {
 			return null;
@@ -55,6 +56,7 @@ public class TestsPlugin {
 
 	/**
 	 * Creates a new project with the specified name
+	 *
 	 * @return a new project with the specified name
 	 */
 	public static IProject createProject(String projectName) throws CoreException {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1213,7 +1212,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		ILaunchConfiguration handle = wc.doSave();
 		assertTrue("Configuration should exist", handle.exists()); //$NON-NLS-1$
 
-		File dir = TestsPlugin.getFileInPlugin(IPath.fromOSString("test-import")); //$NON-NLS-1$
+		File dir = TestsPlugin.getFileInPlugin("test-import"); //$NON-NLS-1$
 		assertTrue("Import directory does not exist", dir.exists()); //$NON-NLS-1$
 		LaunchManager manager = (LaunchManager) getLaunchManager();
 
@@ -1231,12 +1230,10 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 			assertTrue("Import4 should be removed", removed.contains(handle)); //$NON-NLS-1$
 
 			// should be 5 added
-			List<?> added = listener.getAdded();
+			List<ILaunchConfiguration> added = listener.getAdded();
 			assertEquals("Should be 5 added configs", 5, added.size()); //$NON-NLS-1$
 			Set<String> names = new HashSet<>();
-			Iterator<?> iterator = added.iterator();
-			while (iterator.hasNext()) {
-				ILaunchConfiguration lc = (ILaunchConfiguration) iterator.next();
+			for (ILaunchConfiguration lc : added) {
 				names.add(lc.getName());
 			}
 			assertTrue("Missing Name", names.contains("Import1")); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
Replace URL with URI.
Minor cleanup to specify type of collections which allows the forech cleanup to kick up too.