### PR TITLE
Only start the stream monitoring after events are send out

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/RuntimeProcess.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/RuntimeProcess.java
@@ -166,6 +166,22 @@ public class RuntimeProcess extends PlatformObject implements IProcess {
 		launch.addProcess(this);
 		fMonitor.start();
 		fireCreationEvent();
+		startStreams();
+	}
+
+	/**
+	 * Called after notification that this runtime process is created to start
+	 * the reading of streams. Must be overridden if a custom
+	 * {@link IStreamsProxy} instance is provided by
+	 * {@link #createStreamsProxy()} that do not extends {@link StreamsProxy}
+	 * and does not start the stream reading in any other mean.
+	 *
+	 * @since 3.23
+	 */
+	protected void startStreams() {
+		if (fStreamsProxy instanceof StreamsProxy impl) {
+			impl.startMonitoring(fThreadNameSuffix);
+		}
 	}
 
 	private static String getPidInfo(Process process, ILaunch launch) {
@@ -389,7 +405,7 @@ public class RuntimeProcess extends PlatformObject implements IProcess {
 		if (charset == null) {
 			charset = Platform.getSystemCharset();
 		}
-		return new StreamsProxy(getSystemProcess(), charset, fThreadNameSuffix);
+		return new StreamsProxy(getSystemProcess(), charset);
 	}
 
 	/**


### PR DESCRIPTION
Currently it is almost impossible to capture the full binary stream of a process even if one adds a listener right after creation of the stream proxy. The reason is that the streams are immediately started to being read in the constructor. The code currently uses some caching in place but this only works reliable for a single listener and is then reset afterwards having other missing data depending on how fast they can register. Even worse there is a small chance that after registration and before reading the buffer some bytes are received and then is processed before the buffer contents.

This now creates a new constructor that only creates the stream but do not start them. Instead users must call the method `startMonitoring` for this. The `RuntimeProcess` now uses this constructor to delay the start of stream reading unless all notifications are performed so other parties can register accordingly.

See
- https://github.com/eclipse-platform/eclipse.platform/pull/1762