### PR TITLE
Remove dispose call for Color

### DIFF
--- a/debug/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.debug.examples.ui;singleton:=true
-Bundle-Version: 1.8.500.qualifier
+Bundle-Version: 1.8.600.qualifier
 Bundle-Activator: org.eclipse.debug.examples.ui.pda.DebugUIPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.resources,

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,7 @@ package org.eclipse.debug.examples.ui.pda;
 
 import java.net.URL;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -118,11 +116,6 @@ public class DebugUIPlugin extends AbstractUIPlugin {
 		super.stop(context);
 		plugin = null;
 		resourceBundle = null;
-		Iterator<Entry<RGB, Color>> colors = fColors.entrySet().iterator();
-		while (colors.hasNext()) {
-			Entry<RGB, Color> entry = colors.next();
-			entry.getValue().dispose();
-		}
 	}
 
 	/**

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/ColorManager.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/ColorManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -49,11 +49,6 @@ public class ColorManager {
 		return color;
 	}
 
-	public void dispose() {
-		for (Color color : fColorTable.values()) {
-			color.dispose();
-		}
-	}
 }
 
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -457,8 +457,6 @@ public class DebugUIPlugin extends AbstractUIPlugin implements ILaunchListener, 
 			if(fContextLaunchingManager != null) {
 				fContextLaunchingManager.shutdown();
 			}
-
-			ColorManager.getDefault().dispose();
 
 			if (fgPresentation != null) {
 				fgPresentation.dispose();

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2013 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -166,9 +166,6 @@ public abstract class AsynchronousViewer extends StructuredViewer implements Lis
 			font.dispose();
 		}
 		fFontCache.clear();
-		for (Color color : fColorCache.values()) {
-			color.dispose();
-		}
 		fColorCache.clear();
 
 		if (fModel != null) {

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/breadcrumb/BreadcrumbItemDropDown.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/breadcrumb/BreadcrumbItemDropDown.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -96,7 +96,6 @@ class BreadcrumbItemDropDown implements IBreadcrumbDropDownSite {
 				gc.fillPolygon(new int[] {
 						0, 0, ARROW_SIZE, ARROW_SIZE, 0, ARROW_SIZE * 2 });
 				gc.dispose();
-				triangleColor.dispose();
 
 				ImageData imageData = image.getImageData(zoom);
 				image.dispose();

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -242,9 +242,6 @@ public class TreeModelLabelProvider extends ColumnLabelProvider
 			font.dispose();
 		}
 		fFontCache.clear();
-		for (Color color : fColorCache.values()) {
-			color.dispose();
-		}
 		fColorCache.clear();
 		super.dispose();
 	}

--- a/debug/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.unittest.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.unittest.ui;singleton:=true
-Bundle-Version: 1.1.400.qualifier
+Bundle-Version: 1.1.500.qualifier
 Bundle-Activator: org.eclipse.unittest.internal.UnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/UnitTestProgressBar.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/UnitTestProgressBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,11 +57,6 @@ public class UnitTestProgressBar extends Canvas {
 			}
 		});
 		addPaintListener(this::paint);
-		addDisposeListener(event -> {
-			fFailureColor.dispose();
-			fOKColor.dispose();
-			fStoppedColor.dispose();
-		});
 		Display display = parent.getDisplay();
 		fFailureColor = new Color(display, 159, 63, 63);
 		fOKColor = new Color(display, 95, 191, 95);


### PR DESCRIPTION
According to the Javadoc on Color:

 * Colors do not need to be disposed, however to maintain compatibility
 * with older code, disposing a Color is not an error.