### PR TITLE
[Light Theme]Fix for background color of bread-crumb in debug view

### DIFF
--- a/debug/org.eclipse.debug.ui/css/e4-light_debug_prefstyle.css
+++ b/debug/org.eclipse.debug.ui/css/e4-light_debug_prefstyle.css
@@ -9,17 +9,30 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-#DebugBreadcrumbComposite
-#DebugBreadcrumbComposite > Composite,
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailTextLabel,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDropDownToolBar
+.View #DebugBreadcrumbComposite
+.View #DebugBreadcrumbComposite > Composite,
+.View #DebugBreadcrumbItemComposite,
+.View #DebugBreadcrumbItemDetailComposite,
+.View #DebugBreadcrumbItemDetailTextComposite,
+.View #DebugBreadcrumbItemDetailImageComposite,
+.View #DebugBreadcrumbItemDetailTextLabel,
+.View #DebugBreadcrumbItemDetailImageLabel,
+.View #DebugBreadcrumbItemDropDownToolBar
 {
-    background-color:COLOR-WIDGET-LIGHT-SHADOW;
+    background-color:'#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+}
+
+.Editor #DebugBreadcrumbComposite
+.Editor #DebugBreadcrumbComposite > Composite,
+.Editor #DebugBreadcrumbItemComposite,
+.Editor #DebugBreadcrumbItemDetailComposite,
+.Editor #DebugBreadcrumbItemDetailTextComposite,
+.Editor #DebugBreadcrumbItemDetailImageComposite,
+.Editor #DebugBreadcrumbItemDetailTextLabel,
+.Editor #DebugBreadcrumbItemDetailImageLabel,
+.Editor #DebugBreadcrumbItemDropDownToolBar
+{
+    background-color:#FFFFFF;
 }
 
 #VariablesViewer {


### PR DESCRIPTION
The background color of bread-crumb items did not match the background color in the debug view, and this has been fixed with this PR. Find the before and after screen shots below for the same.

Before:
![Screenshot 2025-01-22 125537](https://github.com/user-attachments/assets/bfbbdde5-b195-49d1-8c7e-f05caba81131)

After:
![Screenshot 2025-01-22 125326](https://github.com/user-attachments/assets/b35677ac-37bd-41ef-876d-bed0389276d5)
