### PR TITLE
Add SVGs to org.eclipse.compare bundles

### DIFF
--- a/team/bundles/org.eclipse.compare.win32/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.win32;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (osgi.os=win32)

--- a/team/bundles/org.eclipse.compare.win32/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare.win32/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Bundle-Activator: org.eclipse.compare.internal.win32.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.compare.win32
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/team/bundles/org.eclipse.compare.win32/icons/full/elcl16/editor_area.svg
+++ b/team/bundles/org.eclipse.compare.win32/icons/full/elcl16/editor_area.svg
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="editor_area.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient12204">
+      <stop
+         style="stop-color:#f5b9ac;stop-opacity:1"
+         offset="0"
+         id="stop12206" />
+      <stop
+         id="stop12214"
+         offset="0.25"
+         style="stop-color:#f7cec5;stop-opacity:1" />
+      <stop
+         id="stop12212"
+         offset="0.5"
+         style="stop-color:#f7ccc3;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5b9ac;stop-opacity:1"
+         offset="1"
+         id="stop12208" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12144">
+      <stop
+         style="stop-color:#ca9189;stop-opacity:1"
+         offset="0"
+         id="stop12146" />
+      <stop
+         id="stop12154"
+         offset="0.25"
+         style="stop-color:#f5b9ac;stop-opacity:1" />
+      <stop
+         id="stop12152"
+         offset="0.5"
+         style="stop-color:#f5b9ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#bd847e;stop-opacity:1"
+         offset="1"
+         id="stop12148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8" />
+      <stop
+         id="stop4864-7"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-9"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-5" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-0"
+         offset="0"
+         style="stop-color:#be9a4b;stop-opacity:1" />
+      <stop
+         id="stop4814-4"
+         offset="1"
+         style="stop-color:#877e60;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient8878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.87616643,1.0002456)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient8881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,0.9999451)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient8884"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-5.0312549)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810-5"
+       id="linearGradient8887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.91881011,1.0357451)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       id="linearGradient4908-52-3-2-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4910-7-2-7-1"
+         offset="0"
+         style="stop-color:#986443;stop-opacity:1" />
+      <stop
+         id="stop4912-6-2-9-49"
+         offset="1"
+         style="stop-color:#994f1b;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter5428-3"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur5430-8"
+         stdDeviation="0.22207033"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient5077-5-3">
+      <stop
+         id="stop5079-7-3"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-7" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-30" />
+      <stop
+         id="stop5081-8-1"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300-8">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-8" />
+      <stop
+         id="stop5304-9"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4908-52-3-2-6"
+       id="linearGradient12292"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,0)"
+       x1="-11.21119"
+       y1="1042.1598"
+       x2="-8.7005796"
+       y2="1044.6704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5077-5-3"
+       id="linearGradient12294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-1036.3622)"
+       x1="-0.9810437"
+       y1="1047.4242"
+       x2="1.9838035"
+       y2="1050.3188" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-8"
+       id="linearGradient12296"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12144"
+       id="linearGradient12298"
+       gradientUnits="userSpaceOnUse"
+       x1="29.095431"
+       y1="0.03125"
+       x2="32.279569"
+       y2="0.03125"
+       gradientTransform="translate(3.3308581e-7,1037.1136)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12204"
+       id="linearGradient12300"
+       gradientUnits="userSpaceOnUse"
+       x1="29.150082"
+       y1="1.046875"
+       x2="32.162418"
+       y2="1.046875" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7584">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path7586"
+         d="m 1.5076731,1040.8978 13.0019249,0 0,10.9667 -13.0019248,0 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter8356"
+       x="-0.23975421"
+       width="1.4795084"
+       y="-0.24024629"
+       height="1.4804926">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.90851138"
+         id="feGaussianBlur8358" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="-0.40626607"
+     inkscape:cy="7.707515"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-5-8"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="1083"
+     inkscape:window-y="526"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 1.5076731,1040.8978 13.0019249,0 0,10.9667 -13.0019248,0 z"
+       style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4853-82-7"
+       d="m 3,1044.331 0,7.0312 -1,0 0,-8.0312 z"
+       style="fill:url(#linearGradient8884);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4853-82-0"
+       d="m 3,1044.3622 10.928078,0 0,-1 -11.928078,0 z"
+       style="fill:url(#linearGradient8881);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-9"
+       d="m 1.503712,1040.8623 13.004333,0 0,2.0053 -13.004333,0 z"
+       style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient8878);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <g
+       id="g7581"
+       mask="url(#mask7584)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path5226-6-14-1-5-9-9"
+         d="m 14.945713,1040.3274 -5.5989979,5.572 -3.4954296,1.6602 1.6601595,-3.4924 5.545372,-5.5834 c 0.812805,0.3857 1.414835,1.0349 1.888896,1.8439 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;filter:url(#filter8356)" />
+    </g>
+    <g
+       id="g12278"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,726.06628,283.93164)">
+      <g
+         transform="matrix(0.45259182,-0.45259182,0.45259182,0.45259182,-446.0304,573.84462)"
+         inkscape:label="Layer 1"
+         id="layer1-5-8"
+         style="display:inline">
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient12292);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 15.685953,1040.5523 -8.7475939,8.7054 -5.461084,2.5938 2.59375,-5.4564 8.6638109,-8.7231 c 1.269887,0.6025 2.210467,1.6169 2.951117,2.8807 z"
+           id="path5226-6-14-1-5-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffcb72;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 12.75,1037.6747 -8.6875,8.7188 0.9375,0.9062 8.9375,-8.875 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875,-0.75 z"
+           id="path5424-7"
+           inkscape:connector-curvature="0" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#e5a856;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 15.3125,1039.956 -8.78125,8.9062 0.40625,0.4063 8.75,-8.7188 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+           id="path5226-6-14-1-5-2-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#fbbc67;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 6.536718,1048.8567 -1.548139,-1.5456 8.939717,-8.8821 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+           id="path5226-6-14-1-5-2-7-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-3)"
+           d="m 4.984376,1047.2528 8.937501,-8.8281"
+           id="path5426-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:url(#linearGradient12294);fill-opacity:1;stroke:none;display:inline"
+           d="M 4.09375,10 2.6875,12.9375 c 0.1928924,0.586348 0.244767,1.257306 1.375,1.28125 L 4.03125,14.28125 6.96875,12.875 C 7.3020356,11.516034 6.7891722,11.737439 5.9815375,11.315162 5.6074141,10.176906 5.9121401,10.42899 4.6833038,10.420015 4.6786211,9.4016554 4.2560993,10.44918 4.09375,10 z"
+           id="path5006-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:url(#linearGradient12296);fill-opacity:1;stroke:none;display:inline"
+           d="m 2.6874999,1049.2997 -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c -0.7244984,-0.1443 -1.1657597,-0.5692 -1.375,-1.2818 z"
+           id="path5006-1-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+      <path
+         sodipodi:nodetypes="sccsccs"
+         inkscape:connector-curvature="0"
+         id="path11335"
+         d="m 30.6875,1035.7699 c -0.790527,0 -1.4375,0.166 -1.4375,0.375 l 0,2 c 0,0.209 0.646973,0.375 1.4375,0.375 0.790527,0 1.4375,-0.166 1.4375,-0.375 l 0,-2 c 0,-0.209 -0.646973,-0.375 -1.4375,-0.375 z"
+         style="fill:url(#linearGradient12298);fill-opacity:1;stroke:none" />
+      <path
+         transform="matrix(1.0529667,0,0,1.0529667,-1.5886036,1035.0448)"
+         d="m 32.015625,1.046875 c 0,0.1984773 -0.608613,0.359375 -1.359375,0.359375 -0.750762,0 -1.359375,-0.1608977 -1.359375,-0.359375 0,-0.19847733 0.608613,-0.359375 1.359375,-0.359375 0.750762,0 1.359375,0.16089767 1.359375,0.359375 z"
+         sodipodi:ry="0.359375"
+         sodipodi:rx="1.359375"
+         sodipodi:cy="1.046875"
+         sodipodi:cx="30.65625"
+         id="path11335-9"
+         style="fill:#f5b9ac;fill-opacity:1;stroke:url(#linearGradient12300);stroke-width:0.2935867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="sccsccs"
+         inkscape:connector-curvature="0"
+         id="path11335-4"
+         d="m 30.687499,1035.7698 c -0.790526,0 -1.437499,0.166 -1.437499,0.375 l 0,1.4807 c 0,0.209 0.646973,0.375 1.437499,0.375 0.790527,0 1.4375,-0.166 1.4375,-0.375 l 0,-1.4807 c 0,-0.209 -0.646973,-0.375 -1.4375,-0.375 z"
+         style="fill:none;stroke:#b6766f;stroke-width:0.30913702;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="cssscsc"
+         inkscape:connector-curvature="0"
+         id="path11335-4-0"
+         d="m 29.09375,1037.7074 0,1.6022 c 0,0.2327 0.713814,0.4063 1.59375,0.4063 0.879938,0 1.59375,-0.1736 1.59375,-0.4063 l 0,-1.6022 c 0,0.2327 -0.713812,0.4062 -1.59375,0.4062 -0.879936,0 -1.59375,-0.1735 -1.59375,-0.4062 z"
+         style="fill:#dedfe2;fill-opacity:1;stroke:#a79a9e;stroke-width:0.34410122;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare.win32/icons/full/elcl16/save.svg
+++ b/team/bundles/org.eclipse.compare.win32/icons/full/elcl16/save.svg
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="save.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4987">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="stop4989" />
+      <stop
+         id="stop4997"
+         offset="0.38282764"
+         style="stop-color:#b5cef2;stop-opacity:1" />
+      <stop
+         id="stop4995"
+         offset="0.62501514"
+         style="stop-color:#97b2d9;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f8fc;stop-opacity:1"
+         offset="1"
+         id="stop4991" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4893">
+      <stop
+         style="stop-color:#b7c9e3;stop-opacity:1;"
+         offset="0"
+         id="stop4895" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop4897" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="stop4885" />
+      <stop
+         id="stop4891"
+         offset="0.16666377"
+         style="stop-color:#dce9f2;stop-opacity:1" />
+      <stop
+         style="stop-color:#fefdfa;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4780"
+       inkscape:collect="always">
+      <stop
+         id="stop4782"
+         offset="0"
+         style="stop-color:#b1bdbf;stop-opacity:1" />
+      <stop
+         id="stop4784"
+         offset="1"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4738">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="stop4740" />
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="1"
+         id="stop4742" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4738"
+       id="linearGradient4744"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,1.7382813e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4780"
+       id="linearGradient4858"
+       gradientUnits="userSpaceOnUse"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1044.8586"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="29"
+       y1="1044.3622"
+       x2="29"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.94028876,-20,61.972037)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4893"
+       id="linearGradient4899"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,1.7382813e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4987"
+       id="linearGradient4993"
+       x1="48"
+       y1="1050.3621"
+       x2="48"
+       y2="1046.3621"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="5.2591065"
+     inkscape:cy="10.827572"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="259"
+     inkscape:window-y="60"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3952"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient4899);fill-opacity:1;stroke:url(#linearGradient4744);stroke-opacity:1"
+       id="rect3968"
+       width="14.007257"
+       height="14"
+       x="1.4963722"
+       y="1037.8622"
+       rx="0.8125"
+       ry="0.8125" />
+    <rect
+       style="fill:url(#linearGradient4889);fill-opacity:1;stroke:none;display:inline"
+       id="rect3968-9-1"
+       width="7.96875"
+       height="6.6114054"
+       x="4.53125"
+       y="1037.8622"
+       rx="0.8125"
+       ry="0.76398462" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4858);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1037.3622 0,6.6874 c 0,0.7184 0.594024,1.3124 1.3125,1.3124 l 6.375,0 c 0.718476,0 1.3125,-0.594 1.3125,-1.3124 l 0,-6.6874 z m 8,1 0,5.6874 c 0,0.1817 -0.130726,0.3124 -0.3125,0.3124 l -6.375,0 C 5.130726,1044.362 5,1044.2313 5,1044.0496 l 0,-5.6874 z"
+       id="rect3968-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscccsssscc" />
+    <g
+       id="g4953"
+       transform="translate(-40,1.0002)">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4993);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 51.274749,1050.5808 0,-4.0717 c 0,-0.2017 -0.145092,-0.3467 -0.346843,-0.3467 l -4.855812,0 c -0.201751,0 -0.346843,0.145 -0.346843,0.3467 l 0,4.0717 z"
+         id="rect3968-9-6-8"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssscccsssscc"
+         inkscape:connector-curvature="0"
+         id="rect3968-9-6"
+         d="m 45,1051.362 0,-4.6685 c 0,-0.7184 0.594024,-1.3124 1.3125,-1.3124 l 4.375,0 c 0.718476,0 1.3125,0.594 1.3125,1.3124 l 0,4.6685 z m 6,-1 0,-3.6685 c 0,-0.1817 -0.130726,-0.3124 -0.3125,-0.3124 l -4.375,0 c -0.181774,0 -0.3125,0.1307 -0.3125,0.3124 l 0,3.6685 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#5b7aaa;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <rect
+         style="fill:#5b7aaa;fill-opacity:1;stroke:none"
+         id="rect4963"
+         width="1"
+         height="2.90625"
+         x="49"
+         y="1046.9246" />
+      <rect
+         style="opacity:0.35;fill:#9baaac;fill-opacity:1;stroke:none;display:inline"
+         id="rect4963-5"
+         width="0.99985409"
+         height="5.0000024"
+         x="1040.3621"
+         y="-51"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <rect
+         style="opacity:0.35;fill:#a6b4b6;fill-opacity:1;stroke:none;display:inline"
+         id="rect4963-5-7"
+         width="0.99993944"
+         height="5"
+         x="1038.3621"
+         y="-51"
+         transform="matrix(0,1,-1,0,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare.win32/pom.xml
+++ b/team/bundles/org.eclipse.compare.win32/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.compare.win32</artifactId>
-  <version>1.3.400-SNAPSHOT</version>
+  <version>1.3.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/WordMergeViewer.properties
+++ b/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/WordMergeViewer.properties
@@ -14,8 +14,8 @@
 
 action.save.label=Save
 action.save.tooltip=Save the changes to the Word document comparison
-action.save.image=save.png
+action.save.image=save.svg
 
 action.inplace.label=Edit Inplace
 action.inplace.tooltip=Toggle whether the word document is edited in-place or in a separate window
-action.inplace.image=editor_area.png
+action.inplace.image=editor_area.svg

