### PR TITLE
Help search: Make the number of max hits before filtering configurable

### DIFF
--- a/ua/org.eclipse.help.base/preferences.ini
+++ b/ua/org.eclipse.help.base/preferences.ini
@@ -207,6 +207,12 @@ maxConnections=10
 # Example: maxTopics=
 maxTopics=500
 
+# Max number of topics to be searched for before filtering is applied
+# If the number is too small, hits may be missed when searching e.g. in a topic and its subtopics
+# The higher the number, the slightly worse the performance
+# Assign a value greater than maxTopics (see above), but no greater than Integer.MAX_VALUE
+maxHitsBeforeFiltering=1000
+
 #########################
 # Search Results
 #########################

--- a/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/SearchIndex.java
+++ b/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/SearchIndex.java
@@ -92,6 +92,9 @@ import org.osgi.framework.Version;
  */
 public class SearchIndex implements IHelpSearchIndex {
 
+	private static final int MAX_HITS_BEFORE_FILTERING = Platform.getPreferencesService()
+			.getInt(HelpBasePlugin.PLUGIN_ID, "maxHitsBeforeFiltering", 1_000, null); //$NON-NLS-1$
+
 	private IndexReader ir;
 
 	private IndexWriter iw;
@@ -662,7 +665,7 @@ public class SearchIndex implements IHelpSearchIndex {
 			}
 			if (luceneQuery == null)
 				return;
-			TopDocs topDocs = searcher.search(luceneQuery, 1000);
+			TopDocs topDocs = searcher.search(luceneQuery, MAX_HITS_BEFORE_FILTERING);
 			collector.addHits(LocalSearchManager.asList(topDocs, searcher), queryBuilder.gethighlightTerms());
 		} catch (IndexSearcher.TooManyClauses tmc) {
 			collector.addQTCException(new QueryTooComplexException());


### PR DESCRIPTION
In the search of the help system, make the number of topics to be searched for before the filtering is applied configurable, so that it can be set in the `plugin_customization.ini` file.

If the number is too small, hits may be missed, e.g. when searching in a topic and its subtopics. The higher the number, the slightly worse the performance. The default is 1,000 and the maximum number of hits displayed to the user is 500, which means that if more than 500 of the hits before filtering are outside of the search scope, some hits will be missed.

See also: [Eclipse Bug 357857 - \[Help\]\[Search\] "Search selected topic and subtopics" sometimes shows "Nothing found" by mistake](https://bugs.eclipse.org/bugs/show_bug.cgi?id=357857)