### PR TITLE
Add option to disable all breakpoints except selected ones

### DIFF
--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.18.700.qualifier
+Bundle-Version: 3.18.800.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2020 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -83,6 +83,7 @@ DetailPaneFontDefinition.description=The detail pane text font is used in the de
 DetailPaneFactoriesExtension.name=Detail Pane Factories
 DisableBreakpointsAction.label=&Disable
 DisableAllBreakpointsAction.label=Disa&ble All
+DisableOtherBreakpointsAction.label=Disable Others
 EnableAllBreakpointsAction.label=Ena&ble All
 EnableBreakpointsAction.label=&Enable
 ExpandAll.label=Expand All

--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-     Copyright (c) 2005, 2021 IBM Corporation and others.
+     Copyright (c) 2005, 2025 IBM Corporation and others.
 
      This program and the accompanying materials
      are made available under the terms of the Eclipse Public License 2.0
@@ -1547,6 +1547,15 @@
                class="org.eclipse.debug.internal.ui.actions.breakpoints.DisableAllBreakpointsAction"
                menubarPath="breakpointGroup"
                id="org.eclipse.debug.ui.actions.DisableAllBreakpoint">
+        </action>
+        <action
+               label="%DisableOtherBreakpointsAction.label"
+               icon="$nl$/icons/full/elcl16/disabled_co.png"
+               helpContextId="disable_breakpoint_action_context"
+               class="org.eclipse.debug.internal.ui.actions.breakpoints.DisableAllOtherBreakpointsAction"
+               menubarPath="breakpointGroup"
+               enablesFor="+"
+               id="org.eclipse.debug.ui.actions.DisableAllOtherBreakpoint">
         </action>
         <action
                label="%DisableBreakpointsAction.label"

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/DisableAllOtherBreakpointsAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/DisableAllOtherBreakpointsAction.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.internal.ui.actions.breakpoints;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.model.IBreakpoint;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.actions.ActionMessages;
+import org.eclipse.debug.internal.ui.breakpoints.provisional.IBreakpointContainer;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IWorkbenchWindow;
+
+public class DisableAllOtherBreakpointsAction extends EnableBreakpointsAction {
+
+	/**
+	 * If this action can enable breakpoints
+	 *
+	 * @return always <code>false</code>
+	 */
+	@Override
+	protected boolean isEnableAction() {
+		return false;
+	}
+
+	@Override
+	public void run(IAction action) {
+		IStructuredSelection selection = getSelection();
+		if (selection.isEmpty()) {
+			return;
+		}
+		final List<Object> selectedBreakpoints = selection.toList();
+		final MultiStatus ms = new MultiStatus(DebugUIPlugin.getUniqueIdentifier(), DebugException.REQUEST_FAILED,
+				ActionMessages.EnableBreakpointAction_Enable_breakpoint_s__failed_2, null);
+		IWorkspaceRunnable runnable = monitor -> {
+			try {
+				Set<IBreakpoint> excludedBreakpoints = new HashSet<>();
+				for (Object selectedObj : selectedBreakpoints) {
+					if (selectedObj instanceof IBreakpoint breakPoint && breakPoint.isEnabled()) {
+						excludedBreakpoints.add(breakPoint);
+					}
+					if (selectedObj instanceof IBreakpointContainer breakPointContainer) {
+						for (IBreakpoint bp : breakPointContainer.getBreakpoints()) {
+							if (bp.isEnabled()) {
+								excludedBreakpoints.add(bp);
+							}
+						}
+					}
+				}
+				for (IBreakpoint brk : DebugPlugin.getDefault().getBreakpointManager().getBreakpoints()) {
+					if (!excludedBreakpoints.contains(brk)) {
+						brk.setEnabled(false);
+					}
+				}
+
+			} catch (CoreException e) {
+				ms.merge(e.getStatus());
+			}
+		};
+
+		try {
+			ResourcesPlugin.getWorkspace().run(runnable, null, 0, new NullProgressMonitor());
+		} catch (CoreException e) {
+			DebugUIPlugin.log(e);
+		}
+
+		if (!ms.isOK()) {
+			IWorkbenchWindow window = DebugUIPlugin.getActiveWorkbenchWindow();
+			if (window != null) {
+				DebugUIPlugin.errorDialog(window.getShell(),
+						ActionMessages.EnableBreakpointAction_Enabling_breakpoints_3,
+						ActionMessages.EnableBreakpointAction_Exceptions_occurred_enabling_the_breakpoint_s___4, ms); //
+			} else {
+				DebugUIPlugin.log(ms);
+			}
+		}
+	}
+}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/EnableBreakpointsAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/EnableBreakpointsAction.java
@@ -134,7 +134,7 @@ public class EnableBreakpointsAction implements IViewActionDelegate, IPartListen
 		}
 	}
 
-	private IStructuredSelection getSelection() {
+	protected IStructuredSelection getSelection() {
 		return (IStructuredSelection)getView().getViewSite().getSelectionProvider().getSelection();
 	}
 


### PR DESCRIPTION

Reference : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/549#issuecomment-2610384125

PR introduces a new menu option that allows users to select multiple enabled breakpoints and disable all other breakpoints except the ones selected. This provides more flexibility and control over breakpoint management.

Screens - 

<img width="315" alt="image" src="https://github.com/user-attachments/assets/e9eea86c-5c07-4080-b14c-c43088ebb3e3" />
 <br><br>
After clicking - 
 <br><br>
<img width="360" alt="image" src="https://github.com/user-attachments/assets/16fd191a-9064-49e7-8142-7cce86bc4d6e" />

<br><br> works with 
<img width="559" alt="image" src="https://github.com/user-attachments/assets/d8c54e22-cdc5-4a92-92fd-5ff083e02e20" />


