### PR TITLE
Don't use SubMonitor when saving project in SaveManager

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.22.100.qualifier
+Bundle-Version: 3.22.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1188,7 +1188,7 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		private boolean ignoreCancel;
 
 		public InternalMonitorWrapper(IProgressMonitor monitor) {
-			super(SubMonitor.convert(monitor));
+			super(Policy.monitorFor(monitor));
 		}
 
 		public void ignoreCancelState(boolean ignore) {


### PR DESCRIPTION
The migration from the IProgressMonitor to the SubMonitor done as part of 40114d2ce9a41cbec7f01d8342d4371a6d970af0 also converts the progress monitor used within the InternalMonitorWrapper.

If the parent monitor is a SubMonitor, this calls beginTask() both when the InternalMonitorWrapper is created, as well as explicitly later on. To avoid this, switch back to create a null-safe progress monitor via Policy.monitorFor(...).

Closes https://github.com/eclipse-platform/eclipse.platform/issues/1758