### PR TITLE
Stop maven-war-plugin from recompressing zip files

### DIFF
--- a/ua/infocenter-web/infocenter-app/pom.xml
+++ b/ua/infocenter-web/infocenter-app/pom.xml
@@ -38,6 +38,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>3.4.0</version>
+				<configuration>
+					<recompressZippedFiles>false</recompressZippedFiles>
+				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
There is no need for that and it should (hopefully) reduce the cases where build OOMs.