--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.compare
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareConfiguration.java
@@ -91,36 +91,49 @@ public class CompareConfiguration {
 
 	static {
 		// Not swapped (a.k.a. left is local)
-		fgImages[Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/add_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.LEFT + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/r_inadd_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.RIGHT + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/r_outadd_ov.png"); //$NON-NLS-1$
+		fgImages[Differencer.ADDITION] = CompareUIPlugin.getImageDescriptor("ovr16/add_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.LEFT + Differencer.ADDITION] = CompareUIPlugin.getImageDescriptor("ovr16/r_inadd_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.RIGHT + Differencer.ADDITION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/r_outadd_ov.svg"); //$NON-NLS-1$
 
-		fgImages[Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/del_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.LEFT + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/r_indel_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.RIGHT + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/r_outdel_ov.png"); //$NON-NLS-1$
+		fgImages[Differencer.DELETION] = CompareUIPlugin.getImageDescriptor("ovr16/del_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.LEFT + Differencer.DELETION] = CompareUIPlugin.getImageDescriptor("ovr16/r_indel_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.RIGHT + Differencer.DELETION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/r_outdel_ov.svg"); //$NON-NLS-1$
 
-		fgImages[Differencer.LEFT + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/r_inchg_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.RIGHT + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/r_outchg_ov.png"); //$NON-NLS-1$
+		fgImages[Differencer.LEFT + Differencer.CHANGE] = CompareUIPlugin.getImageDescriptor("ovr16/r_inchg_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.RIGHT + Differencer.CHANGE] = CompareUIPlugin.getImageDescriptor("ovr16/r_outchg_ov.svg"); //$NON-NLS-1$
 
-		fgImages[Differencer.CONFLICTING + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/confadd_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.CONFLICTING + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/confdel_ov.png"); //$NON-NLS-1$
-		fgImages[Differencer.CONFLICTING + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/confchg_ov.png"); //$NON-NLS-1$
+		fgImages[Differencer.CONFLICTING + Differencer.ADDITION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confadd_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.CONFLICTING + Differencer.DELETION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confdel_ov.svg"); //$NON-NLS-1$
+		fgImages[Differencer.CONFLICTING + Differencer.CHANGE] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confchg_ov.svg"); //$NON-NLS-1$
 
 		// Mirrored (a.k.a. right is local)
-		fgImages[16 + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/add_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.LEFT + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/inadd_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.RIGHT + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/outadd_ov.png"); //$NON-NLS-1$
+		fgImages[16 + Differencer.ADDITION] = CompareUIPlugin.getImageDescriptor("ovr16/add_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.LEFT + Differencer.ADDITION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/inadd_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.RIGHT + Differencer.ADDITION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/outadd_ov.svg"); //$NON-NLS-1$
 
-		fgImages[16 + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/del_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.LEFT + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/indel_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.RIGHT + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/outdel_ov.png"); //$NON-NLS-1$
+		fgImages[16 + Differencer.DELETION] = CompareUIPlugin.getImageDescriptor("ovr16/del_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.LEFT + Differencer.DELETION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/indel_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.RIGHT + Differencer.DELETION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/outdel_ov.svg"); //$NON-NLS-1$
 
-		fgImages[16 + Differencer.LEFT + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/inchg_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.RIGHT + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/outchg_ov.png"); //$NON-NLS-1$
+		fgImages[16 + Differencer.LEFT + Differencer.CHANGE] = CompareUIPlugin.getImageDescriptor("ovr16/inchg_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.RIGHT + Differencer.CHANGE] = CompareUIPlugin
+				.getImageDescriptor("ovr16/outchg_ov.svg"); //$NON-NLS-1$
 
-		fgImages[16 + Differencer.CONFLICTING + Differencer.ADDITION]= CompareUIPlugin.getImageDescriptor("ovr16/confadd_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.CONFLICTING + Differencer.DELETION]= CompareUIPlugin.getImageDescriptor("ovr16/confdel_ov.png"); //$NON-NLS-1$
-		fgImages[16 + Differencer.CONFLICTING + Differencer.CHANGE]= CompareUIPlugin.getImageDescriptor("ovr16/confchg_ov.png"); //$NON-NLS-1$
+		fgImages[16 + Differencer.CONFLICTING + Differencer.ADDITION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confadd_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.CONFLICTING + Differencer.DELETION] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confdel_ov.svg"); //$NON-NLS-1$
+		fgImages[16 + Differencer.CONFLICTING + Differencer.CHANGE] = CompareUIPlugin
+				.getImageDescriptor("ovr16/confchg_ov.svg"); //$NON-NLS-1$
 	}
 
 	private final IPreferenceStore fPreferenceStore;

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareEditorInput.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/CompareEditorInput.java
@@ -176,7 +176,7 @@ public abstract class CompareEditorInput extends PlatformObject implements IEdit
 	 */
 	public static final String PROP_SELECTED_EDITION= ICompareUIConstants.PROP_SELECTED_EDITION;
 
-	private static final String COMPARE_EDITOR_IMAGE_NAME= "eview16/compare_view.png"; //$NON-NLS-1$
+	private static final String COMPARE_EDITOR_IMAGE_NAME = "eview16/compare_view.svg"; //$NON-NLS-1$
 	private static Image fgTitleImage;
 
 	private Splitter fComposite;

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/EditionSelectionDialog.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/EditionSelectionDialog.java
@@ -727,7 +727,7 @@ public class EditionSelectionDialog extends ResizableDialog {
 			return selectedEdition.getImage();
 		if (selectedEdition instanceof HistoryItem) {
 			if (fTimeImage == null) {
-				String iconName= Utilities.getString(fBundle, "timeIcon", "obj16/resource_obj.png"); //$NON-NLS-1$ //$NON-NLS-2$
+				String iconName= Utilities.getString(fBundle, "timeIcon", "obj16/resource_obj.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 				ImageDescriptor id= CompareUIPlugin.getImageDescriptor(iconName);
 				if (id != null)
 					fTimeImage= id.createImage();
@@ -1031,7 +1031,7 @@ public class EditionSelectionDialog extends ResizableDialog {
 		if (lastDay == null || day != dayNumber(((Date)lastDay.getData()).getTime())) {
 			lastDay= new TreeItem(fEditionTree, SWT.NONE);
 			if (fDateImage == null) {
-				String iconName= Utilities.getString(fBundle, "dateIcon", "obj16/day_obj.png"); //$NON-NLS-2$ //$NON-NLS-1$
+				String iconName= Utilities.getString(fBundle, "dateIcon", "obj16/day_obj.svg"); //$NON-NLS-2$ //$NON-NLS-1$
 				ImageDescriptor id= CompareUIPlugin.getImageDescriptor(iconName);
 				if (id != null)
 					fDateImage= id.createImage();

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewerResources.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewerResources.properties
@@ -32,53 +32,53 @@ tooComplexError.message= Too many differences. Turn on the 'Ignore White Space' 
 
 action.CopyLeftToRight.label=Copy Left to Right
 action.CopyLeftToRight.tooltip=Copy All Non-Conflicting Changes from Left to Right
-action.CopyLeftToRight.image=copy_r_co.png
+action.CopyLeftToRight.image=copy_r_co.svg
 
 action.CopyRightToLeft.label=Copy Right to Left
 action.CopyRightToLeft.tooltip=Copy All Non-Conflicting Changes from Right to Left
-action.CopyRightToLeft.image=copy_l_co.png
+action.CopyRightToLeft.image=copy_l_co.svg
 
 action.CopyDiffLeftToRight.label=Copy Current Change to Right
 action.CopyDiffLeftToRight.tooltip=Copy Current Change from Left to Right
-action.CopyDiffLeftToRight.image=copycont_r_co.png
+action.CopyDiffLeftToRight.image=copycont_r_co.svg
 
 action.CopyDiffRightToLeft.label=Copy Current Change to Left
 action.CopyDiffRightToLeft.tooltip=Copy Current Change from Right to Left
-action.CopyDiffRightToLeft.image=copycont_l_co.png
+action.CopyDiffRightToLeft.image=copycont_l_co.svg
 
 action.NextDiff.label=Next Difference
 action.NextDiff.tooltip=Next Difference
-action.NextDiff.image=next_diff_nav.png
+action.NextDiff.image=next_diff_nav.svg
 
 action.PrevDiff.label=Previous Difference
 action.PrevDiff.tooltip=Previous Difference
-action.PrevDiff.image=prev_diff_nav.png
+action.PrevDiff.image=prev_diff_nav.svg
 
 action.NextChange.label=Next Change
 action.NextChange.tooltip=Next Change
-action.NextChange.image=next_change_nav.png
+action.NextChange.image=next_change_nav.svg
 
 action.PrevChange.label=Previous Change
 action.PrevChange.tooltip=Previous Change
-action.PrevChange.image=prev_change_nav.png
+action.PrevChange.image=prev_change_nav.svg
 
 action.EnableAncestor.label=Enable Ancestor Pane
 action.EnableAncestor.tooltip.unchecked=Show Ancestor Pane
 action.EnableAncestor.tooltip.checked=Hide Ancestor Pane
 action.EnableAncestor.description.unchecked=Show Ancestor Pane
 action.EnableAncestor.description.checked=Hide Ancestor Pane
-action.EnableAncestor.image=ancestorpane_co.png
+action.EnableAncestor.image=ancestorpane_co.svg
 
 action.IgnoreAncestor.label=Ignore Ancestor
 action.IgnoreAncestor.tooltip.unchecked=Two-Way Compare (Ignore Ancestor)
 action.IgnoreAncestor.tooltip.checked=Three-Way Compare
 action.IgnoreAncestor.description.unchecked=Two-Way Compare (Ignore Ancestor)
 action.IgnoreAncestor.description.checked=Three-Way Compare
-action.IgnoreAncestor.image=twowaycompare_co.png
+action.IgnoreAncestor.image=twowaycompare_co.svg
 
 action.SwitchLeftAndRight.label=Swap Left and Right View
 action.SwitchLeftAndRight.tooltip=Swap Left and Right View
-action.SwitchLeftAndRight.image=switch.png
+action.SwitchLeftAndRight.image=switch.svg
 
 #####################################################
 # Context menu actions

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryAction.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryAction.properties
@@ -21,8 +21,8 @@ title= Restore from Local History
 memberPaneTitle= {0} - Available Files in Local History:
 
 treeTitleFormat= Local History of ''{0}''
-dateIcon= obj16/day_obj.png
-timeIcon= obj16/resource_obj.png
+dateIcon= obj16/day_obj.svg
+timeIcon= obj16/resource_obj.svg
 
 memberDescription= Check files to restore from local history:
 editionDescription= Select an edition of a file:

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryDialog.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryDialog.java
@@ -164,11 +164,11 @@ public class AddFromHistoryDialog extends ResizableDialog {
 	public AddFromHistoryDialog(Shell parent, ResourceBundle bundle) {
 		super(parent, bundle);
 
-		String iconName= Utilities.getString(fBundle, "dateIcon", "obj16/day_obj.png"); //$NON-NLS-2$ //$NON-NLS-1$
+		String iconName= Utilities.getString(fBundle, "dateIcon", "obj16/day_obj.svg"); //$NON-NLS-2$ //$NON-NLS-1$
 		ImageDescriptor id= CompareUIPlugin.getImageDescriptor(iconName);
 		if (id != null)
 			fDateImage= id.createImage();
-		iconName= Utilities.getString(fBundle, "timeIcon", "obj16/resource_obj.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		iconName= Utilities.getString(fBundle, "timeIcon", "obj16/resource_obj.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 		id= CompareUIPlugin.getImageDescriptor(iconName);
 		if (id != null)
 			fTimeImage= id.createImage();

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareContentViewerSwitchingPane.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareContentViewerSwitchingPane.java
@@ -52,7 +52,7 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
 public class CompareContentViewerSwitchingPane extends CompareViewerSwitchingPane {
-	private static final String OPTIMIZED_INFO_IMAGE_NAME = "obj16/message_info.png"; //$NON-NLS-1$
+	private static final String OPTIMIZED_INFO_IMAGE_NAME = "obj16/message_info.svg"; //$NON-NLS-1$
 	public static final String OPTIMIZED_ALGORITHM_USED = "OPTIMIZED_ALGORITHM_USED"; //$NON-NLS-1$
 	public static final String DISABLE_CAPPING_TEMPORARILY = "DISABLE_CAPPING_TEMPORARILY"; //$NON-NLS-1$
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareWithEditionAction.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareWithEditionAction.properties
@@ -19,8 +19,8 @@
 title= Compare with Local History
 
 treeTitleFormat= Local History of ''{0}''
-dateIcon= obj16/day_obj.png
-timeIcon= obj16/resource_obj.png
+dateIcon= obj16/day_obj.svg
+timeIcon= obj16/resource_obj.svg
 
 treeFormat= {0}
 workspaceTreeFormat= {0} (Workspace File)

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
@@ -18,23 +18,23 @@ public interface ICompareUIConstants {
 	public final String PREFIX = CompareUIPlugin.getPluginId() + "."; //$NON-NLS-1$
 
 	public static final String DTOOL_NEXT= "dlcl16/next_nav.png";	//$NON-NLS-1$
-	public static final String ETOOL_NEXT= "elcl16/next_nav.png";	//$NON-NLS-1$
+	public static final String ETOOL_NEXT = "elcl16/next_nav.svg"; //$NON-NLS-1$
 	public static final String CTOOL_NEXT= ETOOL_NEXT;
 
 	public static final String DTOOL_PREV= "dlcl16/prev_nav.png";	//$NON-NLS-1$
-	public static final String ETOOL_PREV= "elcl16/prev_nav.png";	//$NON-NLS-1$
+	public static final String ETOOL_PREV = "elcl16/prev_nav.svg"; //$NON-NLS-1$
 	public static final String CTOOL_PREV= ETOOL_PREV;
 
-	public static final String HUNK_OBJ = "obj16/hunk_obj.png"; //$NON-NLS-1$
+	public static final String HUNK_OBJ = "obj16/hunk_obj.svg"; //$NON-NLS-1$
 
-	public static final String ERROR_OVERLAY= "ovr16/error_ov.png"; //$NON-NLS-1$
-	public static final String IS_MERGED_OVERLAY= "ovr16/merged_ov.png"; //$NON-NLS-1$
-	public static final String REMOVED_OVERLAY= "ovr16/removed_ov.png"; //$NON-NLS-1$
-	public static final String WARNING_OVERLAY= "ovr16/warning_ov.png"; //$NON-NLS-1$
+	public static final String ERROR_OVERLAY = "ovr16/error_ov.svg"; //$NON-NLS-1$
+	public static final String IS_MERGED_OVERLAY = "ovr16/merged_ov.svg"; //$NON-NLS-1$
+	public static final String REMOVED_OVERLAY = "ovr16/removed_ov.svg"; //$NON-NLS-1$
+	public static final String WARNING_OVERLAY = "ovr16/warning_ov.svg"; //$NON-NLS-1$
 
-	public static final String RETARGET_PROJECT= "eview16/compare_view.png";	//$NON-NLS-1$
+	public static final String RETARGET_PROJECT = "eview16/compare_view.svg"; //$NON-NLS-1$
 
-	public static final String IGNORE_WHITESPACE_ENABLED= "etool16/ignorews_edit.png";	//$NON-NLS-1$
+	public static final String IGNORE_WHITESPACE_ENABLED = "etool16/ignorews_edit.svg"; //$NON-NLS-1$
 	public static final String IGNORE_WHITESPACE_DISABLED= "dtool16/ignorews_edit.png";	//$NON-NLS-1$
 
 	public static final String PROP_ANCESTOR_VISIBLE = PREFIX + "AncestorVisible"; //$NON-NLS-1$

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ImageMergeViewerResources.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ImageMergeViewerResources.properties
@@ -27,16 +27,16 @@ saveDialog.message= Resource has been modified. Save changes?
 
 action.CopyLeftToRight.label= Copy Left to Right
 action.CopyLeftToRight.tooltip= Copy Image from Left to Right
-action.CopyLeftToRight.image= elcl16/copy_r_co.png
+action.CopyLeftToRight.image= elcl16/copy_r_co.svg
 
 action.CopyRightToLeft.label= Copy Right to Left
 action.CopyRightToLeft.tooltip= Copy Image from Right to Left
-action.CopyRightToLeft.image= elcl16/copy_l_co.png
+action.CopyRightToLeft.image= elcl16/copy_l_co.svg
 
 action.EnableAncestor.label= Enable Ancestor Pane
 action.EnableAncestor.tooltip= Control Visibility of Ancestor Pane
-action.EnableAncestor.image= elcl16/ancestorpane_co.png
+action.EnableAncestor.image= elcl16/ancestorpane_co.svg
 
 action.SwitchLeftAndRight.label=Swap Left and Right View
 action.SwitchLeftAndRight.tooltip=Swap Left and Right View
-action.SwitchLeftAndRight.image=switch.png
+action.SwitchLeftAndRight.image=switch.svg

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ReplaceWithEditionAction.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ReplaceWithEditionAction.properties
@@ -19,8 +19,8 @@
 title= Replace from Local History
 
 treeTitleFormat= Local History of ''{0}''
-dateIcon= obj16/day_obj.png
-timeIcon= obj16/resource_obj.png
+dateIcon= obj16/day_obj.svg
+timeIcon= obj16/resource_obj.svg
 
 treeFormat= {0}
 workspaceTreeFormat= {0} (Workspace File)

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
@@ -914,7 +914,7 @@ public class Utilities {
 			image = PlatformUI.getWorkbench().getSharedImages().getImage(
 			/* IWorkbenchGraphicConstants */"IMG_LCL_VIEW_MENU"); //$NON-NLS-1$
 		} else {
-			image = CompareUIPlugin.getImageDescriptor("elcl16/view_menu.png").createImage(); //$NON-NLS-1$
+			image = CompareUIPlugin.getImageDescriptor("elcl16/view_menu.svg").createImage(); //$NON-NLS-1$
 			item.addDisposeListener(e -> {
 				Image img = item.getImage();
 				if ((img != null) && (!img.isDisposed())) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchWizard.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchWizard.java
@@ -58,7 +58,7 @@ public class PatchWizard extends Wizard {
 	public PatchWizard(IStorage patch, IResource target, CompareConfiguration configuration) {
 		Assert.isNotNull(configuration);
 		this.fConfiguration = configuration;
-		setDefaultPageImageDescriptor(CompareUIPlugin.getImageDescriptor("wizban/applypatch_wizban.png")); //$NON-NLS-1$
+		setDefaultPageImageDescriptor(CompareUIPlugin.getImageDescriptor("wizban/applypatch_wizban.svg")); //$NON-NLS-1$
 		setWindowTitle(PatchMessages.PatchWizard_title);
 		initializeDialogSettings();
 		fPatcher= new WorkspacePatcher(target);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DiffTreeViewerResources.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DiffTreeViewerResources.properties
@@ -31,7 +31,7 @@ emptyMenuItem= <Empty Menu>
 
 action.Smart.label=Smart
 action.Smart.tooltip=Guess Similar Elements
-action.Smart.image=smartmode_co.png
+action.Smart.image=smartmode_co.svg
 
 action.ExpandAll.label=Expand All
 action.ExpandAll.tooltip=Expand All Nodes
@@ -41,16 +41,16 @@ action.CompareContents.tooltip= Show Content Comparison
 
 action.NextDiff.label=Next
 action.NextDiff.tooltip=Select Next Change
-action.NextDiff.image=next_nav.png
+action.NextDiff.image=next_nav.svg
 
 action.PrevDiff.label=Previous
 action.PrevDiff.tooltip=Select Previous Change
-action.PrevDiff.image=prev_nav.png
+action.PrevDiff.image=prev_nav.svg
 
 action.TakeLeft.label=Copy Left to Right
 action.TakeLeft.tooltip=Copy Selected Nodes from Left to Right
-action.TakeLeft.image=copycont_r_co.png
+action.TakeLeft.image=copycont_r_co.svg
 
 action.TakeRight.label=Copy Right to Left
 action.TakeRight.tooltip=Copy Selected Nodes from Right to Left
-action.TakeRight.image=copycont_l_co.png
+action.TakeRight.image=copycont_l_co.svg

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/ancestorpane_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/ancestorpane_co.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="ancestorpane.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4452"
+       inkscape:collect="always">
+      <stop
+         id="stop4454"
+         offset="0"
+         style="stop-color:#d5f3ff;stop-opacity:1" />
+      <stop
+         id="stop4456"
+         offset="1"
+         style="stop-color:#edfaff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4380"
+       inkscape:collect="always">
+      <stop
+         id="stop4382"
+         offset="0"
+         style="stop-color:#6f94bf;stop-opacity:1" />
+      <stop
+         id="stop4384"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4374"
+       inkscape:collect="always">
+      <stop
+         id="stop4376"
+         offset="0"
+         style="stop-color:#6fb6e2;stop-opacity:1" />
+      <stop
+         id="stop4378"
+         offset="1"
+         style="stop-color:#cee3f3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4333">
+      <stop
+         style="stop-color:#c6e26e;stop-opacity:1"
+         offset="0"
+         id="stop4335" />
+      <stop
+         style="stop-color:#fafcf4;stop-opacity:1"
+         offset="1"
+         id="stop4337" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4288">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4290" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4292" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294"
+       x1="688.31909"
+       y1="317.17447"
+       x2="688.31909"
+       y2="274.16879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-53.757103,-5.9194102e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4333"
+       id="linearGradient4339"
+       x1="666.81628"
+       y1="267.00119"
+       x2="713.40576"
+       y2="299.25543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-53.757103,-5.9194102e-6)" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.14285703,-53.757195,227.32227)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4374"
+       id="linearGradient4339-8"
+       x1="666.81641"
+       y1="277.75256"
+       x2="713.40576"
+       y2="299.25543"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.14285703,-53.757195,227.32227)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4380"
+       id="linearGradient4294-5"
+       x1="713.40582"
+       y1="327.92587"
+       x2="666.81641"
+       y2="327.92587"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.4999998,0,0,0.28571392,278.75515,225.27333)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4452"
+       id="linearGradient4339-9"
+       x1="668.60834"
+       y1="271.48099"
+       x2="697.27881"
+       y2="296.56766"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.4999998,0,0,0.28571392,278.75515,225.27333)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294-4"
+       x1="688.31909"
+       y1="317.17447"
+       x2="690.11121"
+       y2="183.67766"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.4999998,0,0,0.28571392,303.84175,225.27334)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4452"
+       id="linearGradient4339-9-9"
+       x1="668.6084"
+       y1="271.48096"
+       x2="697.27887"
+       y2="296.56763"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.4999998,0,0,0.28571392,303.84175,225.27334)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294-4-9"
+       x1="688.31909"
+       y1="317.17447"
+       x2="690.11127"
+       y2="183.67761"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="34.206291"
+     inkscape:cx="7.6525785"
+     inkscape:cy="8.2561974"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8667"
+     showgrid="true"
+     inkscape:window-width="2341"
+     inkscape:window-height="1019"
+     inkscape:window-x="65"
+     inkscape:window-y="322"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3032" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8667"
+       transform="matrix(0.27903303,0,0,0.27903303,-169.06377,963.86005)">
+      <image
+         y="259.83359"
+         x="666.81628"
+         id="image4283"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAWJJREFU
+OI2lkj1OAzEQhb8ZT5LdiCKRIEVKCiquEETDDVLCOSi4AgegAxQ6QOIENNRUdCAF0aRAXCA/G1PY
+zu4CEUJY2vXM8/Pzm7HFe89/hgEcHF97FcGpoCo4VUwV5wRTh7mIuYhHnqoEgd7ONlv9Hk1ztEzJ
+GkpmStuU3ITclNwgMyF3QlOh6YTLu8cg8P485uPlNZ4eTitdKOaEhtMSd6CipYOT/TGt3QnI3+qf
+PvWDQLFUADrtPSA1VdbEKYfJclwXyLRbIVfnNOp5sXwLAvOlAdCy7p9KmBcaBRYuOLDOSv+r+Sou
+PglYFCiiA9mIzLjNx1go87TuYb6IAtMo0LSc782r+qGGzwpDvPecjy5W8r7Ckd9eucSnPCuMwfDw
+R87DzYjB8GjN2lW9iZsNEClNCqE//VbAE6aE/L5wQWARrzERADQGi8KtNmviSPjmqQenZ7drq/Xp
+V7mMYNPjgU/YXmZ9bM8bnAAAAABJRU5ErkJggg==
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="57.340881"
+         width="57.340881" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient4339);fill-opacity:1;stroke:url(#linearGradient4294);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286"
+         width="50.173248"
+         height="50.173267"
+         x="611.26733"
+         y="265.20929" />
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-8);fill-opacity:1;stroke:url(#linearGradient4294-5);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-8"
+         width="50.173248"
+         height="7.1676044"
+         x="611.26733"
+         y="265.20929" />
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-9);fill-opacity:1;stroke:url(#linearGradient4294-4);stroke-width:3.58380532;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-9"
+         width="25.086613"
+         height="14.335201"
+         x="611.26733"
+         y="301.04733" />
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-9-9);fill-opacity:1;stroke:url(#linearGradient4294-4-9);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-9-4"
+         width="25.086613"
+         height="14.335201"
+         x="636.35394"
+         y="301.04733" />
+    </g>
+    <g
+       transform="translate(-20.000002,2.6171874e-6)"
+       style="stroke:#694337;stroke-opacity:1;display:inline"
+       id="g11029" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/copy_l_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/copy_l_co.svg
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copy_l_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#c6e26e;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#f8fbf0;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.74074234,0,0,-0.72727303,14.611112,1804.399)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.74074234,0,0,-0.72727303,14.611112,1804.399)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.33333333,0,0,1,10.333333,3.5182813e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="11"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.521996"
+     inkscape:cx="-3.1139976"
+     inkscape:cy="9.2730245"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="114"
+     inkscape:window-y="317"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4278">
+      <rect
+         y="1037.8622"
+         x="0.5"
+         height="14.000017"
+         width="15"
+         id="rect4225"
+         style="opacity:1;fill:#d5f3ff;fill-opacity:1;stroke:url(#linearGradient4233);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1037.8622"
+         x="10.5"
+         height="14.000017"
+         width="5"
+         id="rect4225-9"
+         style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4222"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAbVJREFU
+OI2lk79rVEEQxz87b04OgqfiwXuYzkoEG0tBonJoYQoVS/8GiXj4I7FI4UXvOAQrG8HGQoiCimAh
+giAqFopwlRIEsbgLpjgIIcLbHxbv3OTMkQgZGHaZ2f3Od747a0IIbMf0zcvmthDUe0M2cWXLgz9f
+z1E5vDgUW+2MozYkAFRLWwAM1t1jR2Ns2f1AnRcAzIhLnXYKwKH6Iv1+nwogRmPeBUFsBAhD3mmn
+HL/+NeZ+LRX0xWh06xLUOh0k1ip/aqbUZr4VVTx8aWYcMLDyILBiHrH/4kMAcp+guS80EDwAHxsZ
+tRsf8G4JgBPX3m1o7dXNIxy8PF8wyG0SGbydzThVv0/4/X1TQa31JFIuGNjIIDAx2+XFTMrkVGNz
+gDxQMmWsVTT/qwHFPJ1s9Hh6NeVMfQ6AZ+1pijcKcT3WeD/QQJDcyaCFEH2y1ePJ7elCRBs43ery
+fPkc+y5doHbrMyplVMpYn6BuXQvr7eydLvNTWcxVdlWBVRKzI57JXYLGORgxSefv9uJ+z95xYGEI
+wHlBXZCRDP61sZ1VYAExazPvg2Ba9x7/12/MrVBSvyH+B44do9SyLAPnAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5113824,1048.8622 0,-1.9852 4.0858006,0 c 0.494741,0 0.902817,-0.4007 0.902817,-0.8864 l 0,-2.224 c 0,-0.4857 -0.408001,-0.8864 -0.902817,-0.8864 l -4.0858006,0 0,-2.018 -0.9373218,0 -4.0740828,4 4.0740828,4 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssscccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/copy_r_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/copy_r_co.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copy_r_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#c6e26e;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#f8fbf0;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74074234,0,0,-0.72727303,2.388888,1804.399)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74074234,0,0,-0.72727303,2.388888,1804.399)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.33333333,0,0,1,10.333333,3.5182813e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="11"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.311107"
+     inkscape:cx="-0.5"
+     inkscape:cy="8.0000088"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="114"
+     inkscape:window-y="340"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4278"
+       transform="matrix(-1,0,0,1,16,0)">
+      <rect
+         y="1037.8622"
+         x="0.5"
+         height="14.000017"
+         width="15"
+         id="rect4225"
+         style="opacity:1;fill:#d5f3ff;fill-opacity:1;stroke:url(#linearGradient4233);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1037.8622"
+         x="10.5"
+         height="14.000017"
+         width="5"
+         id="rect4225-9"
+         style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.4886176,1048.8622 0,-1.9852 -4.0858006,0 C 3.908076,1046.877 3.5,1046.4763 3.5,1045.9906 l 0,-2.224 c 0,-0.4857 0.408001,-0.8864 0.902817,-0.8864 l 4.0858006,0 0,-2.018 0.9373218,0 4.0740826,4 -4.0740826,4 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssscccccc" />
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4235"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAdZJREFU
+OI2lkz1rVEEUhp9z7tzdleAXBnZB/AOiYGMjBlmilWgRtfQn2EnwxkIU2eC6YAIBC39ChDQBwcKP
+InbamMJYiIXiXQyyKIJ678yxmLubSGAtMsUUc7nPPOe8Z8TM2M1yL57c2xXBBRP2HP/8z+H3N02O
+TM/99+f8ZRdX+gSAAxNTWwDeAzCZjgd8sgT1pgCoOFQSlITBYACAAOu9Juu9JoIhgIghEr/5oOjQ
+QMWhpKikfN3sV4DYnna2wdteK0IMFEMwyqC4IkRAInUQ4+PSVY4C+WKTfJtuO9vg+XyLE9e/RLgI
+pXdbPXBS493CFaazVztqDX4TgDOzazybb3Eyy8ECRUi2GWiD4o9hvz6MbVz72iOe3m5y+lZOUSa4
+snQApNKg+B3gx3jA6oObnO30AaOMBloZ1Jm6s8bKjVMgYFUKBszMdgBY6c5x/n4fxMCg8A4tqxKc
+NnBa51z3Nas/Zzh29xsXezm+jEksdzIu9PqoGIqhYhRecYUfplCrJI19+ycB0OpkuZNxaaEPhMoq
+7j4kOD8sQWojtYOHDldRBS4v5mDVTEi8QMwwkTgHYTSJaQQAE3ujgRio2OjGigAIguFNke7Dxzte
+Y1EqqQtj0xiuv95Et5PufASTAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/copycont_l_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/copycont_l_co.svg
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copycont_l_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4305">
+      <stop
+         style="stop-color:#a3c060;stop-opacity:1"
+         offset="0"
+         id="stop4307" />
+      <stop
+         id="stop4313"
+         offset="0.50893211"
+         style="stop-color:#93aa3c;stop-opacity:1" />
+      <stop
+         style="stop-color:#a3c060;stop-opacity:1"
+         offset="1"
+         id="stop4309" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#e0eaf7;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.74074234,0,0,-0.72727303,12.611113,1804.399)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.74074234,0,0,-0.72727303,12.611113,1804.399)" />
+    <linearGradient
+       gradientTransform="matrix(0.46666666,0,0,1,8.2666662,3.5182813e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="15.142858"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4,0,0,1,-6.2,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4305"
+       id="linearGradient4311"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75,0,0,1,3.5,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="34.523266"
+     inkscape:cx="-5.4899138"
+     inkscape:cy="9.2730245"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="95"
+     inkscape:window-y="316"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4225-9"
+       width="7"
+       height="14.000017"
+       x="8.5"
+       y="1037.8622" />
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4235"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAcBJREFU
+OI2lkstLVHEUxz/HmUCIHtbNgdqVUISrypBKYnoQJGHRIvofWoRIYRqFNIUlQRBEQdseC6FowiIb
+a4iMHrs2hbUNa8ghCGruvb+vi59eR2ycRWd1np9zfuf8TBL/I+l6CS9GBhftUBfwtxKTPXj6n7HX
+o0P1AQBO8PbDl3m+7Vs31J6gkMsIYE/fpJXLZSRo27J+JmoASBA7Wwgo5DLK9n5i7NJGAH6UJnES
+b95PYBggJGhvayFWaj7g2UCz9vV/9mPHMDqQ0SaD8StrkYyO7kKSGzoRxSls9oxPzq3R/v7xmntQ
+WOLeu5uJfWjbLV4+veEneNwX6EDPbfTna00AQPn7RKLHEpU47QGduZI9PBWo8+SF2tWNASubWxLT
+OSN06bkddF0u2XD3KnX1XATgwdAZvzIzTADi8PliAvjtHGGUoqG6ydGrP214sNePGHn70a8j7Dj7
+jXDvc/LFiHwxJF8McTIqUWrhGY9dm7K7J5qS77t8RYBzoqN9c1WWcE5E1U+oluPXp2xWb1q9DicY
+e/XRO/xXILurdW6Ji8nSZQFOYvfOVl8pD3ESUdxQHxDTyJ37I2BJrVcAsYRp/JC7omjQ1b4AAAAA
+SUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#c1c6d9;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 10,1039.8622 4,0"
+       id="path4240"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bcc2d7;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,1041.8622 4,0"
+       id="path4240-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a1b0cc;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,1049.8622 4,0"
+       id="path4240-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a7b3ce;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,1047.8622 4,0"
+       id="path4240-79"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11,1042.8802 -4.4886168,0 0,-2.018 -0.9373218,0 -4.0740828,4 4.0740828,4 0.9373218,0 0,-1.9852 4.4886168,0"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#f7f3d4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11,1042.8622 3,0"
+       id="path4240-0-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#f3f1d3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11,1046.8622 3,0"
+       id="path4240-0-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4311);stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11,1044.8622 3,0"
+       id="path4240-0-3"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/copycont_r_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/copycont_r_co.svg
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copycont_r_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4305">
+      <stop
+         style="stop-color:#a3c060;stop-opacity:1"
+         offset="0"
+         id="stop4307" />
+      <stop
+         id="stop4313"
+         offset="0.50893211"
+         style="stop-color:#93aa3c;stop-opacity:1" />
+      <stop
+         style="stop-color:#a3c060;stop-opacity:1"
+         offset="1"
+         id="stop4309" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#e0eaf7;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74074234,0,0,0.72727303,4.3818717,285.36162)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74074234,0,0,0.72727303,4.3818717,285.36162)" />
+    <linearGradient
+       gradientTransform="matrix(0.46666666,0,0,1,1.2666662,6.9888833e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="15.142858"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4,0,0,1,-13.2,3.470602e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4305"
+       id="linearGradient4311"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75,0,0,1,-4.5,3.470602e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="27.61187"
+     inkscape:cx="-7.5904597"
+     inkscape:cy="7.9991265"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="95"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4225-9"
+       width="7"
+       height="14.000017"
+       x="1.5"
+       y="1037.8622" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#c1c6d9;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1039.8622 4,0"
+       id="path4240"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bcc2d7;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1041.8622 4,0"
+       id="path4240-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a1b0cc;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1049.8622 4,0"
+       id="path4240-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a7b3ce;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1047.8622 4,0"
+       id="path4240-79"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.9929717,1046.8804 4.4885993,0 0,2.018 0.937301,0 4.0741,-4 -4.0741,-4 -0.937301,0 0,1.9852 -4.4885993,0"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#f7f3d4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1042.8622 3,0"
+       id="path4240-0-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#f3f1d3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 3,0"
+       id="path4240-0-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4311);stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3,1044.8622 3,0"
+       id="path4240-0-3"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1036.3622"
+       x="-16"
+       id="image4244"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAbhJREFU
+OI2lkk1rU0EYhZ9JbkEQvzC0C3faVenCDyrFVmtDEdyVLor+CUGUSgxYXDRQK2jBnXtBKoIQLQi2
+Ej9QsTs3Qt3bmrYhIJTcO+9xceNNQtK4cFbDvOc8c+YwThL/swKAt8vzXSkXL99yXQEA5yZudhSs
+vpr/dwIAE3xZ+9EyPHvmRFdzAvDmkGDo9PH6cZxYgkqlAsDKXJ8AsvkN1w5QGpP49HUdhwOEBMND
+/fwqbyTi8dx3Vub61AwJACKfxkyMnPSJ+ONils8lGGi6vROkDkhhgmdr9xPAlesvcD2ZlveaLwMw
+NvOB13d7dWl20wUANR/gJSqb6w21ryJf3bO87LXHvMxnFACEFmDmONzb31CEVdgt7wkoPsgzubAV
+JwijNN6MyVM3EsHzOxf425QEOJiaKcSze7eZfrjtAFIAtSiNyVF8F1IsRRRLITbxhtHZnxR/TzG9
+uO18FPe4VMgl5kaJFmAmzg8PNIUUZuLgoUaRS4UcVx/ttP+Dmg8wwer7b/Fp/BUYHx3kyNFjAG3G
+1gQ+hUmMjQzGzvqbTWL/gUwnXytgN+zhydNlcIk33gBiX1fAH1DrvYc0tqXlAAAAAElFTkSuQmCC
+
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/next_change_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/next_change_nav.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="next_change_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#e0eaf7;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.70175581,-0.72727303,0,771.0368,1038.3359)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.70175581,-0.72727303,0,771.0368,1038.3359)" />
+    <linearGradient
+       gradientTransform="matrix(0.53333331,0,0,1,7.233333,6.9888833e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="15.142858"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5999999,0,0,1,-9.2999992,3.470602e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3100874,0,0,1.1885431,-8.5365645,-8.0209)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817-9">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819-5" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="28.242019"
+     inkscape:cx="5.0956614"
+     inkscape:cy="3.2058742"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="95"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4244"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAfFJREFU OI2lkk9I03EYxj/fGUVChwyihAhLiJEV2EWTLJKsBuvWjpF0qmNLvRgZ+QeD8tBhFx0siMCEVcsx JxGIg6LoJEgQeSgHQumGh7Tt9306bM6tbV36wgtfHt73eZ/3eV8jif952yqBkWhCj2a/cav9ALVK /JPAVFJwuueZWg7t5v3XVWYGfVWLZ6dHyxVEogllrHAZw28r4jPvaG45wefA4ULOz+YY3o7jWJly grvxRe51NtAfX+RC0z7az5zk4+hBOvqWCzlvBvZizyVxrMH1d/cNx+L1tJkNx9Jav5NdtTuwDmB/ oXxYCxI4tqZUwfXnC4xfcQMw//iq+fBlWdYKK6HsWs40wFpwBI51bRHkuguvp81sYj9CTcTzRWTS YMAKHEfMDe1nO0Vr9D2dp/f8kRI/HAuenigglF0t4BdvTwEQHfHkPIhEE8o4ov/aWVNMkD46SGT4 EmRTKJtCmXxkU0SGPaSPDeXuwPgCVc9REzcId+/hsj+QH0a8eniTU31JYq+fgKSqMRYKamllXW/n FjTpr1Pm+7gm/XWamPqkpZV1jYWCqnjKWx7UYAWN7gYa3UnC9+tpvZMEwErlaywnMMhCZ28wjwxA d+4//aCrdI3VFYjYSFd+foCcXRI4lU65+Fng5YtwGb7puMHFHwW7C585bDniAAAAAElFTkSuQmCC  "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <rect
+       y="1046.3622"
+       x="6"
+       height="1.0000174"
+       width="6.0096579"
+       id="rect4009-1"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4225-9"
+       width="7.9999995"
+       height="14.000017"
+       x="7.5000005"
+       y="1037.8622" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#c1c6d9;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1039.8622 5,0"
+       id="path4240"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#286296;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1049.8622 5,0"
+       id="path4240-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a7b3ce;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1047.8622 5,0"
+       id="path4240-79"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.5180001,1039.8622 0,4.0121 -2.018,0 0,1.1282 3.9999999,3.8597 4,-3.8597 0,-1.1282 -1.9852,0 0,-4.0121 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       y="1046.3622"
+       x="0.99624252"
+       height="0.99996698"
+       width="7.0037575"
+       id="rect4009"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <path
+       style="display:inline;fill:url(#linearGradient4002-1);fill-opacity:1;stroke:#095799;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.6147942,3.8780259 6.5175781,2.0664062 1.9433594,10.431641 l 3.5,-6.3750004 2.1360265,2.8453278"
+       transform="translate(0,1036.3622)"
+       id="path4005"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/next_diff_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/next_diff_nav.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="next_diff_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbe49d;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.70175581,-0.72727303,0,771.0368,1041.3359)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.70175581,-0.72727303,0,771.0368,1041.3359)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4272605,0,0,1.2227194,-9.8528808,1031.0009)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817-9">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819-5" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4272605,0,0,1.2227194,-6.9841725,1027.9781)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4397"
+       x="-0.070083913"
+       width="1.1401678"
+       y="-0.052452898"
+       height="1.1049058">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.17419389"
+         id="feGaussianBlur4399" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#d4d4d4"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.944396"
+     inkscape:cx="1.3382484"
+     inkscape:cy="4.8250032"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="95"
+     inkscape:window-y="385"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4261"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAalJREFU
+OI2lk09IVHEQx78/C4RICBe95EHoIGKXJAQpoQ5BLCQYZOC1UxKssK5riIR4KunSZQ/hQZYsVEhc
+fLLlwUN78tIh6OJJN2jrRX8UTd97v0+H1q2Xb9migbkMM5/5zgxjAP2P1dVKyDkFLo8+I+cUIjvV
+BDxY29T51lOaWtv8dwU5p4BnUZ0xOrAoUgVwxJeWX3Ep/RTP89kqluhMZLn7+CWdiSx/5kYCLqZm
+Gc6s0JOaBaDjzgyfvu2y8/2ArWIpBDleS3bx3QflJ67r9aPWSk7LWKn6COcS2ZDsLzt7rE4287ut
+TjYRqSDnFNgPrFpON5t7A90Y970aTtTLBpLsng43aO2vmhDg1vxbTd9olyT1dp0x6xsnsRZZEP62
+JMlUA/zsjq7FL5jDmDtzVi/KRfK+SkaySEGAnPEmQoD+J2+UvtIWWmhgpfiIIwnhf67Erw4vS5Kc
++3FV7n7sZubIjQEtpmMEbh7fzeN/LLubZzEdA5ABZPozVT+Kudt6noqpN5kpD4OWHg6qb8o1kWes
+5gvJRrziNAvJxpDSvwYAmhsKFwP6AT8WnXyr6HeAAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4005-8"
+       d="m 7.7822634,1041.2321 1.6334796,-2.8768 3.825257,6.2577 -1.649114,2.3478 -3.5638289,-6.1468"
+       style="display:inline;fill:url(#linearGradient4002-1-2);fill-opacity:1;stroke:#095799;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4005"
+       d="m 1.5639845,1049.9836 4.9830505,-8.6055 5.046128,8.6055 -3.9030303,-1.9722 -2.5307833,-4.1746"
+       style="display:inline;fill:url(#linearGradient4002-1);fill-opacity:1;stroke:#095799;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="1049.3622"
+       x="0.45927238"
+       height="1.0000174"
+       width="6.5407276"
+       id="rect4009"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <path
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.99049962;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4397)"
+       d="m 8.518,1041.8622 0,4.0121 -0.984955,0 0.011702,3.9579 2.736122,-0.066 3.123477,-2.6388 0.09391,-1.2534 -0.983459,0 0,-4.0121 z"
+       id="rect3968-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       transform="matrix(1.019275,0,0,1,-0.26017935,0)" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.518,1042.8622 0,4.0121 -2.018,0 0,1.1282 4,3.8597 4,-3.8597 0,-1.1282 -1.9852,0 0,-4.0121 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/next_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/next_nav.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="next_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-7.4627612"
+     inkscape:cy="10.319471"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1044.8626 3,0 0,-5.7812 c 0,-0.6679 0.5509,-1.2188 1.2188,-1.2188 l 2.5625,0 c 0.6678,0 1.2187,0.5508 1.2187,1.2188 l 0,5.7812 3,0 0,1 -5.5,5.5 -5.5,-5.5 0,-1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/next_nav_into.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/next_nav_into.svg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="stepinto_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7255">
+      <stop
+         style="stop-color:#c28a1d;stop-opacity:1;"
+         offset="0"
+         id="stop7257" />
+      <stop
+         style="stop-color:#c28a1d;stop-opacity:0;"
+         offset="1"
+         id="stop7259" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7084"
+       inkscape:collect="always">
+      <stop
+         id="stop7086"
+         offset="0"
+         style="stop-color:#fefaef;stop-opacity:1" />
+      <stop
+         id="stop7088"
+         offset="1"
+         style="stop-color:#fce5a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7076">
+      <stop
+         style="stop-color:#956413;stop-opacity:1"
+         offset="0"
+         id="stop7078" />
+      <stop
+         style="stop-color:#c38b1d;stop-opacity:1"
+         offset="1"
+         id="stop7080" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7029">
+      <stop
+         style="stop-color:#3a435f;stop-opacity:1;"
+         offset="0"
+         id="stop7031" />
+      <stop
+         style="stop-color:#5689b4;stop-opacity:1"
+         offset="1"
+         id="stop7033" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7029"
+       id="radialGradient7035"
+       cx="2"
+       cy="16"
+       fx="2"
+       fy="16"
+       r="2"
+       gradientTransform="matrix(2,0,0,1.5,-1,1026.3622)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7029-1">
+      <stop
+         style="stop-color:#3a435f;stop-opacity:1;"
+         offset="0"
+         id="stop7031-3" />
+      <stop
+         style="stop-color:#5689b4;stop-opacity:1"
+         offset="1"
+         id="stop7033-1" />
+    </linearGradient>
+    <radialGradient
+       r="2"
+       fy="16"
+       fx="2"
+       cy="16"
+       cx="2"
+       gradientTransform="matrix(2,0,0,1.5,10,1026.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7055"
+       xlink:href="#linearGradient7029-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7084"
+       id="linearGradient7074"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.58432111,0.58432111,0,-601.73696,1040.3056)"
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7076"
+       id="linearGradient7082"
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19,-0.93755)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7255"
+       id="linearGradient7263"
+       x1="27.4375"
+       y1="1049.0347"
+       x2="27.4375"
+       y2="1046.4401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19,-0.93755)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254837"
+     inkscape:cx="9.3949068"
+     inkscape:cy="8.8503656"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="1367"
+     inkscape:window-y="418"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#radialGradient7035);fill-opacity:1;stroke:none"
+       d="m 2,1048.3622 c -0.554,0 -1.00000003,0.446 -1.00000003,1 l 0,1 4.00000003,0 0,-1 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 z"
+       id="rect6259"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient7055);fill-opacity:1;stroke:none;display:inline"
+       d="m 13,1048.3622 c -0.554,0 -1,0.446 -1,1 l 0,1 4,0 0,-1 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 z"
+       id="rect6259-5" />
+    <path
+       style="fill:url(#linearGradient7074);fill-opacity:1;stroke:url(#linearGradient7082);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 7.953125,1039.8626 -5.703125,0 c -0.39031,0 -0.71875,0.2972 -0.71875,0.6875 l 0,0.5312 c 0,0.3903 0.32845,0.7188 0.71875,0.7188 l 5.28125,0 0,3.0625 -2.25,0 0,1 3.21875,3.2188 3.21875,-3.2188 0,-1 -2.21875,0 0,-3.4687 c 0,-0.9367 -0.439519,-1.5313 -1.546875,-1.5313 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscccccccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.5;color:#000000;fill:url(#linearGradient7263);fill-opacity:1;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 7.8124999,1042.3001 0,2.5625 a 0.29218979,0.29218979 0 0 1 -0.03125,0.125 0.29218979,0.29218979 0 0 1 -0.0625,0.094 0.29218979,0.29218979 0 0 1 -0.0625,0.031 0.29218979,0.29218979 0 0 1 -0.125,0.031 l -1.96875,0 0,0.5625 2.9375,2.9375 2.9375001,-2.9375 0,-0.5625 -1.9375001,0 a 0.29218979,0.29218979 0 0 1 -0.0625,0 0.29218979,0.29218979 0 0 1 -0.15625,-0.094 0.29218979,0.29218979 0 0 1 -0.03125,-0.062 0.29218979,0.29218979 0 0 1 -0.03125,-0.094 0.29218979,0.29218979 0 0 1 0,-0.031 l 0,-2.5625 -0.46875,0 0,2.5625 a 0.750075,0.750075 0 0 0 0.75,0.75 l 1.4062501,0 -2.4062501,2.4063 -2.40625,-2.4063 1.4375,0 a 0.750075,0.750075 0 0 0 0.75,-0.75 l 0,-2.5625 -0.46875,0 z"
+       id="rect3968-7"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_change_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_change_nav.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="prev_change_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4270">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4272" />
+      <stop
+         style="stop-color:#e0eaf7;stop-opacity:1"
+         offset="1"
+         id="stop4274" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.70175581,-0.72727303,0,765.0368,1051.3885)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.70175581,-0.72727303,0,765.0368,1051.3885)" />
+    <linearGradient
+       gradientTransform="matrix(0.53333331,0,0,1,1.2333328,5.2535823e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4233-0"
+       x1="2"
+       y1="1052.3622"
+       x2="2"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4270"
+       id="linearGradient4276"
+       x1="15.142858"
+       y1="1038.3622"
+       x2="15"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5999999,0,0,1,-15.299999,1.735301e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3100874,0,0,1.1885431,-4.6039502,-4.0494)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817-9">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819-5" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="60.424242"
+     inkscape:cx="2.5900791"
+     inkscape:cy="8.0000088"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:url(#linearGradient4233-0);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4225-9"
+       width="7.9999995"
+       height="14.000017"
+       x="1.5"
+       y="1037.8622" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#c1c6d9;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1049.8622 5,0"
+       id="path4240"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#286296;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1039.8622 5,0"
+       id="path4240-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a7b3ce;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.0000004,1047.8622 5,0"
+       id="path4240-79"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="1050.3622"
+       x="9.9903421"
+       height="1.0000174"
+       width="6.0096579"
+       id="rect4009-1"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <rect
+       y="1050.3622"
+       x="6.9962425"
+       height="0.99996698"
+       width="7.0037575"
+       id="rect4009"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4293"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAftJREFU OI2lkk9IlFEUxX/v+xQXEQTZoiGilZtWRWQgDJRWYBqGFLiOhAgKF6WWi1aiYxBFZJS7SA1qk1qE RVJoWFAgMUYFhdLfxSg2Bc58754Ww0zEOLXowlk8eO+c8+45ThL/M2UAD8cS/2Sp3XfKlSQwBcT3 tpV8/Pj++b87MAMJthy9WnTh5ZVWTCuK/+lAEi/6WwF42hdjx8mPOBxmwltpggAgsgATTD9/y2Rv jF1nvjKViHHv0SsM8OXV7OwY1sjdyaJdBQDeQkyQfRCn9vR7ZD+p7fzA6uk9mEFiYo5tm9bQNzFX ykHIVM966jpmwC9BlENd+wxTPTGeJFoInCNjosiFJMa6KmXfk7J0Uj6dlE/Pyqfz51mNda2TJHVe G9fWE9cliTzKAHwkRrvjOIn69jtATmS0t6kg9GM5Sxg6ln3ORWN9jSt8IbW5l+r2T3gDZVOQTUG0 gHnR0P2N3WfnWVVRztCzeQ5u30DbyLviFLyERYLsAsouokwq1w8cN24OAbhlL8rCkExkhV0UUpDA C/BLKMrBmyEJbyEAl5uquDD+hmN1VRy+9fp3kbw5TKKyeZLb52rACQQNPV/4vJDBWwBAY32Nywwn FYZBwYWTxKWBQe0/0JzbnYONaysAcIf6SzYwP04SFwcGxQp9zwfugONHWlbs8y+xECfK/730wwAA AABJRU5ErkJggg== "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;fill:url(#linearGradient4002-1);fill-opacity:1;stroke:#095799;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 10.449219,6.0371094 C 9.6127446,7.5097762 10.555667,5.6429288 9.5920985,7.6506081 l 3.2872035,6.8426089 1.812104,0.01655 z"
+       transform="translate(0,1036.3622)"
+       id="path4005"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.5180001,1049.8622 0,-4.0121 -2.018,0 0,-1.1282 3.9999999,-3.8597 4,3.8597 0,1.1282 -1.9852,0 0,4.0121 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_diff_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_diff_nav.svg
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="prev_diff_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbe49d;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.70175581,-0.72727303,0,765.0368,1048.3885)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="14.287449"
+       y1="1043.6752"
+       x2="2.8874717"
+       y2="1042.3002"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.70175581,-0.72727303,0,765.0368,1048.3885)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4397"
+       x="-0.070083913"
+       width="1.1401678"
+       y="-0.052452898"
+       height="1.1049058">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.17419389"
+         id="feGaussianBlur4399" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3073974,0,0,1.2539923,-7.446125,1032.3853)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817-9">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819-5" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3073974,0,0,1.2539923,-4.4434433,1029.3853)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#d4d4d4"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="49.9375"
+     inkscape:cx="-1.4860848"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2377"
+     inkscape:window-height="1064"
+     inkscape:window-x="95"
+     inkscape:window-y="408"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4005-6"
+       d="m 9.3015807,1042.4987 1.2776063,-2.4709 4.622347,8.8257 -2.62896,0 -3.2645328,-6.3041"
+       style="display:inline;fill:url(#linearGradient4002-1-1);fill-opacity:1;stroke:#095799;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="1048.3622"
+       x="12"
+       height="1.0000174"
+       width="3.9999995"
+       id="rect4009-1-5"
+       style="display:inline;fill:#095799;fill-opacity:1;stroke:none" />
+    <g
+       id="g4550">
+      <path
+         style="display:inline;fill:url(#linearGradient4002-1);fill-opacity:1;stroke:#095799;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.011937,1051.8535 4.5645678,-8.8257 4.6223472,8.8257 -2.6289598,0 -3.2645334,-6.3041"
+         id="path4005"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="display:inline;fill:#095799;fill-opacity:1;stroke:none"
+         id="rect4009"
+         width="5.9914289"
+         height="1.0000174"
+         x="2.0085716"
+         y="1051.3622" />
+      <rect
+         style="display:inline;fill:#095799;fill-opacity:1;stroke:none"
+         id="rect4009-1"
+         width="5.9973178"
+         height="1.0000174"
+         x="7"
+         y="1051.3622" />
+    </g>
+    <image
+       y="1036.3622"
+       x="-19"
+       id="image4499"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAf1JREFU OI2lk0toU0EUhr/pzcKVG5t0I6gr60pQqGB9FLtQghUFHyAodelKpC3xUfryVUHXFVQUQavdSJMm qUYUIQEpKMVFqyBEKFhBqY+GkNed30VMyG1UCh44iznM/Oebf84YSfxPNPyp+PxS0/JVJXkyMRSQ JCUu+FWphaNJtYVGFY4mtXS/hyAxGFD7uTSyWdrPfiQx1CTg3zQVpcm+RtncvGz+d+bmZXOfFe/z S5K6R+La3vOgjgJJRHsbZRdnZDMzcjMzcjOzcjOV9ayivWWRLV336wR8AG5JTFzegZEIhsJV6omr +6uk2XyRXc0BBp6mAdQRbDVAWaDjylcDMB5qlIoLGATGYF2xd/gLToMh9jqN4xjyrtcSj4m2JCh+ Q8XvqLCAtbCYLRCJpQhuXmdGp+Y41LKa05EPRGIp1Qm4AtyfqFRO11pAFWzyrvA5DoWSrZ4xSydx 7NQqYQSCbf1zjIy/4vGbT0ye2Q3Apt4wXXs2cP3JO24fbC57UBst59OsDawE4N7L94xOzXFs6xra LsZ5NniAgiscp6FK4blCJJbSxu5HAAYwx3euN7XYvmKO6WtH6Bmb5keuxL67b72jvOLoDfXfeeF5 53A0KX/nTQ0/TMp/4tbfRzkSS6noioHONlNL1RFsNbXYFffrTDSHR5b9AzV2strkFzkweuCRmx1g AAAAAElFTkSuQmCC "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.93360454;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4397)"
+       d="m 8.518,1041.8622 0,4.0121 -0.984955,0 0.7487999,2.6786 5.1624031,-0.066 0.789333,-0.692 0.0632,-2.3381 -1.689845,0 -0.09214,-3.5949 z"
+       id="rect3968-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       transform="matrix(1.019275,0,0,-1.1255965,-4.1845584,2220.6077)" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.518,1046.8622 0,-4.0121 -2.018,0 0,-1.1282 4,-3.8597 4,3.8597 0,1.1282 -1.9852,0 0,4.0121 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_nav.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_nav.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prev_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-4.5683281"
+     inkscape:cy="9.6786205"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1043.8618 3,0 0,5.7812 c 0,0.6679 0.5509,1.2188 1.2188,1.2188 l 2.5625,0 c 0.6678,0 1.2187,-0.5508 1.2187,-1.2188 l 0,-5.7812 3,0 0,-1 -5.5,-5.5 -5.5,5.5 0,1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_nav_into.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/prev_nav_into.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="prev_nav_into.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7084"
+       inkscape:collect="always">
+      <stop
+         id="stop7086"
+         offset="0"
+         style="stop-color:#fefaef;stop-opacity:1" />
+      <stop
+         id="stop7088"
+         offset="1"
+         style="stop-color:#fce5a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7076">
+      <stop
+         style="stop-color:#956413;stop-opacity:1"
+         offset="0"
+         id="stop7078" />
+      <stop
+         style="stop-color:#c38b1d;stop-opacity:1"
+         offset="1"
+         id="stop7080" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7029">
+      <stop
+         style="stop-color:#3a435f;stop-opacity:1;"
+         offset="0"
+         id="stop7031" />
+      <stop
+         style="stop-color:#5689b4;stop-opacity:1"
+         offset="1"
+         id="stop7033" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7029"
+       id="radialGradient7035"
+       cx="2"
+       cy="16"
+       fx="2"
+       fy="16"
+       r="2"
+       gradientTransform="matrix(-2,0,0,-1.5,17,1062.3622)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7029-1">
+      <stop
+         style="stop-color:#3a435f;stop-opacity:1;"
+         offset="0"
+         id="stop7031-3" />
+      <stop
+         style="stop-color:#5689b4;stop-opacity:1"
+         offset="1"
+         id="stop7033-1" />
+    </linearGradient>
+    <radialGradient
+       r="2"
+       fy="16"
+       fx="2"
+       cy="16"
+       cx="2"
+       gradientTransform="matrix(-2,0,0,-1.5,6,1062.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7055"
+       xlink:href="#linearGradient7029-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7084"
+       id="linearGradient7074"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.58432111,-0.58432111,0,617.71444,1048.4602)"
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7076"
+       id="linearGradient7082"
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,-1,34.977476,2089.7034)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="69.332706"
+     inkscape:cx="6.1338905"
+     inkscape:cy="7.4008148"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2431"
+     inkscape:window-height="998"
+     inkscape:window-x="71"
+     inkscape:window-y="342"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:url(#radialGradient7055);fill-opacity:1;stroke:none"
+       d="m 3,1040.3622 c 0.554,0 1,-0.446 1,-1 l 0,-1 -4.00000003,0 0,1 c 0,0.554 0.44600003,1 1.00000003,1 l 2,0 z"
+       id="rect6259-5" />
+    <path
+       style="fill:url(#radialGradient7035);fill-opacity:1;stroke:none"
+       d="m 14,1040.3622 c 0.554,0 1,-0.446 1,-1 l 0,-1 -4,0 0,1 c 0,0.554 0.446,1 1,1 l 2,0 z"
+       id="rect6259"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient7074);fill-opacity:1;stroke:url(#linearGradient7082);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.0543496,1048.8542 5.7031254,0 c 0.39031,0 0.708954,-0.2974 0.71875,-0.6875 l 0.01442,-0.5745 c 0.0098,-0.3902 -0.32845,-0.7188 -0.71875,-0.7188 l -5.2812502,0 0.013271,-3.0135 2.0480756,-0.014 0,-0.9567 -3.0745184,-3.0457 -2.9879787,3.0601 0,0.9567 1.9879787,0 0.029999,3.362 c 0,0.9367 0.439519,1.6323 1.546875,1.6323 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssccccccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/smartmode_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/smartmode_co.svg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="smartmode_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894">
+      <stop
+         style="stop-color:#e9a328;stop-opacity:1"
+         offset="0"
+         id="stop5896" />
+      <stop
+         style="stop-color:#f9c537;stop-opacity:1"
+         offset="1"
+         id="stop5898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5992">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop5994" />
+      <stop
+         id="stop6002"
+         offset="0.38312635"
+         style="stop-color:#fdfbeb;stop-opacity:1" />
+      <stop
+         id="stop6000"
+         offset="0.59470785"
+         style="stop-color:#f8eb99;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe4b1;stop-opacity:1"
+         offset="1"
+         id="stop5996" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5933">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5935" />
+      <stop
+         style="stop-color:#abb6c2;stop-opacity:1"
+         offset="1"
+         id="stop5937" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5925">
+      <stop
+         style="stop-color:#9eacbc;stop-opacity:1;"
+         offset="0"
+         id="stop5927" />
+      <stop
+         style="stop-color:#667480;stop-opacity:1"
+         offset="1"
+         id="stop5929" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5925"
+       id="linearGradient5931"
+       x1="26.384804"
+       y1="1047.3513"
+       x2="28.898684"
+       y2="1051.0419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5933"
+       id="linearGradient5939"
+       x1="27.739658"
+       y1="1048.96"
+       x2="28.339197"
+       y2="1050.1135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5992"
+       id="radialGradient5998"
+       cx="28.6875"
+       cy="1046.2943"
+       fx="28.6875"
+       fy="1046.2943"
+       r="4.5"
+       gradientTransform="matrix(1.4312189,0,0,1.9064579,-32.370592,-947.65067)"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       id="filter6048"
+       x="-0.2704695"
+       width="1.540939"
+       y="-0.21570046"
+       height="1.4314009">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.901565"
+         id="feGaussianBlur6050" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5894"
+       id="linearGradient5900"
+       x1="3.2902069"
+       y1="1038.3929"
+       x2="3.2902069"
+       y2="1046.9003"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-0.74545946"
+     inkscape:cy="24.761997"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="250"
+     inkscape:window-y="180"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:none;stroke:#edaa2b;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter6048)"
+       d="m 8.5,1037.8622 c -2.207266,0 -4,1.7927 -4,4 0,2.5493 2.007905,1.3816 2.03125,4.0313 l 3.9375,0 c 0,-2.5279 2.03125,-1.4244 2.03125,-4.0313 0,-2.2073 -1.792734,-4 -4,-4 z"
+       id="path5108-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <path
+       style="fill:url(#radialGradient5998);fill-opacity:1;stroke:url(#linearGradient5900);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 8.5,1037.8622 c -2.207266,0 -4,1.7927 -4,4 0,2.5493 2.007905,3.3816 2.03125,6.0313 l 3.9375,0 c 0,-2.5279 2.03125,-3.4244 2.03125,-6.0313 0,-2.2073 -1.792734,-4 -4,-4 z"
+       id="path5108"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <rect
+       style="fill:#4a607a;fill-opacity:1;stroke:#4a607a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="rect5896-7"
+       width="2.03125"
+       height="3.4375"
+       x="7.46875"
+       y="1048.4247" />
+    <rect
+       style="fill:url(#linearGradient5939);fill-opacity:1;stroke:url(#linearGradient5931);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect5896"
+       width="3.9375"
+       height="3"
+       x="6.53125"
+       y="1047.8622" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/switch.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/switch.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="switch.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4738"
+       id="linearGradient4744"
+       x1="-13.936629"
+       y1="1049.9579"
+       x2="-13.936629"
+       y2="1040.053"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,0)" />
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         style="stop-color:#8cc861;stop-opacity:1"
+         offset="0"
+         id="stop4740" />
+      <stop
+         id="stop4746"
+         offset="0.43753415"
+         style="stop-color:#4aa766;stop-opacity:1" />
+      <stop
+         style="stop-color:#c2dd97;stop-opacity:1"
+         offset="1"
+         id="stop4742" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.314993,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#30825a;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#106643;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e1e1e1"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.728212"
+     inkscape:cx="7.9978214"
+     inkscape:cy="7.48655"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2174"
+     inkscape:window-height="1053"
+     inkscape:window-x="287"
+     inkscape:window-y="390"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="-17"
+       id="image4243"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAALHRFWHRDcmVhdGlvbiBUaW1lAFN1
+biAxMCBKdWwgMjAxNiAxODo0Mjo1OSAtMDgwMCa8JpgAAAAHdElNRQfgBwsEKymMeifqAAAACXBI
+WXMAAB7CAAAewgFu0HU+AAAABGdBTUEAALGPC/xhBQAAAYVJREFUeNpjYMAHQqa9YyAAmBiCp2YQ
+UoQVQPUxMTAyTGUInpJKmmagepA+kAHsbCxMMqK804GCScRpnpbEz80+nYWZiQlsAAcrM8PeOj9m
+KRGeWUDJeAKa4/m4WWalOygzszAzQsMACNQkBRj2AQ2REOKaA/RbDA4/x/ByscxJt1dhFuXlQApE
+KFCXEgQZwiIuyDWfIWhyFIrm0GlRvJys89MdVFjE+DhQpJiQOZoyggwLsp1YGJiYFjD4TlGBaAbS
+//8vCDOTYxFH04xhwOO3Xxhy5h7+z/CPoZRhc84dsOBqIA3kbzj35P+Hb79wG/D03RcGp8aN/+8+
+e1/CsC57IooqIP/tp58lMw/c+f8RzRCwAc/efQVq3vT/ztMP5QzrcvuwBuK67L43H3+Uzzxw9//H
+778RBvz685fBuXnT/1vP31cxrMvpxhuNQPnXX35WzQK65M+//xADvv/88//G0/e1QL92MBADVmd1
+vPr8o/YPzASG0Kl1OBXjy0z49BFlALUAACOvkwn1BZucAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16.000017"
+       width="16" />
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#0f5f9c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 0.5,1037.8622 0,2.4266 0,5.9834 0,3.59 0.4545197,0 4.3391572,-5.4177 c 0.2691984,-0.4483 0.2809509,-0.7538 0,-1.1967 l -4.1483294,-5.3856 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="display:inline;fill:#8babc6;fill-opacity:1;stroke:#0f5f9c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.5,1037.8622 0,2.4266 0,5.9834 0,3.59 -0.45452,0 -4.339157,-5.4177 c -0.269198,-0.4483 -0.280951,-0.7538 0,-1.1967 l 4.14833,-5.3856 z"
+       id="rect3968-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#0f5f9c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.5,1036.3622 0,15"
+       id="path4261"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/syncpane_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/syncpane_co.svg
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="syncpane_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4401"
+       inkscape:collect="always">
+      <stop
+         id="stop4403"
+         offset="0"
+         style="stop-color:#9ebe4f;stop-opacity:1" />
+      <stop
+         id="stop4405"
+         offset="1"
+         style="stop-color:#b3ca78;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4309"
+       inkscape:collect="always">
+      <stop
+         id="stop4311"
+         offset="0"
+         style="stop-color:#d5f3ff;stop-opacity:1" />
+      <stop
+         id="stop4313"
+         offset="1"
+         style="stop-color:#fafcf4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4452"
+       inkscape:collect="always">
+      <stop
+         id="stop4454"
+         offset="0"
+         style="stop-color:#d5f3ff;stop-opacity:1" />
+      <stop
+         id="stop4456"
+         offset="1"
+         style="stop-color:#edfaff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4288">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4290" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4292" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294"
+       x1="688.31909"
+       y1="317.17447"
+       x2="688.31909"
+       y2="274.16879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000022,0,0,1,303.84158,-5.9194102e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4309"
+       id="linearGradient4339"
+       x1="668.60822"
+       y1="281.33643"
+       x2="711.61389"
+       y2="313.59067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000022,0,0,1,303.84158,-5.9194102e-6)" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.28571392,-53.757419,189.43528)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4452"
+       id="linearGradient4339-9-9"
+       x1="668.6084"
+       y1="271.48096"
+       x2="697.27887"
+       y2="296.56763"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.28571392,-53.757419,189.43528)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294-4-9"
+       x1="688.31946"
+       y1="447.08771"
+       x2="688.31946"
+       y2="258.93768"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4309"
+       id="linearGradient4339-8"
+       x1="668.60834"
+       y1="281.33643"
+       x2="711.61395"
+       y2="313.59067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000023,0,0,1,278.75489,-1.7801679e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294-9"
+       x1="688.31909"
+       y1="317.17447"
+       x2="688.31909"
+       y2="274.16879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000023,0,0,1,278.75489,-1.7801679e-5)" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.14285704,-53.757514,255.9927)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4401"
+       id="linearGradient4294-4-9-0"
+       x1="688.31958"
+       y1="327.92599"
+       x2="688.31958"
+       y2="252.66603"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.564698"
+     inkscape:cx="5.4093113"
+     inkscape:cy="6.0682947"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8667"
+     showgrid="true"
+     inkscape:window-width="2341"
+     inkscape:window-height="1019"
+     inkscape:window-x="65"
+     inkscape:window-y="345"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3032" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8667"
+       transform="matrix(0.27903303,0,0,0.27903303,-169.06377,963.86005)">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-8);fill-opacity:1;stroke:url(#linearGradient4294-9);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-1"
+         width="25.086636"
+         height="50.173267"
+         x="611.26733"
+         y="265.20929" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient4339);fill-opacity:1;stroke:url(#linearGradient4294);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286"
+         width="25.086636"
+         height="50.173267"
+         x="636.35394"
+         y="265.20929" />
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-9-9);fill-opacity:1;stroke:url(#linearGradient4294-4-9);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-9-4"
+         width="50.173248"
+         height="14.335201"
+         x="611.26733"
+         y="265.20929" />
+      <image
+         y="259.83359"
+         x="544.96692"
+         id="image4273"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAXFJREFU
+OI2lkr1KA1EQhb/JrmhhZWVpEbUVQauY1sa/ImBjrQQlpZBHUCtR0crGP4QIimI0iIgPkYDgxkqE
+PEHM7o7FvesmmgjqbW5xZr6559wRVeU/xwV4KK79meIChCr0p1d/3fz2uBEBEgD0df0O8BqKAfiB
+A0CvC0RmxN4/mPNDxwLCBN7dJlUURUyTKKggAopakDSBFSRhAI3AYXhype2Up9tthjpqWwYQBCaD
+8vVu/GKBiZksDWuvnfZp4T1wAUjPZb9NaYQGnp7NxtmouRuBG2XgUK3k8eIBYCLA95N45TyetIIF
+ePeTUQYuI8kUV4eZlqKphQI3lRqjgykuv2jTCwWKlRqiquztH2j3QAEQJPoJO6b+kqFnoACAqiLW
+gwrUq5nIgkt6/KJt0vfPJ4yPnXfQjuM9ACgdnbYULC/OUwp+0qJFskW5xfnWlDSG55as1rSZvjom
+g/WdMwVBRe0Cmm7zGzYVaepVu5GqfABY96MP3Q7DeQAAAABJRU5ErkJggg==
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="57.340881"
+         width="57.340881" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#aaa996;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 616.64302,286.71211 14.33522,0"
+         id="path4315"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;opacity:1;fill:#e5eeb4;fill-opacity:1;stroke:url(#linearGradient4294-4-9-0);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 613.05921,293.87973 46.58947,0 m 0,7.1676 -46.58947,0"
+         id="rect4286-9-4-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#e5eeb4;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 613.05921,297.46353 21.50283,0"
+         id="path4315-1-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#989208;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 616.64302,297.46353 14.33522,0"
+         id="path4315-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#8f98a8;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 616.64302,308.21495 14.33522,0"
+         id="path4315-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#e5eeb4;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 638.14585,297.46353 21.50283,0"
+         id="path4315-1-5-2"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#aaa996;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 641.72965,286.71211 14.33522,0"
+         id="path4315-4"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#989208;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 641.72965,297.46353 14.33522,0"
+         id="path4315-1-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#8f98a8;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 641.72965,308.21495 14.33522,0"
+         id="path4315-6-3"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-20.000002,2.6171874e-6)"
+       style="stroke:#694337;stroke-opacity:1;display:inline"
+       id="g11029" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/twowaycompare_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/twowaycompare_co.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="twowaycompare_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4309"
+       inkscape:collect="always">
+      <stop
+         id="stop4311"
+         offset="0"
+         style="stop-color:#d5f3ff;stop-opacity:1" />
+      <stop
+         id="stop4313"
+         offset="1"
+         style="stop-color:#fafcf4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4288">
+      <stop
+         style="stop-color:#8a97ac;stop-opacity:1"
+         offset="0"
+         id="stop4290" />
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="1"
+         id="stop4292" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294"
+       x1="688.31909"
+       y1="317.17447"
+       x2="688.31909"
+       y2="274.16879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000022,0,0,0.50000008,303.84158,157.69125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4309"
+       id="linearGradient4339"
+       x1="668.60822"
+       y1="281.33643"
+       x2="711.61389"
+       y2="313.59067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000022,0,0,0.50000008,303.84158,157.69125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4309"
+       id="linearGradient4339-8"
+       x1="668.60834"
+       y1="281.33643"
+       x2="711.61395"
+       y2="313.59067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000023,0,0,0.50000008,278.75489,157.69124)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4288"
+       id="linearGradient4294-9"
+       x1="688.31909"
+       y1="317.17447"
+       x2="688.31909"
+       y2="274.16879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000023,0,0,0.50000008,278.75489,157.69124)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.1237409,0,0,-1.9548044,643.12335,2313.9017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.1237409,0,0,-1.9548044,643.12335,2313.9017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755-2"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1237409,0,0,-1.9548044,629.58458,2313.9017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747-8"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1237409,0,0,-1.9548044,629.58458,2313.9017)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="27.63777"
+     inkscape:cx="3.3107339"
+     inkscape:cy="6.0682947"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8667"
+     showgrid="true"
+     inkscape:window-width="2341"
+     inkscape:window-height="1019"
+     inkscape:window-x="65"
+     inkscape:window-y="368"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3032" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8667"
+       transform="matrix(0.27903303,0,0,0.27903303,-169.06377,963.86005)">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient4339-8);fill-opacity:1;stroke:url(#linearGradient4294-9);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286-1"
+         width="25.086636"
+         height="25.086637"
+         x="611.26733"
+         y="290.29593" />
+      <rect
+         style="opacity:1;fill:url(#linearGradient4339);fill-opacity:1;stroke:url(#linearGradient4294);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4286"
+         width="25.086636"
+         height="25.086637"
+         x="636.35394"
+         y="290.29593" />
+      <image
+         y="259.83359"
+         x="548.55072"
+         id="image4247"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAUVJREFU
+OI2dkr1KA0EUhb9ZN7E1iAn4MhJBsQpY+g5CQBIhqEgKC03QRrCzFYMgRDAQQeJjxMYuoCCW/mTx
+WMzsZvO3qBeGu8w58+3MvddIIh73BzkBLO88G0ZikuaNGvKV7ui5ochXuhEIwA8/2tWsVvYeAQgC
+cVfNSsZgwhsaQANIu5rV6v6LMZK43V3Q2naTyGlkswQmlhFoQGodFTBhDa7L8yps1QG4OSk5r3Es
+65Eg9DSPS6zXXg2SonVZzCjonatRnFN8P1yNSM9EuhntwsVmRgAbp29jXZikjQH+Gj5Ap3X4b4oP
+EHx7LC6VJxp6D7XpWqduAZ/9FAC5WWyHXKcM8JSkBb4FfDiThzPEcrKWtoD3fhqAmbjJVSVZSznA
+lzV5np0Z4QbwF5ofXiX+FzF4Z6IWpO0c1M+uQnZUp+GYrv0APjfG9pTo1OoAAAAASUVORK5CYII=
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="57.340881"
+         width="57.340881" />
+      <path
+         style="display:inline;fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 625.63516,283.12831 0,-7.02164 11.71417,0 c 1.41845,0 2.58842,-1.07703 2.58842,-2.38252 l 0,-2.60635 c 0,-1.30549 -1.16976,-2.38251 -2.58842,-2.38251 l -11.71417,0 0,-7.10981 -2.68734,0 -11.68058,10.75142 11.68058,10.75141 z"
+         id="rect3968"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsssscccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient4755-2);fill-opacity:1;stroke:url(#linearGradient4747-8);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 635.35858,268.73529 11.71417,0 0,-7.10981 2.68734,0 11.68058,10.75142 -11.68058,10.75141 -2.68734,0 0,-7.02164 -11.71417,0"
+         id="rect3968-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+    <g
+       transform="translate(-20.000002,2.6171874e-6)"
+       style="stroke:#694337;stroke-opacity:1;display:inline"
+       id="g11029" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/view_menu.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/view_menu.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="view_menu.svg"
+   inkscape:export-filename="C:\Users\jongw\Desktop\view_menu@2x.png"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#b8b8b8"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.968673"
+     inkscape:cx="7.7830763"
+     inkscape:cy="5.9552658"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:window-width="1707"
+     inkscape:window-height="907"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="false"
+     objecttolerance="10000"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,13"
+       orientation="0,4"
+       id="guide817"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:title></dc:title>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Remain BV, W.S. Jongman</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Eclipse Foundation</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <cc:license
+           rdf:resource="https://www.eclipse.org/legal/epl-2.0/" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790"
+       cx="10.499991"
+       cy="1040.8622"
+       r="1.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4"
+       cx="10.499983"
+       cy="1044.8622"
+       r="1.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4-7"
+       cx="10.499983"
+       cy="1048.8622"
+       r="1.5" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/etool16/conflict_edit.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/etool16/conflict_edit.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conflict_edit.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ef8281;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4352"
+         offset="0.49014422"
+         style="stop-color:#e53041;stop-opacity:1" />
+      <stop
+         style="stop-color:#df3f3f;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#bb1320;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#c25749;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23"
+       y1="1047.3622"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-16.808802,165.69218)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-16.808802,165.69218)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="28.785616"
+     inkscape:cx="11.405516"
+     inkscape:cy="1.9999694"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="270"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.7534647,1044.8505 3.7645781,-3.373 0,0.3847 4.9599182,0 0,-0.3847 3.772346,3.373 -3.733882,3.3729 -4e-5,-0.3687 -4.9599178,0 -0.00356,0.4078 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4252"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAARtJREFU
+OI3Nk81LAlEUxc+byE2jIYGDMFGaYBYkpbsis6KgVcv+y9Z9oGW1k8JFqZRJZMi4kXRqYTSnxaDx
+ehMULurA3Ry4hx/nvStIYhhpQ23/34CzvR2lGC8PAMTXEgu7W1xIraB0eS75ySXXy+wfim8DTrez
+nE8sumjdjhTg+AMAgOvyFTIHeaEEnKwuczY46UWpqNJ+xFrhQgwC8uk0I7oO37MGTR+D8/IKePyP
+kbCB96aF3riDum0jWyyKAUFuLsloKAjdH3LR3nrSMkd9AAC728J9q431m9InQV+5SILRKQMBw/RE
+71gN1B4sbNTLagd9HYdjjMVN1KoNyZ+Jm7irPmGzeSu9AkgqczQxzZ94JFWC3+rvb+EDCembc3wG
+vZUAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/etool16/ignorews_edit.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/etool16/ignorews_edit.svg
@@ -1,0 +1,463 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="ignorews_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4259">
+      <stop
+         style="stop-color:#cfedfb;stop-opacity:1"
+         offset="0"
+         id="stop4261" />
+      <stop
+         style="stop-color:#fbfcfe;stop-opacity:1"
+         offset="1"
+         id="stop4263" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#a2b3cf;stop-opacity:1" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#869abe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#8391b1;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#9aaccb;stop-opacity:1" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#869abe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#acbcd5;stop-opacity:1"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#869abe;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24867587,0,0,1,1.2645654,-1.9999803)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71399769,0,0,1,3.9969828,-3.9895869)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,-3.0091529)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9835338,-3.9895869)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,-3.0091529)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4002158,0,0,1,-6.2071487,-0.98960427)" />
+    <linearGradient
+       id="linearGradient4852-7-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#606060;stop-opacity:1" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#787878;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-5"
+       id="linearGradient4869-6"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,-3.0091529)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-5">
+      <stop
+         style="stop-color:#acbcd5;stop-opacity:1"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#869abe;stop-opacity:1"
+         offset="1"
+         id="stop4865-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       gradientTransform="matrix(0.71500578,0,0,1,-2.010081,-0.98958297)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066"
+       xlink:href="#linearGradient4861-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       gradientTransform="translate(-2,-1.0091316)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066-1"
+       xlink:href="#linearGradient4861-5-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-5-1">
+      <stop
+         style="stop-color:#acbcd5;stop-opacity:1"
+         offset="0"
+         id="stop4863-1-6" />
+      <stop
+         style="stop-color:#869abe;stop-opacity:1"
+         offset="1"
+         id="stop4865-2-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4259"
+       id="linearGradient4265"
+       x1="2"
+       y1="1038.3622"
+       x2="13"
+       y2="1047.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-0"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24867587,0,0,1,11.264565,1.0000244)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-1"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24867587,0,0,1,1.2575158,4.0104178)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.812501"
+     inkscape:cx="-6.4922447"
+     inkscape:cy="1.3600169"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2384"
+     inkscape:window-height="1263"
+     inkscape:window-x="54"
+     inkscape:window-y="48"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4265);stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;fill-opacity:1"
+       d="m 1.5,1037.8622 14,0 0,13 -14,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+       id="rect4001-1"
+       width="0.99295044"
+       height="1.0103934"
+       x="3.0070496"
+       y="1041.3518" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+       id="rect4001-1-7"
+       width="4.9929504"
+       height="1.0103934"
+       x="9"
+       y="1041.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4873);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="8.9905834"
+       y="1047.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient3066);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-9"
+       width="5"
+       height="1.0103934"
+       x="3"
+       y="1044.3622" />
+    <image
+       y="1036.3622"
+       x="-18"
+       id="image4256"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAclJREFU
+OI2lkr9PVEEUhb8zs/YYLVYSZAMYxCCNUfyZmIDrSowWxILW0tZ/wcbCxn/ExJiwLqtYmWxjLDax
+QBBcWSVIlAJ0376312Lee0qwUaZ4Z15m7sl37lyZGQdZBYBX8w//26WQbfom7/9z8ffGo2AQ9zwA
+R3sJYJiBBHuxlH4NTCDja8/jAOIkgMiBJEbHZpAToydncBJewjlwCufZvTgpBIJuEggWX79j6tIY
+K0vzDJ24wfJSFTDeND/S6XTZ/Rmxsxux86PD3K1zdBO/16B8+RQApZEKq++ruZ6dGPydR6laqHMA
+UWrgvPAeWitVvBetD89xXpSGK3gnSiOVPJL3IsoIojj0oPF2dR/q3dnztNdq9A+WWV+rIeDZYpOb
+V8eJ4rQHUXIIgCtnhgJbhpmiFo+X+dKqURwIentqHEvrQoQ4RPDO8A6KA2W8FNSJzU8LeInN9aBO
+wjsRxXkTQ4Qn9Saz5dNstesc6Z9mq70AiJeN5X3R7s1dpJs/Y0pw5/oEAvqOTfPtc53DqV67MJyO
+kIV06Sx1c4JeFgHMxPbGCwRsb9TRH4VmAoFkgOj2PDIzHjx+mluHMRbZw//9Px0IIxgcZP0CrRPR
+7InL8QcAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-0);fill-opacity:1;stroke:none"
+       id="rect4001-1-2"
+       width="0.99295044"
+       height="1.0103934"
+       x="13.00705"
+       y="1044.3518" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-1);fill-opacity:1;stroke:none"
+       id="rect4001-1-6"
+       width="0.99295044"
+       height="1.0103934"
+       x="3"
+       y="1047.3622" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8"
+       width="3.5305259"
+       height="0.71210289"
+       x="739.53882"
+       y="731.75562"
+       transform="matrix(0.70710679,0.70710677,-0.70710679,0.70710677,0,0)" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8-4"
+       width="3.5305259"
+       height="0.71210289"
+       x="730.34637"
+       y="-741.6601"
+       transform="matrix(-0.70710679,0.70710677,-0.70710679,-0.70710677,0,0)" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8-7"
+       width="3.5305259"
+       height="0.71210289"
+       x="744.48853"
+       y="731.04852"
+       transform="matrix(0.70710679,0.70710677,-0.70710679,0.70710677,0,0)" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8-4-7"
+       width="3.5305259"
+       height="0.71210289"
+       x="729.63928"
+       y="-746.6098"
+       transform="matrix(-0.70710679,0.70710677,-0.70710679,-0.70710677,0,0)" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8-9"
+       width="3.5305259"
+       height="0.71210289"
+       x="743.78143"
+       y="735.99829"
+       transform="matrix(0.70710679,0.70710677,-0.70710679,0.70710677,0,0)" />
+    <rect
+       style="display:inline;fill:#091341;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4001-1-7-4-0-9-8-4-9"
+       width="3.5305259"
+       height="0.71210289"
+       x="734.58905"
+       y="-745.90271"
+       transform="matrix(-0.70710679,0.70710677,-0.70710679,-0.70710677,0,0)" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/eview16/compare_view.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/eview16/compare_view.svg
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="compare.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4501">
+      <stop
+         style="stop-color:#446cbe;stop-opacity:1"
+         offset="0"
+         id="stop4503" />
+      <stop
+         style="stop-color:#446193;stop-opacity:1"
+         offset="1"
+         id="stop4505" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4428">
+      <stop
+         style="stop-color:#d0f1ff;stop-opacity:1"
+         offset="0"
+         id="stop4430" />
+      <stop
+         style="stop-color:#f1f9fe;stop-opacity:1"
+         offset="1"
+         id="stop4432" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4420">
+      <stop
+         style="stop-color:#475b82;stop-opacity:1"
+         offset="0"
+         id="stop4422" />
+      <stop
+         style="stop-color:#596f9b;stop-opacity:1"
+         offset="1"
+         id="stop4424" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4412">
+      <stop
+         style="stop-color:#6da8e5;stop-opacity:1"
+         offset="0"
+         id="stop4414" />
+      <stop
+         style="stop-color:#c5e9f2;stop-opacity:1"
+         offset="1"
+         id="stop4416" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4346">
+      <stop
+         style="stop-color:#75673b;stop-opacity:1;"
+         offset="0"
+         id="stop4348" />
+      <stop
+         style="stop-color:#9d7c2f;stop-opacity:1"
+         offset="1"
+         id="stop4350" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4346"
+       id="linearGradient4352"
+       x1="13"
+       y1="1044.3622"
+       x2="13"
+       y2="1041.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4412"
+       id="linearGradient4418"
+       x1="10"
+       y1="1038.3622"
+       x2="15"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4426"
+       x1="9"
+       y1="1039.3622"
+       x2="16"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4428"
+       id="linearGradient4434"
+       x1="10"
+       y1="1040.3622"
+       x2="15"
+       y2="1043.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4428"
+       id="linearGradient4493"
+       gradientUnits="userSpaceOnUse"
+       x1="10"
+       y1="1040.3622"
+       x2="15"
+       y2="1043.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4346"
+       id="linearGradient4495"
+       gradientUnits="userSpaceOnUse"
+       x1="13"
+       y1="1044.3622"
+       x2="13"
+       y2="1041.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4412"
+       id="linearGradient4497"
+       gradientUnits="userSpaceOnUse"
+       x1="10"
+       y1="1038.3622"
+       x2="15"
+       y2="1038.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       x1="9"
+       y1="1039.3622"
+       x2="16"
+       y2="1039.3622" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4501"
+       id="radialGradient4507"
+       cx="1.9999791"
+       cy="1039.0129"
+       fx="1.9999791"
+       fy="1039.0129"
+       r="3.5097984"
+       gradientTransform="matrix(1.2439339e-6,1.4245917,-1.7094765,1.4926914e-6,1778.1682,1036.5114)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="40.090743"
+     inkscape:cx="9.4783603"
+     inkscape:cy="7.9895547"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="rect4186-9"
+       style="display:inline;opacity:1;fill:url(#radialGradient4507);fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1,1043.3872 0,-1.0072 3.0258837,0 0,1.0072 z m 1.0562135,-3.0084 0,-1.0072 5.9633832,0 0,1.0072 z m 3.9468134,-2.0166 1.0072572,0 0,3.0259 -1.0072572,0 z m -3.999973,1.0312 1.0072023,0 0,4.938 -1.0072023,0 z"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4321"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAUNJREFU
+OI2lka9LQ1EcxT/3x3NvBseGxWCwKKYJ1gmGDfwLTBbHgmEGg6Y1wWIRXJMtCgajaaBFMAnrthWj
+jMFjTtzXMN/zXfcTPfCFe7mHc8/5HiUi/Ad2FtLO3qkobdDGkJhLYozFWIPWZrxAoViVRr2sAD7T
+OdZzayykeqxmMiRSSZbTXapnN6gwQuHwQQC0tOgHnUioUS+rSQ4QEUSEfPlewrOIkN+/jO61Slaa
+bRmaWiUrUQQtLSdCaB8g6BkAlhJuzODDoMO8/aBDoVgdWUn73QPAV+JMu+vFdhBb2m+cHGyJAgbM
+7z+UApEfgb/CgtuzMR7WWGfT1xelkc4igXjPi/MpMr5xup7qwLw98nL3NHCgPax1HUwV2F25ZfO4
+OZLwfL4BlCYLvHZ8YLjn+NtMAr4abmQmAYCro+2JxHH4Ai2Tky6f2y0rAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g4436">
+      <rect
+         y="1037.8622"
+         x="9.5"
+         height="6.0000172"
+         width="6"
+         id="rect4329"
+         style="opacity:1;fill:url(#linearGradient4434);fill-opacity:1;stroke:url(#linearGradient4352);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1037.8622"
+         x="9.5"
+         height="2.0000174"
+         width="6"
+         id="rect4410"
+         style="opacity:1;fill:url(#linearGradient4418);fill-opacity:1;stroke:url(#linearGradient4426);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       transform="translate(-8,8.0000174)"
+       style="display:inline"
+       id="g4436-7">
+      <rect
+         y="1037.8622"
+         x="9.5"
+         height="6.0000172"
+         width="6"
+         id="rect4329-9"
+         style="opacity:1;fill:url(#linearGradient4493);fill-opacity:1;stroke:url(#linearGradient4495);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1037.8622"
+         x="9.5"
+         height="2.0000174"
+         width="6"
+         id="rect4410-2"
+         style="opacity:1;fill:url(#linearGradient4497);fill-opacity:1;stroke:url(#linearGradient4499);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/obj16/date_obj.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/obj16/date_obj.svg
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="date_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3821">
+      <stop
+         style="stop-color:#6e7a8e;stop-opacity:1;"
+         offset="0"
+         id="stop3823" />
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="1"
+         id="stop3825" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3813">
+      <stop
+         style="stop-color:#55a4db;stop-opacity:1"
+         offset="0"
+         id="stop3815" />
+      <stop
+         style="stop-color:#c7e0f5;stop-opacity:1"
+         offset="1"
+         id="stop3817" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3797">
+      <stop
+         style="stop-color:#2b568d;stop-opacity:1"
+         offset="0"
+         id="stop3799" />
+      <stop
+         style="stop-color:#5176a8;stop-opacity:1"
+         offset="1"
+         id="stop3801" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3803"
+       x1="9.2568913"
+       y1="1054.2682"
+       x2="17.34898"
+       y2="1054.2682"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient3819"
+       x1="9.2256413"
+       y1="1055.7682"
+       x2="17.220118"
+       y2="1055.7682"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3821"
+       id="linearGradient3827"
+       x1="13.376367"
+       y1="1064.095"
+       x2="13.376367"
+       y2="1057.1886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3821-8"
+       id="linearGradient3827-0"
+       x1="13.376367"
+       y1="1064.095"
+       x2="13.376367"
+       y2="1057.1886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3821-8">
+      <stop
+         style="stop-color:#6e7a8e;stop-opacity:1;"
+         offset="0"
+         id="stop3823-0" />
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="1"
+         id="stop3825-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755-7">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-2"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-2"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-3" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter3952"
+       x="-0.136875"
+       width="1.27375"
+       y="-0.10682927"
+       height="1.2136585">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.39921875"
+         id="feGaussianBlur3954" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask3959">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g3961"
+         transform="translate(-34.986137,7.993719)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path3963"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3965"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3967"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="6.5503944"
+     inkscape:cy="-0.6197633"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g8579"
+         transform="translate(-34.986137,7.9937193)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745"
+           style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+      <g
+         id="g3956"
+         mask="url(#mask3959)"
+         style="opacity:0.75">
+        <path
+           id="rect3009-7-6"
+           transform="translate(8.2201163,1049.2669)"
+           d="M 1.5 5.5 L 1.5 7.5 L 1.5 14.46875 L 8.5 14.46875 L 8.5 7.5 L 8.5 5.5 L 1.5 5.5 z "
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter3952)" />
+      </g>
+      <rect
+         style="fill:#ebf9ff;fill-opacity:1;stroke:url(#linearGradient3827);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         id="rect3009-7"
+         width="7"
+         height="8.96875"
+         x="9.7201166"
+         y="1054.7668" />
+      <rect
+         style="fill:url(#linearGradient3819);fill-opacity:1;stroke:url(#linearGradient3803);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect3009"
+         width="6.9944768"
+         height="1.9973192"
+         x="9.7256413"
+         y="1054.7695" />
+      <path
+         style="fill:none;stroke:#2b568d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 11.720115,1058.2747 0,3.9922"
+         id="path3829"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#2b568d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 13.216193,1058.7606 1.502602,0 0,0.9489 -0.99319,1.1104 0,0.946 1.512472,0"
+         id="path3831"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/obj16/hunk_obj.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/obj16/hunk_obj.svg
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="hunk_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.79849618,0,0,1,2.404898,-2.9996671)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57200463,0,0,1,3.9919355,-2.9996845)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57200463,0,0,1,3.9919355,-2.9892911)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57099653,0,0,1,3.9989993,-2.9892911)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#556e90;stop-opacity:1"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#597293;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.0000005,-2.9996845)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#96a9c8;stop-opacity:1" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#a0b1ce;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0921662,0,0,1.0801469,-3.5039462,-85.306513)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b4903d;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#7d754f;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.0459,-1.990194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.99287838,0,0,1.0029935,-2.458133,-4.6517047)" />
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4875-9-0"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42900347,0,0,1,0.99395125,-2.9892826)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4875-9-0-3"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42900347,0,0,1,1042.3561,-1055.3619)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4875-9-0-1"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42900347,0,0,1,0.993951,-6.9892826)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.212121"
+     inkscape:cx="16.5"
+     inkscape:cy="7.9941"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient4101);fill-opacity:1;stroke:none"
+       d="m 3,1037.3622 6.9597498,0 3.0402502,3.0156 0,9.9844 -10,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none"
+       d="m 10.022521,1036.451 0,3.9112 3.977479,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 2.5,1036.8622 7.655724,0 3.344276,3.2476 0,10.7524 -11,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="8.0070496"
+       y="1040.3518" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none"
+       id="rect4001-1-7"
+       width="3.9929504"
+       height="1.0103934"
+       x="8"
+       y="1042.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4871-2);fill-opacity:1.0;stroke:none"
+       id="rect4001-1-7-4"
+       width="4"
+       height="1.0103934"
+       x="8"
+       y="1044.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875-9);fill-opacity:1.0;stroke:none"
+       id="rect4001-1-7-4-0"
+       width="4"
+       height="1.0103934"
+       x="8"
+       y="1046.3518" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4873-1);fill-opacity:1.0;stroke:none"
+       id="rect4001-1-7-4-0-9"
+       width="4"
+       height="1.0103934"
+       x="8"
+       y="1048.3518" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4318"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAbtJREFU
+OI2dkz1rFFEUhp9zZ0yz5f6EkCIEUWyssioiEVLYWIilIEnWFdFGFJeNH6RQ3Bg0G0EbsRWRBUGw
+0loEIYV/QcgfMDP3vBbzsZGdWHjgcGcuc555z3vPNUkAfNzqFA//iOUbX21qUxKSGG929Hs/PzR3
+x2sab3ZUfV9lqEC5GxJI4Aey2BMzrTazswt8GJ7+S2kNiDKiiyghF16v4DJmWm2OtNrMzc3z7umZ
+GpLWgBhqBQAmcODt+BtJEkjDIkkSuHjuKLs/l5gCZDJiWS3AZIC4vHwCo/BOBtEhc5sG5NGIDldu
+P8fMMDNeb1xj5d4IC8V7MOPF+gp5bABkCkSHVxs9sOLvUWL0sFtqKhZ3yDw0AGIguir9dcH7z99J
+QkKaGkkInF9cID+sBXchoNcfsf2giwQXzh4HDLPC4CiRxSYFXrRwfbDNr709eoMdtgZr3Hr0svYk
+mPH4zlX2mxRkXszBs/UuN+/vMOyvEh2e3F2deEA5K02AKEMyJDHsd3EJEJ++/CANCUnpwamT880m
+5h7KIhCTaV3qHONguCCqARDdeDO8VBwC9SHUYdgEbJMWrLrO/xt/AIJ9Cohf2yuyAAAAAElFTkSu
+QmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875-9-0);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-2"
+       width="3"
+       height="1.0103934"
+       x="4"
+       y="1046.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875-9-0-3);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-2-7"
+       width="3"
+       height="1.0103934"
+       x="1045.3622"
+       y="-6.0103931"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875-9-0-1);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-2-5"
+       width="3"
+       height="1.0103934"
+       x="4"
+       y="1042.3622" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/obj16/message_info.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/obj16/message_info.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="message_info.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3857">
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="0"
+         id="stop3859" />
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="1"
+         id="stop3861" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4996-4"
+       id="linearGradient5028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(38.469436,55.035191)"
+       x1="13.903196"
+       y1="1062.1353"
+       x2="13.903196"
+       y2="1051.7347" />
+    <linearGradient
+       id="linearGradient4996-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4998-5"
+         offset="0"
+         style="stop-color:#02468c;stop-opacity:1" />
+      <stop
+         id="stop5000-5"
+         offset="1"
+         style="stop-color:#0e62a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         id="stop4892"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896-1"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4890-6">
+      <stop
+         id="stop4892-2"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894-2"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898-7"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3052">
+      <stop
+         id="stop3054"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop3056"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3060"
+       xlink:href="#linearGradient3857"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="7.4539771"
+     inkscape:cy="21.313618"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="900"
+     inkscape:window-x="222"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:#f8fdff;fill-opacity:1;stroke:#02468c;stroke-width:1.52293062;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4110"
+         sodipodi:cx="11.9375"
+         sodipodi:cy="11.6875"
+         sodipodi:rx="9.875"
+         sodipodi:ry="9.875"
+         d="m 21.8125,11.6875 a 9.875,9.875 0 1 1 -19.75,0 9.875,9.875 0 1 1 19.75,0 z"
+         transform="matrix(0.65662871,0,0,0.65662871,8.3816111,1049.5926)" />
+      <g
+         transform="translate(1.790992,32.464778)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <g
+           transform="translate(-8.2201163,-12.904699)"
+           id="g8159-9"
+           style="display:inline">
+          <text
+             sodipodi:linespacing="125%"
+             id="text4140-1-8-1"
+             y="1117.2119"
+             x="50.288464"
+             style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+             xml:space="preserve"><tspan
+               style="fill:url(#linearGradient5028);fill-opacity:1"
+               y="1117.2119"
+               x="50.288464"
+               id="tspan4142-7-8-7"
+               sodipodi:role="line">Kozuka Mincho Pr6N H</tspan></text>
+        </g>
+      </g>
+      <g
+         transform="matrix(0.87196374,0,0,0.80250065,2.0740224,208.83353)"
+         id="text4140-1-8"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896-1);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy">
+        <path
+           inkscape:connector-curvature="0"
+           id="path5058"
+           style="fill:url(#linearGradient3060);fill-opacity:1"
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/obj16/resource_obj.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/obj16/resource_obj.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="resource_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028"
+       gradientTransform="matrix(0.92075421,0,0,0.92075421,-7.2194933,1058.6085)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624"
+       gradientTransform="matrix(0.92075421,0,0,0.92075421,-7.2194933,1058.6085)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.390686"
+     inkscape:cx="10.313642"
+     inkscape:cy="10.205458"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="2411"
+     inkscape:window-height="994"
+     inkscape:window-x="97"
+     inkscape:window-y="308"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <circle
+         r="4.9847631"
+         cy="1056.7668"
+         cx="16.720116"
+         style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:1.03047395;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path13745" />
+      <path
+         style="fill:none;stroke:#1f4a83;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.720167,1057.6931 0,-2.9675"
+         id="path13811"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="display:inline;fill:none;stroke:#1f4a83;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.724686,1057.7722 0.990861,0.9894"
+         id="path13811-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <image
+         y="1049.2668"
+         x="24.220116"
+         id="image4327"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAY5JREFU
+OI2lk08og3EYx7/vO7Z3VnZworgQ5SAn4yInhTiQvyeJnCQkKQdxIwc5bI3yJwdGDg4OTjsgamhy
+UGbFRfKn/Qxj715fF728tpXaU996nuf3/D6H549EEqmYnNJvAGnJHmZ3Dzk3f4SIELDa7ejrcaC/
+ulyKKyRp0H7gkvnNLg4u+XgtBIUWY+DxgUMrPuY3u7gfuOTv+jhAQauLxzc3FCRDf7R1csH0VqcB
+YOjBuMfLpoYy5OXkIqoBqgaU1k1C/fYrS4rgyMrEuMerd94AWN3wo70qG2oMujTKuh+NAQsTtXCt
+nyZu4lsoBEgmvEaies6cBkMsywoYfk4MsGba8f7xjs9Ps56T0s0Iv0b0OKZFINtsP8DfgMb6Ymzu
+3cOiWKB8a9vdh67RZSiKBVbFguFpLzobS5OPsajDzW3/Fa+EalBQqPT4Lmj6M4WEe1DY5ubYmp/n
+d08MiijPbu9Z0btKucUZtwdSsluY2Tng1KIPcvgFtGVgpNuBgZqKuE1MCvivpXxMKQO+ADRUKVba
+oRjDAAAAAElFTkSuQmCC
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16"
+         width="16" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/add_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/add_ov.svg
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="add_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4206">
+      <stop
+         style="stop-color:#297209;stop-opacity:1"
+         offset="0"
+         id="stop4208" />
+      <stop
+         style="stop-color:#5d9f0d;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198">
+      <stop
+         style="stop-color:#001202;stop-opacity:1"
+         offset="0"
+         id="stop4200" />
+      <stop
+         style="stop-color:#02460c;stop-opacity:1"
+         offset="1"
+         id="stop4202" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4198"
+       id="linearGradient4204"
+       x1="4"
+       y1="1050.3622"
+       x2="4"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4206"
+       id="linearGradient4212"
+       x1="7"
+       y1="1049.3622"
+       x2="7"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="55.905487"
+     inkscape:cx="0.46357211"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="316"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <image
+       y="1042.3622"
+       x="-11"
+       id="image4191"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAKJJREFU
+GJWdkMEJwlAUBOcRQVH0Yh961A5ShKB2EuxEBYuwA5vxkuQnQchfD5qfCIrinvYwLMuYJADxPdZr
+WhSPP1L1OQMgwNw8q00EwHGbst5PADgdfEACrEoUFdjzUVkKDKg6DyUhSTYb6F1s3m9q54bzLJIR
+Blx2jmUyBAxcu9zCpSfLFcSkOYBQUbc6GnU2jV4V6DFsgL/WAGb/eLYfYO6xp116Dd90kQAAAABJ
+RU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4194"
+       width="9"
+       height="9"
+       x="1"
+       y="1042.3622" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4212);fill-opacity:1;stroke:url(#linearGradient4204);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196"
+       width="6"
+       height="6.0000172"
+       x="2.5"
+       y="1043.8622" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4214"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.5,1044.3622 0,5"
+       id="path4214-6"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/chg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/chg_ov.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="chg_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4206">
+      <stop
+         style="stop-color:#297209;stop-opacity:1"
+         offset="0"
+         id="stop4208" />
+      <stop
+         style="stop-color:#5d9f0d;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198">
+      <stop
+         style="stop-color:#001202;stop-opacity:1"
+         offset="0"
+         id="stop4200" />
+      <stop
+         style="stop-color:#02460c;stop-opacity:1"
+         offset="1"
+         id="stop4202" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4198"
+       id="linearGradient4204"
+       x1="4"
+       y1="1050.3622"
+       x2="4"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4206"
+       id="linearGradient4212"
+       x1="7"
+       y1="1049.3622"
+       x2="7"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(-4.4122314e-8,1.104375e-5)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4198"
+       id="linearGradient4204-9"
+       x1="4"
+       y1="1050.3622"
+       x2="4"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="63.774861"
+     inkscape:cx="-0.82258336"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4194"
+       width="9"
+       height="9"
+       x="1"
+       y="1042.3622" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4212);fill-opacity:1;stroke:url(#linearGradient4204);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196"
+       width="6"
+       height="6.0000172"
+       x="2.5"
+       y="1043.8622" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1048.8622 5,0"
+       id="path4214"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.5,1044.3622 0,2"
+       id="path4214-6"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1042.3622"
+       x="-10"
+       id="image4209"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAALVJREFU
+GJWdkD8SwWAUxH8vMaOJSqfmLBS6zDDGATRO4Agq51BpUzkIlzAhkpBvFcin8GfGVjvv7ezbtyYJ
+QPyGNZ4s7Lc+qqokBSCoJ6VjOjFGY6NKUuIYphOD0h+tnZWLLIfA7suyBDlB7sXeORO6ONazlOEq
+YjNPORyFzpUP/Xww6DZx+4LBMqJy4upguzgR9Jq4XQFgSEKSrNPQO9AJa/qS2WHt0FcgwMBeu/un
+Z/sqe+AGciNrGTSvzFIAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.3498076,1046.1685 -2.4371769,2.2578"
+       id="path4214-6-8"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="0.37831248"
+       inkscape:transform-center-y="-1.6772707" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.6022809,1046.1685 2.437177,2.2578"
+       id="path4214-6-8-0"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="-0.37831248"
+       inkscape:transform-center-y="-1.6772707" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4204-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196-9"
+       width="6"
+       height="6.0000172"
+       x="2.5"
+       y="1043.8622" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/confadd_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/confadd_ov.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="confadd_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ef8281;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4352"
+         offset="0.49014422"
+         style="stop-color:#e53041;stop-opacity:1" />
+      <stop
+         style="stop-color:#df3f3f;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#bb1320;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#c25749;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23"
+       y1="1047.3622"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="49.007139"
+     inkscape:cx="-2.1410565"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="293"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -1.4961658,1046.851 5.9275283,-5.3727 1.9195451,-0.02 6.2413744,5.3727 -5.9988584,5.6379 -2.004805,-0 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <image
+       y="1042.3622"
+       x="-14"
+       id="image4204"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAQZJREFU
+GJVdkEFLAnEQxX//PSwiGxGFUghZCQtqRHgJBMMlkg5BXeo7dunQrWJx/QKxlwUpXYQyXJKM3VMs
+TQdx/ePA8B68NzO8QUTQWnq3F6KjrhssS3pX5xzWTvCulwjIwrAwi9dpUy3XSaczTu8fSaczart1
+vE47GzAA6baa2LkiaTgmDccAGbdzRbqtJoAot9GQPcvC/DHYeXFZrfGxw+/6H2GSoERE3OoR+4UN
+rLUCAFsPd3xd3gCQxBHD6Bsn8DEA5QQ+w9GEJI4w8uY8TN4kiSMGowlO4AMoJZKFleftChW7xKD/
+zoFd4q3/wdnnK4CaO1b+/LRZFh11Xd+cXdC40oV/uDCja+ByQPIAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.7488013,1046.8545 3.764578,-3.373 0,0.3847 2.001166,0 0,-0.3847 3.7723457,3.373 -3.7338817,3.3729 -4e-5,-0.3687 -2.001165,0 -0.0036,0.4078 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.5,1044.3622 0,5"
+       id="path4207"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/confchg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/confchg_ov.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="confchg_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ef8281;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4352"
+         offset="0.49014422"
+         style="stop-color:#e53041;stop-opacity:1" />
+      <stop
+         style="stop-color:#df3f3f;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#bb1320;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#c25749;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23"
+       y1="1047.3622"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="2.6215881"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -1.4961658,1046.851 5.9275283,-5.3727 1.9195451,-0.02 6.2413744,5.3727 -5.9988584,5.6379 -2.004805,-0 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.7488013,1046.8545 3.764578,-3.373 0,0.3847 2.001166,0 0,-0.3847 3.7723457,3.373 -3.7338817,3.3729 -4e-5,-0.3687 -2.001165,0 -0.0036,0.4078 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/confdel_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/confdel_ov.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="confdel_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ef8281;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4352"
+         offset="0.49014422"
+         style="stop-color:#e53041;stop-opacity:1" />
+      <stop
+         style="stop-color:#df3f3f;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#bb1320;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#c25749;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23"
+       y1="1047.3622"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-17.813465,167.6963)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="2.6215881"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="316"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -1.4961658,1046.851 5.9275283,-5.3727 1.9195451,-0.02 6.2413744,5.3727 -5.9988584,5.6379 -2.004805,-0 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.7488013,1046.8545 3.764578,-3.373 0,0.3847 2.001166,0 0,-0.3847 3.7723457,3.373 -3.7338817,3.3729 -4e-5,-0.3687 -2.001165,0 -0.0036,0.4078 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/del_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/del_ov.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="del_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4206">
+      <stop
+         style="stop-color:#297209;stop-opacity:1"
+         offset="0"
+         id="stop4208" />
+      <stop
+         style="stop-color:#5d9f0d;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198">
+      <stop
+         style="stop-color:#001202;stop-opacity:1"
+         offset="0"
+         id="stop4200" />
+      <stop
+         style="stop-color:#02460c;stop-opacity:1"
+         offset="1"
+         id="stop4202" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4198"
+       id="linearGradient4204"
+       x1="4"
+       y1="1050.3622"
+       x2="4"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4206"
+       id="linearGradient4212"
+       x1="7"
+       y1="1049.3622"
+       x2="7"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="5.5"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4194"
+       width="9"
+       height="9"
+       x="1"
+       y="1042.3622" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4212);fill-opacity:1;stroke:url(#linearGradient4204);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196"
+       width="6"
+       height="6.0000172"
+       x="2.5"
+       y="1043.8622" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4214"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/error_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/error_ov.svg
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_ov.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="477.77817"
+       x2="388.63736"
+       y2="458.68076" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#eb6d71;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#f13f53;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7a29a;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4886"
+       x1="393.43765"
+       y1="458.68076"
+       x2="393.43765"
+       y2="477.77817"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880-4">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882-5" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884-5" />
+    </linearGradient>
+    <linearGradient
+       y2="477.77817"
+       x2="393.43765"
+       y1="458.68076"
+       x1="393.43765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4986"
+       xlink:href="#linearGradient4880-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="19.742952"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1821"
+     inkscape:window-height="1168"
+     inkscape:window-x="438"
+     inkscape:window-y="142"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient8163-2);fill-opacity:1;stroke:url(#linearGradient4886);stroke-width:2.10502887;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 a 10.625,10.625 0 0 1 -10.625,10.625 10.625,10.625 0 0 1 -10.625,-10.625 10.625,10.625 0 0 1 10.625,-10.625 10.625,10.625 0 0 1 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 11,3.15625 5,10.34375 5,11 l 0.75,0 5.9375,-7.09375 0,-0.75 z"
+         transform="translate(8.2201163,1049.2669)"
+         id="path4911-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 14.1875,1053.25 0.0625,1 c 0.22353,-0.011 0.341247,0.031 0.46875,0.125 0.127503,0.094 0.253587,0.2612 0.375,0.5 0.242825,0.4777 0.429979,1.2198 0.65625,2 0.226271,0.7802 0.505095,1.6148 1.03125,2.2812 0.526155,0.6665 1.365276,1.1485 2.46875,1.125 l -0.03125,-1 c -0.837969,0.018 -1.282983,-0.2771 -1.65625,-0.75 -0.373267,-0.4728 -0.626513,-1.1884 -0.84375,-1.9374 -0.217237,-0.7491 -0.387875,-1.5054 -0.71875,-2.1563 -0.165437,-0.3254 -0.38571,-0.6529 -0.6875,-0.875 -0.30179,-0.2221 -0.70353,-0.333 -1.125,-0.3125 z"
+         id="path4911-7-4"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:none;fill-opacity:1;stroke:url(#linearGradient4986);stroke-width:2.10502886999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0-1"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 a 10.625,10.625 0 0 1 -10.625,10.625 10.625,10.625 0 0 1 -10.625,-10.625 10.625,10.625 0 0 1 10.625,-10.625 10.625,10.625 0 0 1 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+      <image
+         y="1049.2668"
+         x="-8.7798834"
+         id="image4211"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAa5JREFU
+OI2lk79rE2EYxz9XIs17+YEOTc2ZHyYidEkhc5dwGQrO4uAoKrg7FY5KC/kLnEQ6SFNQpAoWN+Vd
+bs6QUWwqSc7Go9jc9XIclL4OorHlOkie6eXh/X6e5/vlfTWlFLPU3ExqIBHXHNi2ct+84PSni/oR
+oOVSJK4tsHDvMYWVFe3fu9pFCwPbVs7mGotGkUzlNvpNg8mBg9/7wsjpY1itc5C5OPGyuUp5axsB
+qAMHAZS3tlk2V3E21xjYtooFRO1dcsk8Z8cnICXCWkeFEcJaByk5Oz4hl8wTtXeJBQSdLumSAUHE
+5P0HAPRWC6QkeLcHQUS6ZBB0uvEhhvt9xNISp70hMM3Ke/b871lUDML9fjxAVIuEgc98Oknm6aNp
+0un56ZDAR1SL8RZS9Rqee/Rb3Gjg3X8IUpLZa6OyApUVeO4RqXotHqCbTcbDQ2g08B88QUtewX/1
+GqQku/OSRKXAeOSim83pdhffwfe3H9WhtcHVWwUy1RK6scjEGeF97TPuDbi+YZG/e0e7FPAHMvn8
+iaDTJfw2RJRvkKrX0M3mOfGlgP+pmT/TzIBfcgetVymTPKAAAAAASUVORK5CYII=
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16"
+         width="16" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/inadd_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/inadd_ov.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inadd_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#00104a;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="55.905487"
+     inkscape:cx="1.5201852"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="316"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 4.5,1044.3622 0,5"
+       id="path4207"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1042.3622"
+       x="-11"
+       id="image4223"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAOJJREFU
+GJVtkLFqAkEQhr898wCXShDhqrRp01hJELk8QCAghIAIqSxS2AlWab1WrGxsfYuITfpUsbBLkSJw
+e673W+he9JIPBj5mh5nZQRIqEUQ9r5zGBaBK1OVAAMDtS0Il6rL7nAgweCTJ1J/USlK1klSSCjf1
+x7MJh1a5w2UWl1kAXGbZZZZmf0xQ6wDot3P1oby2JKkx2qgx2shU7+V3htxyM/gAYPl6VTjAajrg
+ez0H8MWObfpTFHh/nw3JvxYUn5QkLu+OEYsw1vXzmwjjP+fzcgZh+987G0mU8AlTftgDb8rYXOMa
+JQYAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/inchg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/inchg_ov.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inchg_ov copy.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#00104a;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="180.38255"
+     inkscape:cx="0.23402973"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/indel_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/indel_ov.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="indel_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#00104a;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="180.38255"
+     inkscape:cx="0.23402973"
+     inkscape:cy="6.2308314"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="220"
+     inkscape:window-y="177"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/merged_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/merged_ov.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="merged_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4206">
+      <stop
+         style="stop-color:#a3b8d5;stop-opacity:1"
+         offset="0"
+         id="stop4208" />
+      <stop
+         style="stop-color:#e2ebf4;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198">
+      <stop
+         style="stop-color:#456398;stop-opacity:1"
+         offset="0"
+         id="stop4200" />
+      <stop
+         style="stop-color:#4e6ca0;stop-opacity:1"
+         offset="1"
+         id="stop4202" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4198"
+       id="linearGradient4204"
+       x1="4"
+       y1="1050.3622"
+       x2="4"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66666666,0,0,0.66666763,1.8333334,348.9531)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4206"
+       id="linearGradient4212"
+       x1="7"
+       y1="1049.3622"
+       x2="7"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66666666,0,0,0.66666763,1.8333334,348.9531)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="74.666667"
+     inkscape:cx="1.9637639"
+     inkscape:cy="5.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4194"
+       width="9"
+       height="9"
+       x="1"
+       y="1042.3622" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4212);fill-opacity:1;stroke:url(#linearGradient4204);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196"
+       width="4"
+       height="4.0000172"
+       x="3.5"
+       y="1044.8622" />
+    <image
+       y="1042.3622"
+       x="-10"
+       id="image4229"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABHNCSVQICAgIfAhkiAAAAJdJREFU
+GJVj/P//PwMDA8N/BgKACcYw9KxnMPSsR5FEFmNB1+mfuxDCYEST+P//P8N/KPDJmvf/0esvcOyT
+NQ8m9R/FxL///jM8ffURbtzff3/hcigK//39w3D38QeG/wz/GRgYGBn+/UP4kRHma5ijRaWlYNoY
+Xj99wcDAwMBwfnsjpmd2zUlH8TWGiega0AHMRPTAwAAAV7tRLgOCfskAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="10" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#30487e;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196-9"
+       width="1.0000105"
+       height="1.0000174"
+       x="2.5"
+       y="1043.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#30487e;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196-9-4"
+       width="1.0000105"
+       height="1.0000174"
+       x="7.4999895"
+       y="1043.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#30487e;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196-9-1"
+       width="1.0000105"
+       height="1.0000174"
+       x="7.4999895"
+       y="1048.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#30487e;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4196-9-2"
+       width="1.0000105"
+       height="1.0000174"
+       x="2.4999895"
+       y="1048.8622" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/outadd_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/outadd_ov.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="outadd_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4227"
+         offset="0.38178766"
+         style="stop-color:#676e7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="69.135717"
+     inkscape:cx="0.48547616"
+     inkscape:cy="4.9875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.5,1044.3622 0,5"
+       id="path4207"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1042.3622"
+       x="-11"
+       id="image4224"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAPZJREFU
+GJVtkDFLQmEUhp9zraHBtaHlEpj0pR8pkhE3sMGcIpoaCve2foGbf8DNvT/QWrNFGC0GieAdHMIh
+XByCSu9pEK8f2Tue8zzw8oqq4kSDShWAh/sb9y4A4sAaVKpY4/PaHbjgXBRvDh6UL7HGj5/W+Fjj
+E0VRLHmAFo/O2c1s8l+m08miSz441WLBAtBs1JfgwuEZL61bAJHx57fmstscn1yAAqI0G3Wurmug
+8PjUptO+A5CV5NqqhGGoJl8ilc7MBOB9OAJg8vO1qOGusZXdZ30jzcewDwriJQDodVqzGn93Tu3s
+AdB/e3bvSzvHggu4+QVwB1bx/d0StwAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/outchg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/outchg_ov.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="outchg_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4227"
+         offset="0.38178766"
+         style="stop-color:#676e7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="74.631391"
+     inkscape:cx="-0.49503698"
+     inkscape:cy="4.9733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/outdel_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/outdel_ov.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="outdel_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4227"
+         offset="0.38178766"
+         style="stop-color:#676e7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="74.631391"
+     inkscape:cx="-0.49503698"
+     inkscape:cy="4.9733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_inadd_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_inadd_ov.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_inadd.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#001048;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="39.433703"
+     inkscape:cx="-0.5545528"
+     inkscape:cy="4.9875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.5,1044.3622 0,5"
+       id="path4207"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1042.3622"
+       x="-11"
+       id="image4247"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAOdJREFU
+GJV1kL1qAmEQRc+shpBCjJUQJFvZ2gUbKwki+AAGIRASgg+gRaoUVtailaV1ijxGyCOkkDQ2IYWF
+sOvP3jTrt8tiLsxwmYEzw0USqZLn93VCSCJPIuX8Z26HU3J+Px5FABy+5wLMEa3yoNYkUGsSSJLz
+Vnl09Dwg7+qe5mDGYRsiAM7Zb8MYvk9uW7mrxmilxmh16ldZuZeQ18sFxes7bp7G1F++APgYV50n
+Ch3YK1ycWfTzxud8yC7YsAs2AIlPvXFMw6Lfd1mpQ633ipU6YBC3VF6ZnLls/5uzSSKj48Cyiz9x
+sMVnpSqOygAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_inchg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_inchg_ov.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_inchg_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#001048;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="74.631391"
+     inkscape:cx="-0.49503698"
+     inkscape:cy="4.9733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="385"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_indel_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_indel_ov.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_indel_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#4692f8;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#2e6ac8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#001048;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#021e66;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99198369,0,0,0.84322365,28.848365,167.6939)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="5.5"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="385"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.99831,1042.3695 -5.2418927,-0.021 -5.4364448,4.5141 5.9809715,5.5127 1.6767902,0.054 -0.039124,-1.0034 3.0775878,-0.071 0.93736,-0.9626 c 0,0 0.08471,-5.012 0.04644,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.5,1043.8764 -3.9796444,0 -3.551e-4,-0.3972 -3.7719906,3.373 3.7338817,3.3729 4e-5,-0.3487 4.0180684,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3,1046.8622 5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outadd_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outadd_ov.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_outadd_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4226"
+         offset="0.48954517"
+         style="stop-color:#676d7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="39.976986"
+     inkscape:cx="-2.5616555"
+     inkscape:cy="4.9875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 4.5,1044.3622 0,5"
+       id="path4207"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1042.3622"
+       x="-11"
+       id="image4223"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAYAAABi8KSDAAAABHNCSVQICAgIfAhkiAAAAO9JREFU
+GJVtkD9LQgEUxX9X/AoOTg9BiJe8HKQgcnCI5qaWaHfKL6CTn6CtPXAucKrVhgoj0P5gvqHBjKBW
+KX3vNNR75NPfeO8593KOSQIQf2ztHABweX4CYPzDJCkSRHiuQ+/xZcGQAgjDEM918FwnEuC5Dpvb
++3NfUwBBMGMZxUKOjcpebDBJKpV36XZOF8TVWh2A626P286ZpQGm3xOqhw0wOD5q/opkYMZFu8Vd
+/wmANMBs+sXo7SO+OBp/gsFwcI/v+3FIk6SVtTIACgMwyGTzvL8OeO5fzbVhyZ7zq+sADB9ulvac
+zBUNLLn4AYCfXemy3ag2AAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="11" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outchg_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outchg_ov.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_outchg_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4226"
+         offset="0.48954517"
+         style="stop-color:#676d7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="5.5"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outdel_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/r_outdel_ov.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="r_outdel_ov.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#676e7b;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         id="stop4226"
+         offset="0.48954517"
+         style="stop-color:#676d7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#232934;stop-opacity:1"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#3a455c;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="23.033005"
+       y1="1047.9811"
+       x2="23"
+       y2="1038.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99198369,0,0,0.84322365,-18.848365,167.67976)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e3e3e3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="80.6"
+     inkscape:cx="5.5"
+     inkscape:cy="5"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2134"
+     inkscape:window-height="1071"
+     inkscape:window-x="312"
+     inkscape:window-y="362"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.0016906,1042.3553 5.2418926,-0.021 5.4364448,4.5141 -5.9809715,5.5127 -1.6767902,0.054 0.039124,-1.0034 -3.07758735,-0.071 -0.9373608,-0.9626 c 0,0 -0.08471088,-5.012 -0.04644245,-7.0212 z"
+       id="path4334-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:url(#linearGradient4350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4342);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.5,1043.8622 3.9796449,0 3.551e-4,-0.3972 3.7719906,3.373 -3.7338817,3.3729 -4e-5,-0.3487 -4.0180689,0 z"
+       id="path4334"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,1046.8622 -5,0"
+       id="path4207-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/removed_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/removed_ov.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="10"
+   height="10"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="removed_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#414141;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#535353;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.49820728,0,0,0.49922596,1.2025308,525.50598)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.49820728,0,0,0.49922596,1.2025308,525.50598)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="18.928144"
+     inkscape:cx="8.5166365"
+     inkscape:cy="8.267487"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1894"
+     inkscape:window-height="987"
+     inkscape:window-x="629"
+     inkscape:window-y="388"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1042.3622)">
+    <image
+       y="1042.3622"
+       x="11"
+       id="image4249"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABHNCSVQICAgIfAhkiAAAALRJREFU
+GJWNkKGOwzAQRF9OBQsDAxcuzCcY9lgK8zWWvyYwYaWG/oSFhgcLzXKgau+ignbQzuppNJpu33eA
+nTc6PY6UEl4rpkqM8e7dMTNijHw9QHdnOp9prQHQWmOaJrxWgD/QzNi2jUGNeZ4Z9O5NFYDuf8fv
+ywVVZeh7fm43aq1c1/WYmFICoBfB3elFDv8nmHNmNENEWJYFEWE0I+d8BEMIlFIOk5RSCCG8dvxk
+x+4d+AtosEg5Sz784gAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="10"
+       width="10" />
+    <path
+       style="display:inline;fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.8881188,1044.0297 c -0.2332531,-0.2337 -0.6087962,-0.2337 -0.8420371,-10e-5 l -1.5508183,1.554 -1.550806,-1.5539 c -0.2332177,-0.2337 -0.6087963,-0.2337 -0.8420371,0 l -0.4284858,0.4294 c -0.2332304,0.2336 -0.2332244,0.6099 1.82e-5,0.8436 l 1.550781,1.5541 -1.5507833,1.554 c -0.2332656,0.2337 -0.2332597,0.61 -6.7e-6,0.8437 l 0.4285089,0.4294 c 0.233228,0.2337 0.6087716,0.2337 0.842037,0 l 1.5508084,-1.5539 1.5615834,1.5647 c 0.2332288,0.2338 0.608772,0.2338 0.8420375,0 l 0.428486,-0.4293 c 0.2332412,-0.2338 0.2308976,-0.6077 -1.82e-5,-0.8438 l -1.5615845,-1.5648 1.5508082,-1.554 c 0.2332517,-0.2337 0.2332461,-0.61 1.74e-5,-0.8437 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/ovr16/warning_ov.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/ovr16/warning_ov.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="warning_ovr.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.5002841,0,0,1.4331549,2.7493137,1038.114)"
+       y2="0.98171616"
+       x2="3.3833356"
+       y1="7.0159616"
+       x1="3.3833356"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4230"
+       xlink:href="#linearGradient5081"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5002841,0,0,1.4331549,2.7493137,1038.114)"
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4232"
+       xlink:href="#linearGradient5091"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.273966"
+     inkscape:cx="13.898832"
+     inkscape:cy="8.5251045"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1951"
+     inkscape:window-height="1061"
+     inkscape:window-x="523"
+     inkscape:window-y="285"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3024"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4281"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAV5JREFU
+OI2lkz1LglEUx3/Po/m2NOjQEK0NkUQvSyiFH0Bwsai+QbS2GE0NrhFSVLNDi98g0KAhEsKpF0F5
+EBWLp8FUtLynQSjs0Sg8cJf7P/d/f+eeezQRYZTQRzoN2IcJ1WxK2ncJAJxz20wsRLSBiSIycBVO
+QyJmWsRMS+EsJMPyBpZQzaZECdBuQbuFUr29PxPkT1ZEzLTEIl6JRbwiZlqejlcHUlgIjGRUGo0W
+VDKM2XWcDhtUMjSbTYxk1EJhMXgpF/GHA4DgdtjwOO0gCn84gFkuWiro60Lvhi7YxqF+z+5OqCe8
+PYBnmg9RGMmoTG1cfHWkj6Bq5Jlf2wTzGXxB4keXJM6vwBeE1xqL61vUjPxwAlCgu8HuBN1Bp6Oo
+8w66A2wu0Fwo1HCDblco3T4yuTQLmsb+YfxbdM1QusnRVf3vqP2chesD/6/DsbyX6/uRFoP/xsjD
+NLLBJ1afzwqO1fARAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;fill:url(#linearGradient4230);fill-opacity:1;stroke:url(#linearGradient4232);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.9688624,1039.4128 -3.0474518,5.867 c -0.9092163,1.4691 -0.2892788,3.5567 1.4065161,3.5829 l 1.922239,0 1.5002841,0 1.9222392,0 c 1.695796,-0.026 2.315733,-2.1139 1.406516,-3.5829 l -3.047452,-5.867 c -0.441522,-0.7979 -1.6785293,-0.6696 -2.0628906,0 z"
+       id="path4292"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <ellipse
+       style="display:inline;fill:#502800;fill-opacity:1;stroke:none"
+       id="path4253"
+       cx="8.000308"
+       cy="1046.2438"
+       rx="0.98679423"
+       ry="0.94264084" />
+    <path
+       style="display:inline;fill:#502800;fill-opacity:1;stroke:none"
+       d="m 8.0216636,1040.8239 c -0.5307232,0 -0.9823158,0.4511 -0.9823158,1.0369 l 0.1281273,1.9944 c 0,0.5206 0.3824334,0.9425 0.8541879,0.9425 0.4717546,0 0.8541851,-0.4219 0.8541851,-0.9425 l 0.085412,-1.9944 c 0,-0.5858 -0.4088817,-1.0369 -0.939608,-1.0369 z"
+       id="path4253-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccsccs" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/wizban/applypatch_wizban.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/wizban/applypatch_wizban.svg
@@ -1,0 +1,1180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="applypatch_wizban.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,22.503359,158.27907)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#dbe2eb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7798932,0,0,2.8715894,22.273474,-1974.3527)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,22.503359,158.27905)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6411">
+      <stop
+         style="stop-color:#4f605c;stop-opacity:1"
+         offset="0"
+         id="stop6413" />
+      <stop
+         style="stop-color:#dbe2eb;stop-opacity:0"
+         offset="1"
+         id="stop6415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4456935,0,0,1.5152448,-25.667265,-537.6685)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#f4ae5f;stop-opacity:1;"
+         offset="0"
+         id="stop4260" />
+      <stop
+         id="stop4266"
+         offset="0.41542953"
+         style="stop-color:#eec290;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7700e;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-0.41994314,1068.4388)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#68b367;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         style="stop-color:#5eaa6e;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4578"
+       id="linearGradient4584"
+       x1="42.780308"
+       y1="1025.5621"
+       x2="40.143147"
+       y2="1039.7532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-8.6400594,2067.7057)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4578">
+      <stop
+         style="stop-color:#c5f0b4;stop-opacity:1"
+         offset="0"
+         id="stop4580" />
+      <stop
+         style="stop-color:#80c171;stop-opacity:1"
+         offset="1"
+         id="stop4582" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient4314-5"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,-9.5473378,158.33322)"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4501"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7798932,0,0,2.8715894,-9.7772236,-1974.2986)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80316308,0,0,0.84170722,-9.5473378,158.3332)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4505"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4456935,0,0,1.5152448,-57.717962,-537.61435)"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient4314-5-4"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344-1"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346-7" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.293333"
+     inkscape:cx="74.924774"
+     inkscape:cy="33.000009"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="86"
+       id="image4401"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAS9ElEQVR42uybaXAlV3XHf+fe7n6rnp40+3hW
+ezAGGy8BHC8sXhJjh8IOpCpJhaUwVVSFpCqYJR9SldRkUlRBYRxC+JAUMbFDQoJZYkOI2UwMGGeA
+YHtsYw8eLzPSaKTRSKOR9KS3dt+TD/329zSj0YwcF86tkt573be7T//vWf7n3HuF/2992ye/dMSq
+klTVQVUGgJT3/7B0AOQDKVVyzmlGlVT7+Zc9WJ/+6rhVJeOUpHOaUqcZpwT9+r5swfrsvRMp50ir
+aqBgUR1ANXGya15WYP39N44apyRUdUAVKwKqpFHNAnKq6182YH3um5MDTjUtYFSBWJtyAoEs8x6/
+8mB9/v7JlFNiTQI0VqGUwoCA6GncS1ZLyDf81a4T1vPy1Urp1r17Ru5+sUG6+zvHAlVyquo7B05B
+VVFlQFXTzoFzitP4M6p/qsZ9X1Swrr/91/Tmm97Pvd/4DJUlALty9/b3Am8GdrQd3gf8cO+ekftW
+8tx/+d6Udao5VZINgOpgCWhelcC5+rGXCljX3f5a/eP3fIzJ6cN8+eufplIpNgG7cvf224Ddu3Zd
+kt92zg7WDQ1jxWFwjI6PcOD5Zzg6PXkI2HM6WvnFB6YyqmRV1ThtaZNTPGBQnXoNcF5SYF37ydfp
+R279OE6V8elRvnTfHVQqxQ8Bt2zbcdE1V151M8O5QTyJWFiYwZcIK450IiCdCBg9cogHf/JDRsfH
+fgC8fe+ekdmlnnXPg9N+XZsC1TYQYrA8YFgVaQfnJaZZr9O/eN/t7H3uKS7Ydi5HZ8b58tfv4LLX
+38yuV12Bqy1y5MhBZmenUFfFisbaZRzZpM/2DRvZvmEj9z3wTfbtf3IfcG0/wL7yg+mMU7KqGKf1
+l62DoLFGDauqOO0EZyVgrVo0NCJkrKVUWuThXzzCr1/4Wt79zo8RegFHjh1hdPRZNKqirkqlXABC
+rFE8cVSrAZVqmSPHxvmNq68lCIJLf/b4I/cC1zbu/+8PHTfOMaRoIBpHuQ4tEDwjDDtFVM/OO60a
+WFYEBySsYaZQ5Of7H+U1F1zK2NExDhw8AC5kbm6aUmkOKw5rWn9zC46EZxnK5XAHarzp9VdzdGry
+GnZz2949I39z34+PJ50yKNLkTF1AiSfCsDqkF8aXIFhGhFAdgTWkPEu1XOSxp37OfLGIBcYmJ4jC
+ElKbJQrnCSuF5rVBIkk6M0AYVimVF3DOccMbr+POe76w+4P/+OdfQyQU1b4wCHhiYh+lZ/udVg8s
+iJQ6WIaEZ9GwRmANVpRd552PHx0nXDwyG1YKe4Cde/eMyN49I1KtlC+bnZm6e3J8jPlCgbGpcabn
+TnDxBRfm909+99aTkEbPGhmWVfLFZjU1y6kSGEPCWhLWkLCGwBo25tdw3SVXcv0N7yYIUnng0N49
+I4ca1+7dM7Jv756RW51zl01OTMzOFwqMTBxm8/pNlKon3tIXKMFaK8PI6gWtVQPLIiiK3wDJGHwj
++GIolhZ55OnHWLdmKze97Y9IJFJ31QlqR9u7Z2RfPrX5xmNHJzkxP8tscZ5Iw4v6qJRYQ15WMbqv
+umZFGnL46AGOHDvI6NGDHD46wtHpcY5OjXPg4AEefPgBJPB5+83vI5FI9gD23Z/P5m67/v5R36Tu
+mZ2bI5lIoupyPY7XyrCIrHqea1bv1o6xsScgrOIZwZr4WKVaplIpU66UGDsyyn3/+S0eO/Ac1117
+C9b6d125e/sOgAcemc0DGYD1A7u+UiqWWFhcQMTMdwBlJCcvUkFg1R4yMTOx73P3fvbS5fR95vHH
+eeZxAGaTftZ8/9HZtar4jfO3XvVP//3x713O2PgRApv6VtPUjaRFNOXci5OcrxpYe/eMXHa61/xg
+35xRZVhV/e6w72nqH07MLOSuOf+DuwGMITDCgNNVxUdU8eopk3Q4xKmH7nhvVwXgbLRDwH3r3viR
+2ZN1+tETc74qwxtLD2/PhYd+t3UmRqOdfCrGOPFTqi2Hrm1f2vGLr1MO1c7/xnPlV44vme44JHTq
+O6eeKn49VZIlc8Oph+54cG79TddIHUOp/+v4RJoQSz1mL3We4jThk3eTWLtt1vipW9e/6SN9yy4/
+fnLeV2XYqZodi/9xleZ2fDUK1vTK0Bze5csgQG3f5/GTAbXUli9+e/6WTzXAiSL1w0h959SPHF4j
+t9Tl5IahU8LkptaDuoRogigg7QLVf2sbsIggmc14A5upjD2ZN0Pb7x3/4adu3fzmj3aUXB7+RQxU
+I9hETnH+MFFy4zJkaAHVDqJAXZb4h91xHbV9d0Ju4Z2/NVy+/Efz1902Fa6pNhLn5eaOphsskbog
+Il3fpeccJ+tbfwH7yt8mk8tiFicI54/dNfpftzfpwd6nC75ICyiAqC2NOdVgtQMlbUB1y2S2vIH0
+uq0E4Qxuav8rrsh+/2/z3kz2jKhDLdK6gO0Pbheo+7d0vVDXdSLo4C68/DaGL72FoDZPVJi66/kH
+PnnNT/cXfKETqMaAcZLn9A5OHcQlBqshk9lwGYO7riabX4d3/JnzXpt56ANnBFbo9BRm12ckl9Su
++j2MUAs2YIwhu+VCEqVxXHnh3vTMg5f043mRq08qyNLAyKlkaoLdurY2+GokqpDddhmphCVT2H/D
+FdnvveMMNes0zW4ZAqs3QHhsPxKVSQ4MERRG8lJ45jP9BGpq1nIHi5MMVpuMYXIjbm6MaG6MZG6Y
+ZHWKIXfwAzsTT523Ip5Vc0qyTcBSqUItjHqjToffaDl13/MIfItnDdYzmMZJdbi5I+AHWONImhrl
+wthVibF//r3SOe+6pxsspW2AlvBdjd8uckSRa4uUfSwDqDkPijNEYQWMECSTpAqH2JrLf+D50qs/
+evpgRa0XV1UOjh5jsVQmlfTw4nylOVsSOSWKHGHkCEMlco78YIa1QxnWDGZJpwJsEGuWC0NMZR4X
+eoixBImA7OIxFheHPgx0gRVzpVNFu4aPLBSKLBRLOOdQbfk72vwmda3cXCujURWMxbNC0oRkFw9e
+8prkgzc8Xrr2u6epWa5uaoIR4YJd5+Cc6zAHukasczQFYyTWLGswxhBFIV7hMD5x5dQZwfpJajUl
+WZzYWh751xvZ+gff7tGsPtSENrNrgDiUzzI4mOkBt9uUq0cejVmmKk4U4/loUsgUpkl7R68CThOs
+ZjSMBfJ9r8MvdI6snPxc/XitViNfeAGXHOJ45hWM1tYyOR9SK81BcZL1mcULLXy75eC1RSr7mF0P
+iGIw/fq19VVVvOnHMQ7KmU0c9bYxVkyzWCyileNkvcWrT9sMw0hbL68wOj5NqVTB901zhOLkoU7m
+nOJUm7MimXTAYDZNLpskmfDwfY+B2hThRe9iccPl1IpFkjPHGUgcZ35untnIY41bxPb4LF3S7LoH
+ZGGxRKlcaZogPUw/lnutpDl00Z+hqWFqlRKJ2RkWpqYomPXgDq7MwTd5C1ov3zVIYlcipg2gXBOs
+KHI454ici1mxgua3U8vvICEQBD6+7+F58V9YmaXmFjoWQ0XNaNjGnbq0tSOw0J0dSjMnFIkHVASm
+z7mJVNInmfBJpxL4ngV1eL5HZfrQCsBqN0Mj7Ni6vhl+YXlm12uiLX9nxJLNZlEXoRpRXshRm5/o
+5FkkEtphhr2+q913DubSDObSfc/1RNC2fNGzEIVVrDEcmZaVgtUaOdoSy4Zpan3piUh8LhZQ68fr
+IKkiRhBj2nxILLxnDAPZAaIoYv5EhskZ19AL65wO4A+uB6VYKTEyMdETWATYuXkzmVQMUBhGTfna
+zZU+5tu4h2eEZDJFbnAQpw4xHriVmGHDKTrliV8eZqFYIp30sEaayh5FMW2InBJGjiiKP4dyaTas
+HWQ4nyabTpBM+BjTm8P5vk82myGTyVCphtRXtWStkYxDrCqMTEyw586/6yv0n77r/Vx18auohRFf
++ubPmJ6ZxxptAlKfjUZV6jPMgudZtm0cYufWNWzfPMy64SyZdBoXhRi7ErCitkTaCDu3raNWC1tm
+1+E8489GbQiUwPdIJjySCZ/AtxiRThbeZhrJRIJEMklEkFJlQARrjaQipyjC+qFh3vbG6ylXwp6K
+kmdjrfI9y5svP59SqdpBRmlzDWEUNYgIqaRPLpskl03iexbPM6TTGdSYMzRDA0O5dP/Mv29I7w7d
+/clk47f1PIIgwImx9UmHDCBRvVi3fniYd77lRsLI9alZSZ3Twblb1i7pI3v8aZ8SUyIRoKwUrIYZ
+ohybLlAsVTC2rbrQCIZ18jg4kCI/kCKZ8E8eubp8B4C1Hg4wRnwjEjhVGpoVa44h8E0X2G2DBRRL
+VUqVap9iZQxoMuGRTgX4ntfXh1lruwvGp0sdQB0cOz5PYbFEMrCIkQ4+FoYR1Zpj7VCWhG9JBh6C
+6SKM/clk01KMIXTgWRlo0KSGZvVEsD6OGmChWKawWEa1Xq6o50qCIEZIJxMEvsX3bB3ozllYEcGx
+ArCqbdTBWuHiV21taQe6NEkUMGJOSTO6m6qiYn0E06BJUVcifSpqsnFdnk3r6etPO2mLWVKBwmVW
+SpfwWf1CrunJy07X7HpmFhUiNR0yxJq1hNn18ZG1WtiqjPSbO2hLqK2N81ZjDNa0gk/kWKEZ9jjF
+PsJ3m8UpcrilmsbgSCdYiqouSTI7NVWZmikwO1/EuahzPl86qw7GCNl0HAkz6YCE72GtdNTQVsTg
+zzjayfJWZ6j2ChrTkM7S9ts++iEAvvaJO0glvLbBMmxan2fj2sHOigRLm74xcUXFtPvglYPVGslK
+pUa5WuuT6Us9ksQPbh9J3xp832KMwZiTg+ZUCSPtKitrW1m58/qpEyW2bxzoGCzfM8v2kUu10Omy
+lpQsAZYQRY7Hnh5loVgmk/JpDITSIKLxi4ZRFBf/IiU/mGbT2gHWDQ+QSSdIp3zsSQifNop9XWYI
+cHB8nDu/fm/Hub/+t8+TDCx/+I7f4bxz4lrbY/vHmCsUm2AZY2jGI1oB0hhDPpdiKJdmcCBFNh1H
+ySZY9rR9lms6aN8zXHzBFqrVsHdis53Rt323RvD9mBn7nq1r3anM0PXVrGK5xJPPP9dx7sBoXEp5
++oVj7NpyDmGk7H/+KMdPzGNM25SxNgsjzZTHGMP64SzbzxlmuwyTCLw6nahXOuyKqEPL5+SyyTOK
+dsvxWbUufxHVX/TiXbv4wu5PMD1b5sOf+UsAPn3bno4Il0p4vOeWyzs5w7KXRLUuCR1n4ODrwzM5
+XaBcCeMkWrSVHbaKEi2+pBD4HqmUTzoREATxxIWc5CUcShjRo1kNMNYNpVg/1NofmUl57NyU6xis
+dke90nbGDj6K4ODhaQqLZZIJj4braVQb4spDPFERRQ6nkM+l2bw+x9p8lozWfdZJwOoXDSNHW8kl
+1tzf/823MFuodlEVqQ/oAvMLpZjBt41kY+oskwrID6bjDGMJWcJI8S2mVa04TZ7le8IVl53bnGnp
+njhYzso/Maf2WdZ66YStrVOJNS2VCPLdvOq9b30r5WqEZ6XDTTRWyFgrqJoOLUd681g5iWbtWscW
+1VZAOG2e5bUX787QPy1FHXzfH7JaOU+JfWw6GWzStpkjQbAWsmmvRwYRYcPa3FkxwzWZ6Hw9yQoR
+VaL+Dh5B1fHC6DSL5Urd97QicoM6RJGSyybZsDZHJp1oFgiX7eABz3hDhNWdjXv71mxabiJ+tlro
+IGVr5/ezP0WcIlWnsrikg1eF+cUy84USgW86TCqeXI3BEiPkqyHpVMDpLhZWBSt2natWLgRURKpW
+JaPd6Y3Iqi5DDp1iXe3czoVroipSVmQxQubBlvrUs6ivvre87qJtq7oGMSbOMuRqNSPGLGLsvKpK
+v5IMqwyWiWr1NQ/i1JgyyAJiqg5TjdSeKIXmsAF47tCR4NnnD68V46U6FoKscqvPPwaAQaQo1h6r
+KMe6Z6RfDLBQzcYby9UHKTqxEzX8g8XQf2Jywf+fZybso97+Xx58a2Wh9AoXRq8czA7slBdLwgYp
+VQpeIjFiPG8KY0rGyNoVcMwzanVupypmTq03Eol3uOy8Fwple2hyTg5PzTPnHOqF1dqNGrotURRt
+DYw38IX773/RhDw+O4fne9M2mRhRlYpGkajT4Ds/+SmPP/vsiybH0eMzOOs/44w3UlXv8ELFvjBV
+MKOTsxyvhjRnTOSpXzz3J6qaVqcJYyQH4hljUoDRPprQOwesPSuEG4clvo+0X1unBRHWLojxZtTY
+Ew4puwiHukBVPXXOtnK7FvfR+hLKjmONpQRt/WnrR1v/BgfruF/9d+SkWqpJYbYoJ04ssFCLiLpf
+qans5WqUUmXIOYad4rV2dTZ3hbZtp9XW0iNt7f5s7iCN6+ppayTtGhu6HTh19R2jvbtI1dWf1fHZ
+3o94qUDXs/r3bV2j6vqfd336n2K1sgGo1pwRJF9fNXzGGwlEEM9Kil+xZur6NaSwBjk7Oy48K4nV
+3qH1fwJWGLkksOlsAQXgW0nzK9gMsPNs7qryjQQiYn4VwfrfAQAc9dDnZ0sguwAAAABJRU5ErkJg
+gg==
+"
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66.000015"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5-7"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient4314-5-4);fill-opacity:1;stroke:none;filter:url(#filter4344-1)"
+       transform="matrix(0.81385308,0,0,0.61823795,-26.010509,404.93119)" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient4314-5);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(0.81385308,0,0,0.61823795,8.9894909,404.93119)" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 37.506494,1008.8603 19.753919,-0.2323 7.608429,8.7088 0.07385,27.9289 -27.288467,0.2323 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 37.555332,1008.952 19.486128,0 c 0,0 5.85893,1.2059 4.373085,3.9843 -0.04608,0.087 4.030127,4.7374 4.030127,4.7374 l 0,28.1389 -27.88934,0 z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0"
+       d="m 57.260413,1008.9265 7.577969,8.4882 0,8.8212 -11.121134,-7.7162 c 1.458578,-3.0944 2.515266,-6.3264 3.543105,-9.5932 z"
+       style="display:inline;fill:url(#linearGradient4240);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4"
+       d="m 57.057798,1008.3236 c 1.63519,2.2276 3.607055,5.0773 2.145555,9.9462 3.363056,-1.9023 6.847609,-0.8933 6.847609,-0.8933 0,-4.5455 -5.518386,-9.2672 -8.993164,-9.0529 z"
+       style="display:inline;fill:url(#linearGradient4264);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1038.3622 9.700639,0"
+       id="path4696"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#879ab6;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1034.3622 14,0"
+       id="path4696-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1016.3622 12,0"
+       id="path4696-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1020.3622 12,0"
+       id="path4696-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#7b8fae;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47.000001,1024.3622 14,0"
+       id="path4696-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1030.3622 12,0"
+       id="path4696-2"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g8662"
+       transform="matrix(-1.0520896,0,0,-1.0534376,64.741831,2090.0588)">
+      <path
+         style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:#398a43;stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.244943,1041.4693 c -0.24182,0.7378 -4.276215,-4.6418 -4.276215,-4.6418 -11.44876,7.9356 -17.573348,-1.4122 -16.632852,-8.3285 0.287455,-2.114 2.873263,9.5491 13.24418,4.9398 0,0 -6.161054,-4.0913 -5.456972,-5.1523 0.390532,-0.5886 13.008987,-0.7195 13.731155,0.03 0.722169,0.75 -0.343071,12.3401 -0.609296,13.1524 z"
+         id="path4522"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scscszs" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4584);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.029866,1028.5266 c 0.335464,3.4409 -0.540551,10.8513 -0.558812,11.097 -0.130143,-0.1351 -3.305251,-4.1177 -3.305251,-4.1177 -13.489832,9.4517 -15.979945,-3.8837 -15.944315,-4.5632 0,0 4.159907,8.1407 14.425918,2.5964 -3.722931,-2.2 -6.36447,-4.7334 -6.416153,-4.8694"
+         id="path4522-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscc" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-3"
+       d="m 5.4557968,1008.9145 19.7539192,-0.2324 7.608429,8.7088 0.07385,27.9289 -27.2884668,0.2324 z"
+       style="display:inline;fill:url(#linearGradient4499);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1-8"
+       d="m 5.5046347,1009.0062 19.4861283,0 c 0,0 5.85893,1.2058 4.373085,3.9843 -0.04608,0.087 4.030127,4.7373 4.030127,4.7373 l 0,28.139 -27.8893403,0 z"
+       style="fill:none;stroke:url(#linearGradient4501);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0-0"
+       d="m 25.209716,1008.9807 7.577969,8.4882 0,8.8212 -11.121134,-7.7163 c 1.458578,-3.0943 2.515266,-6.3264 3.543104,-9.5931 z"
+       style="display:inline;fill:url(#linearGradient4503);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4-7"
+       d="m 25.007101,1008.3777 c 1.63519,2.2277 3.607055,5.0774 2.145555,9.9463 3.363056,-1.9023 6.847609,-0.8933 6.847609,-0.8933 0,-4.5456 -5.518387,-9.2672 -8.993164,-9.053 z"
+       style="display:inline;fill:url(#linearGradient4505);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1041.3622 9.700638,0"
+       id="path4696-88"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1037.3622 13.338378,0"
+       id="path4696-5-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1033.3622 14.550958,0"
+       id="path4696-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1016.3622 13.338378,0"
+       id="path4696-0-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1020.3622 13.338378,0"
+       id="path4696-9-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1024.3622 13.338378,0"
+       id="path4696-8-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9,1028.3622 10.913218,0"
+       id="path4696-2-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 47,1027.3622 10,0"
+       id="path4696-2-4"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g4574"
+       transform="translate(-55,-20)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4696-09"
+         d="m 94,1054.3622 6,0"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4696-09-2"
+         d="m 97,1051.3622 0,6"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#3b6568;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39,1024.3622 6,0"
+       id="path4696-09-1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -193,15 +193,15 @@ CompareEditorInput.defaultTitle= Compare
 #
 action.IgnoreWhiteSpace.label=Ignore White Space
 action.IgnoreWhiteSpace.tooltip=Ignore White Space Where Applicable
