### PR TITLE
Add SVGs to to org.eclipse.ui.console

### DIFF
--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.console
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/icons/full/clcl16/clear_co.svg
+++ b/debug/org.eclipse.ui.console/icons/full/clcl16/clear_co.svg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="clear_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4900"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient5000"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       id="linearGradient4852-7-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter6988"
+       x="-0.24001802"
+       width="1.480036"
+       y="-0.23998199"
+       height="1.479964">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.2049008"
+         id="feGaussianBlur6990" />
+    </filter>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-1"
+       xlink:href="#linearGradient4852-7-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-9"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-1"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-0"
+       xlink:href="#linearGradient4844-4-1-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-4">
+      <stop
+         id="stop4846-8-4-2"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-2"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-4"
+       xlink:href="#linearGradient4852-7-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-5"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-9"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-8"
+       xlink:href="#linearGradient4844-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-7">
+      <stop
+         id="stop4846-8-4-5"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-3"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000002"
+     inkscape:cx="18.223534"
+     inkscape:cy="-36.6021"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8-8"
+     showgrid="true"
+     inkscape:window-width="1542"
+     inkscape:window-height="975"
+     inkscape:window-x="1006"
+     inkscape:window-y="492"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5000);fill-opacity:1;stroke:none;display:inline"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900);fill-opacity:1;stroke:none"
+       d="m 7.976621,1036.441 0,3.9112 3.977476,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1039.3518" />
+    <rect
+       style="fill:url(#linearGradient4869);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1041.3518" />
+    <rect
+       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1043.3518" />
+    <rect
+       style="fill:url(#linearGradient4875);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1045.3518" />
+    <rect
+       style="fill:url(#linearGradient4873);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="3.0070496"
+       y="1047.3518" />
+    <g
+       id="g6200"
+       mask="url(#mask6204)"
+       transform="matrix(1.4660179,0,0,1.2212682,-5.6373987,-232.07964)">
+      <g
+         transform="matrix(0.53947849,0,0,0.53947849,7.846281,484.46953)"
+         inkscape:label="Layer 1"
+         id="layer1-8"
+         style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:3.70728397;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter6988)">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.70728397;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+           id="rect4043"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssccsccsccss" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-8-8"
+       inkscape:label="Layer 1"
+       transform="matrix(0.50767387,0,0,0.5061245,8.120638,519.33645)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.50689858;stroke-opacity:1"
+         d="m 10.09375,7.0489054 c -0.3172668,0.031974 -0.6221509,0.15383 -0.78125,0.3125 l -0.59375,0.5625 C 8.400566,8.241043 8.3380492,9.7451599 8.65625,10.0625 L 10.25,11.59375 8.59375,13.1875 C 8.4346339,13.346119 8.405526,13.69178 8.4375,14.03125 l 3.59375,0 0,-5.7010946 -1.125,-1.09375 c -0.159083,-0.15867 -0.495233,-0.2194744 -0.8125,-0.1875 z"
+         transform="matrix(1.9697685,0,0,1.9757984,-15.995777,1021.5387)"
+         id="rect3911"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccccccccs" />
+      <path
+         sodipodi:nodetypes="sccccccccssccsccsccss"
+         inkscape:connector-curvature="0"
+         id="rect4043-2"
+         d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+         style="fill:url(#linearGradient6120);fill-opacity:1;stroke:url(#linearGradient6122);stroke-width:1.97278117;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/clcl16/lock_co.svg
+++ b/debug/org.eclipse.ui.console/icons/full/clcl16/lock_co.svg
@@ -1,0 +1,663 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="lock_co.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient18855">
+      <stop
+         id="stop18857"
+         offset="0"
+         style="stop-color:#a4b1c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e1e9f8;stop-opacity:0"
+         offset="0.50000364"
+         id="stop18859" />
+      <stop
+         id="stop18861"
+         offset="1"
+         style="stop-color:#e7eefa;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18808">
+      <stop
+         style="stop-color:#a4b1c7;stop-opacity:1;"
+         offset="0"
+         id="stop18810" />
+      <stop
+         id="stop18816"
+         offset="0.24999017"
+         style="stop-color:#e1e9f8;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7eefa;stop-opacity:1"
+         offset="1"
+         id="stop18812" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18543">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1;"
+         offset="0"
+         id="stop18545" />
+      <stop
+         id="stop18555"
+         offset="0.31919643"
+         style="stop-color:#687692;stop-opacity:1" />
+      <stop
+         id="stop18553"
+         offset="0.42585152"
+         style="stop-color:#8c99a6;stop-opacity:1" />
+      <stop
+         id="stop18551"
+         offset="0.671875"
+         style="stop-color:#7b8da7;stop-opacity:1" />
+      <stop
+         style="stop-color:#5e78a8;stop-opacity:1"
+         offset="1"
+         id="stop18547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4862">
+      <stop
+         style="stop-color:#937323;stop-opacity:1;"
+         offset="0"
+         id="stop4864" />
+      <stop
+         style="stop-color:#79601d;stop-opacity:1;"
+         offset="1"
+         id="stop4866" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4886">
+      <stop
+         style="stop-color:#dec26f;stop-opacity:1"
+         offset="0"
+         id="stop4888" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop4890" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5156">
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1;"
+         offset="0"
+         id="stop5158" />
+      <stop
+         id="stop5166"
+         offset="0.48612955"
+         style="stop-color:#fdf3cb;stop-opacity:1" />
+      <stop
+         id="stop5164"
+         offset="0.56520796"
+         style="stop-color:#a77e1c;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:0.5"
+         offset="1"
+         id="stop5160" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5152">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.32374297"
+         id="feGaussianBlur5154" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4878">
+      <stop
+         style="stop-color:#925218;stop-opacity:1"
+         offset="0"
+         id="stop4880" />
+      <stop
+         style="stop-color:#c1aa38;stop-opacity:1"
+         offset="1"
+         id="stop4882" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4862"
+       id="linearGradient8465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-42.734657,2.4992546)"
+       x1="30.0625"
+       y1="1034.4965"
+       x2="30.0625"
+       y2="1040.9708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4886"
+       id="linearGradient8469"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="32.325939"
+       y1="1049.9935"
+       x2="32.325939"
+       y2="1040.7358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5156"
+       id="linearGradient8471"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="27.20822"
+       y1="1041.8381"
+       x2="32.558262"
+       y2="1049.7878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4878"
+       id="linearGradient8473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="29.263437"
+       y1="1048.656"
+       x2="29.263437"
+       y2="1040.7803" />
+    <linearGradient
+       y2="1049.0082"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-22.460469,20.310309)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4079"
+       xlink:href="#linearGradient18543"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(2.539576,14.310209)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4077"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(2.539576,14.310209)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4910-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18543"
+       id="linearGradient18549"
+       x1="-22.476931"
+       y1="1056.5162"
+       x2="-22.476931"
+       y2="1069.6725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18,0)" />
+    <linearGradient
+       id="linearGradient4910-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,14.310292)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7"
+       xlink:href="#linearGradient4994-4-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,14.310292)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18638"
+       xlink:href="#linearGradient4910-4-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4910-4-5-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5-4"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,18.310346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7-5"
+       xlink:href="#linearGradient4994-4-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7-9">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,18.310346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18687"
+       xlink:href="#linearGradient4910-4-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4910-4-5-6-2"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3-4-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5-4-3"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,23.310392)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7-5-2"
+       xlink:href="#linearGradient4994-4-7-9-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7-9-3">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4-2-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4-4-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,23.310392)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18736"
+       xlink:href="#linearGradient4910-4-5-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18808"
+       id="linearGradient18814"
+       x1="-2.4769311"
+       y1="1060.6725"
+       x2="-2.4769311"
+       y2="1064.6725"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(-3.8171387e-7,-5.3951562e-5)"
+       y2="1064.6725"
+       x2="-2.4769311"
+       y1="1060.6725"
+       x1="-2.4769311"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18834"
+       xlink:href="#linearGradient18855"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8608">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         id="rect8610"
+         width="14"
+         height="14"
+         x="1"
+         y="1037.3622"
+         rx="0.67081022"
+         ry="0.67081022" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter9392"
+       x="-0.19209543"
+       width="1.3841909"
+       y="-0.16933754"
+       height="1.3386751">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63281438"
+         id="feGaussianBlur9394" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-12.065247"
+     inkscape:cy="6.0761001"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8451"
+     showgrid="false"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="891"
+     inkscape:window-y="642"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="translate(15.537591,-18.310246)">
+      <rect
+         y="1056.1724"
+         x="-12.977081"
+         height="13.013947"
+         width="12.986286"
+         id="rect3997-9"
+         style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m -11.460469,1057.6724 -0.01646,11 -1,0 0.01646,-12 z"
+         style="fill:url(#linearGradient4077);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m -11.460469,1057.6724 6.983538,0 0,-1 -7.983538,0 z"
+         style="fill:url(#linearGradient4075);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         style="fill:url(#linearGradient18549);fill-opacity:1;stroke:none"
+         id="rect18033"
+         width="1"
+         height="14"
+         x="-4.4769306"
+         y="1055.6725" />
+      <rect
+         style="fill:#687692;fill-opacity:1;stroke:none;display:inline"
+         id="rect18033-4"
+         width="1"
+         height="3.0000005"
+         x="1059.6725"
+         y="0.47693062"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <rect
+         style="fill:#7b8ca7;fill-opacity:1;stroke:none;display:inline"
+         id="rect18033-4-9"
+         width="1"
+         height="3.0000005"
+         x="1064.6725"
+         y="0.47693062"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3"
+         d="m -2.476931,1057.6724 0,2 -1,0 0,-3 z"
+         style="fill:url(#linearGradient18638);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3"
+         d="m -2.476931,1057.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1060.6725"
+         x="-3.4769311"
+         height="3.9999607"
+         width="3.0000005"
+         id="rect3997-9-5"
+         style="fill:url(#linearGradient18814);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3-4"
+         d="m -2.476931,1061.6724 0,3 -1,0 0,-4 z"
+         style="fill:url(#linearGradient18687);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3-2"
+         d="m -2.476931,1061.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7-5);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3-4-2"
+         d="m -2.476931,1066.6724 0,2 -1,0 0,-3 z"
+         style="fill:url(#linearGradient18736);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3-2-3"
+         d="m -2.476931,1066.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7-5-2);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1060.6725"
+         x="-3.4769311"
+         height="3.9999607"
+         width="3.0000005"
+         id="rect3997-9-5-5"
+         style="fill:url(#linearGradient18834);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         style="fill:#4b6ea2;fill-opacity:1;stroke:none"
+         id="rect18863"
+         width="1"
+         height="1"
+         x="12"
+         y="3"
+         transform="translate(-14.476931,1054.6724)" />
+      <rect
+         style="fill:#4b6ea2;fill-opacity:1;stroke:none;display:inline"
+         id="rect18863-7"
+         width="1"
+         height="1"
+         x="-2.4769311"
+         y="1066.6725" />
+    </g>
+    <g
+       id="g8605"
+       mask="url(#mask8608)"
+       transform="translate(1.0606602,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8589"
+         d="m 3.96875,1043.3622 c -1.839313,0 -3.34375,1.4732 -3.34375,3.3125 l 0,0.3125 c -0.347633,0.1472 -0.59375,0.4741 -0.59375,0.875 l 0,3.5 c 0,0.5346 0.434192,0.9688 0.96875,0.9688 l 5.9375,0 c 0.534558,0 1,-0.4342 1,-0.9688 l 0,-3.5 c 0,-0.3852 -0.258682,-0.6877 -0.59375,-0.8437 l 0,-0.3438 c 0,-1.8416 -1.535687,-3.3125 -3.375,-3.3125 z m 0,1.8125 c 0.865247,0 1.53125,0.6385 1.53125,1.5 l 0,0.2188 -3.03125,0 0,-0.2188 c 0,-0.8653 0.634753,-1.5 1.5,-1.5 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.60714811;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter9392);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    </g>
+    <g
+       id="g8451"
+       transform="matrix(0.60714811,0,0,0.60714811,13.623389,413.81637)">
+      <path
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0"
+         id="rect4838-1"
+         d="m -10.059546,1045.0618 0,-2.9375 c 0,-2.7586 -1.253608,-5 -4.012192,-5 -2.758584,0 -4.162918,2.2414 -4.162918,5 l 0,2.9375"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient8465);stroke-width:2.47056686;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <rect
+         ry="1.1048543"
+         rx="1.1048543"
+         y="1042.9824"
+         x="-19.876328"
+         height="7.9382153"
+         width="11.998713"
+         id="rect4838"
+         style="fill:url(#linearGradient8469);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         ry="0.60104567"
+         rx="0.62204111"
+         y="1043.4849"
+         x="-19.241508"
+         height="6.8243604"
+         width="10.729074"
+         id="rect4838-4"
+         style="fill:none;stroke:url(#linearGradient8471);stroke-width:0.87896538;stroke-opacity:1;display:inline;filter:url(#filter5152)" />
+      <rect
+         y="1045.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1047.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894-7"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1049.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894-7-4"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <path
+         d="m 10.496117,12.531184 c 0,0.561379 -0.455088,1.016466 -1.0164665,1.016466 -0.5613787,0 -1.016466,-0.455087 -1.016466,-1.016466 0,-0.561378 0.4550873,-1.016466 1.016466,-1.016466 0.5613785,0 1.0164665,0.455088 1.0164665,1.016466 z"
+         sodipodi:ry="1.016466"
+         sodipodi:rx="1.016466"
+         sodipodi:cy="12.531184"
+         sodipodi:cx="9.4796505"
+         id="path4066"
+         style="fill:#785b13;fill-opacity:1;stroke:none;display:inline"
+         sodipodi:type="arc"
+         transform="translate(-23.389764,1033.4176)" />
+      <rect
+         y="1046.5895"
+         x="-14.440443"
+         height="2.8063302"
+         width="1.0606602"
+         id="rect4836"
+         style="fill:#785b13;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         ry="1.1048543"
+         rx="1.1048543"
+         y="1042.6913"
+         x="-19.876328"
+         height="8.2291298"
+         width="11.509747"
+         id="rect4838-12"
+         style="fill:none;stroke:url(#linearGradient8473);stroke-width:1.64704454;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/clcl16/pin.svg
+++ b/debug/org.eclipse.ui.console/icons/full/clcl16/pin.svg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="pin.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1"
+         offset="0"
+         id="stop4983" />
+      <stop
+         id="stop4991"
+         offset="0.39414415"
+         style="stop-color:#72b649;stop-opacity:1" />
+      <stop
+         id="stop4989"
+         offset="0.5"
+         style="stop-color:#72b649;stop-opacity:1" />
+      <stop
+         style="stop-color:#359b58;stop-opacity:1"
+         offset="1"
+         id="stop4985" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4973">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4975" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4977" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084" />
+      <stop
+         id="stop4864"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810"
+       inkscape:collect="always">
+      <stop
+         id="stop4812"
+         offset="0"
+         style="stop-color:#bfb688;stop-opacity:1;" />
+      <stop
+         id="stop4814"
+         offset="1"
+         style="stop-color:#8694ae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(18,-4.000037)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always"
+       gradientTransform="translate(18,1.999963)" />
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient4046"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.000063)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       y2="1041.8765"
+       x2="8.0137892"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.0001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4063"
+       xlink:href="#linearGradient4082"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4973-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4975-4" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4977-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.63848363,-0.63848363,0,689.62207,1034.1003)"
+       y2="1039.0527"
+       x2="21.074127"
+       y1="1044.9652"
+       x1="21.049656"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5038"
+       xlink:href="#linearGradient4973-9"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask5241">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 2,1041.3622 0,0.5 0,9.0313 0,0.5 0.5,0 12,0 0.5,0 0,-0.5 0,-9.0313 0,-0.5 -0.5,0 -12,0 -0.5,0 z"
+         id="path5243"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4973"
+       id="linearGradient5265"
+       gradientUnits="userSpaceOnUse"
+       x1="21.123072"
+       y1="1045.577"
+       x2="21.123072"
+       y2="1046.688" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient5267"
+       gradientUnits="userSpaceOnUse"
+       x1="18.909349"
+       y1="7.609231"
+       x2="22.095001"
+       y2="8.296731" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient5269"
+       gradientUnits="userSpaceOnUse"
+       x1="19.624538"
+       y1="1041.6436"
+       x2="22"
+       y2="1041.6436" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="6.4843753"
+     inkscape:cy="8.2343754"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4046);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 2.500702,1041.8621 11.999628,0 0,9.033 -11.999628,0 z"
+       id="rect3997-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1045.3622 0,5.0312 -1,0 0,-6.0312 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1045.3622 10,0 0,-1 -11,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 2.500702,1041.8621 11.999628,0 0,2.0053 -11.999628,0 z"
+       id="rect3997-9-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g5014">
+      <g
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,734.42008,290.38128)"
+         id="g5001">
+        <path
+           inkscape:connector-curvature="0"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.25;color:#000000;fill:url(#linearGradient5038);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 26.750924,1047.1294 c -0.01596,-0.035 -0.04489,-0.064 -0.07981,-0.08 -0.02425,-0.013 -0.05202,-0.02 -0.07968,-0.02 l -5.820754,-10e-5 c -0.01325,0 -0.0267,0 -0.03966,10e-5 -0.04253,0.011 -0.07932,0.041 -0.09971,0.08 -0.06128,0.1015 -0.126608,0.2023 -0.139716,0.3392 -0.0134,0.1368 0.04856,0.2783 0.159649,0.419 0.01903,0.028 0.0484,0.049 0.07977,0.06 0.01326,0 0.0267,0 0.03966,-10e-5 l 5.820754,0 c 0.008,0 0.01313,5e-4 0.01983,0 0.02101,0 0.04186,-0.01 0.06021,-0.02 0.03899,-0.02 0.06846,-0.058 0.07982,-0.1 0.0014,-0.013 0.0015,-0.027 -8.6e-5,-0.04 l -8e-6,-0.5787 c 0.0038,-0.02 0.0039,-0.04 -1.31e-4,-0.06 z"
+           id="path4971-0"
+           sodipodi:nodetypes="cccccccccccccccccc" />
+        <path
+           style="fill:#a5adba;fill-opacity:1;stroke:#17325d;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+           d="m 20.492187,1045.1591 0.921876,0 0,2.4062 c -0.376231,0.2965 -0.615362,0.1856 -0.921876,0 z"
+           id="rect4944"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <g
+           id="g5057">
+          <path
+             id="path4971"
+             d="m 20.40625,1044.9062 a 0.250025,0.250025 0 0 0 -0.125,0.125 0.250025,0.250025 0 0 0 -0.03125,0.125 l 0,2.4063 a 0.250025,0.250025 0 0 0 0,0.062 0.250025,0.250025 0 0 0 0.125,0.1562 c 0.159025,0.096 0.31691,0.1983 0.53125,0.2188 0.21434,0.021 0.436009,-0.076 0.65625,-0.25 a 0.250025,0.250025 0 0 0 0.09375,-0.125 0.250025,0.250025 0 0 0 0,-0.062 l 0,-2.4063 a 0.250025,0.250025 0 0 0 0,-0.031 0.250025,0.250025 0 0 0 -0.03125,-0.094 0.250025,0.250025 0 0 0 -0.15625,-0.125 0.250025,0.250025 0 0 0 -0.0625,0 l -0.90625,0 a 0.250025,0.250025 0 0 0 -0.09375,0 z"
+             style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.5;color:#000000;fill:url(#linearGradient5265);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="zcscz"
+             inkscape:connector-curvature="0"
+             id="path4884-8"
+             transform="translate(0,1036.3622)"
+             d="M 20.9375,6.125 C 19.686416,6.1463072 18.732332,7.2495515 18.53125,8 c 0,0.595432 1.068685,1.09375 2.40625,1.09375 C 22.275065,9.09375 23.375,8.595432 23.375,8 23.179528,7.2704899 22.188584,6.1036928 20.9375,6.125 z"
+             style="fill:url(#linearGradient5267);fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+          <path
+             sodipodi:nodetypes="sccsccs"
+             inkscape:connector-curvature="0"
+             id="rect4923"
+             d="m 20.929746,1040.0249 c -0.533598,0 -0.994941,0.084 -1.356203,0.2348 l 0,2.7676 c 0.361262,0.1504 0.822605,0.2348 1.356203,0.2348 0.487606,0 0.928812,-0.081 1.277961,-0.2087 l 0,-2.8198 c -0.349149,-0.128 -0.790355,-0.2087 -1.277961,-0.2087 z"
+             style="fill:url(#linearGradient5269);fill-opacity:1;stroke:#00953e;stroke-width:0.83458644;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+          <path
+             transform="matrix(0.90924832,0,0,0.90924832,2.1288433,1036.5222)"
+             d="m 23.125,3.1406245 c 0,0.595432 -1.08431,1.078125 -2.421875,1.078125 -1.337565,0 -2.421875,-0.482693 -2.421875,-1.078125 0,-0.595432 1.08431,-1.078125 2.421875,-1.078125 1.337565,0 2.421875,0.482693 2.421875,1.078125 z"
+             sodipodi:ry="1.078125"
+             sodipodi:rx="2.421875"
+             sodipodi:cy="3.1406245"
+             sodipodi:cx="20.703125"
+             id="path4884"
+             style="fill:#7db551;fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+             sodipodi:type="arc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/clcl16/wordwrap.svg
+++ b/debug/org.eclipse.ui.console/icons/full/clcl16/wordwrap.svg
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg2"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="wordwrap.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1392"
+     inkscape:window-height="1027"
+     id="namedview71"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="3.7966102"
+     inkscape:cy="-1.8305085"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4199"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147">
+      <stop
+         id="stop5149"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5151"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141">
+      <stop
+         id="stop5143"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5145"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135">
+      <stop
+         id="stop5137"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5139"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994">
+      <stop
+         id="stop4996"
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4998"
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902">
+      <stop
+         id="stop4904"
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4906"
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894">
+      <stop
+         id="stop4896"
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4898"
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877">
+      <stop
+         id="stop4879"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4881"
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4861">
+      <stop
+         id="stop4863"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4865"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5574967,0,0,0.98973058,-7.9134566,6.7250342)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67472995,0,0,0.98973058,-1.7278662,6.7455722)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52052288,0,0,0.98973058,-0.64732963,6.7661112)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       id="linearGradient4873"
+       xlink:href="#linearGradient5135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49069121,0,0,0.98973058,-0.43829777,6.8071892)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       id="linearGradient4875"
+       xlink:href="#linearGradient5141"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35202605,0,0,1,0.5403856,-3.9999613)" />
+    <linearGradient
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <linearGradient
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0729393,-3.9972825,-76.818456)" />
+    <linearGradient
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       id="linearGradient5000"
+       xlink:href="#linearGradient4994"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       id="linearGradient4852-7-8">
+      <stop
+         id="stop4854-4-1"
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4856-0-2"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         style="stop-color:#606060;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4848-8-9"
+         style="stop-color:#787878;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)" />
+    <linearGradient
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)" />
+    <mask
+       id="mask6204">
+      <path
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    </mask>
+    <filter
+       x="-0.39259922"
+       y="-0.39254196"
+       width="1.78503"
+       height="1.78508"
+       color-interpolation-filters="sRGB"
+       id="filter6988">
+      <feGaussianBlur
+         id="feGaussianBlur6990"
+         stdDeviation="1.2049008" />
+    </filter>
+    <linearGradient
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.58432111,0.58432111,0,-601.73696,1040.3056)" />
+    <linearGradient
+       id="linearGradient7084">
+      <stop
+         id="stop7086"
+         style="stop-color:#fefaef;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7088"
+         style="stop-color:#fce5a7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       id="linearGradient7082"
+       xlink:href="#linearGradient7076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19,-0.93755)" />
+    <linearGradient
+       id="linearGradient7076">
+      <stop
+         id="stop7078"
+         style="stop-color:#956413;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7080"
+         style="stop-color:#c38b1d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078"
+       id="linearGradient3026"
+       xlink:href="#linearGradient7084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.58432111,0,0,0.58432111,15.079637,436.72927)" />
+    <linearGradient
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       id="linearGradient3028"
+       xlink:href="#linearGradient7076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,18.428259,1037.8945)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52052288,0,0,0.98973058,-0.64732999,12.766129)"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1036.3622)"
+     id="layer1"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       d="m 1.5,1037.8622 h 7.0096685 l 3.0141185,3.2259 v 10.7741 H 1.5 Z"
+       id="rect4001"
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       width="6"
+       height="1"
+       x="3"
+       y="1039.3622"
+       id="rect4001-1"
+       style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none;stroke-width:0.999995" />
+    <rect
+       width="5"
+       height="1"
+       x="3"
+       y="1041.3622"
+       id="rect4001-1-7"
+       style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none;stroke-width:0.999995" />
+    <rect
+       width="4"
+       height="1"
+       x="3"
+       y="1043.3622"
+       id="rect4001-1-7-4"
+       style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none;stroke-width:0.999995" />
+    <rect
+       width="2"
+       height="0.9999826"
+       x="3"
+       y="1045.3622"
+       id="rect4001-1-7-4-0"
+       style="display:inline;fill:url(#linearGradient4875);fill-opacity:1;stroke:none" />
+    <rect
+       width="1.9999999"
+       height="1"
+       x="2.9999998"
+       y="1047.3622"
+       id="rect4001-1-7-4-0-9"
+       style="display:inline;fill:url(#linearGradient4873);fill-opacity:1;stroke:none;stroke-width:0.999995" />
+    <g
+       mask="url(#mask6204)"
+       id="g6200"
+       transform="translate(0.0027175,0.9585)">
+      <g
+         transform="matrix(0.53947849,0,0,0.53947849,7.846281,484.46953)"
+         id="layer1-8"
+         style="display:inline;opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:3.70728;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter6988)">
+        <path
+           d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+           id="rect4043"
+           style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.70728;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       d="m 15.522638,1046.4194 v -5.8469 c 0,-0.3903 -0.2972,-0.7187 -0.6875,-0.7187 h -0.579139 c -0.3903,0 -0.7188,0.3284 -0.7188,0.7187 v 5.2573 l -3.014561,-0.017 v -2.0145 l -0.9999998,0.017 -3.0323593,3.0323 3.0323593,2.9613 h 0.9999998 v -1.9985 h 3.4687 c 0.9367,0 1.5313,-0.2837 1.5313,-1.3911 z"
+       id="rect3968"
+       style="display:inline;fill:url(#linearGradient3026);fill-opacity:1;stroke:url(#linearGradient3028);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccccccccss" />
+    <rect
+       width="4"
+       height="1"
+       x="2.9999995"
+       y="1049.3622"
+       id="rect4001-1-7-4-4"
+       style="display:inline;fill:url(#linearGradient1);fill-opacity:1;stroke:none;stroke-width:0.999995" />
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/cview16/console_view.svg
+++ b/debug/org.eclipse.ui.console/icons/full/cview16/console_view.svg
@@ -1,0 +1,550 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="console_view.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4008">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#546483;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         style="stop-color:#818b9f;stop-opacity:1;"
+         offset="1"
+         id="stop3910" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#2b5c9c;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#3673c4;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3884">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3886" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3888" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.7236701"
+       id="linearGradient5838"
+       xlink:href="#linearGradient5832"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832">
+      <stop
+         id="stop5834"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840" />
+      <stop
+         id="stop5836"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846" />
+      <stop
+         id="stop5848"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask10494">
+      <path
+         inkscape:connector-curvature="0"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 21,1037.3622 0,0.5 0,2 0,0.5 0,8.5313 0,0.5 0.5,0 13.03125,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -13.03125,0 -0.5,0 z"
+         id="path10496" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter11270"
+       x="-0.24"
+       width="1.48"
+       y="-0.24"
+       height="1.48">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63130821"
+         id="feGaussianBlur11272" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11296"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-7"
+       xlink:href="#linearGradient5832-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-2">
+      <stop
+         id="stop5834-8"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-7" />
+      <stop
+         id="stop5836-9"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-9">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-2" />
+      <stop
+         id="stop5848-9"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter11520"
+       x="-0.24"
+       width="1.48"
+       y="-0.24"
+       height="1.48">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63130821"
+         id="feGaussianBlur11522" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290-2">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292-4" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294-75" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-0"
+       xlink:href="#linearGradient5832-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-7">
+      <stop
+         id="stop5834-1"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-6" />
+      <stop
+         id="stop5836-93"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-7">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-3" />
+      <stop
+         id="stop5848-0"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11407"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11409"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11413"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11415"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11417"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11623"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11625"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11629"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11631"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3898"
+       x1="22.420315"
+       y1="1044.6581"
+       x2="22.420315"
+       y2="1037.9327"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3906"
+       id="linearGradient3912"
+       x1="22.994839"
+       y1="1040.1731"
+       x2="22.994839"
+       y2="1048.3184"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008"
+       id="linearGradient4014"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.0281848,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008-8"
+       id="linearGradient4014-5"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4008-8">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010-9" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.8778"
+       x2="19.998154"
+       y1="1041.8778"
+       x1="25.096403"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4048"
+       xlink:href="#linearGradient4008-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.20625,0,0,1,-5.1479113,2.03125)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-12.355569"
+     inkscape:cy="-9.9662339"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1557"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4067"
+       transform="translate(-14,0)">
+      <rect
+         ry="0.79549515"
+         rx="0.79549515"
+         y="1037.8665"
+         x="16.572817"
+         height="10.010139"
+         width="11.932429"
+         id="rect3101"
+         style="fill:url(#linearGradient3912);fill-opacity:1;stroke:url(#linearGradient3898);stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1039.3717"
+         x="18.002655"
+         height="7.0085478"
+         width="9.0156116"
+         id="rect3902"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <g
+         transform="matrix(1.2279408,0,0,1,-5.1169737,0)"
+         id="g3920-0"
+         style="fill:#4673ad;fill-opacity:1;display:inline">
+        <rect
+           style="fill:#4673ad;fill-opacity:1;stroke:none"
+           id="rect3914-0"
+           width="4.0751266"
+           height="1.0385482"
+           x="20.448273"
+           y="1048.3518"
+           rx="0"
+           ry="0" />
+        <rect
+           style="fill:#4673ad;fill-opacity:1;stroke:none"
+           id="rect3918-9"
+           width="9.015625"
+           height="0.984375"
+           x="17.989351"
+           y="1049.3667" />
+      </g>
+      <g
+         id="g3920">
+        <rect
+           style="fill:#2a5893;fill-opacity:1;stroke:none"
+           id="rect3914"
+           width="3.0493984"
+           height="1.0385482"
+           x="20.970135"
+           y="1048.3518"
+           rx="0"
+           ry="0" />
+        <rect
+           style="fill:#2a5893;fill-opacity:1;stroke:none"
+           id="rect3918"
+           width="9.015625"
+           height="0.984375"
+           x="17.989351"
+           y="1049.3667" />
+      </g>
+      <g
+         transform="translate(0.02209709,0)"
+         id="g3994">
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963"
+           width="8.9990387"
+           height="0.98884457"
+           x="17.987028"
+           y="3.0069129"
+           transform="translate(0,1036.3622)" />
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none;display:inline"
+           id="rect3963-2"
+           width="7.0047607"
+           height="1.0054171"
+           x="1039.3691"
+           y="-18.981396"
+           transform="matrix(0,1,-1,0,0,0)" />
+      </g>
+      <rect
+         y="1041.3622"
+         x="19.003065"
+         height="1"
+         width="5"
+         id="rect3998"
+         style="fill:url(#linearGradient4014);fill-opacity:1;stroke:none" />
+      <rect
+         y="1043.3661"
+         x="19.006971"
+         height="1"
+         width="6.9918041"
+         id="rect3998-6"
+         style="fill:url(#linearGradient4048);fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/clear_co.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/clear_co.svg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="clear_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4900"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient5000"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       id="linearGradient4852-7-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter6988"
+       x="-0.24001802"
+       width="1.480036"
+       y="-0.23998199"
+       height="1.479964">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.2049008"
+         id="feGaussianBlur6990" />
+    </filter>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-1"
+       xlink:href="#linearGradient4852-7-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-9"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-1"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-0"
+       xlink:href="#linearGradient4844-4-1-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-4">
+      <stop
+         id="stop4846-8-4-2"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-2"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-4"
+       xlink:href="#linearGradient4852-7-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-5"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-9"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-8"
+       xlink:href="#linearGradient4844-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-7">
+      <stop
+         id="stop4846-8-4-5"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-3"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000002"
+     inkscape:cx="18.223534"
+     inkscape:cy="-36.6021"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8-8"
+     showgrid="true"
+     inkscape:window-width="1542"
+     inkscape:window-height="975"
+     inkscape:window-x="1006"
+     inkscape:window-y="492"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5000);fill-opacity:1;stroke:none;display:inline"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900);fill-opacity:1;stroke:none"
+       d="m 7.976621,1036.441 0,3.9112 3.977476,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1039.3518" />
+    <rect
+       style="fill:url(#linearGradient4869);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1041.3518" />
+    <rect
+       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1043.3518" />
+    <rect
+       style="fill:url(#linearGradient4875);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1045.3518" />
+    <rect
+       style="fill:url(#linearGradient4873);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="3.0070496"
+       y="1047.3518" />
+    <g
+       id="g6200"
+       mask="url(#mask6204)"
+       transform="matrix(1.4660179,0,0,1.2212682,-5.6373987,-232.07964)">
+      <g
+         transform="matrix(0.53947849,0,0,0.53947849,7.846281,484.46953)"
+         inkscape:label="Layer 1"
+         id="layer1-8"
+         style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:3.70728397;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter6988)">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.70728397;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+           id="rect4043"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssccsccsccss" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-8-8"
+       inkscape:label="Layer 1"
+       transform="matrix(0.50767387,0,0,0.5061245,8.120638,519.33645)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.50689858;stroke-opacity:1"
+         d="m 10.09375,7.0489054 c -0.3172668,0.031974 -0.6221509,0.15383 -0.78125,0.3125 l -0.59375,0.5625 C 8.400566,8.241043 8.3380492,9.7451599 8.65625,10.0625 L 10.25,11.59375 8.59375,13.1875 C 8.4346339,13.346119 8.405526,13.69178 8.4375,14.03125 l 3.59375,0 0,-5.7010946 -1.125,-1.09375 c -0.159083,-0.15867 -0.495233,-0.2194744 -0.8125,-0.1875 z"
+         transform="matrix(1.9697685,0,0,1.9757984,-15.995777,1021.5387)"
+         id="rect3911"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccccccccs" />
+      <path
+         sodipodi:nodetypes="sccccccccssccsccsccss"
+         inkscape:connector-curvature="0"
+         id="rect4043-2"
+         d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+         style="fill:url(#linearGradient6120);fill-opacity:1;stroke:url(#linearGradient6122);stroke-width:1.97278117;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/lock_co.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/lock_co.svg
@@ -1,0 +1,663 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="lock_co.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient18855">
+      <stop
+         id="stop18857"
+         offset="0"
+         style="stop-color:#a4b1c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e1e9f8;stop-opacity:0"
+         offset="0.50000364"
+         id="stop18859" />
+      <stop
+         id="stop18861"
+         offset="1"
+         style="stop-color:#e7eefa;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18808">
+      <stop
+         style="stop-color:#a4b1c7;stop-opacity:1;"
+         offset="0"
+         id="stop18810" />
+      <stop
+         id="stop18816"
+         offset="0.24999017"
+         style="stop-color:#e1e9f8;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7eefa;stop-opacity:1"
+         offset="1"
+         id="stop18812" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18543">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1;"
+         offset="0"
+         id="stop18545" />
+      <stop
+         id="stop18555"
+         offset="0.31919643"
+         style="stop-color:#687692;stop-opacity:1" />
+      <stop
+         id="stop18553"
+         offset="0.42585152"
+         style="stop-color:#8c99a6;stop-opacity:1" />
+      <stop
+         id="stop18551"
+         offset="0.671875"
+         style="stop-color:#7b8da7;stop-opacity:1" />
+      <stop
+         style="stop-color:#5e78a8;stop-opacity:1"
+         offset="1"
+         id="stop18547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4862">
+      <stop
+         style="stop-color:#937323;stop-opacity:1;"
+         offset="0"
+         id="stop4864" />
+      <stop
+         style="stop-color:#79601d;stop-opacity:1;"
+         offset="1"
+         id="stop4866" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4886">
+      <stop
+         style="stop-color:#dec26f;stop-opacity:1"
+         offset="0"
+         id="stop4888" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop4890" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5156">
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1;"
+         offset="0"
+         id="stop5158" />
+      <stop
+         id="stop5166"
+         offset="0.48612955"
+         style="stop-color:#fdf3cb;stop-opacity:1" />
+      <stop
+         id="stop5164"
+         offset="0.56520796"
+         style="stop-color:#a77e1c;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:0.5"
+         offset="1"
+         id="stop5160" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5152">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.32374297"
+         id="feGaussianBlur5154" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4878">
+      <stop
+         style="stop-color:#925218;stop-opacity:1"
+         offset="0"
+         id="stop4880" />
+      <stop
+         style="stop-color:#c1aa38;stop-opacity:1"
+         offset="1"
+         id="stop4882" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4862"
+       id="linearGradient8465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-42.734657,2.4992546)"
+       x1="30.0625"
+       y1="1034.4965"
+       x2="30.0625"
+       y2="1040.9708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4886"
+       id="linearGradient8469"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="32.325939"
+       y1="1049.9935"
+       x2="32.325939"
+       y2="1040.7358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5156"
+       id="linearGradient8471"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="27.20822"
+       y1="1041.8381"
+       x2="32.558262"
+       y2="1049.7878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4878"
+       id="linearGradient8473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.389765,1.0553546)"
+       x1="29.263437"
+       y1="1048.656"
+       x2="29.263437"
+       y2="1040.7803" />
+    <linearGradient
+       y2="1049.0082"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-22.460469,20.310309)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4079"
+       xlink:href="#linearGradient18543"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(2.539576,14.310209)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4077"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(2.539576,14.310209)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4910-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18543"
+       id="linearGradient18549"
+       x1="-22.476931"
+       y1="1056.5162"
+       x2="-22.476931"
+       y2="1069.6725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18,0)" />
+    <linearGradient
+       id="linearGradient4910-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,14.310292)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7"
+       xlink:href="#linearGradient4994-4-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,14.310292)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18638"
+       xlink:href="#linearGradient4910-4-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4910-4-5-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5-4"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,18.310346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7-5"
+       xlink:href="#linearGradient4994-4-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7-9">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,18.310346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18687"
+       xlink:href="#linearGradient4910-4-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4910-4-5-6-2"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-3-4-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-5-4-3"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-13.000045"
+       y1="1042.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,23.310392)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4075-7-5-2"
+       xlink:href="#linearGradient4994-4-7-9-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-7-9-3">
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-4-2-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-4-4-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-15.000045"
+       y1="1044.3622"
+       x1="-13.000045"
+       gradientTransform="translate(11.523114,23.310392)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18736"
+       xlink:href="#linearGradient4910-4-5-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18808"
+       id="linearGradient18814"
+       x1="-2.4769311"
+       y1="1060.6725"
+       x2="-2.4769311"
+       y2="1064.6725"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(-3.8171387e-7,-5.3951562e-5)"
+       y2="1064.6725"
+       x2="-2.4769311"
+       y1="1060.6725"
+       x1="-2.4769311"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient18834"
+       xlink:href="#linearGradient18855"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8608">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         id="rect8610"
+         width="14"
+         height="14"
+         x="1"
+         y="1037.3622"
+         rx="0.67081022"
+         ry="0.67081022" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter9392"
+       x="-0.19209543"
+       width="1.3841909"
+       y="-0.16933754"
+       height="1.3386751">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63281438"
+         id="feGaussianBlur9394" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-12.065247"
+     inkscape:cy="6.0761001"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8451"
+     showgrid="false"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="891"
+     inkscape:window-y="642"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="translate(15.537591,-18.310246)">
+      <rect
+         y="1056.1724"
+         x="-12.977081"
+         height="13.013947"
+         width="12.986286"
+         id="rect3997-9"
+         style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m -11.460469,1057.6724 -0.01646,11 -1,0 0.01646,-12 z"
+         style="fill:url(#linearGradient4077);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m -11.460469,1057.6724 6.983538,0 0,-1 -7.983538,0 z"
+         style="fill:url(#linearGradient4075);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         style="fill:url(#linearGradient18549);fill-opacity:1;stroke:none"
+         id="rect18033"
+         width="1"
+         height="14"
+         x="-4.4769306"
+         y="1055.6725" />
+      <rect
+         style="fill:#687692;fill-opacity:1;stroke:none;display:inline"
+         id="rect18033-4"
+         width="1"
+         height="3.0000005"
+         x="1059.6725"
+         y="0.47693062"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <rect
+         style="fill:#7b8ca7;fill-opacity:1;stroke:none;display:inline"
+         id="rect18033-4-9"
+         width="1"
+         height="3.0000005"
+         x="1064.6725"
+         y="0.47693062"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3"
+         d="m -2.476931,1057.6724 0,2 -1,0 0,-3 z"
+         style="fill:url(#linearGradient18638);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3"
+         d="m -2.476931,1057.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1060.6725"
+         x="-3.4769311"
+         height="3.9999607"
+         width="3.0000005"
+         id="rect3997-9-5"
+         style="fill:url(#linearGradient18814);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3-4"
+         d="m -2.476931,1061.6724 0,3 -1,0 0,-4 z"
+         style="fill:url(#linearGradient18687);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3-2"
+         d="m -2.476931,1061.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7-5);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-3-4-2"
+         d="m -2.476931,1066.6724 0,2 -1,0 0,-3 z"
+         style="fill:url(#linearGradient18736);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-3-2-3"
+         d="m -2.476931,1066.6724 2,0 0,-1 -3,0 z"
+         style="fill:url(#linearGradient4075-7-5-2);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1060.6725"
+         x="-3.4769311"
+         height="3.9999607"
+         width="3.0000005"
+         id="rect3997-9-5-5"
+         style="fill:url(#linearGradient18834);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         style="fill:#4b6ea2;fill-opacity:1;stroke:none"
+         id="rect18863"
+         width="1"
+         height="1"
+         x="12"
+         y="3"
+         transform="translate(-14.476931,1054.6724)" />
+      <rect
+         style="fill:#4b6ea2;fill-opacity:1;stroke:none;display:inline"
+         id="rect18863-7"
+         width="1"
+         height="1"
+         x="-2.4769311"
+         y="1066.6725" />
+    </g>
+    <g
+       id="g8605"
+       mask="url(#mask8608)"
+       transform="translate(1.0606602,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8589"
+         d="m 3.96875,1043.3622 c -1.839313,0 -3.34375,1.4732 -3.34375,3.3125 l 0,0.3125 c -0.347633,0.1472 -0.59375,0.4741 -0.59375,0.875 l 0,3.5 c 0,0.5346 0.434192,0.9688 0.96875,0.9688 l 5.9375,0 c 0.534558,0 1,-0.4342 1,-0.9688 l 0,-3.5 c 0,-0.3852 -0.258682,-0.6877 -0.59375,-0.8437 l 0,-0.3438 c 0,-1.8416 -1.535687,-3.3125 -3.375,-3.3125 z m 0,1.8125 c 0.865247,0 1.53125,0.6385 1.53125,1.5 l 0,0.2188 -3.03125,0 0,-0.2188 c 0,-0.8653 0.634753,-1.5 1.5,-1.5 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.60714811;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter9392);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    </g>
+    <g
+       id="g8451"
+       transform="matrix(0.60714811,0,0,0.60714811,13.623389,413.81637)">
+      <path
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0"
+         id="rect4838-1"
+         d="m -10.059546,1045.0618 0,-2.9375 c 0,-2.7586 -1.253608,-5 -4.012192,-5 -2.758584,0 -4.162918,2.2414 -4.162918,5 l 0,2.9375"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient8465);stroke-width:2.47056686;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <rect
+         ry="1.1048543"
+         rx="1.1048543"
+         y="1042.9824"
+         x="-19.876328"
+         height="7.9382153"
+         width="11.998713"
+         id="rect4838"
+         style="fill:url(#linearGradient8469);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         ry="0.60104567"
+         rx="0.62204111"
+         y="1043.4849"
+         x="-19.241508"
+         height="6.8243604"
+         width="10.729074"
+         id="rect4838-4"
+         style="fill:none;stroke:url(#linearGradient8471);stroke-width:0.87896538;stroke-opacity:1;display:inline;filter:url(#filter5152)" />
+      <rect
+         y="1045.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1047.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894-7"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1049.48"
+         x="-19.392597"
+         height="1"
+         width="11.031251"
+         id="rect4894-7-4"
+         style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline" />
+      <path
+         d="m 10.496117,12.531184 c 0,0.561379 -0.455088,1.016466 -1.0164665,1.016466 -0.5613787,0 -1.016466,-0.455087 -1.016466,-1.016466 0,-0.561378 0.4550873,-1.016466 1.016466,-1.016466 0.5613785,0 1.0164665,0.455088 1.0164665,1.016466 z"
+         sodipodi:ry="1.016466"
+         sodipodi:rx="1.016466"
+         sodipodi:cy="12.531184"
+         sodipodi:cx="9.4796505"
+         id="path4066"
+         style="fill:#785b13;fill-opacity:1;stroke:none;display:inline"
+         sodipodi:type="arc"
+         transform="translate(-23.389764,1033.4176)" />
+      <rect
+         y="1046.5895"
+         x="-14.440443"
+         height="2.8063302"
+         width="1.0606602"
+         id="rect4836"
+         style="fill:#785b13;fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         ry="1.1048543"
+         rx="1.1048543"
+         y="1042.6913"
+         x="-19.876328"
+         height="8.2291298"
+         width="11.509747"
+         id="rect4838-12"
+         style="fill:none;stroke:url(#linearGradient8473);stroke-width:1.64704454;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/new_con.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/new_con.svg
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_con.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1042.3622"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.000063)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046-24"
+       xlink:href="#linearGradient4810-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5">
+      <stop
+         style="stop-color:#be9a4b;stop-opacity:1"
+         offset="0"
+         id="stop4812-0" />
+      <stop
+         style="stop-color:#877e60;stop-opacity:1"
+         offset="1"
+         id="stop4814-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient5062-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18,-4.000037)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       id="linearGradient4910-4-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(18,1.999963)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient4975-2-1"
+       gradientUnits="userSpaceOnUse"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-5">
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient4063-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0001)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         id="stop4084-8"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7" />
+      <stop
+         id="stop4086-2"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter7823-3-4-6"
+       x="-0.18344673"
+       width="1.4377165"
+       y="-0.16038014"
+       height="1.382678">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.6188839"
+         id="feGaussianBlur7825-1-3-8" />
+    </filter>
+    <linearGradient
+       id="linearGradient7540-2-3-8">
+      <stop
+         id="stop7542-8-7-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9" />
+      <stop
+         id="stop7548-98-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-6-33-6-3">
+      <stop
+         id="stop7542-4-4-3-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-5-3-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-2-9-1-2" />
+      <stop
+         id="stop7548-9-2-0-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8465">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 2.005808,1041.3724 0,0.5 0,11.0313 0,0.5 0.5,0 12.9375,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -12.9375,0 -0.5,0 z"
+         id="path8467"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5-8" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1-6"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9-1"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9-7"
+       id="radialGradient3091-1-9-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8"
+       id="linearGradient3093-5-2-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="9.3139221"
+     inkscape:cy="5.1817669"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 2.500702,1041.8621 12.927706,0 0,11.033 -12.927706,0 z"
+           style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4046-24);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-7"
+           d="m 4,1045.3622 0,7.0312 -1,0 0,-8.0312 z"
+           style="fill:url(#linearGradient5062-4);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-0"
+           d="m 4,1045.3622 10.928078,0 0,-1 -11.928078,0 z"
+           style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-9"
+           d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
+           style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7813-2"
+           d="m -106.1326,1054.8481 c 15.377466,0 21.179561,-6.8234 21.179561,-24.2257"
+           style="fill:none;stroke:#ffe99f;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter7823-3-4-6)" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 12.422762,1049.0556 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+           id="rect6501-4-4-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 11.386908,1050.8215 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+           id="rect6501-4-4-1-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 9.1131569,1051.6911 c 0,0 -0.036027,0.2767 0.063869,0.5208 0.099907,0.2441 0.3196179,0.4161 0.3196179,0.4161 0,0 -0.2747289,-0.037 -0.5207938,0.064 -0.2460648,0.1008 -0.4161058,0.3196 -0.4161058,0.3196 0,0 0.040122,-0.2667 -0.063869,-0.5208 -0.1039866,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.2827212,0.034 0.5207942,-0.064 0.2380696,-0.097 0.4161055,-0.3196 0.4161055,-0.3196 z"
+           id="rect6501-4-4-7-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           inkscape:transform-center-y="0.625"
+           inkscape:transform-center-x="1.4375"
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 7.0086025,1052.4527 c 0,0 -0.029292,0.1772 0.029576,0.3364 0.058888,0.1592 0.1964181,0.2748 0.1964181,0.2748 0,0 -0.175934,-0.03 -0.3364077,0.029 -0.1605102,0.059 -0.2747164,0.1964 -0.2747164,0.1964 0,0 0.031682,-0.1707 -0.029616,-0.3364 -0.06129,-0.1657 -0.1964182,-0.2747 -0.1964182,-0.2747 0,0 0.1811118,0.028 0.3364118,-0.03 0.1552919,-0.057 0.2747123,-0.1963 0.2747123,-0.1963 z"
+           id="rect6501-4-4-93-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 13.773399,1046.3172 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+           id="rect6501-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <g
+           style="display:inline"
+           id="g4514"
+           transform="translate(10.382302,-13.90919)">
+          <g
+             id="g4522"
+             transform="translate(-9.9375,0)">
+            <rect
+               style="display:inline;fill:url(#radialGradient3091-1-9-6-4);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect3910"
+               width="4.5825453"
+               height="4.454073"
+               x="-758.82336"
+               y="-740.41083"
+               transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+            <path
+               sodipodi:nodetypes="ccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path5581-5-5"
+               d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+               style="display:inline;fill:url(#linearGradient3093-5-2-7-0);fill-opacity:1;stroke:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/pin.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/pin.svg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="pin.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1"
+         offset="0"
+         id="stop4983" />
+      <stop
+         id="stop4991"
+         offset="0.39414415"
+         style="stop-color:#72b649;stop-opacity:1" />
+      <stop
+         id="stop4989"
+         offset="0.5"
+         style="stop-color:#72b649;stop-opacity:1" />
+      <stop
+         style="stop-color:#359b58;stop-opacity:1"
+         offset="1"
+         id="stop4985" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4973">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4975" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4977" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084" />
+      <stop
+         id="stop4864"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810"
+       inkscape:collect="always">
+      <stop
+         id="stop4812"
+         offset="0"
+         style="stop-color:#bfb688;stop-opacity:1;" />
+      <stop
+         id="stop4814"
+         offset="1"
+         style="stop-color:#8694ae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(18,-4.000037)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always"
+       gradientTransform="translate(18,1.999963)" />
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient4046"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.000063)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       y2="1041.8765"
+       x2="8.0137892"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.0001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4063"
+       xlink:href="#linearGradient4082"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4973-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4975-4" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4977-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.63848363,-0.63848363,0,689.62207,1034.1003)"
+       y2="1039.0527"
+       x2="21.074127"
+       y1="1044.9652"
+       x1="21.049656"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5038"
+       xlink:href="#linearGradient4973-9"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask5241">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 2,1041.3622 0,0.5 0,9.0313 0,0.5 0.5,0 12,0 0.5,0 0,-0.5 0,-9.0313 0,-0.5 -0.5,0 -12,0 -0.5,0 z"
+         id="path5243"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4973"
+       id="linearGradient5265"
+       gradientUnits="userSpaceOnUse"
+       x1="21.123072"
+       y1="1045.577"
+       x2="21.123072"
+       y2="1046.688" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient5267"
+       gradientUnits="userSpaceOnUse"
+       x1="18.909349"
+       y1="7.609231"
+       x2="22.095001"
+       y2="8.296731" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient5269"
+       gradientUnits="userSpaceOnUse"
+       x1="19.624538"
+       y1="1041.6436"
+       x2="22"
+       y2="1041.6436" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="13.435029"
+     inkscape:cy="-3.8006991"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="441"
+     inkscape:window-y="159"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4046);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 2.500702,1041.8621 11.999628,0 0,9.033 -11.999628,0 z"
+       id="rect3997-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1045.3622 0,5.0312 -1,0 0,-6.0312 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1045.3622 10,0 0,-1 -11,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 2.500702,1041.8621 11.999628,0 0,2.0053 -11.999628,0 z"
+       id="rect3997-9-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g5014">
+      <g
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,734.42008,290.38128)"
+         id="g5001">
+        <path
+           inkscape:connector-curvature="0"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.25;color:#000000;fill:url(#linearGradient5038);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 26.750924,1047.1294 c -0.01596,-0.035 -0.04489,-0.064 -0.07981,-0.08 -0.02425,-0.013 -0.05202,-0.02 -0.07968,-0.02 l -5.820754,-10e-5 c -0.01325,0 -0.0267,0 -0.03966,10e-5 -0.04253,0.011 -0.07932,0.041 -0.09971,0.08 -0.06128,0.1015 -0.126608,0.2023 -0.139716,0.3392 -0.0134,0.1368 0.04856,0.2783 0.159649,0.419 0.01903,0.028 0.0484,0.049 0.07977,0.06 0.01326,0 0.0267,0 0.03966,-10e-5 l 5.820754,0 c 0.008,0 0.01313,5e-4 0.01983,0 0.02101,0 0.04186,-0.01 0.06021,-0.02 0.03899,-0.02 0.06846,-0.058 0.07982,-0.1 0.0014,-0.013 0.0015,-0.027 -8.6e-5,-0.04 l -8e-6,-0.5787 c 0.0038,-0.02 0.0039,-0.04 -1.31e-4,-0.06 z"
+           id="path4971-0"
+           sodipodi:nodetypes="cccccccccccccccccc" />
+        <path
+           style="fill:#a5adba;fill-opacity:1;stroke:#17325d;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+           d="m 20.492187,1045.1591 0.921876,0 0,2.4062 c -0.376231,0.2965 -0.615362,0.1856 -0.921876,0 z"
+           id="rect4944"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <g
+           id="g5057">
+          <path
+             id="path4971"
+             d="m 20.40625,1044.9062 a 0.250025,0.250025 0 0 0 -0.125,0.125 0.250025,0.250025 0 0 0 -0.03125,0.125 l 0,2.4063 a 0.250025,0.250025 0 0 0 0,0.062 0.250025,0.250025 0 0 0 0.125,0.1562 c 0.159025,0.096 0.31691,0.1983 0.53125,0.2188 0.21434,0.021 0.436009,-0.076 0.65625,-0.25 a 0.250025,0.250025 0 0 0 0.09375,-0.125 0.250025,0.250025 0 0 0 0,-0.062 l 0,-2.4063 a 0.250025,0.250025 0 0 0 0,-0.031 0.250025,0.250025 0 0 0 -0.03125,-0.094 0.250025,0.250025 0 0 0 -0.15625,-0.125 0.250025,0.250025 0 0 0 -0.0625,0 l -0.90625,0 a 0.250025,0.250025 0 0 0 -0.09375,0 z"
+             style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.5;color:#000000;fill:url(#linearGradient5265);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="zcscz"
+             inkscape:connector-curvature="0"
+             id="path4884-8"
+             transform="translate(0,1036.3622)"
+             d="M 20.9375,6.125 C 19.686416,6.1463072 18.732332,7.2495515 18.53125,8 c 0,0.595432 1.068685,1.09375 2.40625,1.09375 C 22.275065,9.09375 23.375,8.595432 23.375,8 23.179528,7.2704899 22.188584,6.1036928 20.9375,6.125 z"
+             style="fill:url(#linearGradient5267);fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+          <path
+             sodipodi:nodetypes="sccsccs"
+             inkscape:connector-curvature="0"
+             id="rect4923"
+             d="m 20.929746,1040.0249 c -0.533598,0 -0.994941,0.084 -1.356203,0.2348 l 0,2.7676 c 0.361262,0.1504 0.822605,0.2348 1.356203,0.2348 0.487606,0 0.928812,-0.081 1.277961,-0.2087 l 0,-2.8198 c -0.349149,-0.128 -0.790355,-0.2087 -1.277961,-0.2087 z"
+             style="fill:url(#linearGradient5269);fill-opacity:1;stroke:#00953e;stroke-width:0.83458644;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+          <path
+             transform="matrix(0.90924832,0,0,0.90924832,2.1288433,1036.5222)"
+             d="m 23.125,3.1406245 c 0,0.595432 -1.08431,1.078125 -2.421875,1.078125 -1.337565,0 -2.421875,-0.482693 -2.421875,-1.078125 0,-0.595432 1.08431,-1.078125 2.421875,-1.078125 1.337565,0 2.421875,0.482693 2.421875,1.078125 z"
+             sodipodi:ry="1.078125"
+             sodipodi:rx="2.421875"
+             sodipodi:cy="3.1406245"
+             sodipodi:cx="20.703125"
+             id="path4884"
+             style="fill:#7db551;fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+             sodipodi:type="arc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/rem_co.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/rem_co.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="remove_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#414141;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#535353;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="5.5301136"
+     inkscape:cy="7.9227098"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="963"
+     inkscape:window-y="622"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 13.267004,1038.2068 c -0.463993,-0.4858 -1.211033,-0.4858 -1.675002,-10e-5 l -3.0849275,3.2304 -3.0849031,-3.2303 c -0.4639226,-0.4858 -1.2110333,-0.4858 -1.6750018,0 l -0.8523552,0.8927 c -0.4639479,0.4856 -0.463936,1.2678 3.62e-5,1.7537 l 3.0848535,3.2303 -3.084858,3.2302 c -0.4640179,0.4858 -0.4640062,1.268 -1.34e-5,1.7538 l 0.852401,0.8927 c 0.4639431,0.4858 1.2109842,0.4858 1.6750016,0 l 3.084908,-3.2302 3.1063417,3.2526 c 0.463945,0.4859 1.210985,0.4859 1.675003,0 l 0.852355,-0.8925 c 0.463969,-0.4859 0.459308,-1.2632 -3.6e-5,-1.7539 l -3.106344,-3.2527 3.084908,-3.2302 c 0.46399,-0.4859 0.463978,-1.2681 3.4e-5,-1.7538 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/elcl16/wordwrap.svg
+++ b/debug/org.eclipse.ui.console/icons/full/elcl16/wordwrap.svg
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="wordwrap.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1194"
+     inkscape:window-height="794"
+     id="namedview71"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.74621846"
+     inkscape:cy="2.172076"
+     inkscape:window-x="711"
+     inkscape:window-y="593"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4199" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147">
+      <stop
+         id="stop5149"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5151"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141">
+      <stop
+         id="stop5143"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5145"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135">
+      <stop
+         id="stop5137"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5139"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994">
+      <stop
+         id="stop4996"
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4998"
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902">
+      <stop
+         id="stop4904"
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4906"
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894">
+      <stop
+         id="stop4896"
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4898"
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877">
+      <stop
+         id="stop4879"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4881"
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4861">
+      <stop
+         id="stop4863"
+         style="stop-color:#91a5c7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4865"
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5556668,0,0,1,-7.8935846,-4)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67377864,0,0,1,-1.7141507,-4)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51960552,0,0,1,-0.63385206,-4)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       id="linearGradient4873"
+       xlink:href="#linearGradient5135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48896165,0,0,1,-0.41912899,-4)" />
+    <linearGradient
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       id="linearGradient4875"
+       xlink:href="#linearGradient5141"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35202605,0,0,1,0.54038559,-4)" />
+    <linearGradient
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <linearGradient
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       id="linearGradient5000"
+       xlink:href="#linearGradient4994"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       id="linearGradient4852-7-8">
+      <stop
+         id="stop4854-4-1"
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4856-0-2"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         style="stop-color:#606060;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4848-8-9"
+         style="stop-color:#787878;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)" />
+    <linearGradient
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)" />
+    <mask
+       id="mask6204">
+      <path
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    </mask>
+    <filter
+       x="-0.24001803"
+       y="-0.23998199"
+       width="1.480036"
+       height="1.479964"
+       color-interpolation-filters="sRGB"
+       id="filter6988">
+      <feGaussianBlur
+         id="feGaussianBlur6990"
+         stdDeviation="1.2049008" />
+    </filter>
+    <linearGradient
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.58432111,0.58432111,0,-601.73696,1040.3056)" />
+    <linearGradient
+       id="linearGradient7084">
+      <stop
+         id="stop7086"
+         style="stop-color:#fefaef;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7088"
+         style="stop-color:#fce5a7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       id="linearGradient7082"
+       xlink:href="#linearGradient7076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19,-0.93755)" />
+    <linearGradient
+       id="linearGradient7076">
+      <stop
+         id="stop7078"
+         style="stop-color:#956413;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7080"
+         style="stop-color:#c38b1d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="1.1375329"
+       y1="1045.2078"
+       x2="10.472837"
+       y2="1045.2078"
+       id="linearGradient3026"
+       xlink:href="#linearGradient7084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.58432111,0,0,0.58432111,15.07692,435.77077)" />
+    <linearGradient
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       id="linearGradient3028"
+       xlink:href="#linearGradient7076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1056.3201,1018.5078)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1036.3622)"
+     id="layer1"
+     style="display:inline">
+    <path
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001-3"
+       style="fill:url(#linearGradient5000);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 1.4972825,1036.9037 7.0096685,0 3.014118,3.0066 0,9.9546 -10.0237865,0 z"
+       id="rect4001"
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       width="5.9929504"
+       height="1.010376"
+       x="3.0070496"
+       y="1039.3518"
+       id="rect4001-1"
+       style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none" />
+    <rect
+       width="4.9929504"
+       height="1.010376"
+       x="3.0070496"
+       y="1041.3518"
+       id="rect4001-1-7"
+       style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none" />
+    <rect
+       width="3.9929504"
+       height="1.010376"
+       x="3.0070496"
+       y="1043.3518"
+       id="rect4001-1-7-4"
+       style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none" />
+    <rect
+       width="2"
+       height="0.9999826"
+       x="3"
+       y="1045.3622"
+       id="rect4001-1-7-4-0"
+       style="display:inline;fill:url(#linearGradient4875);fill-opacity:1;stroke:none" />
+    <rect
+       width="1.9929504"
+       height="1.010376"
+       x="3.0070496"
+       y="1047.3518"
+       id="rect4001-1-7-4-0-9"
+       style="display:inline;fill:url(#linearGradient4873);fill-opacity:1;stroke:none" />
+    <g
+       mask="url(#mask6204)"
+       id="g6200">
+      <g
+         transform="matrix(0.53947849,0,0,0.53947849,7.846281,484.46953)"
+         id="layer1-8"
+         style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:3.70728397;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter6988)">
+        <path
+           d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+           id="rect4043"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.70728397;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      </g>
+    </g>
+    <path
+       d="m 15.51992,1045.4609 0,-5.8469 c 0,-0.3903 -0.2972,-0.7187 -0.6875,-0.7187 l -0.579139,0 c -0.3903,0 -0.7188,0.3284 -0.7188,0.7187 l 0,5.2573 -3.014561,-0.017 0,-2.0145 -0.9999993,0.017 -3.0323593,3.0323 3.0323593,2.9613 0.9999993,0 0,-1.9985 3.4687,0 c 0.9367,0 1.5313,-0.2837 1.5313,-1.3911 z"
+       id="rect3968"
+       style="display:inline;fill:url(#linearGradient3026);fill-opacity:1;stroke:url(#linearGradient3028);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccccccccss" />
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/icons/full/eview16/console_view.svg
+++ b/debug/org.eclipse.ui.console/icons/full/eview16/console_view.svg
@@ -1,0 +1,550 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="console_view.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4008">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#546483;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         style="stop-color:#818b9f;stop-opacity:1;"
+         offset="1"
+         id="stop3910" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#2b5c9c;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#3673c4;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3884">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3886" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3888" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.7236701"
+       id="linearGradient5838"
+       xlink:href="#linearGradient5832"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832">
+      <stop
+         id="stop5834"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840" />
+      <stop
+         id="stop5836"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846" />
+      <stop
+         id="stop5848"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask10494">
+      <path
+         inkscape:connector-curvature="0"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 21,1037.3622 0,0.5 0,2 0,0.5 0,8.5313 0,0.5 0.5,0 13.03125,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -13.03125,0 -0.5,0 z"
+         id="path10496" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter11270"
+       x="-0.24"
+       width="1.48"
+       y="-0.24"
+       height="1.48">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63130821"
+         id="feGaussianBlur11272" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11296"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-7"
+       xlink:href="#linearGradient5832-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-2">
+      <stop
+         id="stop5834-8"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-7" />
+      <stop
+         id="stop5836-9"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-9">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-2" />
+      <stop
+         id="stop5848-9"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter11520"
+       x="-0.24"
+       width="1.48"
+       y="-0.24"
+       height="1.48">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63130821"
+         id="feGaussianBlur11522" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290-2">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292-4" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294-75" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-0"
+       xlink:href="#linearGradient5832-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-7">
+      <stop
+         id="stop5834-1"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-6" />
+      <stop
+         id="stop5836-93"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-7">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-3" />
+      <stop
+         id="stop5848-0"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11407"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11409"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11413"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11415"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11417"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11623"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11625"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11629"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11631"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3898"
+       x1="22.420315"
+       y1="1044.6581"
+       x2="22.420315"
+       y2="1037.9327"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3906"
+       id="linearGradient3912"
+       x1="22.994839"
+       y1="1040.1731"
+       x2="22.994839"
+       y2="1048.3184"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008"
+       id="linearGradient4014"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.0281848,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008-8"
+       id="linearGradient4014-5"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4008-8">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010-9" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.8778"
+       x2="19.998154"
+       y1="1041.8778"
+       x1="25.096403"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4048"
+       xlink:href="#linearGradient4008-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.20625,0,0,1,-5.1479113,2.03125)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-12.355569"
+     inkscape:cy="-9.9662339"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1557"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4067"
+       transform="translate(-14,0)">
+      <rect
+         ry="0.79549515"
+         rx="0.79549515"
+         y="1037.8665"
+         x="16.572817"
+         height="10.010139"
+         width="11.932429"
+         id="rect3101"
+         style="fill:url(#linearGradient3912);fill-opacity:1;stroke:url(#linearGradient3898);stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1039.3717"
+         x="18.002655"
+         height="7.0085478"
+         width="9.0156116"
+         id="rect3902"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <g
+         transform="matrix(1.2279408,0,0,1,-5.1169737,0)"
+         id="g3920-0"
+         style="fill:#4673ad;fill-opacity:1;display:inline">
+        <rect
+           style="fill:#4673ad;fill-opacity:1;stroke:none"
+           id="rect3914-0"
+           width="4.0751266"
+           height="1.0385482"
+           x="20.448273"
+           y="1048.3518"
+           rx="0"
+           ry="0" />
+        <rect
+           style="fill:#4673ad;fill-opacity:1;stroke:none"
+           id="rect3918-9"
+           width="9.015625"
+           height="0.984375"
+           x="17.989351"
+           y="1049.3667" />
+      </g>
+      <g
+         id="g3920">
+        <rect
+           style="fill:#2a5893;fill-opacity:1;stroke:none"
+           id="rect3914"
+           width="3.0493984"
+           height="1.0385482"
+           x="20.970135"
+           y="1048.3518"
+           rx="0"
+           ry="0" />
+        <rect
+           style="fill:#2a5893;fill-opacity:1;stroke:none"
+           id="rect3918"
+           width="9.015625"
+           height="0.984375"
+           x="17.989351"
+           y="1049.3667" />
+      </g>
+      <g
+         transform="translate(0.02209709,0)"
+         id="g3994">
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963"
+           width="8.9990387"
+           height="0.98884457"
+           x="17.987028"
+           y="3.0069129"
+           transform="translate(0,1036.3622)" />
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none;display:inline"
+           id="rect3963-2"
+           width="7.0047607"
+           height="1.0054171"
+           x="1039.3691"
+           y="-18.981396"
+           transform="matrix(0,1,-1,0,0,0)" />
+      </g>
+      <rect
+         y="1041.3622"
+         x="19.003065"
+         height="1"
+         width="5"
+         id="rect3998"
+         style="fill:url(#linearGradient4014);fill-opacity:1;stroke:none" />
+      <rect
+         y="1043.3661"
+         x="19.006971"
+         height="1"
+         width="6.9918041"
+         id="rect3998-6"
+         style="fill:url(#linearGradient4048);fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.console/plugin.xml
+++ b/debug/org.eclipse.ui.console/plugin.xml
@@ -26,7 +26,7 @@
       <view
             allowMultiple="true"
             class="org.eclipse.ui.internal.console.ConsoleView"
