### PR TITLE
disable flaky ExpressionTests.testSubTypeTiming() #894

### DIFF
--- a/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.expressions.tests; singleton:=true
-Bundle-Version: 3.7.400.qualifier
+Bundle-Version: 3.7.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTests.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 
@@ -1013,6 +1014,7 @@ public class ExpressionTests {
 	}
 
 	@Test
+	@Disabled("CI test environment too unstable for performance tests")
 	public void testSubTypeTiming() throws Exception {
 		HashSet<?> o1 = new HashSet<>();
 


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform/issues/894