### PR TITLE
Add support for launching Eclipse Process in a system terminal session

### DIFF
--- a/debug/org.eclipse.debug.terminal/.classpath
+++ b/debug/org.eclipse.debug.terminal/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/debug/org.eclipse.debug.terminal/.project
+++ b/debug/org.eclipse.debug.terminal/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.debug.terminal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/debug/org.eclipse.debug.terminal/.settings/org.eclipse.core.resources.prefs
+++ b/debug/org.eclipse.debug.terminal/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/debug/org.eclipse.debug.terminal/.settings/org.eclipse.jdt.core.prefs
+++ b/debug/org.eclipse.debug.terminal/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/debug/org.eclipse.debug.terminal/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/debug/org.eclipse.debug.terminal/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/debug/org.eclipse.debug.terminal/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.terminal/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: org.eclipse.debug.terminal;singleton:=true
+Bundle-Vendor: %providerName
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.debug.core;bundle-version="3.23.0",
+ org.eclipse.tm.terminal.control;bundle-version="5.6.0",
+ org.eclipse.cdt.core.native;bundle-version="6.4.0",
+ org.eclipse.swt;bundle-version="3.130.0",
+ org.eclipse.ui;bundle-version="3.207.100"
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Automatic-Module-Name: org.eclipse.debug.terminal
+Bundle-ActivationPolicy: lazy
+Service-Component: OSGI-INF/org.eclipse.debug.terminal.ui.PageBookAdapter.xml

--- a/debug/org.eclipse.debug.terminal/OSGI-INF/org.eclipse.debug.terminal.ui.PageBookAdapter.xml
+++ b/debug/org.eclipse.debug.terminal/OSGI-INF/org.eclipse.debug.terminal.ui.PageBookAdapter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" name="org.eclipse.debug.terminal.ui.PageBookAdapter">
+   <property name="adaptableClass" type="String" value="org.eclipse.debug.terminal.PtyRuntimeProcess"/>
+   <property name="adapterNames" type="String" value="org.eclipse.ui.part.IPageBookViewPage"/>
+   <service>
+      <provide interface="org.eclipse.core.runtime.IAdapterFactory"/>
+   </service>
+   <implementation class="org.eclipse.debug.terminal.ui.PageBookAdapter"/>
+</scr:component>

--- a/debug/org.eclipse.debug.terminal/about.html
+++ b/debug/org.eclipse.debug.terminal/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/debug/org.eclipse.debug.terminal/build.properties
+++ b/debug/org.eclipse.debug.terminal/build.properties
@@ -1,0 +1,8 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               OSGI-INF/,\
+               about.html
+src.includes = about.html

--- a/debug/org.eclipse.debug.terminal/plugin.properties
+++ b/debug/org.eclipse.debug.terminal/plugin.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 Christoph Läubrich and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Christoph Läubrich - initial API and implementation
+###############################################################################
+
+pluginName=Terminal Session Support for Eclipse
+providerName=Eclipse.org

