### PR TITLE
Correct class name in extension point documentation

### DIFF
--- a/ua/org.eclipse.help.base/schema/searchProcessor.exsd
+++ b/ua/org.eclipse.help.base/schema/searchProcessor.exsd
@@ -95,7 +95,7 @@
          <meta.section type="apiinfo"/>
       </appInfo>
       <documentation>
-         The supplied search processor class must extend the abstract class &lt;samp&gt;org.eclipse.help.AbstractSearchProcessor&lt;/samp&gt;.  The processor has the opportunity to modify a search string, provide alternate search expressions, or modify the search result set.
+         The supplied search processor class must extend the abstract class &lt;samp&gt;org.eclipse.help.search.AbstractSearchProcessor&lt;/samp&gt;.  The processor has the opportunity to modify a search string, provide alternate search expressions, or modify the search result set.
       </documentation>
    </annotation>
 


### PR DESCRIPTION
In the extension point `org.eclipse.help.searchProcessor`, the supplied search processor class must extend the class `AbstractSearchProcessor` which is in the package `org.eclipse.help.search`, not in `org.eclipse.help`.