### PR TITLE
Breakpoint.ensureMarker() not MT safe and should provide more info

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/Breakpoint.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/Breakpoint.java
@@ -32,6 +32,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.IBreakpointManager;
 import org.eclipse.debug.internal.core.BreakpointManager;
 import org.eclipse.debug.internal.core.DebugCoreMessages;
+import org.eclipse.osgi.util.NLS;
 
 /**
  * Abstract implementation of a breakpoint. This class is
@@ -58,7 +59,7 @@ public abstract class Breakpoint extends PlatformObject implements IBreakpoint, 
 	/**
 	 * Underlying marker.
 	 */
-	private IMarker fMarker= null;
+	private volatile IMarker fMarker;
 
 	/**
 	 * @see IBreakpoint#setMarker(IMarker)
@@ -66,7 +67,6 @@ public abstract class Breakpoint extends PlatformObject implements IBreakpoint, 
 	@Override
 	public void setMarker(IMarker marker) throws CoreException {
 		fMarker= marker;
-
 	}
 
 	/**
@@ -292,10 +292,15 @@ public abstract class Breakpoint extends PlatformObject implements IBreakpoint, 
 	 *  this breakpoint or the associated marker does not exist
 	 */
 	protected IMarker ensureMarker() throws DebugException {
+		String message = null;
 		IMarker m = getMarker();
-		if (m == null || !m.exists()) {
-			throw new DebugException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugException.REQUEST_FAILED,
-				DebugCoreMessages.Breakpoint_no_associated_marker, null));
+		if (m == null) {
+			message = DebugCoreMessages.Breakpoint_no_associated_marker;
+		} else if (!m.exists()) {
+			message = NLS.bind(DebugCoreMessages.Breakpoint_marker_does_not_exist, m.toString());
+		}
+		if (message != null) {
+			throw new DebugException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugException.REQUEST_FAILED, message, null));
 		}
 		return m;
 	}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugCoreMessages.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugCoreMessages.java
@@ -21,6 +21,7 @@ public class DebugCoreMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.debug.internal.core.DebugCoreMessages";//$NON-NLS-1$
 
 	public static String Breakpoint_no_associated_marker;
+	public static String Breakpoint_marker_does_not_exist;
 	public static String BreakpointManager_Missing_breakpoint_definition;
 	public static String BreakpointManager_Missing_model_identifier;
 	public static String DebugEvent_illegal_detail;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugCoreMessages.properties
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugCoreMessages.properties
@@ -15,6 +15,7 @@
 ###############################################################################
 
 Breakpoint_no_associated_marker=Breakpoint does not have an associated marker.
+Breakpoint_marker_does_not_exist=Breakpoint marker does not exist: {0}
 BreakpointManager_Missing_breakpoint_definition=Missing breakpoint definition for marker type {0}
 BreakpointManager_Missing_model_identifier=Breakpoint missing debug model identifier
 DebugEvent_illegal_detail=detail is not one of the allowed constants, see IDebugEventConstants


### PR DESCRIPTION
- made Breakpoint.fMarker volatile so Breakpoint.ensureMarker() always see the last state
- changed error message to indicate what was the real problem - not set or not existing marker.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1717