### PR TITLE
Remove dispose call for Colors in AntPreviewerUpdater

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntCodeFormatterPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntCodeFormatterPreferencePage.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -44,7 +44,6 @@ import org.eclipse.ui.texteditor.ChainedPreferenceStore;
 public class AntCodeFormatterPreferencePage extends AbstractAntEditorPreferencePage {
 
 	private SourceViewer fPreviewViewer;
-	private AntPreviewerUpdater fPreviewerUpdater;
 
 	@Override
 	protected OverlayPreferenceStore createOverlayStore() {
@@ -137,7 +136,7 @@ public class AntCodeFormatterPreferencePage extends AbstractAntEditorPreferenceP
 		fPreviewViewer.getTextWidget().setFont(font);
 
 		IPreferenceStore store = new ChainedPreferenceStore(new IPreferenceStore[] { getOverlayStore(), EditorsUI.getPreferenceStore() });
-		fPreviewerUpdater = new AntPreviewerUpdater(fPreviewViewer, configuration, store);
+		new AntPreviewerUpdater(fPreviewViewer, configuration, store);
 
 		String content = loadPreviewContentFromFile("FormatPreviewCode.txt"); //$NON-NLS-1$
 		content = formatContent(content, store);
@@ -157,14 +156,6 @@ public class AntCodeFormatterPreferencePage extends AbstractAntEditorPreferenceP
 	@Override
 	protected void handleDefaults() {
 		// do nothing
-	}
-
-	@Override
-	public void dispose() {
-		super.dispose();
-		if (fPreviewerUpdater != null) {
-			fPreviewerUpdater.dispose();
-		}
 	}
 
 	@Override

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
@@ -16,7 +16,6 @@ package org.eclipse.ant.internal.ui.preferences;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -105,7 +104,7 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	/**
 	 * Item in the highlighting color list.
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	private static class HighlightingColorListItem {
@@ -122,7 +121,7 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 		/**
 		 * Initialize the item with the given values.
-		 * 
+		 *
 		 * @param displayName
 		 *            the display name
 		 * @param colorKey
@@ -180,7 +179,7 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	/**
 	 * Color list label provider.
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	private static class ColorListLabelProvider extends LabelProvider implements IColorProvider {
@@ -203,7 +202,7 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	/**
 	 * Color list content provider.
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	private static class ColorListContentProvider implements IStructuredContentProvider {
@@ -239,7 +238,6 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 	private final List<HighlightingColorListItem> fHighlightingColorList = new ArrayList<>(5);
 
 	private SourceViewer fPreviewViewer;
-	private AntPreviewerUpdater fPreviewerUpdater;
 
 	private SelectionListener fSelectionListener;
 	protected Map<String, String> fWorkingValues;
@@ -522,7 +520,7 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 		fPreviewViewer.getTextWidget().setFont(font);
 
 		IPreferenceStore store = new ChainedPreferenceStore(new IPreferenceStore[] { getOverlayStore(), EditorsUI.getPreferenceStore() });
-		fPreviewerUpdater = new AntPreviewerUpdater(fPreviewViewer, configuration, store);
+		new AntPreviewerUpdater(fPreviewViewer, configuration, store);
 
 		String content = loadPreviewContentFromFile("SyntaxPreviewCode.txt"); //$NON-NLS-1$
 		IDocument document = new Document(content);
@@ -542,21 +540,13 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	/**
 	 * Returns the current highlighting color list item.
-	 * 
+	 *
 	 * @return the current highlighting color list item
 	 * @since 3.0
 	 */
 	private HighlightingColorListItem getHighlightingColorListItem() {
 		IStructuredSelection selection = (IStructuredSelection) fHighlightingColorListViewer.getSelection();
 		return (HighlightingColorListItem) selection.getFirstElement();
-	}
-
-	@Override
-	public void dispose() {
-		super.dispose();
-		if (fPreviewerUpdater != null) {
-			fPreviewerUpdater.dispose();
-		}
 	}
 
 	private Composite createProblemsTabContent(TabFolder folder) {
@@ -712,10 +702,8 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 
 	@Override
 	public boolean performOk() {
-		Iterator<String> iter = fWorkingValues.keySet().iterator();
 		IPreferenceStore store = getPreferenceStore();
-		while (iter.hasNext()) {
-			String key = iter.next();
+		for (String key : fWorkingValues.keySet()) {
 			store.putValue(key, fWorkingValues.get(key));
 		}
 		if (store.needsSaving()) {

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
@@ -38,11 +38,6 @@ import org.eclipse.ui.texteditor.AbstractTextEditor;
  */
 class AntPreviewerUpdater {
 
-	private Color fForegroundColor = null;
-	private Color fBackgroundColor = null;
-	private Color fSelectionBackgroundColor = null;
-	private Color fSelectionForegroundColor = null;
-
 	/**
 	 * Creates a source preview updater for the given viewer, configuration and preference store.
 	 * 
@@ -122,44 +117,20 @@ class AntPreviewerUpdater {
 				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND, styledText.getDisplay());
 		styledText.setForeground(color);
 
-		if (fForegroundColor != null) {
-			fForegroundColor.dispose();
-		}
-
-		fForegroundColor = color;
-
 		// ---------- background color ----------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT) ? null
 				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND, styledText.getDisplay());
 		styledText.setBackground(color);
-
-		if (fBackgroundColor != null) {
-			fBackgroundColor.dispose();
-		}
-
-		fBackgroundColor = color;
 
 		// ----------- selection foreground color --------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_SELECTION_FOREGROUND_SYSTEM_DEFAULT) ? null
 				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_FOREGROUND, styledText.getDisplay());
 		styledText.setSelectionForeground(color);
 
-		if (fSelectionForegroundColor != null) {
-			fSelectionForegroundColor.dispose();
-		}
-
-		fSelectionForegroundColor = color;
-
 		// ---------- selection background color ----------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_SELECTION_BACKGROUND_SYSTEM_DEFAULT) ? null
 				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_BACKGROUND, styledText.getDisplay());
 		styledText.setSelectionBackground(color);
-
-		if (fSelectionBackgroundColor != null) {
-			fSelectionBackgroundColor.dispose();
-		}
-
-		fSelectionBackgroundColor = color;
 	}
 
 	/**
@@ -192,25 +163,4 @@ class AntPreviewerUpdater {
 		return null;
 	}
 
-	public void dispose() {
-		if (fForegroundColor != null) {
-			fForegroundColor.dispose();
-			fForegroundColor = null;
-		}
-
-		if (fBackgroundColor != null) {
-			fBackgroundColor.dispose();
-			fBackgroundColor = null;
-		}
-
-		if (fSelectionForegroundColor != null) {
-			fSelectionForegroundColor.dispose();
-			fSelectionForegroundColor = null;
-		}
-
-		if (fSelectionBackgroundColor != null) {
-			fSelectionBackgroundColor.dispose();
-			fSelectionBackgroundColor = null;
-		}
-	}
 }


### PR DESCRIPTION
According to the Javadoc on Colors:

 * Colors do not need to be disposed, however to maintain compatibility
 * with older code, disposing a Color is not an error.