### PR TITLE
Enhance the IContributionFactory to filter contributions

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/contributions/IContributionFactory.java
+++ b/runtime/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/services/contributions/IContributionFactory.java
@@ -16,8 +16,10 @@ package org.eclipse.e4.core.services.contributions;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.osgi.framework.Bundle;
 
-// TBD this became an utility method to create object from a bundle.
-// Change it into an utility method somewhere.
+/**
+ * {@link IContributionFactory} is responsible to create contributions and check
+ * if a contribution is enabled
+ */
 public interface IContributionFactory {
 
 	Object create(String uriString, IEclipseContext context);
@@ -25,5 +27,9 @@ public interface IContributionFactory {
 	Object create(String uriString, IEclipseContext context, IEclipseContext staticContext);
 
 	Bundle getBundle(String uriString);
+
+	default boolean isEnabled(String uriString) {
+		return uriString != null;
+	}
 
 }


### PR DESCRIPTION
Currently there is no way for filtering a contribution to the model on a global level.

This adds a new method to IContributionFactory#isEnabled that allows extenders to mark a given contribution as being disabled.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2217