### PR TITLE
Feature request: Extend `AbstractSearchProcessor#postSearch(...)` of the `org.eclipse.help.searchProcessor` extension point

### DIFF
--- a/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/SearchResults.java
+++ b/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/SearchResults.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.help.IHelpResource;
 import org.eclipse.help.IToc;
 import org.eclipse.help.ITopic;
 import org.eclipse.help.base.AbstractHelpScope;
@@ -297,4 +298,9 @@ public class SearchResults implements ISearchHitCollector {
 	public void addQTCException(QueryTooComplexException exception) throws QueryTooComplexException {
 		this.searchException = exception;
 	}
+
+	public IHelpResource[] getScopes() {
+		return scopes == null ? null : scopes.toArray(IHelpResource[]::new);
+	}
+
 }

--- a/ua/org.eclipse.help.base/src/org/eclipse/help/search/AbstractSearchProcessor.java
+++ b/ua/org.eclipse.help.base/src/org/eclipse/help/search/AbstractSearchProcessor.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.help.search;
 
+import org.eclipse.help.IHelpResource;
+
 /**
  * This class is responsible for handling any pre or post
  * search processing events, including query manipulation
@@ -34,20 +36,52 @@ public abstract class AbstractSearchProcessor {
 	 * See {@link SearchProcessorInfo} for types of information that can be used by
 	 * the search display.
 	 *
-	 * @return <code>SearchProcessorInfo</code>, or <code>null</code> for no changes.
+	 * If a {@link SearchProcessorInfo} with an empty, non-{@code null} query
+	 * ({@code ""}) is returned, no search will be executed, resulting in no search
+	 * results.
+	 *
+	 * @return {@link SearchProcessorInfo}, or {@code null} for no changes.
 	 */
 	public abstract SearchProcessorInfo preSearch(String query);
 
 	/**
 	 * This method is called after the search is performed.
 	 *
-	 * Results are stored as an array of ISearchResult containing
-	 * all available data.
+	 * This method can be used to return a modified result set. For example, one can
+	 * change the result score of an item, add new results to the top of the list,
+	 * or remove results.
 	 *
-	 * This method can be used to return a modified result set.  For example, one can change the
-	 * result score of an item, add new results to the top of the list, or remove results.
+	 * This method exists for backwards compatibility. Overwrite
+	 * {@link #postSearch(String, String, ISearchResult[], String, IHelpResource[])}
+	 * if more information like the locale, etc. is needed instead.
 	 *
-	 * @return <code>{@link ISearchResult}[]</code>, or <code>null</code> for no changes.
+	 * @return The modified results, or {@code null} for no changes.
 	 */
 	public abstract ISearchResult[] postSearch(String query, ISearchResult[] results);
+
+	/**
+	 * This method is called after the search is performed.
+	 *
+	 * This method can be used to return a modified result set. For example, one can
+	 * change the result score of an item, add new results to the top of the list,
+	 * or remove results.
+	 *
+	 * @param query         The actually query that was executed (after any changes
+	 *                      made by {@link #preSearch(String)}).
+	 * @param originalQuery The original query before any changes made by
+	 *                      {@link #preSearch(String)}.
+	 * @param results       The results of the executed query.
+	 * @param results       The locale.
+	 * @param results       The set scopes (might be {@code null}).
+	 *
+	 * @return The modified results, or {@code null} for no changes.
+	 *
+	 * @see #postSearch(String, ISearchResult[])
+	 *
+	 * @since 4.5
+	 */
+	public ISearchResult[] postSearch(String query, String originalQuery, ISearchResult[] results, String locale,
+			IHelpResource[] scopes) {
+		return postSearch(query, results);
+	}
 }

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/AllSearchTests.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/AllSearchTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2006, 2012 IBM Corporation and others.
+ *  Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.junit.platform.suite.api.Suite;
 		MetaKeywords.class, //
 		SearchParticipantTest.class, //
 		SearchParticipantXMLTest.class, //
