### PR TITLE
[Debug ]Removal of Deprecated Constants

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/DefaultVariableCellModifier.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/DefaultVariableCellModifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,17 +18,17 @@ import org.eclipse.debug.core.model.IVariable;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.DefaultLabelProvider;
 import org.eclipse.debug.internal.ui.actions.variables.details.DetailPaneAssignValueAction;
+import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jface.viewers.ICellModifier;
 
 /**
  * @since 3.2
  */
-@SuppressWarnings("deprecation")
 public class DefaultVariableCellModifier implements ICellModifier {
 
 	@Override
 	public boolean canModify(Object element, String property) {
-		if (VariableColumnPresentation.COLUMN_VARIABLE_VALUE.equals(property)) {
+		if (IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE.equals(property)) {
 			if (element instanceof IVariable) {
 				return ((IVariable) element).supportsValueModification();
 			}
@@ -38,7 +38,7 @@ public class DefaultVariableCellModifier implements ICellModifier {
 
 	@Override
 	public Object getValue(Object element, String property) {
-		if (VariableColumnPresentation.COLUMN_VARIABLE_VALUE.equals(property)) {
+		if (IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE.equals(property)) {
 			if (element instanceof IVariable) {
 				IVariable variable = (IVariable) element;
 				try {
@@ -55,7 +55,7 @@ public class DefaultVariableCellModifier implements ICellModifier {
 	public void modify(Object element, String property, Object value) {
 		Object oldValue = getValue(element, property);
 		if (!value.equals(oldValue)) {
-			if (VariableColumnPresentation.COLUMN_VARIABLE_VALUE.equals(property)) {
+			if (IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE.equals(property)) {
 				if (element instanceof IVariable) {
 					if (value instanceof String) {
 						// The value column displays special characters escaped, so encode the string with any special characters escaped properly

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/VariableColumnPresentation.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/VariableColumnPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,35 +22,6 @@ import org.eclipse.debug.ui.IDebugUIConstants;
  * @since 3.2
  */
 public class VariableColumnPresentation extends AbstractColumnPresentation {
-
-	/**
-	 * Constant identifier for the default variable column presentation.
-	 * @deprecated Replaced by {@link IDebugUIConstants#COLUMN_PRESENTATION_ID_VARIABLE}
-	 */
-	@Deprecated
-	public final static String DEFAULT_VARIABLE_COLUMN_PRESENTATION = IDebugUIConstants.COLUMN_PRESENTATION_ID_VARIABLE;
-
-	/**
-	 * Default column identifiers
-	 * @deprecated Replaced by {@link IDebugUIConstants#COLUMN_ID_VARIABLE_NAME}
-	 */
-	@Deprecated
-	public final static String COLUMN_VARIABLE_NAME = IDebugUIConstants.COLUMN_ID_VARIABLE_NAME;
-	/**
-	 * @deprecated Replaced by {@link IDebugUIConstants#COLUMN_ID_VARIABLE_TYPE}
-	 */
-	@Deprecated
-	public final static String COLUMN_VARIABLE_TYPE = IDebugUIConstants.COLUMN_ID_VARIABLE_TYPE;
-	/**
-	 * @deprecated Replaced by {@link IDebugUIConstants#COLUMN_ID_VARIABLE_VALUE}
-	 */
-	@Deprecated
-	public final static String COLUMN_VARIABLE_VALUE = IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE;
-	/**
-	 * @deprecated Replaced by {@link IDebugUIConstants#COLUMN_ID_VARIABLE_VALUE_TYPE}
-	 */
-	@Deprecated
-	public final static String COLUMN_VALUE_TYPE = IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE_TYPE;
 
 	private static final String[] ALL_COLUMNS = new String[]{IDebugUIConstants.COLUMN_ID_VARIABLE_NAME,
 		IDebugUIConstants.COLUMN_ID_VARIABLE_TYPE, IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE, IDebugUIConstants.COLUMN_ID_VARIABLE_VALUE_TYPE};

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/WatchExpressionCellModifier.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/WatchExpressionCellModifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 Wind River Systems and others.
+ * Copyright (c) 2010, 2025 Wind River Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ package org.eclipse.debug.internal.ui.elements.adapters;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.model.IWatchExpression;
 import org.eclipse.debug.internal.ui.DefaultLabelProvider;
+import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jface.viewers.ICellModifier;
 
 /**
@@ -24,12 +25,11 @@ import org.eclipse.jface.viewers.ICellModifier;
  *
  * @since 3.6
  */
-@SuppressWarnings("deprecation")
 public class WatchExpressionCellModifier implements ICellModifier {
 
 	@Override
 	public boolean canModify(Object element, String property) {
-		if (VariableColumnPresentation.COLUMN_VARIABLE_NAME.equals(property)) {
+		if (IDebugUIConstants.COLUMN_ID_VARIABLE_NAME.equals(property)) {
 			return element instanceof IWatchExpression;
 		}
 		return false;
@@ -37,7 +37,7 @@ public class WatchExpressionCellModifier implements ICellModifier {
 
 	@Override
 	public Object getValue(Object element, String property) {
-		if (VariableColumnPresentation.COLUMN_VARIABLE_NAME.equals(property)) {
+		if (IDebugUIConstants.COLUMN_ID_VARIABLE_NAME.equals(property)) {
 			return DefaultLabelProvider.escapeSpecialChars( ((IWatchExpression)element).getExpressionText() );
 		}
 		return null;
@@ -47,7 +47,7 @@ public class WatchExpressionCellModifier implements ICellModifier {
 	public void modify(Object element, String property, Object value) {
 		Object oldValue = getValue(element, property);
 		if (!value.equals(oldValue)) {
-			if (VariableColumnPresentation.COLUMN_VARIABLE_NAME.equals(property)) {
+			if (IDebugUIConstants.COLUMN_ID_VARIABLE_NAME.equals(property)) {
 				if (element instanceof IWatchExpression) {
 					if (value instanceof String) {
 						// The value column displays special characters


### PR DESCRIPTION
This commit removes the deprecated constants in VariableColumnPresentation and updates references in DefaultVariableCellModifier and WatchExpressionCellModifier to use the new constants.