### PR TITLE
Add SVGs to org.eclipse.ui.externaltools

### DIFF
--- a/debug/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/model/ExternalToolsImages.java
+++ b/debug/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/model/ExternalToolsImages.java
@@ -55,8 +55,8 @@ public class ExternalToolsImages {
 	 */
 	private static void declareImages() {
 		// Objects
-		declareRegistryImage(IExternalToolConstants.IMG_TAB_MAIN, OBJECT + "main_tab.png"); //$NON-NLS-1$
-		declareRegistryImage(IExternalToolConstants.IMG_TAB_BUILD, OBJECT + "build_tab.png"); //$NON-NLS-1$
+		declareRegistryImage(IExternalToolConstants.IMG_TAB_MAIN, OBJECT + "main_tab.svg"); //$NON-NLS-1$
+		declareRegistryImage(IExternalToolConstants.IMG_TAB_BUILD, OBJECT + "build_tab.svg"); //$NON-NLS-1$
 	}
 
 	/**

--- a/debug/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/ui/BuilderLabelProvider.java
+++ b/debug/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/ui/BuilderLabelProvider.java
@@ -32,8 +32,8 @@ import org.eclipse.ui.externaltools.internal.ui.BuilderPropertyPage.ErrorConfig;
 
 
 class BuilderLabelProvider extends LabelProvider {
-		private static final String IMG_BUILDER = "icons/full/obj16/builder.png"; //$NON-NLS-1$;
-		private static final String IMG_INVALID_BUILD_TOOL = "icons/full/obj16/invalid_build_tool.png"; //$NON-NLS-1$
+		private static final String IMG_BUILDER = "icons/full/obj16/builder.svg"; //$NON-NLS-1$ ;
+		private static final String IMG_INVALID_BUILD_TOOL = "icons/full/obj16/invalid_build_tool.svg"; //$NON-NLS-1$
 		IDebugModelPresentation debugModelPresentation= DebugUITools.newDebugModelPresentation();
 
 		private final Image builderImage = ExternalToolsPlugin.getDefault().getImageDescriptor(IMG_BUILDER).createImage();

--- a/debug/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.externaltools; singleton:=true
-Bundle-Version: 3.6.500.qualifier
+Bundle-Version: 3.6.600.qualifier
 Bundle-Activator: org.eclipse.ui.externaltools.internal.model.ExternalToolsPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)";resolution:=op
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.externaltools
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/debug/org.eclipse.ui.externaltools/icons/full/etool16/external_tools.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/etool16/external_tools.svg
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="external_tools.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4088">
+      <stop
+         style="stop-color:#b71717;stop-opacity:1;"
+         offset="0"
+         id="stop4090" />
+      <stop
+         style="stop-color:#d80000;stop-opacity:1;"
+         offset="1"
+         id="stop4092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3870">
+      <stop
+         style="stop-color:#ff2727;stop-opacity:1;"
+         offset="0"
+         id="stop3872" />
+      <stop
+         style="stop-color:#bc0000;stop-opacity:1;"
+         offset="1"
+         id="stop3874" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9276-9"
+       inkscape:collect="always">
+      <stop
+         id="stop9278-0"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280-5"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0"
+       id="linearGradient13741"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276-9"
+       id="linearGradient13743"
+       gradientUnits="userSpaceOnUse"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894" />
+    <linearGradient
+       id="linearGradient13755-3">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-0"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-0"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-65" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-9" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1051.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945"
+       xlink:href="#linearGradient13922-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-0" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1053.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-8"
+       xlink:href="#linearGradient13922-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-3" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1055.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-1"
+       xlink:href="#linearGradient13922-7"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask14146">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g14148"
+         transform="matrix(0.73426076,0,0,0.73426076,3.6725146,281.72245)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,-18.103841,1064.137)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path14150"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14152"
+           d="m 14.349242,1061.6734 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14154"
+           d="m 14.349242,1061.6734 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3870"
+       id="linearGradient3890"
+       gradientUnits="userSpaceOnUse"
+       x1="11.468751"
+       y1="8.4543371"
+       x2="11.468751"
+       y2="9.265625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3870-0"
+       id="linearGradient3890-5"
+       gradientUnits="userSpaceOnUse"
+       x1="11.468751"
+       y1="8.4543371"
+       x2="11.468751"
+       y2="9.265625" />
+    <linearGradient
+       id="linearGradient3870-0">
+      <stop
+         style="stop-color:#ff2727;stop-opacity:1;"
+         offset="0"
+         id="stop3872-4" />
+      <stop
+         style="stop-color:#bc0000;stop-opacity:1;"
+         offset="1"
+         id="stop3874-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4088"
+       id="linearGradient4094"
+       x1="20.043768"
+       y1="1061.286"
+       x2="20.043768"
+       y2="1064.6027"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="4.546875"
+     inkscape:cy="7.828125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="false"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="matrix(1.0027901,0,0,1.0027918,-7.2430494,-14.834029)">
+      <g
+         transform="matrix(0.77393739,0,0,0.77393739,7.411332,246.44575)"
+         inkscape:label="Layer 1"
+         id="layer1-0-8"
+         style="display:inline">
+        <g
+           style="display:inline"
+           id="g8159-2-9"
+           transform="translate(-8.2201167,-12.904699)">
+          <circle
+             style="display:inline;fill:url(#linearGradient13741);fill-opacity:1;stroke:none"
+             id="path10796-2-6-0-3-1"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+             cx="388.125"
+             cy="468.23718"
+             r="10.625" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path8117-2-7"
+             d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient13743);stroke-width:0.646047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             style="display:inline;fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path10796-2-6-0-5-3"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+             cx="388.125"
+             cy="468.23718"
+             r="10.625" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.99595426,0,0,1.0000109,-17.210211,-11.916399)"
+       style="display:inline"
+       id="g3986">
+      <g
+         transform="translate(9.125)"
+         id="g3878">
+        <g
+           id="g3884">
+          <g
+             style="display:inline"
+             id="g3864">
+            <rect
+               transform="translate(8.2201163,1049.2669)"
+               y="10"
+               x="7"
+               height="5"
+               width="9"
+               id="rect3069"
+               style="fill:#ff3c3c;fill-opacity:1;stroke:none" />
+            <rect
+               y="1060.2981"
+               x="15.220117"
+               height="3.96875"
+               width="9"
+               id="rect3069-6"
+               style="display:inline;fill:url(#linearGradient4094);fill-opacity:1;stroke:none" />
+          </g>
+          <path
+             sodipodi:nodetypes="cccc"
+             transform="translate(8.2201163,1049.2669)"
+             inkscape:connector-curvature="0"
+             id="path3868"
+             d="M 9.4687504,10.03125 V 8.4999997 H 13.46496 V 10.03125"
+             style="fill:none;stroke:url(#linearGradient3890-5);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894"
+             d="m 16.177926,1060.7812 h 6.963533"
+             style="fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9"
+             d="m 16.177925,1062.7408 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-1"
+             d="m 18.190869,1062.7408 h 3.010408"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-1-1"
+             d="M 22.200022,1062.7408 H 23.17918"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6"
+             d="m 15.183557,1063.7573 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-3"
+             d="m 23.2048,1063.7352 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5"
+             d="m 16.177926,1061.7535 h 1.088533"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-8"
+             d="m 17.260683,1060.765 h 0.979158"
+             style="display:inline;fill:#881818;fill-opacity:1;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-8-6"
+             d="m 21.198183,1060.765 h 0.979158"
+             style="display:inline;fill:#881818;fill-opacity:1;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5-0"
+             d="m 18.209176,1061.7535 h 3.041658"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5-9"
+             d="m 22.131051,1061.7535 h 1.088533"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/build_tab.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/build_tab.svg
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg20691"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="build_tab.svg">
+  <defs
+     id="defs20693">
+    <linearGradient
+       id="linearGradient3893">
+      <stop
+         style="stop-color:#677da9;stop-opacity:1;"
+         offset="0"
+         id="stop3895" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3897" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8-7" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient20689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-1" />
+      <stop
+         style="stop-color:#7f703d;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient20765-1"
+       xlink:href="#linearGradient4902-3-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3-5">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-1-2" />
+      <stop
+         style="stop-color:#7f703d;stop-opacity:1"
+         offset="1"
+         id="stop4906-2-7" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask20934">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g20936"
+         transform="translate(0,1.0283)">
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path20938"
+           d="m 3.488129,1037.8727 7.00967,0 3.062057,3.0066 0,9.9546 -10.071727,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path20940"
+           d="m 9.967468,1037.41 0,3.9112 3.977478,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path20942"
+           d="m 3.488129,1037.8727 6.94717,0 3.062057,3.0066 0,9.9546 -10.009227,0 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter21712"
+       x="-0.1148397"
+       width="1.2296794"
+       y="-0.12564587"
+       height="1.2512917">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.67237819"
+         id="feGaussianBlur21714" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6"
+       id="linearGradient3867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient3869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.0176327,-1.0294)"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient3871"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3893"
+       id="linearGradient3899"
+       x1="8.7180386"
+       y1="3.5223215"
+       x2="1.6572596"
+       y2="3.5223215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1037.3443)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3893"
+       id="linearGradient3901"
+       x1="12.020214"
+       y1="1041.8711"
+       x2="-0.73447263"
+       y2="1041.8711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.98214286)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.2675074"
+     inkscape:cy="5.1858063"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="997"
+     inkscape:window-height="917"
+     inkscape:window-x="81"
+     inkscape:window-y="90"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20699"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20696">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3851"
+       transform="translate(-1.0267857,-1.0267857)">
+      <g
+         transform="translate(0,1.0283)"
+         id="g20680"
+         style="display:inline">
+        <path
+           style="fill:url(#linearGradient3867);fill-opacity:1;stroke:none;display:inline"
+           d="m 3.488129,1037.8727 7.00967,0 3.94594,3.0066 0,10.6491 -10.95561,0 z"
+           id="rect4001-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           style="fill:url(#linearGradient3869);fill-opacity:1;stroke:none;display:inline"
+           d="m 10.994254,1037.41 0,3.9112 3.977478,0 z"
+           id="path4884"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3871);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 3.488129,1037.8727 8.018599,0 3.062057,3.0066 0,10.9422 -11.080656,0 z"
+           id="rect4001"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+      </g>
+      <g
+         style="opacity:0.75"
+         mask="url(#mask20934)"
+         id="g20926">
+        <g
+           style="opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter21712)"
+           id="g20919">
+          <g
+             style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g20816-4">
+            <path
+               inkscape:connector-curvature="0"
+               id="path21763-0"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 7.8107346,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path21765-9"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 10.906779,1045.4778 0,4.727 -0.697184,0 0,-3.8568 -0.4479104,0.4082 -0.408964,-0.4082 0.9464584,-0.8702 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path21763-3-4"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 15.810731,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g20816"
+         transform="translate(0,1.1160714)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path21763"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.47980908;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 7.8107346,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path21765"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.29654568;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 10.906779,1045.4778 0,4.727 -0.697184,0 0,-3.8568 -0.4479104,0.4082 -0.408964,-0.4082 0.9464584,-0.8702 z" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 13.75,8.8125 c 0,0 -0.535714,-0.1339285 -0.714286,0.2232143 -0.178571,0.3571429 -0.401786,1.3839287 -0.401786,1.3839287 0,0 0,1.160714 0.133929,1.383928 0.133929,0.223215 0.625,0.848215 0.803571,0.848215 0.178572,0 0.9375,-0.401786 0.9375,-0.714286 0,-0.3125 0.133929,-0.892857 0.133929,-1.205357 0,-0.3125 -0.178571,-0.8928572 -0.3125,-1.1160715 C 14.196428,9.3928572 13.75,8.8125 13.75,8.8125 z"
+           id="path3906"
+           inkscape:connector-curvature="0"
+           transform="translate(1.0267857,1037.2551)" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path21763-3"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.47980908;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 15.810731,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+      </g>
+    </g>
+    <rect
+       style="fill:url(#linearGradient3899);fill-opacity:1;stroke:none"
+       id="rect3873"
+       width="4.9553571"
+       height="1.0491071"
+       x="3.984375"
+       y="1040.3422" />
+    <rect
+       style="fill:url(#linearGradient3901);fill-opacity:1;stroke:none"
+       id="rect3873-7"
+       width="8.0081358"
+       height="1.0490723"
+       x="3.984375"
+       y="1042.3287" />
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/builder.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/builder.svg
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg20691"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="builder.svg">
+  <defs
+     id="defs20693">
+    <linearGradient
+       id="linearGradient3893">
+      <stop
+         style="stop-color:#677da9;stop-opacity:1;"
+         offset="0"
+         id="stop3895" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3897" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8-7" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient20689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-1" />
+      <stop
+         style="stop-color:#7f703d;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient20765-1"
+       xlink:href="#linearGradient4902-3-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3-5">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-1-2" />
+      <stop
+         style="stop-color:#7f703d;stop-opacity:1"
+         offset="1"
+         id="stop4906-2-7" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask20934">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g20936"
+         transform="translate(0,1.0283)">
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path20938"
+           d="m 3.488129,1037.8727 7.00967,0 3.062057,3.0066 0,9.9546 -10.071727,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path20940"
+           d="m 9.967468,1037.41 0,3.9112 3.977478,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path20942"
+           d="m 3.488129,1037.8727 6.94717,0 3.062057,3.0066 0,9.9546 -10.009227,0 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter21712"
+       x="-0.1148397"
+       width="1.2296794"
+       y="-0.12564587"
+       height="1.2512917">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.67237819"
+         id="feGaussianBlur21714" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6"
+       id="linearGradient3867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient3869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.0176327,-1.0294)"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient3871"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.009153,-1.0294)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3893"
+       id="linearGradient3899"
+       x1="8.7180386"
+       y1="3.5223215"
+       x2="1.6572596"
+       y2="3.5223215"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3893"
+       id="linearGradient3901"
+       x1="12.020214"
+       y1="1041.8711"
+       x2="-0.73447263"
+       y2="1041.8711"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.2675074"
+     inkscape:cy="5.1858063"
+     inkscape:document-units="px"
+     inkscape:current-layer="g20816"
+     showgrid="true"
+     inkscape:window-width="997"
+     inkscape:window-height="917"
+     inkscape:window-x="81"
+     inkscape:window-y="90"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid20699"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20696">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3851"
+       transform="translate(-1.0267857,-2.0089286)">
+      <g
+         transform="translate(0,1.0283)"
+         id="g20680"
+         style="display:inline">
+        <path
+           style="fill:url(#linearGradient3867);fill-opacity:1;stroke:none;display:inline"
+           d="m 3.488129,1037.8727 7.00967,0 3.94594,3.0066 0,10.6491 -10.95561,0 z"
+           id="rect4001-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           style="fill:url(#linearGradient3869);fill-opacity:1;stroke:none;display:inline"
+           d="m 10.994254,1037.41 0,3.9112 3.977478,0 z"
+           id="path4884"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3871);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 3.488129,1037.8727 8.018599,0 3.062057,3.0066 0,10.9422 -11.080656,0 z"
+           id="rect4001"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+      </g>
+      <g
+         style="opacity:0.75"
+         mask="url(#mask20934)"
+         id="g20926">
+        <g
+           style="opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter21712)"
+           id="g20919">
+          <g
+             style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g20816-4">
+            <path
+               inkscape:connector-curvature="0"
+               id="path21763-0"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 7.8107346,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path21765-9"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 10.906779,1045.4778 0,4.727 -0.697184,0 0,-3.8568 -0.4479104,0.4082 -0.408964,-0.4082 0.9464584,-0.8702 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path21763-3-4"
+               style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+               d="m 15.810731,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g20816"
+         transform="translate(0,1.1160714)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path21763"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.47980908;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 7.8107346,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path21765"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.29654568;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 10.906779,1045.4778 0,4.727 -0.697184,0 0,-3.8568 -0.4479104,0.4082 -0.408964,-0.4082 0.9464584,-0.8702 z" />
+        <path
+           style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+           d="m 13.75,8.8125 c 0,0 -0.535714,-0.1339285 -0.714286,0.2232143 -0.178571,0.3571429 -0.401786,1.3839287 -0.401786,1.3839287 0,0 0,1.160714 0.133929,1.383928 0.133929,0.223215 0.625,0.848215 0.803571,0.848215 0.178572,0 0.9375,-0.401786 0.9375,-0.714286 0,-0.3125 0.133929,-0.892857 0.133929,-1.205357 0,-0.3125 -0.178571,-0.8928572 -0.3125,-1.1160715 C 14.196428,9.3928572 13.75,8.8125 13.75,8.8125 z"
+           id="path3906"
+           inkscape:connector-curvature="0"
+           transform="translate(1.0267857,1037.2551)" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path21763-3"
+           style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.47980908;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Gautami;-inkscape-font-specification:Gautami"
+           d="m 15.810731,1047.8772 c -3e-6,0.6378 -0.09556,1.1608 -0.286676,1.5684 -0.220169,0.473 -0.538952,0.7095 -0.956351,0.7095 -0.417401,0 -0.736948,-0.2365 -0.958643,-0.7095 -0.192647,-0.4076 -0.288969,-0.9306 -0.288969,-1.5684 0,-0.6379 0.09632,-1.1608 0.288969,-1.5685 0.221695,-0.473 0.541242,-0.7094 0.958643,-0.7095 0.417399,10e-5 0.736182,0.2365 0.956351,0.7095 0.191115,0.4077 0.286673,0.9306 0.286676,1.5685 z m -0.403639,0 c -4e-6,-0.4599 -0.06956,-0.8538 -0.208701,-1.1813 -0.157482,-0.3688 -0.367711,-0.5531 -0.630687,-0.5531 -0.264507,0 -0.4755,0.1843 -0.63298,0.5531 -0.140663,0.3275 -0.210993,0.7214 -0.210993,1.1813 0,0.4599 0.07033,0.8536 0.210993,1.1813 0.15748,0.3687 0.368473,0.5532 0.63298,0.5532 0.262976,0 0.473205,-0.1845 0.630687,-0.5532 0.139132,-0.3277 0.208697,-0.7214 0.208701,-1.1813 z" />
+      </g>
+    </g>
+    <rect
+       style="fill:url(#linearGradient3899);fill-opacity:1;stroke:none"
+       id="rect3873"
+       width="4.9553571"
+       height="1.0491071"
+       x="3.984375"
+       y="2.9977679"
+       transform="translate(0,1036.3622)" />
+    <rect
+       style="fill:url(#linearGradient3901);fill-opacity:1;stroke:none"
+       id="rect3873-7"
+       width="8.0081358"
+       height="1.0490723"
+       x="3.984375"
+       y="1041.3466" />
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/classpath.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/classpath.svg
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="classpath.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4918-5"
+       id="linearGradient4975-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9790709,0,0,1.0606414,0.3028847,-68.582544)"
+       x1="6.6639614"
+       y1="1051.8521"
+       x2="6.6639614"
+       y2="1053.6217" />
+    <linearGradient
+       id="linearGradient4918-5">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4907-9"
+       id="linearGradient4977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9790709,0,0,1.0606414,0.3028847,-68.582544)"
+       x1="6.6639614"
+       y1="1051.8521"
+       x2="6.6639614"
+       y2="1053.6217" />
+    <linearGradient
+       id="linearGradient4907-9">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928-4"
+       id="linearGradient4979-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93200086,0,0,1.0533679,0.56637026,-65.083369)"
+       x1="5.9250002"
+       y1="1051.6095"
+       x2="5.9250002"
+       y2="1054.2059" />
+    <linearGradient
+       id="linearGradient4928-4">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-8">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-6">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4961-6"
+       id="linearGradient9855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.625,0)"
+       x1="15.073242"
+       y1="1040.0764"
+       x2="18.744612"
+       y2="1049.2014" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4938-8"
+       id="linearGradient9955"
+       x1="-0.81249988"
+       y1="1040.3623"
+       x2="-0.81249994"
+       y2="1044.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5.9999999,-2.0001051)" />
+    <linearGradient
+       y2="1049.2014"
+       x2="18.744612"
+       y1="1040.0764"
+       x1="15.073242"
+       gradientTransform="translate(-4.4524839,0.16604349)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5020-3"
+       xlink:href="#linearGradient4961-6"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="43.8125"
+     inkscape:cx="8"
+     inkscape:cy="6.1740371"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4969"
+     showgrid="true"
+     inkscape:window-width="1475"
+     inkscape:window-height="966"
+     inkscape:window-x="5"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3948" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4969"
+       transform="translate(-0.18750003,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4949-4"
+         d="m 9.8082585,1039.7562 c 0.08839,-0.044 1.5696575,-0.9063 1.5696575,-0.9063 l 3.976711,10.3859 -1.956435,0.5243 z"
+         style="display:inline;fill:#f0c028;fill-opacity:1;stroke:url(#linearGradient5020-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1045.8622"
+         x="1.6875"
+         height="3"
+         width="9"
+         id="rect4897"
+         style="fill:url(#linearGradient4975-9);fill-opacity:1;stroke:url(#linearGradient4977-3);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1042.8622"
+         x="2.6875"
+         height="2"
+         width="7"
+         id="rect4926"
+         style="fill:#78b87c;fill-opacity:1;stroke:url(#linearGradient4979-8);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="fill:url(#linearGradient9955);fill-opacity:1;stroke:none;stroke-width:0.83589131;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4159"
+         width="7"
+         height="2"
+         x="1.1875"
+         y="1040.3622" />
+      <rect
+         y="1040.3622"
+         x="2.1875"
+         height="1"
+         width="5"
+         id="rect4161"
+         style="fill:#0595d3;fill-opacity:1;stroke:none;stroke-width:0.83589131;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/external_tools.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/external_tools.svg
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="external_tools.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4088">
+      <stop
+         style="stop-color:#b71717;stop-opacity:1;"
+         offset="0"
+         id="stop4090" />
+      <stop
+         style="stop-color:#d80000;stop-opacity:1;"
+         offset="1"
+         id="stop4092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3870">
+      <stop
+         style="stop-color:#ff2727;stop-opacity:1;"
+         offset="0"
+         id="stop3872" />
+      <stop
+         style="stop-color:#bc0000;stop-opacity:1;"
+         offset="1"
+         id="stop3874" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9276-9"
+       inkscape:collect="always">
+      <stop
+         id="stop9278-0"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280-5"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0"
+       id="linearGradient13741"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276-9"
+       id="linearGradient13743"
+       gradientUnits="userSpaceOnUse"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894" />
+    <linearGradient
+       id="linearGradient13755-3">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-0"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-0"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-65" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-9" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1051.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945"
+       xlink:href="#linearGradient13922-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-0" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1053.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-8"
+       xlink:href="#linearGradient13922-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-3" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1055.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-1"
+       xlink:href="#linearGradient13922-7"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask14146">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g14148"
+         transform="matrix(0.73426076,0,0,0.73426076,3.6725146,281.72245)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,-18.103841,1064.137)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path14150"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14152"
+           d="m 14.349242,1061.6734 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14154"
+           d="m 14.349242,1061.6734 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3870"
+       id="linearGradient3890"
+       gradientUnits="userSpaceOnUse"
+       x1="11.468751"
+       y1="8.4543371"
+       x2="11.468751"
+       y2="9.265625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3870-0"
+       id="linearGradient3890-5"
+       gradientUnits="userSpaceOnUse"
+       x1="11.468751"
+       y1="8.4543371"
+       x2="11.468751"
+       y2="9.265625" />
+    <linearGradient
+       id="linearGradient3870-0">
+      <stop
+         style="stop-color:#ff2727;stop-opacity:1;"
+         offset="0"
+         id="stop3872-4" />
+      <stop
+         style="stop-color:#bc0000;stop-opacity:1;"
+         offset="1"
+         id="stop3874-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4088"
+       id="linearGradient4094"
+       x1="20.043768"
+       y1="1061.286"
+       x2="20.043768"
+       y2="1064.6027"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="4.546875"
+     inkscape:cy="7.828125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="false"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="matrix(1.0027901,0,0,1.0027918,-7.2430494,-14.834029)">
+      <g
+         transform="matrix(0.77393739,0,0,0.77393739,7.411332,246.44575)"
+         inkscape:label="Layer 1"
+         id="layer1-0-8"
+         style="display:inline">
+        <g
+           style="display:inline"
+           id="g8159-2-9"
+           transform="translate(-8.2201167,-12.904699)">
+          <circle
+             style="display:inline;fill:url(#linearGradient13741);fill-opacity:1;stroke:none"
+             id="path10796-2-6-0-3-1"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+             cx="388.125"
+             cy="468.23718"
+             r="10.625" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path8117-2-7"
+             d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient13743);stroke-width:0.646047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             style="display:inline;fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path10796-2-6-0-5-3"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+             cx="388.125"
+             cy="468.23718"
+             r="10.625" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.99595426,0,0,1.0000109,-17.210211,-11.916399)"
+       style="display:inline"
+       id="g3986">
+      <g
+         transform="translate(9.125)"
+         id="g3878">
+        <g
+           id="g3884">
+          <g
+             style="display:inline"
+             id="g3864">
+            <rect
+               transform="translate(8.2201163,1049.2669)"
+               y="10"
+               x="7"
+               height="5"
+               width="9"
+               id="rect3069"
+               style="fill:#ff3c3c;fill-opacity:1;stroke:none" />
+            <rect
+               y="1060.2981"
+               x="15.220117"
+               height="3.96875"
+               width="9"
+               id="rect3069-6"
+               style="display:inline;fill:url(#linearGradient4094);fill-opacity:1;stroke:none" />
+          </g>
+          <path
+             sodipodi:nodetypes="cccc"
+             transform="translate(8.2201163,1049.2669)"
+             inkscape:connector-curvature="0"
+             id="path3868"
+             d="M 9.4687504,10.03125 V 8.4999997 H 13.46496 V 10.03125"
+             style="fill:none;stroke:url(#linearGradient3890-5);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894"
+             d="m 16.177926,1060.7812 h 6.963533"
+             style="fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9"
+             d="m 16.177925,1062.7408 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-1"
+             d="m 18.190869,1062.7408 h 3.010408"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-1-1"
+             d="M 22.200022,1062.7408 H 23.17918"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.505155" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6"
+             d="m 15.183557,1063.7573 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-3"
+             d="m 23.2048,1063.7352 h 0.979158"
+             style="display:inline;fill:none;stroke:#f09088;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5"
+             d="m 16.177926,1061.7535 h 1.088533"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-8"
+             d="m 17.260683,1060.765 h 0.979158"
+             style="display:inline;fill:#881818;fill-opacity:1;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-9-6-8-6"
+             d="m 21.198183,1060.765 h 0.979158"
+             style="display:inline;fill:#881818;fill-opacity:1;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5-0"
+             d="m 18.209176,1061.7535 h 3.041658"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path3894-5-9"
+             d="m 22.131051,1061.7535 h 1.088533"
+             style="display:inline;fill:none;stroke:#881818;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/invalid_build_tool.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/invalid_build_tool.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="error_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="477.77817"
+       x2="388.63736"
+       y2="458.68076" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#eb6d71;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#f13f53;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7a29a;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4886"
+       x1="393.43765"
+       y1="458.68076"
+       x2="393.43765"
+       y2="477.77817"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880-4">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882-5" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884-5" />
+    </linearGradient>
+    <linearGradient
+       y2="477.77817"
+       x2="393.43765"
+       y1="458.68076"
+       x1="393.43765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4986"
+       xlink:href="#linearGradient4880-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142135"
+     inkscape:cx="-30.039703"
+     inkscape:cy="80.717213"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="175"
+     inkscape:window-y="175"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient8163-2);fill-opacity:1;stroke:url(#linearGradient4886);stroke-width:2.10502887;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 11,3.15625 5,10.34375 5,11 l 0.75,0 5.9375,-7.09375 0,-0.75 z"
+         transform="translate(8.2201163,1049.2669)"
+         id="path4911-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 14.1875,1053.25 0.0625,1 c 0.22353,-0.011 0.341247,0.031 0.46875,0.125 0.127503,0.094 0.253587,0.2612 0.375,0.5 0.242825,0.4777 0.429979,1.2198 0.65625,2 0.226271,0.7802 0.505095,1.6148 1.03125,2.2812 0.526155,0.6665 1.365276,1.1485 2.46875,1.125 l -0.03125,-1 c -0.837969,0.018 -1.282983,-0.2771 -1.65625,-0.75 -0.373267,-0.4728 -0.626513,-1.1884 -0.84375,-1.9374 -0.217237,-0.7491 -0.387875,-1.5054 -0.71875,-2.1563 -0.165437,-0.3254 -0.38571,-0.6529 -0.6875,-0.875 -0.30179,-0.2221 -0.70353,-0.333 -1.125,-0.3125 z"
+         id="path4911-7-4"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:none;fill-opacity:1;stroke:url(#linearGradient4986);stroke-width:2.10502886999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0-1"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/icons/full/obj16/main_tab.svg
+++ b/debug/org.eclipse.ui.externaltools/icons/full/obj16/main_tab.svg
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="main_tab.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4927">
+      <stop
+         style="stop-color:#e8f8f8;stop-opacity:1;"
+         offset="0"
+         id="stop4931" />
+      <stop
+         style="stop-color:#f0f8f8;stop-opacity:1"
+         offset="1"
+         id="stop4933" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4940"
+       inkscape:collect="always">
+      <stop
+         id="stop4943"
+         offset="0"
+         style="stop-color:#a8b8d0;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#8898c0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4934"
+       inkscape:collect="always">
+      <stop
+         id="stop4936"
+         offset="0"
+         style="stop-color:#a8b8d0;stop-opacity:1;" />
+      <stop
+         id="stop4938"
+         offset="1"
+         style="stop-color:#8898c0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4917">
+      <stop
+         style="stop-color:#a8b8d0;stop-opacity:1;"
+         offset="0"
+         id="stop4919" />
+      <stop
+         style="stop-color:#98a8c8;stop-opacity:1"
+         offset="1"
+         id="stop4923" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5105"
+       inkscape:collect="always">
+      <stop
+         id="stop5107"
+         offset="0"
+         style="stop-color:#4068a0;stop-opacity:1" />
+      <stop
+         id="stop5109"
+         offset="1"
+         style="stop-color:#295189;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5063">
+      <stop
+         style="stop-color:#4f9cd2;stop-opacity:1;"
+         offset="0"
+         id="stop5065" />
+      <stop
+         style="stop-color:#295189;stop-opacity:1"
+         offset="1"
+         id="stop5067" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5039"
+       inkscape:collect="always">
+      <stop
+         id="stop5041"
+         offset="0"
+         style="stop-color:#4898d0;stop-opacity:1" />
+      <stop
+         id="stop5043"
+         offset="1"
+         style="stop-color:#80b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5033"
+       inkscape:collect="always">
+      <stop
+         id="stop5035"
+         offset="0"
+         style="stop-color:#d0f0f8;stop-opacity:1" />
+      <stop
+         id="stop5037"
+         offset="1"
+         style="stop-color:#d0f0f8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4925">
+      <stop
+         style="stop-color:#285088;stop-opacity:1;"
+         offset="0"
+         id="stop4927" />
+      <stop
+         style="stop-color:#4068a0;stop-opacity:1"
+         offset="1"
+         id="stop4929" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4916">
+      <stop
+         style="stop-color:#4898d0;stop-opacity:1"
+         offset="0"
+         id="stop4918" />
+      <stop
+         style="stop-color:#90c0e0;stop-opacity:1"
+         offset="1"
+         id="stop4921" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#96792f;stop-opacity:1"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#615941;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c2ecf6;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3ebf5;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-4" />
+      <stop
+         style="stop-color:#b1e6f3;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4916-4">
+      <stop
+         style="stop-color:#4898d0;stop-opacity:1"
+         offset="0"
+         id="stop4918-7" />
+      <stop
+         style="stop-color:#90c0e0;stop-opacity:1"
+         offset="1"
+         id="stop4921-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5063"
+       id="linearGradient4177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,17,1)"
+       x1="1"
+       y1="1039.0999"
+       x2="16"
+       y2="1039.0999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1,1)"
+       x1="9"
+       y1="1037.3622"
+       x2="9"
+       y2="1051.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4927"
+       id="linearGradient4181"
+       gradientUnits="userSpaceOnUse"
+       x1="12"
+       y1="1040.3622"
+       x2="12"
+       y2="1050.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-4"
+       id="linearGradient4183"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-3)"
+       x1="-12"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-7"
+       id="linearGradient4185"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-3)"
+       x1="-11"
+       y1="1043.3622"
+       x2="-11"
+       y2="1046.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-4-7"
+       id="linearGradient4187"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,-1,0,2093.726)"
+       x1="-12"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-7-4"
+       id="linearGradient4189"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,-1,0,2093.726)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1045.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5033"
+       id="linearGradient4191"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,-3.068933,1037.3638)"
+       x1="-17.426371"
+       y1="1.5153586"
+       x2="-10.239074"
+       y2="1.5153586" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5039"
+       id="linearGradient4193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,-3.068933,3)"
+       x1="-15.924768"
+       y1="1037.0402"
+       x2="-15.924768"
+       y2="1034.677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4916"
+       id="linearGradient4195"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,1037.3326)"
+       x1="-17.426371"
+       y1="1.5153586"
+       x2="-10.239074"
+       y2="1.5153586" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4925"
+       id="linearGradient4197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,2.96875)"
+       x1="-19.039457"
+       y1="1035.8776"
+       x2="-8.0294761"
+       y2="1035.8776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4916-4"
+       id="linearGradient4199"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,1037.367)"
+       x1="-17.426371"
+       y1="1.5153586"
+       x2="-10.239074"
+       y2="1.5153586" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5105"
+       id="linearGradient4201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.73333333,0,0,1,12.733333,1)"
+       x1="1"
+       y1="1039.0999"
+       x2="16"
+       y2="1039.0999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4934"
+       id="linearGradient4203"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,1)"
+       x1="-16"
+       y1="1041.8622"
+       x2="-7"
+       y2="1041.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4917"
+       id="linearGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,1)"
+       x1="-16"
+       y1="1045.8622"
+       x2="-11"
+       y2="1045.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4940"
+       id="linearGradient4207"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,1)"
+       x1="-16"
+       y1="1043.8622"
+       x2="-7"
+       y2="1043.8622" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="0.79311012"
+     inkscape:cy="4.9751802"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="25"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4161"
+       transform="translate(0,-1.0024)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect3997-9-1-1-5"
+         d="m 16,1039.8911 -15,-0.052 0,0.5248 15,0 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4177);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <path
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3997-9-1"
+         d="m 1,1040.3638 0,12 15,0 0,-12 z m 1,1 13,0 0,10 -13,0 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4179);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect3997-9-1-1"
+         d="m 2,1040.3638 13,0 0,11 -12.96875,0 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4181);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m 4,1042.3638 0,9 -2,0 0,-11 z"
+         style="fill:url(#linearGradient4183);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m 3,1042.3638 12,0 0,-2 -13,0 z"
+         style="fill:url(#linearGradient4185);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7-2"
+         d="m 13,1049.3638 0,-7 2,-2 0,11 z"
+         style="opacity:0.25;fill:url(#linearGradient4187);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0-4"
+         d="m 13,1049.3638 -9,0 -2,2 13,0 z"
+         style="opacity:0.25;fill:url(#linearGradient4189);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4914-9"
+         d="m 15.498145,1039.8625 -0.469563,-1.9667 -3.535107,-0.022 -2.032932,1.9888 z"
+         style="fill:url(#linearGradient4191);fill-opacity:1;stroke:url(#linearGradient4193);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4914"
+         d="m 1.4996055,1039.8534 0.9553065,-1.9888 6.98268,0.01 2.060553,1.9888 z"
+         style="fill:url(#linearGradient4195);fill-opacity:1;stroke:url(#linearGradient4197);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4914-0"
+         d="m 1.1764988,1039.367 0.4948965,-1 7.6102357,0 0.994369,1 z"
+         style="fill:url(#linearGradient4199);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect3997-9-1-1-5-6"
+         d="m 12,1039.8911 -11,-0.052 0,0.5248 11,0 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4201);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      <rect
+         y="1042.3622"
+         x="4"
+         height="1"
+         width="9"
+         id="rect4142"
+         style="fill:url(#linearGradient4203);fill-opacity:1;stroke:none" />
+      <rect
+         y="1046.3622"
+         x="4"
+         height="1"
+         width="5"
+         id="rect4144"
+         style="fill:url(#linearGradient4205);fill-opacity:1;stroke:none" />
+      <rect
+         y="1044.3622"
+         x="4"
+         height="1"
+         width="9"
+         id="rect4146"
+         style="fill:url(#linearGradient4207);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.ui.externaltools/plugin.xml
+++ b/debug/org.eclipse.ui.externaltools/plugin.xml
@@ -39,7 +39,7 @@
          <action
                label="%Action.externalTools"
                style="pulldown"
-               icon="$nl$/icons/full/obj16/external_tools.png"
+               icon="$nl$/icons/full/obj16/external_tools.svg"
                class="org.eclipse.ui.externaltools.internal.menu.ExternalToolMenuDelegate"
                menubarPath="org.eclipse.ui.run/ExternalToolsGroup"
                id="org.eclipse.ui.externaltools.ExternalToolMenuDelegateMenu">
@@ -48,7 +48,7 @@
                definitionId="org.eclipse.ui.externaltools.ExternalToolMenuDelegateToolbar"
                label="%Action.externalTools"
                style="pulldown"
-               icon="$nl$/icons/full/obj16/external_tools.png"
+               icon="$nl$/icons/full/obj16/external_tools.svg"
                tooltip="%Action.externalToolsTip"
                class="org.eclipse.ui.externaltools.internal.menu.ExternalToolMenuDelegate"
                toolbarPath="org.eclipse.debug.ui.launchActionSet/debug"
@@ -122,12 +122,12 @@
    <extension
          point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
-            icon="$nl$/icons/full/obj16/external_tools.png"
+            icon="$nl$/icons/full/obj16/external_tools.svg"
             configTypeID="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType"
             id="org.eclipse.ui.externaltools.launchConfigurationTypeImage.program">
       </launchConfigurationTypeImage>
       <launchConfigurationTypeImage
-            icon="$nl$/icons/full/obj16/external_tools.png"
+            icon="$nl$/icons/full/obj16/external_tools.svg"
             configTypeID="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType"
             id="org.eclipse.ui.externaltools.launchConfigurationTypeImage.program.builder">
       </launchConfigurationTypeImage>
@@ -138,7 +138,7 @@
             label="%ExternalToolsLaunchGroup.label"
             bannerImage="$nl$/icons/full/wizban/ext_tools_wiz.png"
             category="org.eclipse.ui.externaltools"
-            image="$nl$/icons/full/obj16/external_tools.png"
+            image="$nl$/icons/full/obj16/external_tools.svg"
             mode="run"
             id="org.eclipse.ui.externaltools.launchGroup"
             title="%ExternalToolsLaunchGroup.title">
@@ -147,7 +147,7 @@
             label="%ExternalToolsLaunchGroup.label"
             bannerImage="$nl$/icons/full/wizban/ext_tools_wiz.png"
             category="org.eclipse.ui.externaltools.builder"
-            image="$nl$/icons/full/obj16/external_tools.png"
+            image="$nl$/icons/full/obj16/external_tools.svg"
             public="false"
             mode="run"
             id="org.eclipse.ui.externaltools.launchGroup.builder">


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.ui.externaltools` except for the following as it is not available as SVG yet:

wizban/ext_tools_wiz.svg

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.