--- a/debug/org.eclipse.debug.terminal/plugin.xml
+++ b/debug/org.eclipse.debug.terminal/plugin.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.debug.core.execFactories">
+      <execFactory
+            class="org.eclipse.debug.terminal.PtyExecFactory"
+            id="org.eclipse.debug.terminal.execFactory"
+            priority="100">
+      </execFactory>
+   </extension>
+   <extension
+         point="org.eclipse.debug.core.processFactories">
+      <processFactory
+            class="org.eclipse.debug.terminal.PtyProcessFactory"
+            id="org.eclipse.debug.terminal.processFactory">
+      </processFactory>
+   </extension>
+
+</plugin>

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyExecFactory.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyExecFactory.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.cdt.utils.pty.PTY;
+import org.eclipse.cdt.utils.pty.PTY.Mode;
+import org.eclipse.cdt.utils.spawner.ProcessFactory;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ExecFactory;
+
+public class PtyExecFactory implements ExecFactory {
+
+	@Override
+	public Optional<Process> exec(String[] cmdLine, Optional<File> workingDirectory,
+			Optional<Map<String, String>> environment, boolean mergeOutput) throws CoreException {
+		if (mergeOutput || !PTY.isSupported(Mode.TERMINAL)) {
+			return Optional.empty();
+		}
+		try {
+			PTY pty = new PTY(Mode.TERMINAL);
+			pty.setTerminalSize(80, 24);
+			String[] env;
+			if (environment.isEmpty()) {
+				env = null;
+			} else {
+				env = environment.stream().flatMap(m -> m.entrySet().stream()).map(e -> e.getKey() + "=" + e.getValue())
+						.toArray(String[]::new);
+			}
+			File wd = workingDirectory.orElse(null);
+			return Optional.of(ProcessFactory.getFactory().exec(cmdLine, env, wd, pty));
+		} catch (IOException e) {
+			throw new CoreException(Status.error("Execution failed", e));
+		}
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyProcessFactory.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyProcessFactory.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal;
+
+import java.util.Map;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.IProcessFactory;
+import org.eclipse.debug.core.model.IProcess;
+
+public class PtyProcessFactory implements IProcessFactory {
+
+	@Override
+	public IProcess newProcess(ILaunch launch, Process process, String label, Map<String, String> attributes) {
+		return new PtyRuntimeProcess(launch, process, label, attributes);
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyRuntimeProcess.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/PtyRuntimeProcess.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal;
+
+import java.util.Map;
+
+import org.eclipse.cdt.utils.spawner.Spawner;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.model.RuntimeProcess;
+
+public class PtyRuntimeProcess extends RuntimeProcess {
+
+	PtyRuntimeProcess(ILaunch launch, Process process, String name, Map<String, String> attributes) {
+		super(launch, process, name, attributes);
+	}
+
+	public Spawner getSpawner() {
+		Process systemProcess = super.getSystemProcess();
+		if (systemProcess instanceof Spawner) {
+			return (Spawner) systemProcess;
+		}
+		return null;
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/ConsoleConnector.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/ConsoleConnector.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal.ui;
+
+import java.io.OutputStream;
+
+import org.eclipse.cdt.utils.pty.PTY;
+import org.eclipse.cdt.utils.spawner.Spawner;
+import org.eclipse.tm.internal.terminal.provisional.api.ISettingsStore;
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalConnector;
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalControl;
+import org.eclipse.tm.internal.terminal.provisional.api.TerminalState;
+
+class ConsoleConnector implements ITerminalConnector {
+
+	private Spawner process;
+	private ITerminalControl control;
+
+	public ConsoleConnector(Spawner process) {
+		this.process = process;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public String getId() {
+		return "org.eclipse.debug.terminal"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getName() {
+		return "Eclipse Terminal Console"; //$NON-NLS-1$
+	}
+
+	@Override
+	public boolean isHidden() {
+		return true;
+	}
+
+	@Override
+	public boolean isInitialized() {
+		return true;
+	}
+
+	@Override
+	public String getInitializationErrorMessage() {
+		return null;
+	}
+
+	@Override
+	public void connect(ITerminalControl control) {
+		this.control = control;
+		control.setState(TerminalState.CONNECTED);
+
+	}
+
+	@Override
+	public void disconnect() {
+		control.setState(TerminalState.CLOSED);
+	}
+
+	@Override
+	public boolean isLocalEcho() {
+		return false;
+	}
+
+	@Override
+	public void setTerminalSize(int newWidth, int newHeight) {
+		PTY pty = process.pty();
+		if (pty != null) {
+			pty.setTerminalSize(newWidth, newHeight);
+		}
+	}
+
+	@Override
+	public OutputStream getTerminalToRemoteStream() {
+		return process.getOutputStream();
+	}
+
+	@Override
+	public void load(ISettingsStore store) {
+
+	}
+
+	@Override
+	public void save(ISettingsStore store) {
+
+	}
+
+	@Override
+	public void setDefaultSettings() {
+
+	}
+
+	@Override
+	public String getSettingsSummary() {
+		return ""; //$NON-NLS-1$
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/ConsoleTerminalListener.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/ConsoleTerminalListener.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal.ui;
+
+import org.eclipse.tm.internal.terminal.control.ITerminalListener;
+import org.eclipse.tm.internal.terminal.provisional.api.TerminalState;
+
+class ConsoleTerminalListener implements ITerminalListener {
+
+	@Override
+	public void setState(TerminalState state) {
+
+	}
+
+	@Override
+	public void setTerminalTitle(String title) {
+		// TODO redirect to the console?
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/PageBookAdapter.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/PageBookAdapter.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal.ui;
+
+import org.eclipse.cdt.utils.spawner.Spawner;
+import org.eclipse.core.runtime.AdapterTypes;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.debug.terminal.PtyRuntimeProcess;
+import org.eclipse.ui.part.IPageBookViewPage;
+import org.osgi.service.component.annotations.Component;
+
+@Component
+@AdapterTypes(adaptableClass = PtyRuntimeProcess.class, adapterNames = { IPageBookViewPage.class })
+public class PageBookAdapter implements IAdapterFactory {
+
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		if (adaptableObject instanceof PtyRuntimeProcess rt) {
+			Spawner spawner = rt.getSpawner();
+			if (spawner != null) {
+				return adapterType.cast(new TerminalConsolePage(spawner, rt.getStreamsProxy()));
+			}
+		}
+		return null;
+	}
+
+}

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/TerminalConsolePage.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/TerminalConsolePage.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.terminal.ui;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+import org.eclipse.cdt.utils.spawner.Spawner;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.debug.core.model.IBinaryStreamMonitor;
+import org.eclipse.debug.core.model.IStreamMonitor;
+import org.eclipse.debug.core.model.IStreamsProxy;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.tm.internal.terminal.control.ITerminalViewControl;
+import org.eclipse.tm.internal.terminal.control.TerminalViewControlFactory;
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalConnector;
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalControl;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.part.IPageBookViewPage;
+import org.eclipse.ui.part.IPageSite;
+
+class TerminalConsolePage implements IPageBookViewPage, IAdaptable {
+
+	private Spawner process;
+	private IPageSite site;
+	private ITerminalViewControl viewer;
+	private Composite composite;
+	private IStreamsProxy streamsProxy;
+
+	public TerminalConsolePage(Spawner spawner, IStreamsProxy streamsProxy) {
+		this.process = spawner;
+		this.streamsProxy = streamsProxy;
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		composite = new Composite(parent, SWT.NONE);
+		composite.setLayout(new FillLayout());
+		viewer = TerminalViewControlFactory.makeControl(new ConsoleTerminalListener(), composite,
+				new ITerminalConnector[] {}, true);
+		viewer.setConnector(new ConsoleConnector(process));
+		viewer.setCharset(Charset.defaultCharset());
+		viewer.clearTerminal();
+		viewer.connectTerminal();
+		if (viewer instanceof ITerminalControl ctrl) {
+			ctrl.setConnectOnEnterIfClosed(false);
+			ctrl.setVT100LineWrapping(true);
+			IStreamMonitor streamMonitor = streamsProxy.getOutputStreamMonitor();
+			if (streamMonitor instanceof IBinaryStreamMonitor bin) {
+				OutputStream outputStream = ctrl.getRemoteToTerminalOutputStream();
+				bin.addBinaryListener((data, monitor) -> {
+					try {
+						outputStream.write(data);
+					} catch (IOException e1) {
+						e1.printStackTrace();
+					}
+				});
+			}
+		}
+	}
+
+	@Override
+	public void dispose() {
+		viewer.disposeTerminal();
+	}
+
+	@Override
+	public Control getControl() {
+		return composite;
+	}
+
+	@Override
+	public void setActionBars(IActionBars actionBars) {
+	}
+
+	@Override
+	public void setFocus() {
+		if (viewer != null) {
+			viewer.setFocus();
+		}
+	}
+
+	@Override
+	public IPageSite getSite() {
+		return site;
+	}
+
+	@Override
+	public void init(IPageSite site) throws PartInitException {
+		this.site = site;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+}

--- a/debug/pom.xml
+++ b/debug/pom.xml
@@ -18,7 +18,6 @@
     <version>4.37.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.eclipse.platform</groupId>
   <artifactId>eclipse.platform.debug</artifactId>
   <packaging>pom</packaging>
 
@@ -37,6 +36,7 @@
     <module>org.eclipse.ui.console</module>
     <module>org.eclipse.ui.externaltools</module>
     <module>org.eclipse.unittest.ui</module>
+    <module>org.eclipse.debug.terminal</module>
   </modules>
 </project>
 


### PR DESCRIPTION
Currently processes are launched as a forked process without a terminal session attached to them. Some features of processes require a terminal session (e.g. autocompletion) and currently not work when running from within eclipse (e.g. the gogo-shell).

This is an attempt to bring terminal session support to Eclipse to support real terminal application similar to what is supported by IntelliJ.