-            icon="$nl$/icons/full/cview16/console_view.png"
+            icon="$nl$/icons/full/cview16/console_view.svg"
             category="org.eclipse.ui"
             name="%ConsoleView.name"
             id="org.eclipse.ui.console.ConsoleView">
@@ -107,7 +107,7 @@ M4 = Platform-specific fourth key
           point="org.eclipse.ui.console.consoleFactories">
        <consoleFactory
              label="%consoleViewConsoleFactory.name"
-             icon="$nl$/icons/full/cview16/console_view.png"
+             icon="$nl$/icons/full/cview16/console_view.svg"
              class="org.eclipse.ui.internal.console.ConsoleViewConsoleFactory"/>
     </extension>
 

--- a/debug/org.eclipse.ui.console/schema/consoleFactories.exsd
+++ b/debug/org.eclipse.ui.console/schema/consoleFactories.exsd
@@ -94,7 +94,7 @@
   &lt;consoleFactory 
      label=&quot;Command Console&quot;
      class=&quot;com.example.CommandConsoleFactory&quot;
-     icon=&quot;icons/cmd_console.png&quot;&gt;
+     icon=&quot;icons/cmd_console.svg&quot;&gt;
   &lt;/consoleFactory&gt;
 &lt;/extension&gt;
 &lt;/pre&gt;

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ClearOutputAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ClearOutputAction.java
@@ -49,7 +49,6 @@ public class ClearOutputAction extends Action {
 		super(ConsoleMessages.ClearOutputAction_title);
 		setToolTipText(ConsoleMessages.ClearOutputAction_toolTipText);
 		setHoverImageDescriptor(ConsolePluginImages.getImageDescriptor(IConsoleConstants.IMG_LCL_CLEAR));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_CLEAR));
 		setImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_CLEAR));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CLEAR_CONSOLE_ACTION);
 	}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/CloseConsoleAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/CloseConsoleAction.java
