### PR TITLE
Support alternative PageBookViewPage for console through adapter pattern

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
@@ -44,6 +44,7 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -93,6 +94,7 @@ import org.eclipse.ui.IStorageEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsoleView;
 import org.eclipse.ui.console.IHyperlink;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleInputStream;
@@ -102,6 +104,7 @@ import org.eclipse.ui.console.PatternMatchEvent;
 import org.eclipse.ui.console.TextConsole;
 import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.part.IPageBookViewPage;
 import org.eclipse.ui.progress.UIJob;
 
 /**
@@ -278,6 +281,15 @@ public class ProcessConsole extends IOConsole implements IConsole, IDebugEventSe
 			}
 		}
 		return null;
+	}
+
+	@Override
+	public IPageBookViewPage createPage(IConsoleView view) {
+		IPageBookViewPage adapt = Adapters.adapt(getProcess(), IPageBookViewPage.class);
+		if (adapt != null) {
+			return adapt;
+		}
+		return super.createPage(view);
 	}
 
 	/**


### PR DESCRIPTION
Currently one can supply alternative processes through IProcessFactory's but all of such processes must currently be a textconsole there is no way to supply an alternative or enhanced UI.

This now uses the adapter pattern to support supply an alternative PageBookViewPage that is used to display the console.