-action.IgnoreWhiteSpace.image=etool16/ignorews_edit.png
+action.IgnoreWhiteSpace.image=etool16/ignorews_edit.svg
 
 action.Next.label=Next Difference
 action.Next.tooltip=Next Difference
-action.Next.image=elcl16/next_diff_nav.png
+action.Next.image=elcl16/next_diff_nav.svg
 
 action.Previous.label=Previous Difference
 action.Previous.tooltip=Previous Difference
-action.Previous.image=elcl16/prev_diff_nav.png
+action.Previous.image=elcl16/prev_diff_nav.svg
 
 #
 # Built in Structure Creators

--- a/team/bundles/org.eclipse.compare/plugin.xml
+++ b/team/bundles/org.eclipse.compare/plugin.xml
@@ -120,7 +120,7 @@
          point="org.eclipse.ui.editors">
       <editor
             name="%defaultCompareEditor.name"
-            icon="$nl$/icons/full/eview16/compare_view.png"
+            icon="$nl$/icons/full/eview16/compare_view.svg"
             contributorClass="org.eclipse.compare.internal.CompareEditorContributor"
             class="org.eclipse.compare.internal.CompareEditor"
             id="org.eclipse.compare.CompareEditor">

--- a/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
+++ b/team/tests/org.eclipse.compare.tests/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Export-Package: org.eclipse.compare.tests,
  org.eclipse.compare.tests.performance
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.compare.tests
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUITest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/PatchUITest.java
@@ -201,7 +201,7 @@ public class PatchUITest {
 	}
 
 	private void openPatchWizard() {
-		ImageDescriptor patchWizardImage = CompareUIPlugin.getImageDescriptor("wizban/applypatch_wizban.png");
+		ImageDescriptor patchWizardImage = CompareUIPlugin.getImageDescriptor("wizban/applypatch_wizban.svg");
 		String patchWizardTitle = PatchMessages.PatchWizard_title;
 
 		IStorage patch = null;


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.compare`,  `org.eclipse.compare.tests` and `org.eclipse.compare.win32`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.