### PR TITLE
Use System.lineSeparator()

### DIFF
--- a/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/AntProcessBuildLogger.java
+++ b/ant/org.eclipse.ant.launching/loggers/org/eclipse/ant/internal/launching/runtime/logger/AntProcessBuildLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ public class AntProcessBuildLogger extends NullBuildLogger {
 
 		StringBuffer fullMessage = new StringBuffer();
 		if (!loggingToLogFile()) {
-			fullMessage.append(System.getProperty("line.separator")); //$NON-NLS-1$
+			fullMessage.append(System.lineSeparator());
 		}
 		if (event.getException() == null && event.getTask() != null && !fEmacsMode) {
 			adornMessage(event, fullMessage);
@@ -117,7 +117,7 @@ public class AntProcessBuildLogger extends NullBuildLogger {
 			appendAndLink(fullMessage, location, label, offset, line);
 			line = r.readLine();
 			while (line != null) {
-				fullMessage.append(System.getProperty("line.separator")); //$NON-NLS-1$
+				fullMessage.append(System.lineSeparator());
 				fullMessage.append(column);
 				appendAndLink(fullMessage, location, label, offset, line);
 				line = r.readLine();
@@ -262,7 +262,7 @@ public class AntProcessBuildLogger extends NullBuildLogger {
 			result.append(RuntimeMessages.AntProcessBuildLogger__milliseconds_6);
 		}
 
-		result.append(System.getProperty("line.separator")); //$NON-NLS-1$
+		result.append(System.lineSeparator());
 		return result.toString();
 	}
 
@@ -282,7 +282,7 @@ public class AntProcessBuildLogger extends NullBuildLogger {
 			return;
 		}
 		Target target = event.getTarget();
-		StringBuilder msg = new StringBuilder(System.getProperty("line.separator")); //$NON-NLS-1$
+		StringBuilder msg = new StringBuilder(System.lineSeparator());
 		String targetName = target.getName();
 		msg.append(targetName);
 		msg.append(':');

--- a/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InternalAntRunner.java
+++ b/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InternalAntRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  * Portions Copyright  2000-2005 The Apache Software Foundation
  *
  * This program and the accompanying materials are made
@@ -328,7 +328,7 @@ public class InternalAntRunner {
 	 */
 	private void printTargets(Project project, List<String> names, List<String> descriptions, String heading, int maxlen) {
 		// now, start printing the targets and their descriptions
-		String lSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lSep = System.lineSeparator();
 
 		String spaces = "    "; //$NON-NLS-1$
 		while (spaces.length() < maxlen) {
@@ -1164,7 +1164,7 @@ public class InternalAntRunner {
 	 * Logs a message with the client outlining the usage of <b>Ant</b>.
 	 */
 	private void printUsage() {
-		String lSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lSep = System.lineSeparator();
 		StringBuilder msg = new StringBuilder();
 		msg.append("ant ["); //$NON-NLS-1$
 		msg.append(RemoteAntMessages.getString("InternalAntRunner.options_13")); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/RemoteAntBuildListener.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/RemoteAntBuildListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2003, 2016 IBM Corporation and others.
+ *  Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -192,7 +192,7 @@ public class RemoteAntBuildListener implements ILaunchesListener {
 			if (index > 0) {
 				int priority = Integer.parseInt(message.substring(0, index));
 				String msg = message.substring(index + 1);
-				writeMessage(msg + System.getProperty("line.separator"), priority); //$NON-NLS-1$
+				writeMessage(msg + System.lineSeparator(), priority);
 				if (msg.startsWith("BUILD FAILED")) { //$NON-NLS-1$
 					fBuildFailed = true;
 				} else if (fBuildFailed) {
@@ -222,7 +222,7 @@ public class RemoteAntBuildListener implements ILaunchesListener {
 			int lineNumber = Integer.parseInt(tokenizer.nextToken());
 			generateLink(msg, location, lineNumber, 0, msg.length() - 1);
 		}
-		writeMessage(msg + System.getProperty("line.separator"), Project.MSG_INFO); //$NON-NLS-1$
+		writeMessage(msg + System.lineSeparator(), Project.MSG_INFO);
 	}
 
 	private void receiveTaskMessage(String message) {
@@ -269,7 +269,7 @@ public class RemoteAntBuildListener implements ILaunchesListener {
 
 		StringBuffer fullMessage = new StringBuffer();
 		adornMessage(taskName, line, fullMessage);
-		writeMessage(fullMessage.append(System.getProperty("line.separator")).toString(), priority); //$NON-NLS-1$
+		writeMessage(fullMessage.append(System.lineSeparator()).toString(), priority);
 	}
 
 	private void generateLink(String line, String fileName, int lineNumber, int offset, int length) {

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2005 John-Mason P. Shackelford and others.
+ * Copyright (c) 2004, 2025 John-Mason P. Shackelford and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -93,7 +93,7 @@ public class XmlDocumentFormatterTest extends AbstractAntUITest {
 	private void simpleTest(String sourceFileName, String targetFileName, FormattingPreferences prefs) throws Exception {
 
 		XmlDocumentFormatter xmlFormatter = new XmlDocumentFormatter();
-		xmlFormatter.setDefaultLineDelimiter(System.getProperty("line.separator")); //$NON-NLS-1$
+		xmlFormatter.setDefaultLineDelimiter(System.lineSeparator());
 		String result = xmlFormatter.format(Files.readString(getBuildFile(sourceFileName).toPath()), prefs);
 		String expectedResult = Files.readString(getBuildFile(targetFileName).toPath());
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlFormatterTest.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 John-Mason P. Shackelford and others.
+ * Copyright (c) 2004, 2025 John-Mason P. Shackelford and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     John-Mason P. Shackelford - initial API and implementation
  *     IBM Corporation - bug 84342
@@ -37,7 +37,7 @@ public class XmlFormatterTest {
 			node.putInt(AntEditorPreferenceConstants.FORMATTER_TAB_SIZE, 4);
 			node.flush();
 		}
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String xmlDoc = "<project default=\"go\"><target name=\"go\" description=\"Demonstrate the wrapping of long tags.\"><echo>hi</echo></target></project>"; //$NON-NLS-1$
 		String formattedDoc = XmlFormatter.format(xmlDoc);
 		String expected = "<project default=\"go\">" + lineSep + "\t<target name=\"go\"" + lineSep //$NON-NLS-1$ //$NON-NLS-2$
@@ -74,7 +74,7 @@ public class XmlFormatterTest {
 				return 6;
 			}
 		};
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String xmlDoc = "<project default=\"go\"><target name=\"go\" description=\"Demonstrate the wrapping of long tags.\"><echo>hi</echo></target></project>"; //$NON-NLS-1$
 		String formattedDoc = XmlFormatter.format(xmlDoc, prefs);
 		String expected = "<project default=\"go\">" + lineSep + "      <target name=\"go\"" + lineSep //$NON-NLS-1$ //$NON-NLS-2$
@@ -114,7 +114,7 @@ public class XmlFormatterTest {
 				return 6;
 			}
 		};
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String xmlDoc = "<project default=\"go\"><target name=\"go\" description=\"Demonstrate the wrapping of long tags.\"><echo>hi</echo></target>" //$NON-NLS-1$
 				+ lineSep + lineSep + "</project>"; //$NON-NLS-1$
 		String formattedDoc = XmlFormatter.format(xmlDoc, prefs);

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 John-Mason P. Shackelford and others.
+ * Copyright (c) 2004, 2025 John-Mason P. Shackelford and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     John-Mason P. Shackelford - initial API and implementation
  *     IBM Corporation - Bug 84342
@@ -192,7 +192,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	@Test
 	public void testFormat01() throws Exception {
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String indent = "\t"; //$NON-NLS-1$
 		String source = "<target name=\"myTargetName\" depends=\"a,b,c,d,e,f,g\" description=\"This is a very long element which ought to be wrapped.\">"; //$NON-NLS-1$
 		String target = "<target name=\"myTargetName\"" + lineSep //$NON-NLS-1$
@@ -204,7 +204,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	@Test
 	public void testFormat02() throws Exception {
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String indent = "\t"; //$NON-NLS-1$
 		String source = "<target name=\"myTargetName\" depends=\"a,b,c,d,e,f,g\" description=\"This is a very long element which ought to be wrapped.\">"; //$NON-NLS-1$
 		String target = "<target name=\"myTargetName\"" + lineSep //$NON-NLS-1$
@@ -217,7 +217,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 	@Test
 	public void testBug73411() throws Exception {
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String indent = "\t"; //$NON-NLS-1$
 		String source = "<target name='myTargetName' depends=\"a,b,c,d,e,f,g\" description=\'This is a very long element which ought to be \"wrapped\".'>"; //$NON-NLS-1$
 		String target = "<target name='myTargetName'" + lineSep //$NON-NLS-1$
@@ -307,7 +307,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 
 		tag.setClosed(true);
 
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		assertEquals("<myElement attribute1=\"value1\"" + lineSep //$NON-NLS-1$
 				+ "\t\t             attribute2=\"value2\" />", //$NON-NLS-1$
 				tagFormatter.wrapTag(tag, dontAlignCloseChar, "\t\t  ", lineSep)); //$NON-NLS-1$
@@ -334,7 +334,7 @@ public class XmlTagFormatterTest extends AbstractAntUITest {
 		// Ordinarily the double space after the element name would be repaired
 		// but if the formatter is working correctly these examples will be
 		// considered malformed and will be passed through untouched.
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		String source1 = "<echo  file=\"foo\">" + lineSep + "&lt;html>&lt;body>&lt;pre>" //$NON-NLS-1$ //$NON-NLS-2$
 				+ "${compilelog}&lt;/pre>&lt;/body>&lt;/html>"; //$NON-NLS-1$
 		FormattingPreferences prefs = getPreferences(true, false, 60);

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2003, 2021 IBM Corporation and others.
+ *  Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -285,7 +285,7 @@ public abstract class AbstractAntUITest {
 
 			while (line != null) {
 				if (result.length() != 0) {
-					result.append(System.getProperty("line.separator")); //$NON-NLS-1$
+					result.append(System.lineSeparator());
 				}
 				result.append(line);
 				line = bufferedReader.readLine();

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/ExportUtil.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/ExportUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2017 Richard Hoefter and others.
+ * Copyright (c) 2004, 2025 Richard Hoefter and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,11 +7,11 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *     Richard Hoefter (richard.hoefter@web.de) - initial API and implementation, bug 95300, bug 95297, bug 128104, bug 201180, bug 288830 
- *     IBM Corporation - NLS'ing and incorporating into Eclipse. 
- *                     - Bug 177833 Class created from combination of all utility classes of contribution 
+ *     Richard Hoefter (richard.hoefter@web.de) - initial API and implementation, bug 95300, bug 95297, bug 128104, bug 201180, bug 288830
+ *     IBM Corporation - NLS'ing and incorporating into Eclipse.
+ *                     - Bug 177833 Class created from combination of all utility classes of contribution
  *                     - Bug 267459 Java project with an external jar file from C:\ on the build path throws a NPE during the Ant Buildfile generation.
  *                     - bug fixing
  *******************************************************************************/
@@ -134,7 +134,7 @@ public class ExportUtil {
 
 	/**
 	 * Convert Eclipse path to absolute filename.
-	 * 
+	 *
 	 * @param file
 	 *            Project root optionally followed by resource name. An absolute path is simply converted to a string.
 	 * @return full qualified path
@@ -192,7 +192,7 @@ public class ExportUtil {
 
 	/**
 	 * Remove project root from given project file.
-	 * 
+	 *
 	 * @param newProjectRoot
 	 *            replace project root, e.g. with a variable ${project.location}
 	 */
@@ -213,7 +213,7 @@ public class ExportUtil {
 
 	/**
 	 * Get for given project all directly dependent projects.
-	 * 
+	 *
 	 * @return set of IJavaProject objects
 	 */
 	public static List<IJavaProject> getClasspathProjects(IJavaProject project) throws JavaModelException {
@@ -239,7 +239,7 @@ public class ExportUtil {
 
 	/**
 	 * Get for given project all directly and indirectly dependent projects.
-	 * 
+	 *
 	 * @return set of IJavaProject objects
 	 */
 	public static List<IJavaProject> getClasspathProjectsRecursive(IJavaProject project) throws JavaModelException {
@@ -259,7 +259,7 @@ public class ExportUtil {
 
 	/**
 	 * Sort projects according to General -&gt; Workspace -&gt; Build Order.
-	 * 
+	 *
 	 * @param javaProjects
 	 *            list of IJavaProject objects
 	 * @return list of IJavaProject objects with new order
@@ -303,10 +303,10 @@ public class ExportUtil {
 
 	/**
 	 * Returns cyclic dependency marker for a given project.
-	 * 
+	 *
 	 * <p>
 	 * See org.eclipse.jdt.core.tests.model.ClasspathTests.numberOfCycleMarkers.
-	 * 
+	 *
 	 * @param javaProject
 	 *            project for which cyclic dependency marker should be found
 	 * @return cyclic dependency marker for a given project or <code>null</code> if there is no such marker
@@ -324,7 +324,7 @@ public class ExportUtil {
 
 	/**
 	 * Find JUnit tests. Same tests are also returned by Eclipse run configuration wizard.
-	 * 
+	 *
 	 * @param containerHandle
 	 *            project, package or source folder
 	 */
@@ -411,7 +411,7 @@ public class ExportUtil {
 	/**
 	 * Platform specific newline character(s).
 	 */
-	public static final String NEWLINE = System.getProperty("line.separator"); //$NON-NLS-1$
+	public static final String NEWLINE = System.lineSeparator();
 
 	public static String removePrefix(String s, String prefix) {
 		if (s == null) {
@@ -483,7 +483,7 @@ public class ExportUtil {
 
 	/**
 	 * Converts collection to a separated string.
-	 * 
+	 *
 	 * @param c
 	 *            collection
 	 * @param separator
@@ -504,7 +504,7 @@ public class ExportUtil {
 
 	/**
 	 * Remove duplicates preserving original order.
-	 * 
+	 *
 	 * @param l
 	 *            list to remove duplicates from
 	 * @return new list without duplicates
@@ -548,7 +548,7 @@ public class ExportUtil {
 
 	/**
 	 * Request write access to given file. Depending on the version control plug-in opens a confirm checkout dialog.
-	 * 
+	 *
 	 * @param shell
 	 *            parent instance for dialogs
 	 * @param file
@@ -561,7 +561,7 @@ public class ExportUtil {
 
 	/**
 	 * Request write access to given files. Depending on the version control plug-in opens a confirm checkout dialog.
-	 * 
+	 *
 	 * @param shell
 	 *            parent instance for dialogs
 	 * @return <code>IFile</code> objects for which user confirmed checkout
@@ -633,7 +633,7 @@ public class ExportUtil {
 
 	/**
 	 * Add variable/value for Eclipse variable. If given string is no variable, nothing is added.
-	 * 
+	 *
 	 * @param variable2valueMap
 	 *            property map to add variable/value
 	 * @param s

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntTaskNode.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntTaskNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class AntTaskNode extends AntElementNode {
 
 	/**
 	 * The reference id for this task
-	 * 
+	 *
 	 * @param id
 	 *            The reference id for this task
 	 */
@@ -98,7 +98,7 @@ public class AntTaskNode extends AntElementNode {
 
 	/**
 	 * Returns the reference id for this task or <code>null</code> if it has no reference id.
-	 * 
+	 *
 	 * @return The reference id for this task
 	 */
 	public String getId() {
@@ -108,7 +108,7 @@ public class AntTaskNode extends AntElementNode {
 	/**
 	 * Configures the associated task if required. Allows subclasses to do specific configuration (such as executing the task) by calling
 	 * <code>nodeSpecificConfigure</code>
-	 * 
+	 *
 	 * @return whether the configuration of this node could have impact on other nodes
 	 */
 	public boolean configure(boolean validateFully) {
@@ -187,7 +187,7 @@ public class AntTaskNode extends AntElementNode {
 		List<Integer> results = new ArrayList<>();
 		RuntimeConfigurable wrapper = getTask().getRuntimeConfigurableWrapper();
 		Map<String, Object> attributeMap = wrapper.getAttributeMap();
-		String lineSep = System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSep = System.lineSeparator();
 		for (String key : attributeMap.keySet()) {
 			String value = (String) attributeMap.get(key);
 			int identifierCorrection = 1;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AbstractAntEditorPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AbstractAntEditorPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -330,7 +330,7 @@ public abstract class AbstractAntEditorPreferencePage extends PreferencePage imp
 
 	protected String loadPreviewContentFromFile(String filename) {
 		String line;
-		String separator = System.getProperty("line.separator"); //$NON-NLS-1$
+		String separator = System.lineSeparator();
 		StringBuilder buffer = new StringBuilder(512);
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream(filename)))) {
 			while ((line = reader.readLine()) != null) {

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/CopyFailureListAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/CopyFailureListAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -71,7 +71,7 @@ public class CopyFailureListAction extends Action {
 	 */
 	public String getAllFailureTraces() {
 		StringBuilder buf = new StringBuilder();
-		String lineDelim = System.getProperty("line.separator", "\n"); //$NON-NLS-1$//$NON-NLS-2$
+		String lineDelim = System.lineSeparator();
 		for (TestElement failure : fRunner.getCurrentTestRunSession().getAllFailedTestElements()) {
 			buf.append(failure.getTestName()).append(lineDelim);
 			FailureTrace failureTrace = failure.getFailureTrace();

--- a/team/bundles/org.eclipse.compare.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.core
-Bundle-Version: 3.8.600.qualifier
+Bundle-Version: 3.8.700.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/internal/core/patch/Hunk.java
+++ b/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/internal/core/patch/Hunk.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.compare.patch.*;
+import org.eclipse.compare.patch.IFilePatchResult;
+import org.eclipse.compare.patch.IHunk;
+import org.eclipse.compare.patch.PatchConfiguration;
 import org.eclipse.core.runtime.Assert;
 
 /**
@@ -438,7 +440,7 @@ public class Hunk implements IHunk {
 			// if the file doesn't exist use a line separator from the patch
 			return this.fLines[0].substring(LineReader.length(this.fLines[0]));
 		}
-		return System.getProperty("line.separator"); //$NON-NLS-1$
+		return System.lineSeparator();
 	}
 
 	/*

--- a/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/internal/core/patch/LineReader.java
+++ b/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/internal/core/patch/LineReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -66,7 +66,7 @@ public class LineReader {
 			while (iter.hasNext())
 				sb.append(iter.next());
 		} else {
-			String lineSeparator= System.getProperty("line.separator"); //$NON-NLS-1$
+			String lineSeparator = System.lineSeparator();
 			while (iter.hasNext()) {
 				String line= iter.next();
 				int l= length(line);

--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +90,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		private String loadPreviewContentFromFile(String key) {
 
 			String preview= Utilities.getString(key);
-			String separator= System.getProperty("line.separator"); //$NON-NLS-1$
+			String separator = System.lineSeparator();
 			StringBuilder buffer= new StringBuilder();
 			for (int i= 0; i < preview.length(); i++) {
 				char c= preview.charAt(i);
@@ -474,9 +473,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 
 	private void initializeFields() {
 
-		Iterator<Button> e = fCheckBoxes.keySet().iterator();
-		while (e.hasNext()) {
-			Button b = e.next();
+		for (Button b : fCheckBoxes.keySet()) {
 			String key= fCheckBoxes.get(b);
 			b.setSelection(fOverlayStore.getBoolean(key));
 		}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/TextStreamMerger.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/TextStreamMerger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2011 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,7 @@ public class TextStreamMerger implements IStreamMerger {
 		}
 
 		try {
-			String lineSeparator= System.getProperty("line.separator"); //$NON-NLS-1$
+			String lineSeparator = System.lineSeparator();
 			if (lineSeparator == null)
 				lineSeparator= "\n"; //$NON-NLS-1$
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/LineReader.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/LineReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,7 +90,7 @@ public class LineReader {
 			while (iter.hasNext())
 				sb.append(iter.next());
 		} else {
-			String lineSeparator = System.getProperty("line.separator"); //$NON-NLS-1$
+			String lineSeparator = System.lineSeparator();
 			while (iter.hasNext()) {
 				String line = iter.next();
 				int l = length(line);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Patcher.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Patcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -420,7 +420,7 @@ public class Patcher implements IHunkFilter {
 		if (failedHunks.size() <= 0)
 			return null;
 
-		String lineSeparator= System.getProperty("line.separator"); //$NON-NLS-1$
+		String lineSeparator = System.lineSeparator();
 		StringBuilder sb= new StringBuilder();
 		for (Hunk hunk : failedHunks) {
 			sb.append(hunk.getRejectedDescription());

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/mapping/TextStorageMerger.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/mapping/TextStorageMerger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2017 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -49,7 +49,7 @@ public class TextStorageMerger implements IStorageMerger {
 
 		try {
 			boolean firstLine = true;
-			String lineSeparator= System.getProperty("line.separator"); //$NON-NLS-1$
+			String lineSeparator = System.lineSeparator();
 			if (lineSeparator == null)
 				lineSeparator= "\n"; //$NON-NLS-1$
 

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/actions/CopyToClipboardAction.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/actions/CopyToClipboardAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,7 @@ import org.eclipse.ui.part.ResourceTransfer;
  */
 class CopyToClipboardAction extends SelectionListenerAction {
 
-	private static final String EOL = System.getProperty("line.separator", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+	private static final String EOL = System.lineSeparator();
 
 	private final static String ID= TeamUIPlugin.PLUGIN_ID + ".synchronize.action.copy";  //$NON-NLS-1$
 

--- a/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProvider.java
+++ b/team/examples/org.eclipse.team.examples.filesystem/src/org/eclipse/team/examples/pessimistic/PessimisticFilesystemProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -582,7 +582,7 @@ public class PessimisticFilesystemProvider extends RepositoryProvider  {
 		}
 		buffer.append(contents);
 		if (!prepend) {
-			buffer.append(System.getProperty("line.separator") + text);
+			buffer.append(System.lineSeparator() + text);
 		}
 		file.setContents(buffer.toString().getBytes(), false, false, null);
 	}

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/DiffTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2008 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ public class DiffTest {
 	private static final String _123 = "123"; //$NON-NLS-1$
 	// private static final String _456= "456"; //$NON-NLS-1$
 
-	static final String SEPARATOR = System.getProperty("line.separator"); //$NON-NLS-1$
+	static final String SEPARATOR = System.lineSeparator();
 
 	@Test
 	public void testLineAddition() {

--- a/ua/org.eclipse.help.base/src_demo/org/apache/lucene/demo/html/ParseException.java
+++ b/ua/org.eclipse.help.base/src_demo/org/apache/lucene/demo/html/ParseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -118,14 +118,14 @@ public String getMessage() {
     }
     StringBuilder expected = new StringBuilder();
     int maxSize = 0;
-    for (int i = 0; i < expectedTokenSequences.length; i++) {
-      if (maxSize < expectedTokenSequences[i].length) {
-        maxSize = expectedTokenSequences[i].length;
+    for (int[] element : expectedTokenSequences) {
+      if (maxSize < element.length) {
+        maxSize = element.length;
       }
-      for (int j = 0; j < expectedTokenSequences[i].length; j++) {
-        expected.append(tokenImage[expectedTokenSequences[i][j]]).append(" "); //$NON-NLS-1$
+      for (int j = 0; j < element.length; j++) {
+        expected.append(tokenImage[element[j]]).append(" "); //$NON-NLS-1$
       }
-      if (expectedTokenSequences[i][expectedTokenSequences[i].length - 1] != 0) {
+      if (element[element.length - 1] != 0) {
         expected.append("..."); //$NON-NLS-1$
       }
       expected.append(eol).append("    "); //$NON-NLS-1$
@@ -155,7 +155,7 @@ public String getMessage() {
   /**
    * The end of line string for this machine.
    */
-  protected String eol = System.getProperty("line.separator", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+	protected String eol = System.lineSeparator();
 
   /**
    * Used to convert raw characters to their escaped version


### PR DESCRIPTION
System.getProperty("line.separator") involves SecurityManager checks (depending on JVM used), key validity check and Properties retrieval while lineSeparator() returns the value used to populate the properties with directly.