### PR TITLE
set background color for variables view in dark mode

### DIFF
--- a/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
+++ b/debug/org.eclipse.debug.ui/css/e4-dark_debug_prefstyle.css
@@ -57,4 +57,5 @@ IEclipsePreferences#org-eclipse-debug-ui {
 
 #VariablesViewer {
     font-family: '#org-eclipse-debug-ui-VariableTextFont';
+    background-color: #2F2F2F;
 }


### PR DESCRIPTION
Variables View on MacOS flickers with white background in dark mode when variable nodes are expanded via the keyboard.
See screencast:

https://github.com/user-attachments/assets/4e254658-fcb1-418d-9436-ee4f03a21942

One can also see that the Variables View gets a white background after closing a debug session.
This pull request sets a dark background color for the Variables View in the css style settings so that the flickering disappears.