### PR TITLE
[Dark Theme]Fix for background color of bread crumbs in Debug view

### DIFF
--- a/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
+++ b/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
@@ -26,24 +26,32 @@ IEclipsePreferences#org-eclipse-debug-ui {
 		'org.eclipse.debug.ui.outColor=235,235,235'
 }
 
-#DebugBreadcrumbComposite
-#DebugBreadcrumbComposite > Composite,
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailTextLabel,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDropDownToolBar
+.View #DebugBreadcrumbComposite
+.View #DebugBreadcrumbComposite > Composite,
+.View #DebugBreadcrumbItemComposite,
+.View #DebugBreadcrumbItemDetailComposite,
+.View #DebugBreadcrumbItemDetailTextComposite,
+.View #DebugBreadcrumbItemDetailImageComposite,
+.View #DebugBreadcrumbItemDetailTextLabel,
+.View #DebugBreadcrumbItemDetailImageLabel,
+.View #DebugBreadcrumbItemDropDownToolBar
 {
-    /*
-     * Bug 465666
-     *
-     * Note: as we can't change the arrow to black, we configure
-     * the background with the lighter color used for the background
-     * of toolbars and make the foreground color brighter too.
-     */
-    background-color:#515658;
+    background-color:#2F2F2F;
+    color: white;
+}
+
+.Editor #DebugBreadcrumbComposite
+.Editor #DebugBreadcrumbComposite > Composite,
+.Editor #DebugBreadcrumbItemComposite,
+.Editor #DebugBreadcrumbItemDetailComposite,
+.Editor #DebugBreadcrumbItemDetailTextComposite,
+.Editor #DebugBreadcrumbItemDetailImageComposite,
+.Editor #DebugBreadcrumbItemDetailTextLabel,
+.Editor #DebugBreadcrumbItemDetailImageLabel,
+.Editor #DebugBreadcrumbItemDropDownToolBar
+{
+
+    background-color:#1E1F22;
     color: white;
 }
 


### PR DESCRIPTION
The background color of bread-crumb items did not match the background color in the debug view, which has been fixed with this PR. Please take a look at the before and after screenshots below for the same.

Before:
![Screenshot 2025-01-22 145235](https://github.com/user-attachments/assets/1465b4a5-2416-488c-950d-da78e3d25d53)

After:
![Screenshot 2025-01-22 150449](https://github.com/user-attachments/assets/e475924a-d3fc-4c5a-b87d-b08107aaa31b)