+		SearchProcessorTest.class, //
 		SearchRanking.class, //
 		WorkingSetManagerTest.class, //
 		InfocenterWorkingSetManagerTest.class, //

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchProcessorTest.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/SearchProcessorTest.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Holger Voormann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ua.tests.help.search;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.help.IHelpResource;
+import org.eclipse.help.internal.search.SearchQuery;
+import org.eclipse.help.internal.search.SearchResult;
+import org.eclipse.help.internal.search.federated.LocalHelp;
+import org.eclipse.help.internal.search.federated.LocalHelpScope;
+import org.eclipse.help.search.AbstractSearchProcessor;
+import org.eclipse.help.search.ISearchEngineResult;
+import org.eclipse.help.search.ISearchEngineResultCollector;
+import org.eclipse.help.search.ISearchResult;
+import org.eclipse.help.search.SearchProcessorInfo;
+import org.junit.jupiter.api.Test;
+
+public class SearchProcessorTest {
+
+	@Test
+	void testPreSearch() {
+		var processor = new AbstractSearchProcessor() {
+
+			@Override
+			public SearchProcessorInfo preSearch(String query) {
+				SearchProcessorInfo info = new SearchProcessorInfo();
+				info.setQuery("jkijkijkk");
+				return info;
+			}
+
+			@Override
+			public ISearchResult[] postSearch(String query, ISearchResult[] results) {
+				return null;
+			}
+
+		};
+		test(processor, new String[] { "/org.eclipse.ua.tests/participant1.xml" });
+	}
+
+	@Test
+	void testPostSearch() {
+		var processor = new AbstractSearchProcessor() {
+
+			@Override
+			public SearchProcessorInfo preSearch(String query) {
+				SearchProcessorInfo info = new SearchProcessorInfo();
+				info.setQuery("jkijkijkk");
+				return info;
+			}
+
+			@Override
+			public ISearchResult[] postSearch(String query, ISearchResult[] results) {
+				assertEquals("jkijkijkk", query);
+				assertEquals(1, results.length);
+				assertEquals("/org.eclipse.ua.tests/participant1.xml", withoutQueryPart(results[0].getHref()));
+				var addedResult = new SearchResult();
+				addedResult.setHref("/org.eclipse.ua.tests/added");
+				return new ISearchResult[] { addedResult };
+			}
+
+		};
+		test(processor, new String[] { "/org.eclipse.ua.tests/added" });
+	}
+
+	@Test
+	void testExtendedPostSearch() {
+		var processor = new AbstractSearchProcessor() {
+
+			@Override
+			public SearchProcessorInfo preSearch(String query) {
+				SearchProcessorInfo info = new SearchProcessorInfo();
+				info.setQuery("olhoykk");
+				return info;
+			}
+
+			@Override
+			public ISearchResult[] postSearch(String query, ISearchResult[] results) {
+				return null;
+			}
+
+			@Override
+			public ISearchResult[] postSearch(String query, String originalQuery, ISearchResult[] results,
+					String locale, IHelpResource[] scopes) {
+				assertEquals("olhoykk", query);
+				assertEquals(WrappedSearchProcessor.QUERY, originalQuery);
+				assertEquals(1, results.length);
+				assertEquals("/org.eclipse.ua.tests/participant2.xml", withoutQueryPart(results[0].getHref()));
+				assertEquals(new SearchQuery().getLocale(), locale);
+				assertNull(scopes);
+				var addedResult = new SearchResult();
+				addedResult.setHref("/org.eclipse.ua.tests/added2");
+				return new ISearchResult[] { addedResult };
+			}
+
+		};
+		test(processor, new String[] { "/org.eclipse.ua.tests/added2" });
+	}
+
+	@Test
+	void testNullProcessor() {
+		var processor = new AbstractSearchProcessor() {
+
+			@Override
+			public SearchProcessorInfo preSearch(String query) {
+				assertEquals(WrappedSearchProcessor.QUERY, query);
+				return null;
+			}
+
+			@Override
+			public ISearchResult[] postSearch(String query, ISearchResult[] results) {
+				return null;
+			}
+
+		};
+		test(processor, new String[0]);
+	}
+
+	private void test(AbstractSearchProcessor processor, String[] expected) {
+		try (var autoClosable = WrappedSearchProcessor.set(processor)) {
+			String[] hits = search(WrappedSearchProcessor.QUERY);
+			assertArrayEquals(expected, hits);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e);
+		}
+	}
+
+	private static String[] search(String query) throws Exception {
+
+		var foundHrefs = new ArrayList<String>();
+		ISearchEngineResultCollector collector = new ISearchEngineResultCollector() {
+
+			@Override
+			public void accept(ISearchEngineResult searchResult) {
+				foundHrefs.add(withoutQueryPart(searchResult.getHref()));
+			}
+
+			@Override
+			public void accept(ISearchEngineResult[] searchResults) {
+				for (ISearchEngineResult searchResult : searchResults) {
+					foundHrefs.add(withoutQueryPart(searchResult.getHref()));
+				}
+			}
+
+			@Override
+			public void error(IStatus status) {
+				fail(new RuntimeException(status.getMessage(), status.getException()));
+			}
+
+		};
+		new LocalHelp().run(query, new LocalHelpScope(null, false), collector, new NullProgressMonitor());
+		Collections.sort(foundHrefs);
+		return foundHrefs.toArray(String[]::new);
+	}
+
+	private static String withoutQueryPart(String href) {
+		return href.indexOf('?') < 0 ? href : href.substring(0, href.indexOf('?'));
+	}
+
+}