@@ -34,7 +34,6 @@ public class CloseConsoleAction extends Action {
 
 	public CloseConsoleAction(IConsole console) {
 		super(ConsoleMessages.CloseConsoleAction_0, ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_CLOSE));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_CLOSE));
 		setToolTipText(ConsoleMessages.CloseConsoleAction_1);
 		fConsole = console;
 	}

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsolePluginImages.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsolePluginImages.java
@@ -55,10 +55,10 @@ public class ConsolePluginImages {
 		// Actions
 
 		//local toolbars
-		declareRegistryImage(IConsoleConstants.IMG_LCL_CLEAR, LOCALTOOL + "clear_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_PIN, LOCALTOOL + "pin.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_LOCK, LOCALTOOL + "lock_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_WRAP, LOCALTOOL + "wordwrap.png"); //$NON-NLS-1$
+		declareRegistryImage(IConsoleConstants.IMG_LCL_CLEAR, LOCALTOOL + "clear_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_PIN, LOCALTOOL + "pin.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_LOCK, LOCALTOOL + "lock_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_WRAP, LOCALTOOL + "wordwrap.svg"); //$NON-NLS-1$
 
 		// disabled local toolbars
 		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_CLEAR, DLCL + "clear_co.png"); //$NON-NLS-1$
@@ -69,15 +69,15 @@ public class ConsolePluginImages {
 		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_NEW_CON, DLCL + "new_con.png"); //$NON-NLS-1$
 
 		// enabled local toolbars
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_CLEAR, ELCL + "clear_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_PIN, ELCL + "pin.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_LOCK, ELCL + "lock_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_WRAP, ELCL + "wordwrap.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_CLOSE, ELCL + "rem_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_NEW_CON, ELCL + "new_con.png"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_CLEAR, ELCL + "clear_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_PIN, ELCL + "pin.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_LOCK, ELCL + "lock_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_WRAP, ELCL + "wordwrap.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_CLOSE, ELCL + "rem_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_NEW_CON, ELCL + "new_con.svg"); //$NON-NLS-1$
 
 		// Views
-		declareRegistryImage(IConsoleConstants.IMG_VIEW_CONSOLE, VIEW + "console_view.png"); //$NON-NLS-1$
+		declareRegistryImage(IConsoleConstants.IMG_VIEW_CONSOLE, VIEW + "console_view.svg"); //$NON-NLS-1$
 	}
 
 	/**
@@ -131,7 +131,7 @@ public class ConsolePluginImages {
 	 *		Misc images				MISC_
 	 *
 	 *	Where are the images?
-	 *		The images (typically pngs) are found in the same location as this plugin class.
+	 *		The images (typically svgs) are found in the same location as this plugin class.
 	 *		This may mean the same package directory as the package holding this class.
 	 *		The images are declared using this.getClass() to ensure they are looked up via
 	 *		this plugin class.

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsolePluginImages.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsolePluginImages.java
@@ -44,7 +44,6 @@ public class ConsolePluginImages {
 
 	// Use IPath and toOSString to build the names to ensure they have the slashes correct
 	private final static String LOCALTOOL= "clcl16/"; //basic colors - size 16x16 //$NON-NLS-1$
-	private final static String DLCL= "dlcl16/"; //disabled - size 16x16 //$NON-NLS-1$
 	private final static String ELCL= "elcl16/"; //enabled - size 16x16 //$NON-NLS-1$
 	private final static String VIEW= "cview16/"; // views //$NON-NLS-1$
 
@@ -59,14 +58,6 @@ public class ConsolePluginImages {
 		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_PIN, LOCALTOOL + "pin.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_LOCK, LOCALTOOL + "lock_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalConsoleConstants.IMG_LCL_WRAP, LOCALTOOL + "wordwrap.svg"); //$NON-NLS-1$
-
-		// disabled local toolbars
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_CLEAR, DLCL + "clear_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_PIN, DLCL + "pin.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_LOCK, DLCL + "lock_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_WRAP, DLCL + "wordwrap.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_CLOSE, DLCL + "rem_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalConsoleConstants.IMG_DLCL_NEW_CON, DLCL + "new_con.png"); //$NON-NLS-1$
 
 		// enabled local toolbars
 		declareRegistryImage(IInternalConsoleConstants.IMG_ELCL_CLEAR, ELCL + "clear_co.svg"); //$NON-NLS-1$

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IInternalConsoleConstants.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IInternalConsoleConstants.java
@@ -21,14 +21,6 @@ public interface IInternalConsoleConstants {
 	String IMG_LCL_LOCK = "IMG_LCL_LOCK"; //$NON-NLS-1$
 	String IMG_LCL_WRAP = "IMG_LCL_WRAP"; //$NON-NLS-1$
 
-	// disabled local tool images
-	String IMG_DLCL_PIN = "IMG_DLCL_PIN"; //$NON-NLS-1$
-	String IMG_DLCL_CLEAR= "IMG_DLCL_CLEAR"; //$NON-NLS-1$
-	String IMG_DLCL_LOCK = "IMG_DLCL_LOCK"; //$NON-NLS-1$
-	String IMG_DLCL_WRAP = "IMG_DLCL_WRAP"; //$NON-NLS-1$
-	String IMG_DLCL_CLOSE = "IMG_DLCL_CLOSE"; //$NON-NLS-1$
-	String IMG_DLCL_NEW_CON = "IMG_DLCL_NEW_CON"; //$NON-NLS-1$
-
 	// enabled local tool images
 	String IMG_ELCL_PIN = "IMG_ELCL_PIN"; //$NON-NLS-1$
 	String IMG_ELCL_CLEAR= "IMG_ELCL_CLEAR"; //$NON-NLS-1$

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/OpenConsoleAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/OpenConsoleAction.java
@@ -45,7 +45,6 @@ public class OpenConsoleAction extends Action implements IMenuCreator {
 		fFactoryExtensions = getSortedFactories();
 		setToolTipText(ConsoleMessages.OpenConsoleAction_1);
 		setImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_NEW_CON));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_NEW_CON));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CONSOLE_OPEN_CONSOLE_ACTION);
 	}
 

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/PinConsoleAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/PinConsoleAction.java
@@ -35,7 +35,6 @@ public class PinConsoleAction extends Action implements IUpdate {
 		super(ConsoleMessages.PinConsoleAction_0, IAction.AS_CHECK_BOX);
 		setToolTipText(ConsoleMessages.PinConsoleAction_1);
 		setImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_PIN));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_PIN));
 		setHoverImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_LCL_PIN));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CONSOLE_PIN_CONSOLE_ACITON);
 		fView = view;

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ScrollLockAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ScrollLockAction.java
@@ -32,7 +32,6 @@ public class ScrollLockAction extends Action {
 
 		setToolTipText(ConsoleMessages.ScrollLockAction_1);
 		setHoverImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_LCL_LOCK));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_LOCK));
 		setImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_LOCK));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CONSOLE_SCROLL_LOCK_ACTION);
 		boolean checked = fConsoleView.getScrollLock();

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/WordWrapAction.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/WordWrapAction.java
@@ -40,7 +40,6 @@ public class WordWrapAction extends Action implements IPropertyChangeListener {
 
 		setToolTipText(ConsoleMessages.WordWrapAction_1);
 		setHoverImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_LCL_WRAP));
-		setDisabledImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_WRAP));
 		setImageDescriptor(ConsolePluginImages.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_WRAP));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CONSOLE_WORD_WRAP_ACTION);
 


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle org.eclipse.ui.console.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.