### PR TITLE
[Debug] Add checkbox to toggle display of shortcut numbers in breakpoint grouping types

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/DebugPlugin.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/DebugPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -378,6 +378,13 @@ public class DebugPlugin extends Plugin {
 	 * @since 3.8
 	 */
 	public static final String ATTR_PATH = PI_DEBUG_CORE + ".ATTR_PATH"; //$NON-NLS-1$
+
+	/**
+	 * Attribute key for breakpoint grouping types accelerators
+	 *
+	 * @since 3.23
+	 */
+	public static final String PREF_SHOW_BREAKPOINT_GROUPBY_TYPE_SHORTCUTS = PI_DEBUG_CORE + ".PREF_FOR_BP_GROUP_TYPE_ACCELERATOR"; //$NON-NLS-1$
 
 	/**
 	 * Launch configuration attribute that designates whether or not the

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/DebugPreferenceInitializer.java
@@ -31,6 +31,7 @@ public class DebugPreferenceInitializer extends AbstractPreferenceInitializer {
 		Preferences.setDefaultBoolean(DebugPlugin.getUniqueIdentifier(), DebugPlugin.PREF_DELETE_CONFIGS_ON_PROJECT_DELETE, false);
 		Preferences.setDefaultBoolean(DebugPlugin.getUniqueIdentifier(), IInternalDebugCoreConstants.PREF_ENABLE_STATUS_HANDLERS, true);
 		Preferences.setDefaultBoolean(DebugPlugin.getUniqueIdentifier(), IInternalDebugCoreConstants.PREF_BREAKPOINT_MANAGER_ENABLED_STATE, true);
+		Preferences.setDefaultBoolean(DebugPlugin.getUniqueIdentifier(), DebugPlugin.PREF_SHOW_BREAKPOINT_GROUPBY_TYPE_SHORTCUTS, true);
 		Preferences.savePreferences(DebugPlugin.getUniqueIdentifier());
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/BreakpointGroupMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/BreakpointGroupMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ public class BreakpointGroupMessages extends NLS {
 	public static String GroupBreakpointsByDialog_5;
 	public static String GroupBreakpointsByDialog_6;
 	public static String GroupBreakpointsByDialog_7;
+	public static String GroupBreakpointsByDialog_8;
 	public static String PasteBreakpointsAction_0;
 	public static String PasteBreakpointsAction_1;
 	public static String RemoveFromWorkingSetAction_0;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/BreakpointGroupMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/BreakpointGroupMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2004, 2011 IBM Corporation and others.
+# Copyright (c) 2004, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ GroupBreakpointsByDialog_4=<- &Remove
 GroupBreakpointsByDialog_5=Move &Up
 GroupBreakpointsByDialog_6=Move &Down
 GroupBreakpointsByDialog_7=Group Breakpoints
+GroupBreakpointsByDialog_8=Show group menu item accelerators
 PasteBreakpointsAction_0=&Paste
 PasteBreakpointsAction_1=Paste Breakpoints
 RemoveFromWorkingSetAction_0=Remove from &Working Set

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/GroupBreakpointsByAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/GroupBreakpointsByAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.internal.ui.DebugPluginImages;
 import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
 import org.eclipse.debug.internal.ui.breakpoints.provisional.IBreakpointOrganizer;
@@ -132,17 +134,21 @@ public class GroupBreakpointsByAction extends AbstractBreakpointsViewAction impl
 
 	private void addAccel(int accel, IAction action, String label) {
 		StringBuilder actionLabel= new StringBuilder();
-		if (accel != 10) {
-			if (accel < 10) {
-				// add the numerical accelerators 1 through 9
-				actionLabel.append('&');
+		boolean showAcc = Platform.getPreferencesService().getBoolean(DebugPlugin.getUniqueIdentifier(),
+				DebugPlugin.PREF_SHOW_BREAKPOINT_GROUPBY_TYPE_SHORTCUTS, true, null);
+		if (showAcc) {
+			if (accel != 10) {
+				if (accel < 10) {
+					// add the numerical accelerators 1 through 9
+					actionLabel.append('&');
+				}
+				actionLabel.append(accel);
+			} else {
+				actionLabel.append("1&0"); //$NON-NLS-1$
 			}
-			actionLabel.append(accel);
-		} else {
-			actionLabel.append("1&0"); //$NON-NLS-1$
+			accel++;
+			actionLabel.append(' ');
 		}
-		accel++;
-		actionLabel.append(' ');
 		actionLabel.append(label);
 		action.setText(actionLabel.toString());
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/GroupBreakpointsByDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpointGroups/GroupBreakpointsByDialog.java
@@ -19,6 +19,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.internal.core.Preferences;
 import org.eclipse.debug.internal.ui.IDebugHelpContextIds;
 import org.eclipse.debug.internal.ui.SWTFactory;
 import org.eclipse.debug.internal.ui.breakpoints.provisional.IBreakpointOrganizer;
@@ -73,6 +76,7 @@ public class GroupBreakpointsByDialog extends TrayDialog {
 	private Button fRemoveButton;
 	private Button fMoveUpButton;
 	private Button fMoveDownButton;
+	private Button fBreakpointGroupAccel;
 
 	/**
 	 * Selection listener that listens to selection from all buttons in this
@@ -127,6 +131,15 @@ public class GroupBreakpointsByDialog extends TrayDialog {
 
 		initializeContent();
 		updateViewers();
+
+		fBreakpointGroupAccel = new Button(composite, SWT.CHECK);
+		fBreakpointGroupAccel.setText(BreakpointGroupMessages.GroupBreakpointsByDialog_8);
+		GridData gridDataCheckbox = new GridData();
+		gridDataCheckbox.horizontalSpan = 3;
+		fBreakpointGroupAccel.setLayoutData(gridDataCheckbox);
+		boolean set = Platform.getPreferencesService().getBoolean(DebugPlugin.getUniqueIdentifier(),
+				DebugPlugin.PREF_SHOW_BREAKPOINT_GROUPBY_TYPE_SHORTCUTS, true, null);
+		fBreakpointGroupAccel.setSelection(set);
 		Dialog.applyDialogFont(parentComposite);
 		return parentComposite;
 	}
@@ -254,6 +267,8 @@ public class GroupBreakpointsByDialog extends TrayDialog {
 	 */
 	@Override
 	protected void okPressed() {
+		Preferences.setBoolean(DebugPlugin.getUniqueIdentifier(),
+				DebugPlugin.PREF_SHOW_BREAKPOINT_GROUPBY_TYPE_SHORTCUTS, fBreakpointGroupAccel.getSelection(), null);
 		Object[] factories= fSelectedOrganizersProvider.getElements(null);
 		while (factories.length > 0) {
 			Object factory= factories[0];


### PR DESCRIPTION
This PR introduces a new checkbox to toggle the display of shortcut numbers in the selection list for breakpoint grouping types. By default, shortcut numbers will be shown but it can be disabled for ensuring consistency with other selection lists that do not display these numbers. Users can enable the shortcut numbers by checking the new checkbox, providing more flexibility while maintaining UI consistency.

Before : 
<img width="451" alt="Screenshot 2025-03-12 at 5 32 49 PM" src="https://github.com/user-attachments/assets/420a3cca-7c44-4ebf-8dcf-f14604873738" />

<img width="441" alt="image" src="https://github.com/user-attachments/assets/964ec93d-6e08-45df-96d3-8b3b2e20c3f6" />

After : 
By default it will show the shortcut numbers
<img width="492" alt="image" src="https://github.com/user-attachments/assets/6422dc99-1d57-4973-ad3f-9164eb5d4762" />
<br>
Added a checkbox to enable or disable
<img width="459" alt="image" src="https://github.com/user-attachments/assets/c0ebc064-b1ad-4d07-be92-4b8b85bada25" />
<br>
Unchecking the option will result in list with no shortcut numbers ensuring consistency with other selection lists that do not display these numbers
<img width="406" alt="image" src="https://github.com/user-attachments/assets/088dd5a8-d321-4a6f-935e-a2965c7b6a52" />