--- a/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/WrappedSearchProcessor.java
+++ b/ua/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/WrappedSearchProcessor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Holger Voormann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ua.tests.help.search;
+
+import org.eclipse.help.IHelpResource;
+import org.eclipse.help.search.AbstractSearchProcessor;
+import org.eclipse.help.search.ISearchResult;
+import org.eclipse.help.search.SearchProcessorInfo;
+
+public class WrappedSearchProcessor extends AbstractSearchProcessor {
+
+	public static final String QUERY = "SearchProcessorTest";
+
+	private static volatile AbstractSearchProcessor wrapped = null;
+
+	public static synchronized AutoCloseable set(AbstractSearchProcessor searchProcessor) {
+		wrapped = searchProcessor;
+		return () -> wrapped = null;
+	}
+
+	private static boolean isNotSearchProcessorTest(String query) {
+		return wrapped == null || (query != null && !query.contains(QUERY));
+	}
+
+	@Override
+	public SearchProcessorInfo preSearch(String query) {
+		if (isNotSearchProcessorTest(query))
+			return null;
+		synchronized (WrappedSearchProcessor.class) {
+			if (isNotSearchProcessorTest(query))
+				return null;
+			return wrapped.preSearch(query);
+		}
+	}
+
+	@Override
+	public ISearchResult[] postSearch(String query, ISearchResult[] results) {
+		if (wrapped == null)
+			return null;
+		synchronized (WrappedSearchProcessor.class) {
+			if (wrapped == null)
+				return null;
+			return wrapped.postSearch(query, results);
+		}
+	}
+
+	@Override
+	public ISearchResult[] postSearch(String query, String originalQuery, ISearchResult[] results, String locale,
+			IHelpResource[] scopes) {
+		if (isNotSearchProcessorTest(originalQuery))
+			return null;
+		synchronized (WrappedSearchProcessor.class) {
+			if (isNotSearchProcessorTest(originalQuery))
+				return null;
+			return wrapped.postSearch(query, originalQuery, results, locale, scopes);
+		}
+	}
+
+}

--- a/ua/org.eclipse.ua.tests/plugin.xml
+++ b/ua/org.eclipse.ua.tests/plugin.xml
@@ -9,7 +9,7 @@
     https://www.eclipse.org/legal/epl-2.0/
 
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
          IBM Corporation - initial API and implementation
          George Suaridze <suag@1c.ru> (1C-Soft LLC) - Bug 559885
@@ -17,7 +17,7 @@
 
 <plugin>
 
-   <!-- 
+   <!--
       Cheat sheet test content
    -->
    <extension
@@ -224,14 +224,14 @@
       </cheatsheet>
    </extension>
 
-   <!-- 
+   <!--
       Cheat sheet context help test
    -->
-   <extension point="org.eclipse.help.contexts"> 
+   <extension point="org.eclipse.help.contexts">
        <contexts file="data/cheatsheet/contexts.xml"/>
    </extension>
 
-   <!-- 
+   <!--
       Command used in tests
    -->
    <extension
@@ -297,7 +297,7 @@
             introId="org.eclipse.ua.tests.intro.static"
             productId="org.eclipse.ua.tests.testproduct">
       </introProductBinding>
-   </extension>   
+   </extension>
    <extension
          point="org.eclipse.ui.intro.config">
       <config
@@ -358,7 +358,7 @@
             </implementation>
          </presentation>
       </config>
-      
+
       <config
             introId="org.eclipse.ua.tests.intro.static"
             id="org.eclipse.ua.tests.intro.config.static"
@@ -389,7 +389,7 @@
             content="data/intro/dynamicXML/ext.xml"
             configId="org.eclipse.ua.tests.intro.config.dynamicXML">
       </configExtension>
-      
+
       <configExtension
             content="data/intro/anchors/extn1.xml"
             configId="org.eclipse.ua.tests.intro.config.anchors">
@@ -416,16 +416,16 @@
       </configExtension>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
