### PR TITLE
Dark theme breadcrumb fix

### DIFF
--- a/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
+++ b/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
@@ -26,15 +26,15 @@ IEclipsePreferences#org-eclipse-debug-ui {
 		'org.eclipse.debug.ui.outColor=235,235,235'
 }
 
-#DebugBreadcrumbComposite
-#DebugBreadcrumbComposite > Composite,
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailTextLabel,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDropDownToolBar
+.View #DebugBreadcrumbComposite
+.View #DebugBreadcrumbComposite > Composite,
+.View #DebugBreadcrumbItemComposite,
+.View #DebugBreadcrumbItemDetailComposite,
+.View #DebugBreadcrumbItemDetailTextComposite,
+.View #DebugBreadcrumbItemDetailImageComposite,
+.View #DebugBreadcrumbItemDetailTextLabel,
+.View #DebugBreadcrumbItemDetailImageLabel,
+.View #DebugBreadcrumbItemDropDownToolBar
 {
     /*
      * Bug 465666
@@ -43,7 +43,28 @@ IEclipsePreferences#org-eclipse-debug-ui {
      * the background with the lighter color used for the background
      * of toolbars and make the foreground color brighter too.
      */
-    background-color:#515658;
+    background-color:#2F2F2F;
+    color: white;
+}
+
+.Editor #DebugBreadcrumbComposite
+.Editor #DebugBreadcrumbComposite > Composite,
+.Editor #DebugBreadcrumbItemComposite,
+.Editor #DebugBreadcrumbItemDetailComposite,
+.Editor #DebugBreadcrumbItemDetailTextComposite,
+.Editor #DebugBreadcrumbItemDetailImageComposite,
+.Editor #DebugBreadcrumbItemDetailTextLabel,
+.Editor #DebugBreadcrumbItemDetailImageLabel,
+.Editor #DebugBreadcrumbItemDropDownToolBar
+{
+    /*
+     * Bug 465666
+     *
+     * Note: as we can't change the arrow to black, we configure
+     * the background with the lighter color used for the background
+     * of toolbars and make the foreground color brighter too.
+     */
+    background-color:#1E1F22;
     color: white;
 }
 

--- a/debug/org.eclipse.debug.ui/css/e4-light_debug_prefstyle.css
+++ b/debug/org.eclipse.debug.ui/css/e4-light_debug_prefstyle.css
@@ -9,17 +9,30 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-#DebugBreadcrumbComposite
-#DebugBreadcrumbComposite > Composite,
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailTextLabel,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDropDownToolBar
+.View #DebugBreadcrumbComposite
+.View #DebugBreadcrumbComposite > Composite,
+.View #DebugBreadcrumbItemComposite,
+.View #DebugBreadcrumbItemDetailComposite,
+.View #DebugBreadcrumbItemDetailTextComposite,
+.View #DebugBreadcrumbItemDetailImageComposite,
+.View #DebugBreadcrumbItemDetailTextLabel,
+.View #DebugBreadcrumbItemDetailImageLabel,
+.View #DebugBreadcrumbItemDropDownToolBar
 {
-    background-color:COLOR-WIDGET-LIGHT-SHADOW;
+    background-color:'#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+}
+
+.Editor #DebugBreadcrumbComposite
+.Editor #DebugBreadcrumbComposite > Composite,
+.Editor #DebugBreadcrumbItemComposite,
+.Editor #DebugBreadcrumbItemDetailComposite,
+.Editor #DebugBreadcrumbItemDetailTextComposite,
+.Editor #DebugBreadcrumbItemDetailImageComposite,
+.Editor #DebugBreadcrumbItemDetailTextLabel,
+.Editor #DebugBreadcrumbItemDetailImageLabel,
+.Editor #DebugBreadcrumbItemDropDownToolBar
+{
+    background-color:#FFFFFF;
 }
 
 #VariablesViewer {


### PR DESCRIPTION
The background color of bread-crumb items did not match the background color in the debug view, which has been fixed with this PR. Please take a look at the before and after screenshots below for the same.

Before:
![Screenshot 2025-01-22 145235](https://github.com/user-attachments/assets/a945afa3-5a93-4473-be81-742c51456c9c)

After:
![Screenshot 2025-01-22 150449](https://github.com/user-attachments/assets/aa555b72-02a4-4353-860d-2e684e3d19f0)
