### PR TITLE
Remove dispose call for Colors in MessageLine

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/MessageLine.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/MessageLine.java
@@ -84,12 +84,4 @@ public class MessageLine extends CLabel {
 		setBackground(fNormalMsgAreaBackground);
 	}
 
-	@Override
-	public void dispose() {
-		if (fErrorMsgAreaBackground != null) {
-			fErrorMsgAreaBackground.dispose();
-			fErrorMsgAreaBackground = null;
-		}
-		super.dispose();
-	}
 }


### PR DESCRIPTION
According to the Javadoc on Colors:

 * Colors do not need to be disposed, however to maintain compatibility
 * with older code, disposing a Color is not an error.