-            content="data/intro/search/samplesExtensionContent.xml"/>  
-      
+            content="data/intro/search/samplesExtensionContent.xml"/>
+
       <!-- 3.2 welcome content used for open welcome performance test -->
       <!-- filtered unless running test -->
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
-            content="data/intro/performance/org.eclipse.jdt/overviewExtensionContent.xml"/>  
+            content="data/intro/performance/org.eclipse.jdt/overviewExtensionContent.xml"/>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
-            content="data/intro/performance/org.eclipse.jdt/tutorialsExtensionContent.xml"/>  
+            content="data/intro/performance/org.eclipse.jdt/tutorialsExtensionContent.xml"/>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
             content="data/intro/performance/org.eclipse.jdt/samplesExtensionContent.xml"/>
@@ -433,8 +433,8 @@
             configId="org.eclipse.ui.intro.universalConfig"
             content="data/intro/performance/org.eclipse.jdt/newsExtensionContent.xml"/>
       <configExtension
-            configId="org.eclipse.ui.intro.universalConfig" 
-            content="data/intro/performance/org.eclipse.pde/overviewExtensionContent.xml"/>  
+            configId="org.eclipse.ui.intro.universalConfig"
+            content="data/intro/performance/org.eclipse.pde/overviewExtensionContent.xml"/>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
             content="data/intro/performance/org.eclipse.pde/tutorialsExtensionContent.xml"/>
@@ -446,7 +446,7 @@
             content="data/intro/performance/org.eclipse.pde/samplesExtensionContent2.xml"/>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
-            content="data/intro/performance/org.eclipse.pde/newsExtensionContent.xml"/> 
+            content="data/intro/performance/org.eclipse.pde/newsExtensionContent.xml"/>
       <configExtension
             configId="org.eclipse.ui.intro.universalConfig"
             content="data/intro/performance/org.eclipse.platform/overviewEx.xml"/>
@@ -507,7 +507,7 @@
       </toc>
    </extension>
 
-   <extension point= "org.eclipse.help.contentExtension"> 
+   <extension point= "org.eclipse.help.contentExtension">
       <contentExtension file="data/help/dynamic/include/extension.xml"/>
       <contentExtension file="data/help/dynamic/extension/extension.xml"/>
       <contentExtension file="data/help/dynamic/shared/extension.xml"/>
@@ -529,12 +529,12 @@
    <!--
       A dummy product used to arrange the welcome contributions for the performance test.
    -->
-   <extension id="dummy" point="org.eclipse.core.runtime.products"> 
-      <product name="dummyProductName" application="org.eclipse.ui.ide.workbench" description="dummyProductName"> 
+   <extension id="dummy" point="org.eclipse.core.runtime.products">
+      <product name="dummyProductName" application="org.eclipse.ui.ide.workbench" description="dummyProductName">
          <property name="preferenceCustomization" value="data/intro/performance/plugin_customization.ini"/>
-      </product> 
-   </extension> 
-   
+      </product>
+   </extension>
+
    <extension
          point="org.eclipse.equinox.http.registry.servlets">
       <servlet
@@ -552,7 +552,7 @@
             producer="org.eclipse.ua.tests.util.UATestContentProducer">
       </contentProducer>
    </extension>
-   
+
    <extension
          point="org.eclipse.equinox.http.registry.servlets">
        <servlet
@@ -641,7 +641,7 @@
              alias="/index"
              class="org.eclipse.ua.tests.help.remote.MockIndexServlet">
        </servlet>
-      
+
       <serviceSelector
             filter="(other.info=org.eclipse.ua.tests)">
       </serviceSelector>
@@ -704,6 +704,9 @@
                value="data/criteria_customization.ini">
          </property>
       </product>
+   </extension>
+   <extension point="org.eclipse.help.base.searchProcessor">
+      <processor class="org.eclipse.ua.tests.help.search.WrappedSearchProcessor"/>
    </extension>
 
 </plugin>


### PR DESCRIPTION
The `org.eclipse.help.searchProcessor` extension point allows to modify the help search results. This is done by calling the `postSearch(...)` method of all implementations of `org.eclipse.help.search.AbstractSearchProcessor` specified by this extension point. In some cases, the search results to be modified and the query that are passed as parameters to the `postSearch(...)` method may not be enough. So this change adds another `postSearch(...)` method with additional parameters like the locale and the scopes if any. The simpler `postSearch(...)` is be kept for backward compatibility.

Additionally, if `preSearch(...)` returns a `SearchProcessorInfo` with an empty, non-`null` query (`""`), no search will be executed, resulting in no search results or in the search results that has been added via `postSearch(...)`.