### PR TITLE
Cleanup progress monitor handling in resource plugin

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/DeleteVisitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/DeleteVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,7 +30,7 @@ import org.eclipse.osgi.util.NLS;
 public class DeleteVisitor implements IUnifiedTreeVisitor, ICoreConstants {
 	protected boolean force;
 	protected boolean keepHistory;
-	protected IProgressMonitor monitor;
+	protected SubMonitor monitor;
 	protected List<Resource> skipList;
 	protected MultiStatus status;
 
@@ -44,7 +44,7 @@ public class DeleteVisitor implements IUnifiedTreeVisitor, ICoreConstants {
 		this.ticks = ticks;
 		this.force = (flags & IResource.FORCE) != 0;
 		this.keepHistory = (flags & IResource.KEEP_HISTORY) != 0;
-		this.monitor = monitor;
+		this.monitor = SubMonitor.convert(monitor, ticks);
 		status = new MultiStatus(ResourcesPlugin.PI_RESOURCES, IResourceStatus.FAILED_DELETE_LOCAL, Messages.localstore_deleteProblem, null);
 	}
 
@@ -63,7 +63,7 @@ public class DeleteVisitor implements IUnifiedTreeVisitor, ICoreConstants {
 			int work = ticks < 0 ? 0 : ticks;
 			ticks -= work;
 			if (deleteLocalFile)
-				localFile.delete(EFS.NONE, Policy.subMonitorFor(monitor, work));
+				localFile.delete(EFS.NONE, monitor.split(work));
 			else
 				monitor.worked(work);
 			//delete from tree

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -378,7 +378,8 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 			throw new ResourceException(IResourceStatus.FAILED_WRITE_LOCAL, destination.getFullPath(), message, null);
 		}
 		getHistoryStore().copyHistory(target, destination, false);
-		CopyVisitor visitor = new CopyVisitor(target, destination, updateFlags, subMonitor.split(100));
+		int totalWork = ((Resource) target).countResources(IResource.DEPTH_INFINITE, false);
+		CopyVisitor visitor = new CopyVisitor(target, destination, updateFlags, subMonitor.split(100), totalWork);
 		UnifiedTree tree = new UnifiedTree(target);
 		tree.accept(visitor, IResource.DEPTH_INFINITE);
 		IStatus status = visitor.getStatus();

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ResourceTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ResourceTree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -337,9 +337,8 @@ class ResourceTree implements IResourceTree {
 	 */
 	private boolean internalDeleteFolder(IFolder folder, int flags, IProgressMonitor monitor) {
 		String message = NLS.bind(Messages.resources_deleting, folder.getFullPath());
-		monitor.beginTask("", Policy.totalWork); //$NON-NLS-1$
-		monitor.subTask(message);
-		Policy.checkCanceled(monitor);
+		SubMonitor subMonitor = SubMonitor.convert(monitor, Policy.totalWork).checkCanceled();
+		subMonitor.subTask(message);
 
 		// Do nothing if the folder doesn't exist in the workspace.
 		if (!folder.exists())
@@ -360,7 +359,7 @@ class ResourceTree implements IResourceTree {
 
 		try {
 			//this will delete local and workspace
-			localManager.delete(folder, flags, Policy.subMonitorFor(monitor, Policy.totalWork));
+			localManager.delete(folder, flags, subMonitor.split(Policy.totalWork, SubMonitor.SUPPRESS_NONE));
 		} catch (CoreException ce) {
 			message = NLS.bind(Messages.localstore_couldnotDelete, folder.getFullPath());
 			IStatus status = new ResourceStatus(IStatus.ERROR, IResourceStatus.FAILED_DELETE_LOCAL, folder.getFullPath(), message, ce);
@@ -907,7 +906,7 @@ class ResourceTree implements IResourceTree {
 		try {
 			lock.acquire();
 			String message = NLS.bind(Messages.resources_moving, source.getFullPath());
-			monitor.subTask(message);
+			monitor.beginTask(message, Policy.totalWork);
 
 			// These pre-conditions should all be ok but just in case...
 			if (!source.exists() || destination.exists() || !destination.getParent().isAccessible())


### PR DESCRIPTION
This resolves several trace errors thrown by an improper use of the
progress monitor while moving, deleting or copying files or folders.

- ResourceTree

The deprecated SubProgressMonitor has been replaced by a SubMonitor, due
to an improved handling of rounding errors when reporting fractional
work back to its parent. In addition, the standardMoveFile() method now
explicitly calls beginTask() on its given progress monitor, to remain
consistent with the standardMoveFolder() and standardMoveProject()
methods and to avoid an error being reported when moving files.

- DeleteVisitor

beginTask() is called on the given progress monitor by converting it to
a SubMonitor with the given number of ticks. This number is based on the
number of to-be-deleted files. When deleting a file, a SubMonitor is
used instead of the deprecated SubProgressMonitor, consuming a number of
ticks based on the total number of ticks.

- CopyVisitor

This method has been adapted similarly to the DeleteVisitor as
beginTask() also needs to be called on the given progress monitor here.
Additionally, the progress handling has been adapted to avoid creating
"zero ticks" SubMonitors, as this also causes an error.


Closes https://github.com/eclipse-platform/eclipse.platform/issues/1776