### PR TITLE
Add SVGs to org.eclipse.ui.cheatsheets

### DIFF
--- a/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Require-Bundle: org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.cheatsheets
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/collapse_expand_all.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/collapse_expand_all.svg
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="collapse_expand_all.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3547">
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop3543" />
+      <stop
+         id="stop3551"
+         offset="0.32438135"
+         style="stop-color:#7086b0;stop-opacity:1" />
+      <stop
+         style="stop-color:#7086b0;stop-opacity:1"
+         offset="0.62148249"
+         id="stop3557" />
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="1"
+         id="stop3545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-15.837424,-509.37421)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,4.6955372,34.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3547"
+       id="linearGradient3549"
+       x1="8.5355339"
+       y1="1044.574"
+       x2="8.5276003"
+       y2="1042.9905"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,6.6956469,34.252148)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,8.6956474,34.252132)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695647,34.252196)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,12.695647,34.252181)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.259798"
+     inkscape:cx="8.3909387"
+     inkscape:cy="7.936907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="3.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 4.0000001,1037.8622 H 13"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient3549);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3541"
+       width="7"
+       height="3"
+       x="5"
+       y="1042.3623" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/collapseall.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/collapseall.svg
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="9.8506072"
+     inkscape:cy="9.9346296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="809"
+     inkscape:window-x="1159"
+     inkscape:window-y="450"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/complete_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/complete_task.svg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="complete_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-16.837424,-509.37421)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,3.6955372,34.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,5.6956469,34.252148)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,7.6956474,34.252132)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,9.695647,34.252196)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,11.695647,34.252181)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.259798"
+     inkscape:cx="8.3909387"
+     inkscape:cy="7.936907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="2.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.0000001,1037.8622 H 12"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline;stroke-width:1.00041938"
+       id="layer1-9"
+       inkscape:label="Layer 1"
+       transform="matrix(1,0,0,0.99916176,2.0050501,0.87753861)">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path996"
+         d="m 3.5,1043.8622 3,3 6,-6"
+         style="fill:none;stroke:#317f5a;stroke-width:1.00041938px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/goto_ccs_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/goto_ccs_task.svg
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="goto_ccs_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-14.837424,-509.37421)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,5.6955372,34.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,7.6956469,34.252148)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,9.6956474,34.252132)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,11.695647,34.252196)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,13.695647,34.252181)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always">
+      <stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" />
+      <stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbe597;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       id="linearGradient4747"
+       xlink:href="#linearGradient4741"
+       inkscape:collect="always"
+       gradientTransform="translate(-0.08895903,-0.17944608)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1046.4902"
+       x2="4.5"
+       y1="1042.047"
+       x1="4.5"
+       id="linearGradient4755"
+       xlink:href="#linearGradient4749"
+       inkscape:collect="always"
+       gradientTransform="translate(-0.08895903,-0.17944608)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.259798"
+     inkscape:cx="8.3909387"
+     inkscape:cy="7.936907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="4.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 5.0000001,1037.8622 H 14"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline;stroke-width:1.35170841"
+       id="layer1-7"
+       inkscape:label="Layer 1"
+       transform="matrix(0.74297454,0,0,0.73664799,0.29881122,275.51631)">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="m 8.3464351,1038.9574 v 2.715 H 2.8521886 c -0.6678671,0 -1.2354592,0.5416 -1.2354592,1.2095 v 3.011 c 0,0.6678 0.567601,1.206 1.2354592,1.2095 h 5.4942465 v 2.715 H 9.411041 l 5.5,-5.43 -5.5444795,-5.43 z"
+         style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1.35170841;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:nodetypes="ccsssscccccc" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/linkto_help.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/linkto_help.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="linkto_help.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#f7fdff;stop-opacity:1"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#e8f0f5;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4883"
+       x1="12.108335"
+       y1="2.7923172"
+       x2="12.108335"
+       y2="17.832731"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="9.2128289"
+     inkscape:cy="8.5632458"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="900"
+     inkscape:window-x="210"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient4883);fill-opacity:1;stroke:#546782;stroke-width:1.51549268;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4110"
+         sodipodi:cx="11.9375"
+         sodipodi:cy="11.6875"
+         sodipodi:rx="9.875"
+         sodipodi:ry="9.875"
+         d="m 21.8125,11.6875 a 9.875,9.875 0 1 1 -19.75,0 9.875,9.875 0 1 1 19.75,0 z"
+         transform="matrix(0.65985142,0,0,0.65985142,8.3743896,1049.555)" />
+      <path
+         style="font-size:20.03678703px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#475b78;fill-opacity:1;stroke:none;font-family:Reznor;-inkscape-font-specification:Reznor Bold"
+         d="m 16.198558,1052.2089 c -0.989362,0 -1.779246,0.2751 -2.381946,0.8285 -0.602703,0.5534 -0.916817,1.32 -0.952778,2.2784 l 1.636293,0.2071 c 0.0538,-1.185 0.596173,-1.7606 1.594868,-1.7606 0.422752,0 0.765773,0.1082 1.035628,0.3522 0.269846,0.244 0.393533,0.5573 0.393539,0.932 -6e-6,0.3486 -0.120825,0.6499 -0.372826,0.9113 -0.134793,0.1394 -0.402883,0.3481 -0.80779,0.6008 -0.36868,0.2265 -0.607999,0.4852 -0.72494,0.8077 -0.108163,0.2702 -0.165704,0.6852 -0.165701,1.2428 l 0,0.7456 1.512018,0 0,-0.4764 c -5e-6,-0.5489 0.236445,-0.9703 0.704227,-1.2841 0.611892,-0.4183 1.029572,-0.7896 1.263467,-1.0771 0.323648,-0.4183 0.497094,-0.9226 0.497101,-1.5327 -7e-6,-0.8366 -0.33497,-1.5277 -0.97349,-2.0505 -0.611904,-0.488 -1.367142,-0.725 -2.25767,-0.725 z"
+         id="text4882"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccccccsccsccccc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#475b78;fill-opacity:1;stroke:none;display:inline"
+         id="path4908-1"
+         sodipodi:cx="11.932427"
+         sodipodi:cy="16.531185"
+         sodipodi:rx="0.64356911"
+         sodipodi:ry="0.39774758"
+         d="m 12.575997,16.531185 a 0.64356911,0.39774758 0 1 1 -1.287139,0 0.64356911,0.39774758 0 1 1 1.287139,0 z"
+         transform="matrix(1.7775683,0,0,2.4520496,-5.0999685,1020.5689)" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_all.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_all.svg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="restart_all.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7531701,0,0,0.91742879,-2.1024537,89.716833)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695537,38.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,12.695647,38.252122)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,14.695647,38.252096)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7531701,0,0,0.91742879,-6.1024537,87.71685)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,6.695537,36.252162)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4634"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,8.695647,36.252139)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4636"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695647,36.252113)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4673"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7531701,0,0,0.91742879,-10.102454,85.71685)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,2.695537,34.252162)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,4.695647,34.252139)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4679"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,6.695647,34.252113)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         id="stop7493"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7495"
+         offset="1"
+         style="stop-color:#a0b0cc;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         id="stop7256"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,20.936643,283.97383)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,20.936643,283.97383)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient5397"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695537,38.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5779"
+       x="-0.10000927"
+       width="1.2000185"
+       y="-0.1409974"
+       height="1.2819948">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.075880519"
+         id="feGaussianBlur5781" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.381042"
+     inkscape:cx="9.0070855"
+     inkscape:cy="5.6979725"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4673);stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6-5"
+       width="6"
+       height="8"
+       x="1.5"
+       y="1037.8622"
+       rx="0.37885904"
+       ry="0.37885907" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b7d2e4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2,1037.8622 H 7"
+       id="path4307-4-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4675);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.500059,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-12"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4677);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4679);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-4-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4630);stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6-8"
+       width="6"
+       height="8"
+       x="5.5"
+       y="1039.8622"
+       rx="0.37885904"
+       ry="0.37885907" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b7d2e4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6,1039.8622 h 5"
+       id="path4307-4-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4632);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.500059,1038.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-9"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4634);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.500169,1038.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-1-6"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4636);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500169,1038.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-4-4"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="6"
+       height="8"
+       x="9.5"
+       y="1041.8622"
+       rx="0.37885904"
+       ry="0.37885907" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5397);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500059,1040.8693 -1.19e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.500169,1040.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#f9feff;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.500169,1040.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-4"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g7056"
+       transform="matrix(0,1.3170263,1.4044518,0,-1459.049,1014.598)">
+      <path
+         transform="translate(-12.551145)"
+         style="display:inline;fill:url(#linearGradient7063);fill-opacity:1;stroke:url(#linearGradient7065);stroke-width:0.73527426;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 37.048909,1040.6544 v -1.068 c 0,0 -0.264552,-0.5793 -1.004535,0 -0.739983,0.5791 -1.608775,1.3067 -1.737468,1.5641 -0.128693,0.2574 -0.675637,0.7078 0.06435,1.4156 0.739983,0.7079 1.457968,1.2319 1.457968,1.2319 0,0 1.219685,0.8728 1.219685,-0.1249 v -0.8826 c 0.994736,-0.046 1.993517,-0.1337 2.571418,0.2535 0.652448,0.4371 0.562714,1.676 0.858464,1.7671 0.295748,0.091 0.454627,-1.7022 0.454627,-2.0206 0,-0.3185 -0.126878,-0.796 -0.522878,-1.3237 -0.213698,-0.2846 -0.732779,-0.5875 -1.114743,-0.6926 -0.685923,-0.071 -1.244185,-0.1528 -2.246888,-0.1198 z"
+         id="path7582"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscscsssscc" />
+      <path
+         style="display:inline;opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none;filter:url(#filter5779)"
+         d="m 27.55363,1041.8824 -0.722164,-0.081 c 0,0 -0.291655,0.1949 -0.188749,0.4208 0.103439,0.2263 0.514635,0.3938 0.600479,0.4391 0.08531,0.045 0.520692,0.9447 0.692273,0.8391 0.171581,-0.1056 -0.06394,-1.2385 -0.06394,-1.2385 z"
+         id="path7602-2-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscc" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b7d2e4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,1041.8622 h 5"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_cheatsheet.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_cheatsheet.svg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="return_to_start.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6378">
+      <stop
+         style="stop-color:#dfe8f8;stop-opacity:1"
+         offset="0"
+         id="stop6374" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop6376" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695537,38.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         id="stop7493"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7495"
+         offset="1"
+         style="stop-color:#a0b0cc;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         id="stop7256"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5779"
+       x="-0.10000927"
+       width="1.2000185"
+       y="-0.1409974"
+       height="1.2819948">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.075880519"
+         id="feGaussianBlur5781" />
+    </filter>
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4837"
+       inkscape:collect="always">
+      <stop
+         id="stop4839"
+         offset="0"
+         style="stop-color:#acbfd5;stop-opacity:1;" />
+      <stop
+         id="stop4841"
+         offset="1"
+         style="stop-color:#627297;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4767"
+       inkscape:collect="always">
+      <stop
+         id="stop4769"
+         offset="0"
+         style="stop-color:#f1c373;stop-opacity:1" />
+      <stop
+         id="stop4771"
+         offset="1"
+         style="stop-color:#f6e3c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(21.96875,-0.00521732)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.2782"
+       x2="-11.375669"
+       y1="1036.296"
+       x1="-11.375669"
+       id="linearGradient4843"
+       xlink:href="#linearGradient4837"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(21.96875,-0.00521732)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-7"
+       id="linearGradient5000-6"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-7">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-7" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.307072)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-7"
+       id="linearGradient5000-6-7"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.0285852,1.9123827)" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.99777994,22.000768,2.3453808)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.2782"
+       x2="-11.375669"
+       y1="1036.296"
+       x1="-11.375669"
+       id="linearGradient4843-2"
+       xlink:href="#linearGradient4837"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.06528268)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.52564024)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.8655"
+       x2="-11.999999"
+       y1="1050.9951"
+       x1="-11.999999"
+       id="linearGradient4774-3"
+       xlink:href="#linearGradient4767"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.52564024)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.0842"
+       x2="-17.34375"
+       y1="1050.9445"
+       x1="-17.3125"
+       id="linearGradient4790-5"
+       xlink:href="#linearGradient4784"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient6370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.94440354,1.0625213,0,-1101.9544,1021.9209)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient6372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.94440354,1.0625213,0,-1101.9544,1021.9209)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4921875,0,0,1.4921875,-5.90625,-514.29258)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380-8"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-6,-524.50565)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380-8-1"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-5.9348351,-520.46828)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.331305"
+     inkscape:cy="6.7068531"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 4.9843752,1040.3414 1.53125,-1.3672 0.9375,-2.1172 h 1.5 1.4999998 l 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3125002,1036.3698 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 h 1.1875 H 10.125 l 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 h -1.4999998 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(3.1589148,4.1623875)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="M 1.4972825,1036.9037 H 9.653585 l 0.759173,3.0066 v 6.5483 H 1.4972825 Z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 h 8.4908829 l 0.04042,3.0066 v 6.4546 H 1.4972807 Z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11"
+       height="11.999999"
+       x="3.5"
+       y="1038.9119"
+       rx="1.21875"
+       ry="1.2187499" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 5.0312502,1040.4119 1.53125,-1.3672 0.9375,-2.1172 h 1.5 H 10.5 l 0.953125,2.1172 L 13,1040.4119"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3445181,1036.4196 c -0.138213,0.043 -0.255616,0.1479 -0.3125,0.2806 l -0.875,1.9955 -0.966084,0.8615 c -0.219449,0.2189 -0.161431,0.3245 -0.190934,0.8365 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0116 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.156 l 0.8125,-1.8084 h 1.1875 1.1562499 l 0.8125,1.8084 c 0.0306,0.06 0.0734,0.1131 0.125,0.156 l 1.173251,1.0302 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2125 0.08262,-0.5741 -0.123815,-0.78 l -1.015435,-0.9055 -0.90625,-1.9955 c -0.07974,-0.1637 -0.255243,-0.2762 -0.4375,-0.2806 h -1.4999999 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="M 4.4686973,1040.8161 H 13.28125 l 0.102923,3.0066 v 6.5483 H 4.4686973 Z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="M 4.5000017,1040.9119 H 13.5 v 9 H 4.5000001 Z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1044.9119 H 6.03125"
+       id="path908-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380-8);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1042.8622 H 6"
+       id="path908-9-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380-8-1);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12.065165,1046.8996 H 6.0651648"
+       id="path908-9-7-3"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccssscscsssscc"
+       inkscape:connector-curvature="0"
+       id="path7582"
+       d="M 2.4325024,1042.8228 H 0.87374016 c 0,0 -0.84549721,-0.3432 0,-1.3032 0.84520524,-0.96 1.90714854,-2.087 2.28282774,-2.2539 0.3756793,-0.167 1.0330449,-0.8765 2.0660897,0.084 1.0331909,0.9599 1.7979769,1.8913 1.7979769,1.8913 0,0 1.2738649,1.5823 -0.1822935,1.5823 H 5.5501729 c -0.067137,1.2904 -0.1951372,2.5861 0.3699871,3.3358 0.6379541,0.8464 2.4461475,0.7299 2.5791094,1.1136 0.1328159,0.3837 -2.4843869,0.5898 -2.9490965,0.5898 -0.4648556,0 -1.1617742,-0.1646 -1.9319603,-0.6783 -0.4153781,-0.2772 -0.8574652,-0.9506 -1.0108603,-1.4461 -0.1036255,-0.8899 -0.2230139,-1.614 -0.1748499,-2.9148 z"
+       style="display:inline;fill:url(#linearGradient6370);fill-opacity:1;stroke:url(#linearGradient6372);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccssscc"
+       inkscape:connector-curvature="0"
+       id="path7602-2-3"
+       d="m 27.55363,1041.8824 -0.722164,-0.081 c 0,0 -0.291655,0.1949 -0.188749,0.4208 0.103439,0.2263 0.514635,0.3938 0.600479,0.4391 0.08531,0.045 0.520692,0.9447 0.692273,0.8391 0.171581,-0.1056 -0.06394,-1.2385 -0.06394,-1.2385 z"
+       style="display:inline;opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.98257542;filter:url(#filter5779)"
+       transform="matrix(0,1.3170263,1.4547054,0,-1511.5359,1010.5183)" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/restart_task.svg
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="restart_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient6462">
+      <stop
+         id="stop6458"
+         offset="0"
+         style="stop-color:#a3cb8a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4da766;stop-opacity:1"
+         offset="0.34381843"
+         id="stop6464" />
+      <stop
+         id="stop6460"
+         offset="1"
+         style="stop-color:#79ba5d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6456">
+      <stop
+         id="stop6452"
+         offset="0"
+         style="stop-color:#277652;stop-opacity:1" />
+      <stop
+         id="stop6454"
+         offset="1"
+         style="stop-color:#34845c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695537,38.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         id="stop7493"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7495"
+         offset="1"
+         style="stop-color:#a0b0cc;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         id="stop7256"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5779"
+       x="-0.10000927"
+       width="1.2000185"
+       y="-0.1409974"
+       height="1.2819948">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.075880519"
+         id="feGaussianBlur5781" />
+    </filter>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6462"
+       id="linearGradient6370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3408346,0,0,-1.5465943,38.331072,2654.0387)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.589273"
+       y2="1038.0674" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6456"
+       id="linearGradient6372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3408346,0,0,-1.5465943,38.331072,2654.0387)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.331305"
+     inkscape:cy="6.7068531"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccssscscscccc"
+       inkscape:connector-curvature="0"
+       id="path7582"
+       d="M 8.4989583,1046.5053 8.5,1049.3372 c 0,0 0.6424729,1.2302 2.005451,-5e-4 1.362978,-1.2302 3.213057,-3.3384 3.450017,-3.8853 0.237101,-0.5468 1.244427,-1.5037 -0.119261,-3.0074 -1.362836,-1.5039 -2.997708,-2.7109 -2.997708,-2.7109 0,0 -2.3420877,-2.0105 -2.3402502,0.1091 l 0.00175,2.02 c -1.8320696,0.098 -3.7359152,0.1391 -4.8003158,-0.6834 -1.2016923,-0.9287 -0.8487892,-3.0919 -1.3935545,-3.2854 -1.1929749,2.6805 -0.9852176,5.0915 0.1568995,6.886 1.6647067,1.5896 3.7772206,0.9587 6.0369708,1.0824 z"
+       style="display:inline;fill:url(#linearGradient6370);fill-opacity:1;stroke:url(#linearGradient6372);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/return_to_start.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/return_to_start.svg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="return_to_start.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6378">
+      <stop
+         style="stop-color:#dfe8f8;stop-opacity:1"
+         offset="0"
+         id="stop6374" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop6376" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695537,38.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         id="stop7493"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7495"
+         offset="1"
+         style="stop-color:#a0b0cc;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         id="stop7256"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient7065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,7.8634887,278.53888)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5779"
+       x="-0.10000927"
+       width="1.2000185"
+       y="-0.1409974"
+       height="1.2819948">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.075880519"
+         id="feGaussianBlur5781" />
+    </filter>
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4837"
+       inkscape:collect="always">
+      <stop
+         id="stop4839"
+         offset="0"
+         style="stop-color:#acbfd5;stop-opacity:1;" />
+      <stop
+         id="stop4841"
+         offset="1"
+         style="stop-color:#627297;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4767"
+       inkscape:collect="always">
+      <stop
+         id="stop4769"
+         offset="0"
+         style="stop-color:#f1c373;stop-opacity:1" />
+      <stop
+         id="stop4771"
+         offset="1"
+         style="stop-color:#f6e3c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(21.96875,-0.00521732)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.2782"
+       x2="-11.375669"
+       y1="1036.296"
+       x1="-11.375669"
+       id="linearGradient4843"
+       xlink:href="#linearGradient4837"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(21.96875,-0.00521732)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-7"
+       id="linearGradient5000-6"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-7">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-7" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.307072)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-7"
+       id="linearGradient5000-6-7"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.0285852,1.9123827)" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.99777994,22.000768,2.3453808)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.2782"
+       x2="-11.375669"
+       y1="1036.296"
+       x1="-11.375669"
+       id="linearGradient4843-2"
+       xlink:href="#linearGradient4837"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.06528268)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.52564024)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.8655"
+       x2="-11.999999"
+       y1="1050.9951"
+       x1="-11.999999"
+       id="linearGradient4774-3"
+       xlink:href="#linearGradient4767"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.52564024)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.0842"
+       x2="-17.34375"
+       y1="1050.9445"
+       x1="-17.3125"
+       id="linearGradient4790-5"
+       xlink:href="#linearGradient4784"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient6370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.94440354,1.0625213,0,-1101.9544,1021.9209)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient6372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.94440354,1.0625213,0,-1101.9544,1021.9209)"
+       x1="24.928591"
+       y1="1038.3658"
+       x2="24.928591"
+       y2="1044.5624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4921875,0,0,1.4921875,-5.90625,-514.29258)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380-8"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-6,-524.50565)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6378"
+       id="linearGradient6380-8-1"
+       x1="8"
+       y1="1044.9119"
+       x2="12"
+       y2="1044.9119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-5.9348351,-520.46828)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.331305"
+     inkscape:cy="6.7068531"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 4.9843752,1040.3414 1.53125,-1.3672 0.9375,-2.1172 h 1.5 1.4999998 l 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3125002,1036.3698 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 h 1.1875 H 10.125 l 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 h -1.4999998 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(3.1589148,4.1623875)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="M 1.4972825,1036.9037 H 9.653585 l 0.759173,3.0066 v 6.5483 H 1.4972825 Z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 h 8.4908829 l 0.04042,3.0066 v 6.4546 H 1.4972807 Z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11"
+       height="11.999999"
+       x="3.5"
+       y="1038.9119"
+       rx="1.21875"
+       ry="1.2187499" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 5.0312502,1040.4119 1.53125,-1.3672 0.9375,-2.1172 h 1.5 H 10.5 l 0.953125,2.1172 L 13,1040.4119"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3445181,1036.4196 c -0.138213,0.043 -0.255616,0.1479 -0.3125,0.2806 l -0.875,1.9955 -0.966084,0.8615 c -0.219449,0.2189 -0.161431,0.3245 -0.190934,0.8365 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0116 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.156 l 0.8125,-1.8084 h 1.1875 1.1562499 l 0.8125,1.8084 c 0.0306,0.06 0.0734,0.1131 0.125,0.156 l 1.173251,1.0302 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2125 0.08262,-0.5741 -0.123815,-0.78 l -1.015435,-0.9055 -0.90625,-1.9955 c -0.07974,-0.1637 -0.255243,-0.2762 -0.4375,-0.2806 h -1.4999999 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="M 4.4686973,1040.8161 H 13.28125 l 0.102923,3.0066 v 6.5483 H 4.4686973 Z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="M 4.5000017,1040.9119 H 13.5 v 9 H 4.5000001 Z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1044.9119 H 6.03125"
+       id="path908-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380-8);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1042.8622 H 6"
+       id="path908-9-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient6380-8-1);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12.065165,1046.8996 H 6.0651648"
+       id="path908-9-7-3"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccssscscsssscc"
+       inkscape:connector-curvature="0"
+       id="path7582"
+       d="M 2.4325024,1042.8228 H 0.87374016 c 0,0 -0.84549721,-0.3432 0,-1.3032 0.84520524,-0.96 1.90714854,-2.087 2.28282774,-2.2539 0.3756793,-0.167 1.0330449,-0.8765 2.0660897,0.084 1.0331909,0.9599 1.7979769,1.8913 1.7979769,1.8913 0,0 1.2738649,1.5823 -0.1822935,1.5823 H 5.5501729 c -0.067137,1.2904 -0.1951372,2.5861 0.3699871,3.3358 0.6379541,0.8464 2.4461475,0.7299 2.5791094,1.1136 0.1328159,0.3837 -2.4843869,0.5898 -2.9490965,0.5898 -0.4648556,0 -1.1617742,-0.1646 -1.9319603,-0.6783 -0.4153781,-0.2772 -0.8574652,-0.9506 -1.0108603,-1.4461 -0.1036255,-0.8899 -0.2230139,-1.614 -0.1748499,-2.9148 z"
+       style="display:inline;fill:url(#linearGradient6370);fill-opacity:1;stroke:url(#linearGradient6372);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccssscc"
+       inkscape:connector-curvature="0"
+       id="path7602-2-3"
+       d="m 27.55363,1041.8824 -0.722164,-0.081 c 0,0 -0.291655,0.1949 -0.188749,0.4208 0.103439,0.2263 0.514635,0.3938 0.600479,0.4391 0.08531,0.045 0.520692,0.9447 0.692273,0.8391 0.171581,-0.1056 -0.06394,-1.2385 -0.06394,-1.2385 z"
+       style="display:inline;opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.98257542;filter:url(#filter5779)"
+       transform="matrix(0,1.3170263,1.4547054,0,-1511.5359,1010.5183)" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/review_ccs_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/review_ccs_task.svg
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="review_ccs_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-14.837424,-509.37421)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,5.6955372,34.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,7.6956469,34.252148)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,9.6956474,34.252132)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,11.695647,34.252196)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,13.695647,34.252181)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="8.1045008"
+       x2="3.0734024"
+       y1="6.4610124"
+       x1="1.4333301"
+       id="linearGradient4945-1"
+       xlink:href="#linearGradient4939-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4939-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4941-4"
+         offset="0"
+         style="stop-color:#d5f3ff;stop-opacity:1;" />
+      <stop
+         id="stop4943-0"
+         offset="1"
+         style="stop-color:#fcffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-3-7">
+      <stop
+         id="stop5105-5-4"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         style="stop-color:#b3dac7;stop-opacity:1"
+         offset="0.26694915"
+         id="stop7550-07-0" />
+      <stop
+         style="stop-color:#9ec2c3;stop-opacity:1"
+         offset="0.51694918"
+         id="stop7548-6-9" />
+      <stop
+         id="stop5107-7-48"
+         offset="1"
+         style="stop-color:#7a99bb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4939-7"
+       id="linearGradient7728"
+       gradientUnits="userSpaceOnUse"
+       x1="1.4333301"
+       y1="6.4610124"
+       x2="3.0734024"
+       y2="8.1045008" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.259798"
+     inkscape:cx="2.8720651"
+     inkscape:cy="7.936907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="4.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 5.0000001,1037.8622 H 14"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(0.77147567,0,0,0.77147567,-5.3548516,228.63975)"
+       id="g4106"
+       style="display:inline">
+      <path
+         style="fill:none;stroke:#324e6e;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 12.535948,1057.3138 c 0,0 0.409535,-0.5625 1.699794,-0.5625 1.290259,0 1.658145,0.5 1.658145,0.5"
+         id="path4981-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;stroke:#324e6e;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 8.780508,1057.2857 0.5226274,-0.5467 3.3916416,-3.5479 c 0.828641,-0.7734 2.088175,-0.8729 2.088175,1.7014"
+         id="path4985-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;stroke:#324e6e;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 17.623497,1058.2071 4.076913,-4.2647 c 0.828641,-0.7734 2.088175,-0.8729 2.088175,1.7015"
+         id="path4985-5-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <circle
+         style="fill:url(#linearGradient7728);fill-opacity:1;stroke:#324e6e;stroke-width:1.11897111;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4150-8"
+         transform="matrix(0.89367816,0,0,0.89367816,8.471957,1052.0008)"
+         cx="2.5156252"
+         cy="7.5624995"
+         r="2.2187502" />
+      <circle
+         style="display:inline;fill:url(#linearGradient4945-1);fill-opacity:1;stroke:#324e6e;stroke-width:1.11897111;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4150-4-8"
+         transform="matrix(0.89367816,0,0,0.89367816,15.471957,1052.0008)"
+         cx="2.5156252"
+         cy="7.5624995"
+         r="2.2187502" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/skip_ccs_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/skip_ccs_task.svg
@@ -1,0 +1,462 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="skip_ccs_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-17.837424,-509.37419)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,2.6955372,34.252162)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,4.6956469,34.252165)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,6.6956474,34.252149)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,8.695647,34.252213)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695647,34.252198)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5103-3-7">
+      <stop
+         id="stop5105-5-4"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         style="stop-color:#b3dac7;stop-opacity:1"
+         offset="0.26694915"
+         id="stop7550-07-0" />
+      <stop
+         style="stop-color:#9ec2c3;stop-opacity:1"
+         offset="0.51694918"
+         id="stop7548-6-9" />
+      <stop
+         id="stop5107-7-48"
+         offset="1"
+         style="stop-color:#7a99bb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1113"
+       inkscape:collect="always">
+      <stop
+         id="stop1109"
+         offset="0"
+         style="stop-color:#53a968;stop-opacity:1" />
+      <stop
+         id="stop1111"
+         offset="1"
+         style="stop-color:#93c586;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7084"
+       inkscape:collect="always">
+      <stop
+         id="stop7086"
+         offset="0"
+         style="stop-color:#67b170;stop-opacity:1" />
+      <stop
+         id="stop7088"
+         offset="1"
+         style="stop-color:#5bad6c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7076">
+      <stop
+         style="stop-color:#317f5a;stop-opacity:1"
+         offset="0"
+         id="stop7078" />
+      <stop
+         id="stop1097"
+         offset="0.26772746"
+         style="stop-color:#317f5a;stop-opacity:1" />
+      <stop
+         id="stop1095"
+         offset="0.30219939"
+         style="stop-color:#66b170;stop-opacity:1" />
+      <stop
+         style="stop-color:#93c586;stop-opacity:1"
+         offset="1"
+         id="stop7080" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7084"
+       id="linearGradient7074"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.57045407,0.58432111,0,-599.95571,1040.2949)"
+       x1="8.6973"
+       y1="1045.1008"
+       x2="10.472837"
+       y2="1045.2078" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7076"
+       id="linearGradient7082"
+       x1="32"
+       y1="1050.3622"
+       x2="32"
+       y2="1037.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.97626811,-17.21875,23.762488)" />
+    <linearGradient
+       gradientTransform="translate(4,1.7382813e-5)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3622"
+       x2="1"
+       y1="1040.3622"
+       x1="-1"
+       id="linearGradient1115"
+       xlink:href="#linearGradient1113"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.403713"
+     inkscape:cx="8.4919666"
+     inkscape:cy="7.9986765"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="1.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.0000001,1037.8622 H 11"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline;stroke-width:1.00932658"
+       id="layer1-8"
+       inkscape:label="Layer 1"
+       transform="matrix(0.99958649,0,0,0.9820108,2.0012405,20.701983)">
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="M 9.578125,1039.8624 6.5,1039.8622 v 1.0002 h 3 v 4.0002 h -3 v 0.8576 l 3.5,3.1422 3.5,-3.1424 v -0.8576 l -3,-2e-4 v -3.5043 c 0,-0.9145 0.185481,-1.4955 -0.921875,-1.4955 z"
+         style="fill:url(#linearGradient7074);fill-opacity:1;stroke:url(#linearGradient7082);stroke-width:1.00932658;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.3622"
+         x="3"
+         height="2.0000174"
+         width="2"
+         id="rect1099"
+         style="opacity:1;fill:url(#linearGradient1115);fill-opacity:1;stroke:none;stroke-width:1.00932658;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/skip_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/skip_task.svg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="skip_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9985">
+      <stop
+         style="stop-color:#f8f5d8;stop-opacity:1"
+         offset="0"
+         id="stop9981" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop9983" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9977">
+      <stop
+         style="stop-color:#a37c1a;stop-opacity:1"
+         offset="0"
+         id="stop9973" />
+      <stop
+         style="stop-color:#b89828;stop-opacity:1"
+         offset="1"
+         id="stop9975" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9967">
+      <stop
+         style="stop-color:#4da766;stop-opacity:1"
+         offset="0"
+         id="stop9963" />
+      <stop
+         style="stop-color:#accf8e;stop-opacity:1"
+         offset="1"
+         id="stop9965" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5103-3-7">
+      <stop
+         id="stop5105-5-4"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         style="stop-color:#b3dac7;stop-opacity:1"
+         offset="0.26694915"
+         id="stop7550-07-0" />
+      <stop
+         style="stop-color:#9ec2c3;stop-opacity:1"
+         offset="0.51694918"
+         id="stop7548-6-9" />
+      <stop
+         id="stop5107-7-48"
+         offset="1"
+         style="stop-color:#7a99bb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9967"
+       id="linearGradient9969"
+       x1="20.853327"
+       y1="1048.0575"
+       x2="28.662928"
+       y2="1039.9664"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-14.143009,6.7107143e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9977"
+       id="linearGradient9979"
+       x1="1.9867216"
+       y1="1043.329"
+       x2="1.9607754"
+       y2="1038.2638"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9985"
+       id="linearGradient9987"
+       x1="2.9734433"
+       y1="1042.3423"
+       x2="3.0132785"
+       y2="1039.4479"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.403713"
+     inkscape:cx="8.4919666"
+     inkscape:cy="7.9986765"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       style="fill:url(#linearGradient9969);fill-opacity:1;stroke:#2d7b57;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 5.5,1038.8622 v 4 h 3 v 2 h -3 v 1 l 5,5 5,-5 v -1 h -3 v -4 l -2,-2 z"
+       id="path9961"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient9987);fill-opacity:1;stroke:url(#linearGradient9979);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9971"
+       width="2"
+       height="4"
+       x="1.5"
+       y="1038.8622" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_ccs_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_ccs_task.svg
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="start_ccs_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2552836,0,0,1.4908217,-15.837424,-509.37421)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,4.6955372,34.252145)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,6.6956469,34.252148)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,8.6956474,34.252132)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,10.695647,34.252196)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674-54"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04378704,0,0,0.96696415,12.695647,34.252181)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       id="linearGradient983"
+       inkscape:collect="always">
+      <stop
+         id="stop979"
+         offset="0"
+         style="stop-color:#f8f9fb;stop-opacity:1" />
+      <stop
+         id="stop981"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893"
+       inkscape:collect="always">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#cdddeb;stop-opacity:1" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#5d92bc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4845"
+       inkscape:collect="always">
+      <stop
+         id="stop4847"
+         offset="0"
+         style="stop-color:#afb8cd;stop-opacity:1;" />
+      <stop
+         id="stop4849"
+         offset="1"
+         style="stop-color:#8192b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient983"
+       id="linearGradient4908-9"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)" />
+    <linearGradient
+       gradientTransform="translate(22.015625,0.01560006)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3914"
+       x2="-12.921875"
+       y1="1037.3231"
+       x1="-12.921875"
+       id="linearGradient4851-7"
+       xlink:href="#linearGradient4845"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.74592834,0.66828818)"
+       gradientUnits="userSpaceOnUse"
+       y2="734.09845"
+       x2="745.94769"
+       y1="732.34845"
+       x1="745.58008"
+       id="linearGradient895"
+       xlink:href="#linearGradient893"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         id="stop4740"
+         offset="0"
+         style="stop-color:#8cc861;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa766;stop-opacity:1"
+         offset="0.43753415"
+         id="stop4746" />
+      <stop
+         id="stop4742"
+         offset="1"
+         style="stop-color:#c2dd97;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4743-0"
+         offset="0"
+         style="stop-color:#30825a;stop-opacity:1" />
+      <stop
+         id="stop4745-1"
+         offset="1"
+         style="stop-color:#106643;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.314993)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       id="linearGradient4747-8"
+       xlink:href="#linearGradient4741-0"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       id="linearGradient4744"
+       xlink:href="#linearGradient4738"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.808484"
+     inkscape:cx="11.64797"
+     inkscape:cy="8.0304129"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#f9feff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368-9-6"
+       width="10"
+       height="13"
+       x="3.5"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 4.0000001,1037.8622 H 13"
+       id="path4307-4-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4307-4-2"
+       d="m -15.041343,1037.4952 v 2.149 h 6.662109 v -2.149 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.5000593,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-7);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.500169,1036.8693 -1.186e-4,1.9858"
+       id="path4198-65-4-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-5);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.5001694,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674-54);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.500169,1036.8693 -1.19e-4,1.9858"
+       id="path4198-65-4-87"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline;stroke-width:1.7523154"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="matrix(0.55025886,0,0,0.59184548,0.0991296,426.46175)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968-8"
+         d="m 2.497507,1039.8618 v 2.0277 5 3 h 1 l 9.546687,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.126842,-4.5004 z"
+         style="fill:url(#linearGradient4744);fill-opacity:1;stroke:url(#linearGradient4747-8);stroke-width:1.7523154;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_cheatsheet.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_cheatsheet.svg
@@ -1,0 +1,552 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="start_cheatsheet.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2752">
+      <stop
+         style="stop-color:#dfe8f8;stop-opacity:1"
+         offset="0"
+         id="stop2748" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop2750" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4837">
+      <stop
+         style="stop-color:#acbfd5;stop-opacity:1;"
+         offset="0"
+         id="stop4839" />
+      <stop
+         style="stop-color:#627297;stop-opacity:1"
+         offset="1"
+         id="stop4841" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4767">
+      <stop
+         style="stop-color:#f1c373;stop-opacity:1"
+         offset="0"
+         id="stop4769" />
+      <stop
+         style="stop-color:#f6e3c9;stop-opacity:1"
+         offset="1"
+         id="stop4771" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,-0.05489994)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,-0.05489994)" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.857"
+       x2="14"
+       y1="1047.857"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.857"
+       x2="14"
+       y1="1045.857"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.857"
+       x2="11"
+       y1="1043.857"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861"
+       inkscape:collect="always">
+      <stop
+         id="stop4863"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-7"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-4"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.0285852,1.8627001)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6-7"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843-2"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.99777994,22.000768,2.2956982)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4767"
+       id="linearGradient4774-3"
+       x1="-11.999999"
+       y1="1050.9951"
+       x2="-11.999999"
+       y2="1038.8655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.57532286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790-5"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.57532286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         id="stop4740"
+         offset="0"
+         style="stop-color:#8cc861;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa766;stop-opacity:1"
+         offset="0.43753415"
+         id="stop4746" />
+      <stop
+         id="stop4742"
+         offset="1"
+         style="stop-color:#c2dd97;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#30825a;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#106643;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.54542366,0,0,0.59834279,6.3871435,417.21309)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       id="linearGradient4747"
+       xlink:href="#linearGradient4741"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.54542366,0,0,0.59834279,18.012845,417.21309)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       id="linearGradient4744"
+       xlink:href="#linearGradient4738"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient2746"
+       x1="8"
+       y1="1042.8622"
+       x2="12"
+       y2="1042.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-6.0000005,-521.43114)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient2746-7"
+       x1="8"
+       y1="1042.8622"
+       x2="12"
+       y2="1042.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-6.0000004,-519.4311)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient2746-2"
+       x1="8"
+       y1="1042.8622"
+       x2="12"
+       y2="1042.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1.5,-6.0000004,-517.4311)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="1.2666278"
+     inkscape:cy="7.390162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1680"
+     inkscape:window-height="942"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 4.9843752,1040.2917 1.53125,-1.3672 0.9375,-2.1172 h 1.5 1.4999998 l 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3125002,1036.3201 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 h 1.1875 H 10.125 l 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 h -1.4999998 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(3.1589148,4.1127049)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="M 1.4972825,1036.9037 H 9.653585 l 0.759173,3.0066 v 6.5483 H 1.4972825 Z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 h 8.4908829 l 0.04042,3.0066 v 6.4546 H 1.4972807 Z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11"
+       height="11.999999"
+       x="3.5"
+       y="1038.8622"
+       rx="1.21875"
+       ry="1.2187499" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 5.0312502,1040.3622 1.53125,-1.3672 0.9375,-2.1172 h 1.5 H 10.5 l 0.953125,2.1172 L 13,1040.3622"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3445181,1036.3699 c -0.138213,0.043 -0.255616,0.1479 -0.3125,0.2806 l -0.875,1.9955 -0.966084,0.8615 c -0.219449,0.2189 -0.161431,0.3245 -0.190934,0.8365 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0116 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.156 l 0.8125,-1.8084 h 1.1875 1.1562499 l 0.8125,1.8084 c 0.0306,0.06 0.0734,0.1131 0.125,0.156 l 1.173251,1.0302 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2125 0.08262,-0.5741 -0.123815,-0.78 l -1.015435,-0.9055 -0.90625,-1.9955 c -0.07974,-0.1637 -0.255243,-0.2762 -0.4375,-0.2806 h -1.4999999 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="M 4.4686973,1040.7664 H 13.28125 l 0.102923,3.0066 v 6.5483 H 4.4686973 Z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="M 4.5000017,1040.8622 H 13.5 v 9 H 4.5000001 Z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:url(#linearGradient2746);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1042.8622 H 5.9999996"
+       id="path908"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 7,1044.8622 H 6"
+       id="path908-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient2746-7);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1044.8622 H 6"
+       id="path908-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient2746-2);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1046.8622 H 6"
+       id="path908-8"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline"
+       id="layer1-8"
+       inkscape:label="Layer 1"
+       transform="translate(-6.9665714,2.4552998)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="m 8.4665714,1039.4069 v 1.2133 2.9917 1.795 h 0.5454237 l 5.2069889,-2.7089 c 0.323038,-0.2241 0.337141,-0.3769 0,-0.5983 l -4.9779956,-2.6928 z"
+         style="fill:url(#linearGradient4744);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/start_task.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="ctxhelp_command_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         style="stop-color:#8cc861;stop-opacity:1"
+         offset="0"
+         id="stop4740" />
+      <stop
+         id="stop4746"
+         offset="0.43753415"
+         style="stop-color:#4aa766;stop-opacity:1" />
+      <stop
+         style="stop-color:#c2dd97;stop-opacity:1"
+         offset="1"
+         id="stop4742" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#30825a;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#106643;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.314993,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4738"
+       id="linearGradient4744"
+       x1="-13.936629"
+       y1="1049.9579"
+       x2="-13.936629"
+       y2="1040.053"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="-26.185413"
+     inkscape:cy="2.4368339"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1389"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4744);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.497507,1039.8618 0,2.0277 0,5 0,3 1,0 9.546687,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.126842,-4.5004 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/elcl16/tree_explorer.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/elcl16/tree_explorer.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="tree_explorer.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2020">
+      <stop
+         style="stop-color:#7e713d;stop-opacity:1"
+         offset="0"
+         id="stop2014" />
+      <stop
+         id="stop2016"
+         offset="0.7301597"
+         style="stop-color:#a98533;stop-opacity:1" />
+      <stop
+         style="stop-color:#a7bfd0;stop-opacity:1"
+         offset="0.83813739"
+         id="stop2022" />
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="1"
+         id="stop2018" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4980"
+       inkscape:collect="always">
+      <stop
+         id="stop4982"
+         offset="0"
+         style="stop-color:#6c8ab7;stop-opacity:1" />
+      <stop
+         id="stop4984"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4974"
+       inkscape:collect="always">
+      <stop
+         id="stop4976"
+         offset="0"
+         style="stop-color:#7694be;stop-opacity:1" />
+      <stop
+         id="stop4978"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4962">
+      <stop
+         style="stop-color:#6c8ab7;stop-opacity:1"
+         offset="0"
+         id="stop4964" />
+      <stop
+         style="stop-color:#607ead;stop-opacity:1"
+         offset="1"
+         id="stop4966" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4962"
+       id="linearGradient4968"
+       x1="11"
+       y1="1048.8622"
+       x2="14"
+       y2="1048.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1,1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4980"
+       id="linearGradient4970"
+       x1="11"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4972"
+       x1="7"
+       y1="1040.8622"
+       x2="14"
+       y2="1040.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1,-3)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2020"
+       id="linearGradient1969"
+       x1="24.062479"
+       y1="1047.139"
+       x2="24.129147"
+       y2="1043.2987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2862258,0,0,1.2867664,-7.2433149,-299.72846)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2020"
+       id="linearGradient1969-4"
+       x1="24.062479"
+       y1="1047.139"
+       x2="24.129147"
+       y2="1043.2987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0214747,0,0,1.277391,-16.850702,-291.26866)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2020"
+       id="linearGradient1969-8"
+       x1="24.062479"
+       y1="1047.139"
+       x2="24.129147"
+       y2="1043.2987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0214747,0,0,1.277391,-16.850701,-285.26866)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.9190923"
+     inkscape:cy="8.017986"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1680"
+     inkscape:window-height="942"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="false"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient1969-8);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1896-9"
+       width="3.9999995"
+       height="5"
+       x="7.0000005"
+       y="1047.3622" />
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient1969-4);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1896-91"
+       width="3.9999995"
+       height="5"
+       x="7"
+       y="1041.3622" />
+    <path
+       style="display:inline;fill:url(#linearGradient4970);fill-opacity:1;stroke:none"
+       d="m 12,1043.3622 h 3 v 1 h -3 z"
+       id="rect4035-1-1-5-2-2-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4968);fill-opacity:1;stroke:none"
+       d="m 12,1049.3622 h 3 v 1 h -3 z"
+       id="rect4035-1-1-5-2-2-6-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g5029"
+       transform="matrix(0.79416439,0,0,0.99271396,-17.098319,1.275883)"
+       style="stroke-width:1.12624462;stroke:#000000;stroke-opacity:1;fill:#ffff6a;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:square">
+      <rect
+         style="opacity:1;fill:url(#linearGradient1969);fill-opacity:1;stroke:none;stroke-width:1.12624466;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1896"
+         width="5.0367398"
+         height="5.0366974"
+         x="22.789135"
+         y="1042.6833" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.12624454;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1961"
+         width="2.5183709"
+         height="3.0220339"
+         x="24.048319"
+         y="1043.6907" />
+    </g>
+    <path
+       style="display:inline;fill:#5c7aaa;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 3,1041.3622 h 1.0000146 v 9 H 3 Z"
+       id="rect4035-1-1-5-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:#5c7aaa;fill-opacity:1;stroke:none"
+       d="m 4,1043.3622 h 3.0000003 v 1 H 4 Z"
+       id="rect4035-1-1-5-2-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:#5c7aaa;fill-opacity:1;stroke:none"
+       d="m 4,1049.3623 h 3.0000003 v 0.9999 H 4 Z"
+       id="rect4035-1-1-5-2-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient4972);fill-opacity:1;stroke:none"
+       d="m 6,1037.3622 h 7 v 1 H 6 Z"
+       id="rect4035-1-1-5-2-2-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1961-6"
+       width="2.0000005"
+       height="3.0000153"
+       x="7.999999"
+       y="1042.3622" />
+    <rect
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1961-2"
+       width="2.0000005"
+       height="3.0000153"
+       x="7.999999"
+       y="1048.3622" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/cheatsheet_obj.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/cheatsheet_obj.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="cheatsheet_composite_obj (copy).svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4307">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4309" />
+      <stop
+         id="stop4312"
+         offset="0.59997982"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4314" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4187"
+       inkscape:collect="always">
+      <stop
+         id="stop4189"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.49999079"
+         id="stop4201" />
+      <stop
+         id="stop4191"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4178">
+      <stop
+         style="stop-color:#7e713d;stop-opacity:1"
+         offset="0"
+         id="stop4180" />
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="1"
+         id="stop4182" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178"
+       id="linearGradient4184"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-11.869292,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.07102635,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8303571,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1-9"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.8839285,-4.2568467e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1-9-5"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4307"
+       id="linearGradient4206-1-9-5-1"
+       x1="3.9750192"
+       y1="1036.963"
+       x2="3.9750192"
+       y2="1038.5204"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.9352678,-4.2546071e-7)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="15.742216"
+     inkscape:cy="7.5875244"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1234"
+     inkscape:window-height="964"
+     inkscape:window-x="512"
+     inkscape:window-y="347"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4184);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368"
+       width="9.975256"
+       height="13.005714"
+       x="3.5355337"
+       y="1037.8413"
+       rx="0.37885904"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 4.0354196,1037.8348 8.9380894,0"
+       id="path4307"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <g
+       id="g4280"
+       transform="translate(0.12626957,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198"
+         d="m 4.3932593,1036.8711 0.00271,2.0536"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7"
+         d="M 6.294643,1036.8711 6.25,1038.9247"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2"
+         d="m 8.3482144,1036.8711 -0.044643,2.0536"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2-6"
+         d="m 10.375824,1036.6737 -0.03736,2.2699"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2-6-7"
+         d="m 12.399554,1036.8711 -0.03348,2.0424"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/cheatsheet_task.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/cheatsheet_task.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="cheatsheet_composite_obj (copy).svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4307">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4309" />
+      <stop
+         id="stop4312"
+         offset="0.59997982"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4314" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4187"
+       inkscape:collect="always">
+      <stop
+         id="stop4189"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.49999079"
+         id="stop4201" />
+      <stop
+         id="stop4191"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4178">
+      <stop
+         style="stop-color:#7e713d;stop-opacity:1"
+         offset="0"
+         id="stop4180" />
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="1"
+         id="stop4182" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178"
+       id="linearGradient4184"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-11.869292,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.07102635,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8303571,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1-9"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.8839285,-4.2568467e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-1-9-5"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4307"
+       id="linearGradient4206-1-9-5-1"
+       x1="3.9750192"
+       y1="1036.963"
+       x2="3.9750192"
+       y2="1038.5204"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.9352678,-4.2546071e-7)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="15.742216"
+     inkscape:cy="7.5875244"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1234"
+     inkscape:window-height="964"
+     inkscape:window-x="512"
+     inkscape:window-y="347"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4184);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368"
+       width="9.975256"
+       height="13.005714"
+       x="3.5355337"
+       y="1037.8413"
+       rx="0.37885904"
+       ry="0.37885904" />
+    <path
+       style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 4.0354196,1037.8348 8.9380894,0"
+       id="path4307"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <g
+       id="g4280"
+       transform="translate(0.12626957,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198"
+         d="m 4.3932593,1036.8711 0.00271,2.0536"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7"
+         d="M 6.294643,1036.8711 6.25,1038.9247"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2"
+         d="m 8.3482144,1036.8711 -0.044643,2.0536"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2-6"
+         d="m 10.375824,1036.6737 -0.03736,2.2699"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4198-7-2-6-7"
+         d="m 12.399554,1036.8711 -0.03348,2.0424"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/complete_status.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/complete_status.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="complete_status.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="6.485378"
+     inkscape:cy="7.390162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:none;stroke:#317f5a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 3.5,1043.8622 3,3 6,-6"
+       id="path996"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/composite_obj.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/composite_obj.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="composite_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1747">
+      <stop
+         style="stop-color:#2846b3;stop-opacity:1"
+         offset="0"
+         id="stop1743" />
+      <stop
+         style="stop-color:#92808a;stop-opacity:1"
+         offset="1"
+         id="stop1745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1737">
+      <stop
+         style="stop-color:#85c0ee;stop-opacity:1"
+         offset="0"
+         id="stop1733" />
+      <stop
+         style="stop-color:#cfe9fd;stop-opacity:1"
+         offset="1"
+         id="stop1735" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4187"
+       inkscape:collect="always">
+      <stop
+         id="stop4189"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.49999079"
+         id="stop4201" />
+      <stop
+         id="stop4191"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4178">
+      <stop
+         style="stop-color:#2846b3;stop-opacity:1"
+         offset="0"
+         id="stop4180" />
+      <stop
+         style="stop-color:#92808a;stop-opacity:1"
+         offset="1"
+         id="stop4182" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178"
+       id="linearGradient4184"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0024805,0,0,0.99956063,-11.943037,0.47687858)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04475908,0,0,0.96697783,4.6998766,34.237893)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1737"
+       id="linearGradient1739"
+       x1="11.883928"
+       y1="1050.1658"
+       x2="11.723214"
+       y2="1038.38"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1747"
+       id="linearGradient1749"
+       x1="5.8928571"
+       y1="1044.2461"
+       x2="5.9285712"
+       y2="1041.3889"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-4"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04475908,0,0,0.96697783,6.6999893,34.237908)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-3"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04475908,0,0,0.96697783,8.6999893,34.237986)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-2"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04475908,0,0,0.96697783,10.699989,34.237958)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4206-8"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04475908,0,0,0.96697783,12.699989,34.237929)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="8.2868589"
+     inkscape:cy="7.5875244"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1680"
+     inkscape:window-height="942"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:url(#linearGradient1739);fill-opacity:1;stroke:url(#linearGradient4184);stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3368"
+       width="10"
+       height="13"
+       x="3.4999998"
+       y="1037.8622"
+       rx="0.37885901"
+       ry="0.37885904" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#3e72a7;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.9999999,1037.8622 H 13"
+       id="path4307"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.5000593,1036.8693 -1.214e-4,1.9857"
+       id="path4198"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#f3f6fa;fill-opacity:1;stroke:url(#linearGradient1749);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1741"
+       width="6"
+       height="2"
+       x="5.5"
+       y="1041.8622" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-4);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5001723,1036.8694 -1.22e-4,1.9857"
+       id="path4198-9"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-3);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.5001723,1036.8694 -1.22e-4,1.9857"
+       id="path4198-7"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-2);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.500172,1036.8694 -1.22e-4,1.9857"
+       id="path4198-5"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-8);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.500172,1036.8694 -1.22e-4,1.9857"
+       id="path4198-74"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/error.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/error.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="message_error.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="470.63007"
+       x2="388.63736"
+       y2="465.52719"
+       gradientTransform="matrix(0.61298617,0,0,0.60857439,-221.69517,772.32162)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#d04046;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999998"
+     inkscape:cx="-7.7543015"
+     inkscape:cy="-1.458585"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1269"
+     inkscape:window-height="982"
+     inkscape:window-x="382"
+     inkscape:window-y="268"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <ellipse
+         style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path10796-2-6-0"
+         cx="16.220102"
+         cy="1057.2789"
+         rx="6.5129781"
+         ry="6.4661031" />
+      <g
+         id="g5025"
+         transform="matrix(1.1880342,0,0,1.1860465,14.30619,-196.66823)">
+        <g
+           id="g4095"
+           transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+             d="M 6.2265625,3.6953125 C 5.9177427,3.7062384 5.125,4.3515625 5.125,4.3515625 c 0,0 0.2885111,0.2731764 0.78125,0.6796875 0.4927389,0.4065111 0.9552143,0.9554552 1.0625,1.4375 C 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.2010947,10.96967 5.0906092,11.868663 7.4375,9.375 c 0.2792655,0.4616799 0.5966442,0.914462 0.8125,1.28125 0.2533102,0.354 0.6860498,0.734189 1.40625,1.09375 1.285897,0.641907 1.105068,0.565316 1.105068,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.508177,-0.898667 C 9.6433969,10.337868 9.4953002,10.118107 9.34375,9.90625 8.8239337,9.3154094 8.6327445,8.816423 8.5,8.1875 L 11.629711,4.6423859 10.681163,3.8870243 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.3191341,4.5264873 6.71875,4.03125 6.4464909,3.8171333 6.4806949,3.8796991 6.2265625,3.6953125 Z"
+             transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+             id="path5021"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccscccccccccccccccccc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/information.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/information.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="message_info.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3857">
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="0"
+         id="stop3859" />
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="1"
+         id="stop3861" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4996-4"
+       id="linearGradient5028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(38.469436,55.035191)"
+       x1="13.903196"
+       y1="1062.1353"
+       x2="13.903196"
+       y2="1051.7347" />
+    <linearGradient
+       id="linearGradient4996-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4998-5"
+         offset="0"
+         style="stop-color:#02468c;stop-opacity:1" />
+      <stop
+         id="stop5000-5"
+         offset="1"
+         style="stop-color:#0e62a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         id="stop4892"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896-1"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4890-6">
+      <stop
+         id="stop4892-2"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894-2"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898-7"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3052">
+      <stop
+         id="stop3054"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop3056"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3060"
+       xlink:href="#linearGradient3857"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="7.4539771"
+     inkscape:cy="21.313618"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="900"
+     inkscape:window-x="222"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:#f8fdff;fill-opacity:1;stroke:#02468c;stroke-width:1.52293062;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4110"
+         sodipodi:cx="11.9375"
+         sodipodi:cy="11.6875"
+         sodipodi:rx="9.875"
+         sodipodi:ry="9.875"
+         d="m 21.8125,11.6875 a 9.875,9.875 0 1 1 -19.75,0 9.875,9.875 0 1 1 19.75,0 z"
+         transform="matrix(0.65662871,0,0,0.65662871,8.3816111,1049.5926)" />
+      <g
+         transform="translate(1.790992,32.464778)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <g
+           transform="translate(-8.2201163,-12.904699)"
+           id="g8159-9"
+           style="display:inline">
+          <text
+             sodipodi:linespacing="125%"
+             id="text4140-1-8-1"
+             y="1117.2119"
+             x="50.288464"
+             style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+             xml:space="preserve"><tspan
+               style="fill:url(#linearGradient5028);fill-opacity:1"
+               y="1117.2119"
+               x="50.288464"
+               id="tspan4142-7-8-7"
+               sodipodi:role="line">Kozuka Mincho Pr6N H</tspan></text>
+        </g>
+      </g>
+      <g
+         transform="matrix(0.87196374,0,0,0.80250065,2.0740224,208.83353)"
+         id="text4140-1-8"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896-1);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy">
+        <path
+           inkscape:connector-curvature="0"
+           id="path5058"
+           style="fill:url(#linearGradient3060);fill-opacity:1"
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/skip_status.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/skip_status.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="skip_status.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1113">
+      <stop
+         style="stop-color:#53a968;stop-opacity:1"
+         offset="0"
+         id="stop1109" />
+      <stop
+         style="stop-color:#93c586;stop-opacity:1"
+         offset="1"
+         id="stop1111" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7084">
+      <stop
+         style="stop-color:#67b170;stop-opacity:1"
+         offset="0"
+         id="stop7086" />
+      <stop
+         style="stop-color:#5bad6c;stop-opacity:1"
+         offset="1"
+         id="stop7088" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7076"
+       inkscape:collect="always">
+      <stop
+         id="stop7078"
+         offset="0"
+         style="stop-color:#317f5a;stop-opacity:1" />
+      <stop
+         style="stop-color:#317f5a;stop-opacity:1"
+         offset="0.26772746"
+         id="stop1097" />
+      <stop
+         style="stop-color:#66b170;stop-opacity:1"
+         offset="0.30219939"
+         id="stop1095" />
+      <stop
+         id="stop7080"
+         offset="1"
+         style="stop-color:#93c586;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.2078"
+       x2="10.472837"
+       y1="1045.1008"
+       x1="8.6973"
+       gradientTransform="matrix(0,0.57045407,0.58432111,0,-599.95571,1040.2949)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.97626811,-17.21875,23.762488)"
+       gradientUnits="userSpaceOnUse"
+       y2="1037.3622"
+       x2="32"
+       y1="1050.3622"
+       x1="32"
+       id="linearGradient7082"
+       xlink:href="#linearGradient7076"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1113"
+       id="linearGradient1115"
+       x1="-1"
+       y1="1040.3622"
+       x2="1"
+       y2="1040.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,1.7382813e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="6.485378"
+     inkscape:cy="5.7668766"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1680"
+     inkscape:window-height="942"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient7074);fill-opacity:1;stroke:url(#linearGradient7082);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.578125,1039.8624 6.5,1039.8622 v 1.0002 h 3 v 4.0002 h -3 v 0.8576 l 3.5,3.1422 3.5,-3.1424 v -0.8576 l -3,-2e-4 v -3.5043 c 0,-0.9145 0.185481,-1.4955 -0.921875,-1.4955 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient1115);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1099"
+       width="2"
+       height="2.0000174"
+       x="3"
+       y="1039.3622" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_choice.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_choice.svg
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="task_choice.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4837">
+      <stop
+         style="stop-color:#acbfd5;stop-opacity:1;"
+         offset="0"
+         id="stop4839" />
+      <stop
+         style="stop-color:#627297;stop-opacity:1"
+         offset="1"
+         id="stop4841" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4767">
+      <stop
+         style="stop-color:#f1c373;stop-opacity:1"
+         offset="0"
+         id="stop4769" />
+      <stop
+         style="stop-color:#f6e3c9;stop-opacity:1"
+         offset="1"
+         id="stop4771" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.96875,-0.0549)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.96875,-0.0549)" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.857"
+       x2="14"
+       y1="1047.857"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.857"
+       x2="14"
+       y1="1045.857"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.857"
+       x2="11"
+       y1="1043.857"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861"
+       inkscape:collect="always">
+      <stop
+         id="stop4863"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-7"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-4"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-1.9593359,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-2.0285853,1.8627)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6-7"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843-2"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.99777994,21.000768,2.2956981)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.015625,0.0156)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4767"
+       id="linearGradient4774-3"
+       x1="-11.999999"
+       y1="1050.9951"
+       x2="-11.999999"
+       y2="1038.8655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,20.932264,-0.57532292)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790-5"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,20.932264,-0.57532292)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="6.485378"
+     inkscape:cy="7.390162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 3.9843751,1040.2917 1.53125,-1.3672 0.9375,-2.1172 h 1.5 1.4999999 l 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 6.3125001,1036.3201 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 h 1.1875 H 9.125 l 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 h -1.4999999 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(2.1589147,4.1127048)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="M 1.4972825,1036.9037 H 9.653585 l 0.759173,3.0066 v 6.5483 H 1.4972825 Z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 h 8.4908829 l 0.04042,3.0066 v 6.4546 H 1.4972807 Z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11"
+       height="11.999999"
+       x="2.5"
+       y="1038.8622"
+       rx="1.21875"
+       ry="1.2187499" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 4.0312501,1040.3622 1.53125,-1.3672 0.9375,-2.1172 h 1.5 H 9.5 l 0.953125,2.1172 L 12,1040.3622"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 6.344518,1036.3699 c -0.138213,0.043 -0.255616,0.1479 -0.3125,0.2806 l -0.875,1.9955 -0.966084,0.8615 C 3.971485,1039.7264 4.029503,1039.832 4,1040.344 c 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0116 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.156 l 0.8125,-1.8084 h 1.1875 1.15625 l 0.8125,1.8084 c 0.0306,0.06 0.0734,0.1131 0.125,0.156 l 1.173251,1.0302 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2125 0.08262,-0.5741 -0.123815,-0.78 l -1.015435,-0.9055 -0.90625,-1.9955 c -0.07974,-0.1637 -0.255243,-0.2762 -0.4375,-0.2806 h -1.5 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="M 3.4686972,1040.7664 H 12.28125 l 0.102923,3.0066 v 6.5483 H 3.4686972 Z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="M 3.5000017,1040.8622 H 12.5 v 9 H 3.5000001 Z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient895);fill-opacity:1;stroke:#1d68a1;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect887"
+       width="3.2426286"
+       height="3.2426286"
+       x="743.17792"
+       y="731.86414"
+       transform="matrix(0.70710528,0.70710828,-0.70710528,0.70710828,0,0)" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_sequence.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_sequence.svg
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="task_sequence.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4837">
+      <stop
+         style="stop-color:#acbfd5;stop-opacity:1;"
+         offset="0"
+         id="stop4839" />
+      <stop
+         style="stop-color:#627297;stop-opacity:1"
+         offset="1"
+         id="stop4841" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4767">
+      <stop
+         style="stop-color:#f1c373;stop-opacity:1"
+         offset="0"
+         id="stop4769" />
+      <stop
+         style="stop-color:#f6e3c9;stop-opacity:1"
+         offset="1"
+         id="stop4771" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,-0.05489994)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,-0.05489994)" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.857"
+       x2="14"
+       y1="1047.857"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.857"
+       x2="14"
+       y1="1045.857"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.857"
+       x2="11"
+       y1="1043.857"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861"
+       inkscape:collect="always">
+      <stop
+         id="stop4863"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-7"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-4"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.0285852,1.8627001)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6-7"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843-2"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.99777994,22.000768,2.2956982)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4767"
+       id="linearGradient4774-3"
+       x1="-11.999999"
+       y1="1050.9951"
+       x2="-11.999999"
+       y2="1038.8655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.57532286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790-5"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9951149,0,0,1.0005475,21.932264,-0.57532286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="6.485378"
+     inkscape:cy="7.390162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 4.9843752,1040.2917 1.53125,-1.3672 0.9375,-2.1172 h 1.5 1.4999998 l 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3125002,1036.3201 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 h 1.1875 H 10.125 l 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 h -1.4999998 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(3.1589148,4.1127049)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="M 1.4972825,1036.9037 H 9.653585 l 0.759173,3.0066 v 6.5483 H 1.4972825 Z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 h 8.4908829 l 0.04042,3.0066 v 6.4546 H 1.4972807 Z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11"
+       height="11.999999"
+       x="3.5"
+       y="1038.8622"
+       rx="1.21875"
+       ry="1.2187499" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 5.0312502,1040.3622 1.53125,-1.3672 0.9375,-2.1172 h 1.5 H 10.5 l 0.953125,2.1172 L 13,1040.3622"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3445181,1036.3699 c -0.138213,0.043 -0.255616,0.1479 -0.3125,0.2806 l -0.875,1.9955 -0.966084,0.8615 c -0.219449,0.2189 -0.161431,0.3245 -0.190934,0.8365 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0116 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.156 l 0.8125,-1.8084 h 1.1875 1.1562499 l 0.8125,1.8084 c 0.0306,0.06 0.0734,0.1131 0.125,0.156 l 1.173251,1.0302 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2125 0.08262,-0.5741 -0.123815,-0.78 l -1.015435,-0.9055 -0.90625,-1.9955 c -0.07974,-0.1637 -0.255243,-0.2762 -0.4375,-0.2806 h -1.4999999 -1.5 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="M 4.4686973,1040.7664 H 13.28125 l 0.102923,3.0066 v 6.5483 H 4.4686973 Z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="M 4.5000017,1040.8622 H 13.5 v 9 H 4.5000001 Z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1042.8622 H 8.0000001"
+       id="path908"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 7,1042.8622 H 6"
+       id="path908-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1044.8622 H 8"
+       id="path908-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 7,1044.8622 H 6"
+       id="path908-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,1046.8622 H 8"
+       id="path908-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 7,1046.8622 H 6"
+       id="path908-2-9"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.25985992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path962"
+       sodipodi:sides="3"
+       sodipodi:cx="-10.476683"
+       sodipodi:cy="1042.9738"
+       sodipodi:r1="3.0233469"
+       sodipodi:r2="1.520692"
+       sodipodi:arg1="2.0899424"
+       sodipodi:arg2="3.1167719"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m -11.976683,1045.5988 -0.02022,-2.5873 -0.0031,-2.6493 2.2507446,1.2761 2.2958897,1.322 -2.2305206,1.3111 z"
+       inkscape:transform-center-x="-0.4668498"
+       inkscape:transform-center-y="-0.023416603"
+       transform="matrix(0.65982872,0,0,0.95482604,10.917944,46.997265)" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 4,1042.8622 H 0"
+       id="path908-6"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_set.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/task_set.svg
@@ -1,0 +1,477 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cheatsheet_taskgroup_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4837">
+      <stop
+         style="stop-color:#acbfd5;stop-opacity:1;"
+         offset="0"
+         id="stop4839" />
+      <stop
+         style="stop-color:#627297;stop-opacity:1"
+         offset="1"
+         id="stop4841" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4767">
+      <stop
+         style="stop-color:#f1c373;stop-opacity:1"
+         offset="0"
+         id="stop4769" />
+      <stop
+         style="stop-color:#f6e3c9;stop-opacity:1"
+         offset="1"
+         id="stop4771" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4767"
+       id="linearGradient4774"
+       x1="-11.999999"
+       y1="1050.9951"
+       x2="-11.999999"
+       y2="1038.8655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-13.971893,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.857"
+       x2="14"
+       y1="1047.857"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,-12.938564,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.857"
+       x2="14"
+       y1="1045.857"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-14.692092,-4.125)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.857"
+       x2="11"
+       y1="1043.857"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861"
+       inkscape:collect="always">
+      <stop
+         id="stop4863"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-7"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-4"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.86146763,0,0,1,-18.070261,-0.9574)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-8"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.85699884,0,0,1,-18.038949,-0.9574)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869-2"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5144312,0,0,1,-22.645609,-0.9574)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       id="linearGradient4867-9"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.0285853,1.9176)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.0285853,1.9176)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6-7"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4837"
+       id="linearGradient4843-2"
+       x1="-11.375669"
+       y1="1036.296"
+       x2="-11.375669"
+       y2="1040.2782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4767"
+       id="linearGradient4774-3"
+       x1="-11.999999"
+       y1="1050.9951"
+       x2="-11.999999"
+       y2="1038.8655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790-5"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.96875,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568541"
+     inkscape:cx="24.546447"
+     inkscape:cy="24.966829"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="887"
+     inkscape:window-y="418"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient4774);fill-opacity:1;stroke:url(#linearGradient4790);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3997"
+       width="11.054"
+       height="11.993433"
+       x="3.4460011"
+       y="1038.8688"
+       rx="1.21875"
+       ry="1.21875" />
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 4.9843751,1040.3466 1.53125,-1.3672 0.9375,-2.1172 1.5,0 1.4999999,0 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4843);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;"
+       d="m 7.3125001,1036.375 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 1.1875,0 1.1562499,0 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 l -1.4999999,0 -1.5,0 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(3.1589147,4.1676048)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="m 1.4972825,1036.9037 8.1563025,0 0.759173,3.0066 0,6.5483 -8.9154755,0 z"
+         style="fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 1.4972825,1036.9037 8.4908829,0 0.04042,3.0066 0,6.4546 -8.5313047,0 z"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0" />
+      <rect
+         y="1039.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0470486"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1041.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1043.2268"
+         x="-8.90625"
+         height="1.010376"
+         width="6.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <rect
+       style="display:inline;fill:url(#linearGradient4774-3);fill-opacity:1;stroke:url(#linearGradient4790-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997-8"
+       width="11.054"
+       height="11.993433"
+       x="3.4460011"
+       y="1038.8688"
+       rx="1.21875"
+       ry="1.21875" />
+    <path
+       style="display:inline;fill:url(#linearGradient4851-7);fill-opacity:1;stroke:none"
+       d="m 4.9843751,1040.3466 1.53125,-1.3672 0.9375,-2.1172 1.5,0 1.4999999,0 0.953125,2.1172 1.546875,1.3672"
+       id="path4794-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4843-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       d="m 7.3125001,1036.375 c -0.138213,0.043 -0.255616,0.1482 -0.3125,0.2812 l -0.875,2 -0.966084,0.8634 c -0.219449,0.2194 -0.161431,0.3252 -0.190934,0.8384 0.205415,0 0.484943,0 0.746694,-3e-4 l 1.129074,-1.0139 c 0.0516,-0.043 0.0944,-0.097 0.125,-0.1563 l 0.8125,-1.8125 1.1875,0 1.1562499,0 0.8125,1.8125 c 0.0306,0.06 0.0734,0.1133 0.125,0.1563 l 1.173251,1.0325 c 0.113518,0 0.471938,-0.02 0.715999,-0.031 0,-0.2129 0.08262,-0.5753 -0.123815,-0.7817 l -1.015435,-0.9075 -0.90625,-2 c -0.07974,-0.164 -0.255243,-0.2768 -0.4375,-0.2812 l -1.4999999,0 -1.5,0 c -0.05166,-0.01 -0.104595,-0.01 -0.15625,0 z"
+       id="path4794-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-6"
+       d="m 4.4686972,1040.8213 8.8125528,0 0.102923,3.0066 0,6.5483 -8.9154758,0 z"
+       style="display:inline;fill:url(#linearGradient5000-6-7);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-4"
+       d="m 4.4686972,1040.8213 9.0221328,0 0.04042,3.0066 0,6.0483 -9.0625534,0 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-9);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       y="1042.3944"
+       x="-12.033915"
+       height="1.0103934"
+       width="6.0470486"
+       id="rect4001-1-5"
+       style="display:inline;fill:url(#linearGradient4867-9);fill-opacity:1;stroke:none"
+       transform="scale(-1,1)" />
+    <rect
+       y="1044.3944"
+       x="-12.033915"
+       height="1.0103934"
+       width="5.9929504"
+       id="rect4001-1-7-0"
+       style="display:inline;fill:url(#linearGradient4869-2);fill-opacity:1;stroke:none"
+       transform="scale(-1,1)" />
+    <rect
+       y="1046.3944"
+       x="-12.033915"
+       height="1.0103934"
+       width="6.0242004"
+       id="rect4001-1-7-4-3"
+       style="display:inline;fill:url(#linearGradient4871-8);fill-opacity:1;stroke:none"
+       transform="scale(-1,1)" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/obj16/warning.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/obj16/warning.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="warning_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-1.5208779"
+     inkscape:cy="2.0545684"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="false"
+     inkscape:window-width="1638"
+     inkscape:window-height="1174"
+     inkscape:window-x="398"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <path
+         style="fill:url(#linearGradient5087);stroke:url(#linearGradient5097);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+         d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+         id="path4292"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#502800;fill-opacity:1;stroke:none"
+         id="path4253"
+         sodipodi:cx="3.484375"
+         sodipodi:cy="5.484375"
+         sodipodi:rx="0.625"
+         sodipodi:ry="0.625"
+         d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+         transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)" />
+      <path
+         style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+         d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+         id="path4253-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccs" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_complete.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_complete.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="task_complete.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient873">
+      <stop
+         style="stop-color:#005f3e;stop-opacity:1"
+         offset="0"
+         id="stop869" />
+      <stop
+         style="stop-color:#006e5d;stop-opacity:1"
+         offset="1"
+         id="stop871" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7084">
+      <stop
+         style="stop-color:#2f7c58;stop-opacity:1"
+         offset="0"
+         id="stop7086" />
+      <stop
+         style="stop-color:#5bad6c;stop-opacity:1"
+         offset="1"
+         id="stop7088" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.2078"
+       x2="7.9534445"
+       y1="1044.1981"
+       x1="0.059381608"
+       gradientTransform="matrix(0,0.43413239,0.4153792,0,-427.6022,1045.2014)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient873"
+       id="linearGradient875"
+       x1="8.8340588"
+       y1="1051.4862"
+       x2="8.8292818"
+       y2="1046.4038"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.2928932,-0.06070677)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254833"
+     inkscape:cx="1.2666278"
+     inkscape:cy="5.7668766"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <path
+       style="fill:none;stroke:url(#linearGradient875);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.35355339,1048.6551 2.00000001,2 5.0000004,-5"
+       id="path867"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_in_progress.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_in_progress.svg
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="task_in_progress.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient873">
+      <stop
+         style="stop-color:#005f3e;stop-opacity:1"
+         offset="0"
+         id="stop869" />
+      <stop
+         style="stop-color:#006e5d;stop-opacity:1"
+         offset="1"
+         id="stop871" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7084">
+      <stop
+         style="stop-color:#2f7c58;stop-opacity:1"
+         offset="0"
+         id="stop7086" />
+      <stop
+         style="stop-color:#5bad6c;stop-opacity:1"
+         offset="1"
+         id="stop7088" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.2078"
+       x2="7.9534445"
+       y1="1044.1981"
+       x1="0.059381608"
+       gradientTransform="matrix(0,0.43413239,0.4153792,0,-427.6022,1045.2014)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient873"
+       id="linearGradient875"
+       x1="8.8340588"
+       y1="1051.4862"
+       x2="8.8292818"
+       y2="1046.4038"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.2928932,-0.06070677)" />
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         style="stop-color:#8cc861;stop-opacity:1"
+         offset="0"
+         id="stop4740" />
+      <stop
+         id="stop4746"
+         offset="0.43753415"
+         style="stop-color:#4aa766;stop-opacity:1" />
+      <stop
+         style="stop-color:#c2dd97;stop-opacity:1"
+         offset="1"
+         id="stop4742" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#30825a;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#106643;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.54542366,0,0,0.59834279,6.3871435,417.21309)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4738"
+       id="linearGradient4744"
+       x1="-13.936629"
+       y1="1049.9579"
+       x2="-13.936629"
+       y2="1040.053"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.54542366,0,0,0.59834279,18.012845,417.21309)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254833"
+     inkscape:cx="1.2666278"
+     inkscape:cy="5.7668766"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline;stroke-width:1.34027648"
+       id="layer1-8"
+       inkscape:label="Layer 1"
+       transform="matrix(0.81411525,0,0,0.68379408,-5.335109,336.06791)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="m 8.4665714,1039.4069 v 1.2133 2.9917 1.795 h 0.5454237 l 5.2069889,-2.7089 c 0.323038,-0.2241 0.337141,-0.3769 0,-0.5983 l -4.9779956,-2.6928 z"
+         style="fill:url(#linearGradient4744);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1.34027648;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_skipped.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/ovr16/task_skipped.svg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="9"
+   height="9"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="task_skipped.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient983">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop979" />
+      <stop
+         style="stop-color:#8794ad;stop-opacity:1"
+         offset="1"
+         id="stop981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient893">
+      <stop
+         style="stop-color:#cdddeb;stop-opacity:1"
+         offset="0"
+         id="stop889" />
+      <stop
+         style="stop-color:#5d92bc;stop-opacity:1"
+         offset="1"
+         id="stop891" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99309753,0,0,0.99393698,-0.95933587,8.2573894)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-9"
+       xlink:href="#linearGradient983"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851-7"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.015625,0.01560006)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient893"
+       id="linearGradient895"
+       x1="745.58008"
+       y1="732.34845"
+       x2="745.94769"
+       y2="734.09845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.74592834,0.66828818)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7084">
+      <stop
+         style="stop-color:#2f7c58;stop-opacity:1"
+         offset="0"
+         id="stop7086" />
+      <stop
+         style="stop-color:#5bad6c;stop-opacity:1"
+         offset="1"
+         id="stop7088" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.2078"
+       x2="7.9534445"
+       y1="1044.1981"
+       x1="0.059381608"
+       gradientTransform="matrix(0,0.43413239,0.4153792,0,-427.6022,1045.2014)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7074"
+       xlink:href="#linearGradient7084"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="1.2666278"
+     inkscape:cy="5.7668766"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="972"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1043.3622)">
+    <image
+       y="1043.3622"
+       x="10"
+       id="image853"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAABHNCSVQICAgIfAhkiAAAAKtJREFU
+GJV1kLEKgmAUhb9fXaNB6A0cQxF6gObcWhJHob294H+DaK+cHFt6jAJpF4S2CHyEvC0pf1Jnu/d8
+l8s5SkSE/1IAFkCwiQEIdYKdRSzPK063LYAAOOZZ82oYVwMu1QOAefAx5If89UKs46wdcdq/hgQg
+db1uYZmmnUVdiENdAjDdxaKMcBLqhEk4Yl+XpK6HAq7FE9Vr4Av070MKnas+1IEAhc4VwBtS21ex
+pXw5cQAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="9"
+       width="9" />
+    <path
+       style="fill:url(#linearGradient7074);fill-opacity:1;stroke:#317f5a;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.7000997,1044.8722 -2.1881618,-10e-5 v 0.9901 L 5.5,1045.8626 v 2.9999 l -1.9880621,-3e-4 v 0.468 L 6,1051.7215 8.4880621,1049.33 v -0.4679 l -2.1326246,-2e-4 v -2.8516 c 0,-0.6959 0.1318538,-1.1381 -0.6553378,-1.1381 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <rect
+       style="opacity:1;fill:#2f7c58;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1099"
+       width="1"
+       height="2.0000174"
+       x="1"
+       y="1044.3622" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/icons/view16/cheatsheet_view.svg
+++ b/ua/org.eclipse.ui.cheatsheets/icons/view16/cheatsheet_view.svg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cheatsheet_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4350">
+      <stop
+         style="stop-color:#304bb0;stop-opacity:1"
+         offset="0"
+         id="stop4352" />
+      <stop
+         style="stop-color:#897b8d;stop-opacity:1"
+         offset="1"
+         id="stop4354" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4190">
+      <stop
+         style="stop-color:#2846b3;stop-opacity:1"
+         offset="0"
+         id="stop4192" />
+      <stop
+         style="stop-color:#92808a;stop-opacity:1"
+         offset="1"
+         id="stop4194" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4170">
+      <stop
+         style="stop-color:#85c0ed;stop-opacity:1;"
+         offset="0"
+         id="stop4172" />
+      <stop
+         style="stop-color:#dbedfa;stop-opacity:1"
+         offset="1"
+         id="stop4174" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-11.869292,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1036.755"
+       x2="20.299725"
+       y1="1052.2014"
+       x1="20.299725"
+       id="linearGradient4184-2"
+       xlink:href="#linearGradient4350"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-11.869292,0)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4170"
+       id="linearGradient4362"
+       x1="6.5091562"
+       y1="1044.7267"
+       x2="6.5091562"
+       y2="1040.5598"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4190"
+       id="linearGradient4196-9"
+       x1="20.767859"
+       y1="1044.5051"
+       x2="20.767859"
+       y2="1041.6479"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.034189,-0.06260848)" />
+    <linearGradient
+       gradientTransform="translate(-0.18040135,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-38"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1-9"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1-9-5"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.18040135,0)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4676"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8459821,0)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4680"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="4.2696908"
+     inkscape:cy="14.238158"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-3-2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1234"
+     inkscape:window-height="964"
+     inkscape:window-x="512"
+     inkscape:window-y="347"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="layer1-3-2"
+       inkscape:label="Layer 1"
+       transform="translate(4.0074104,4.2785891)">
+      <rect
+         ry="0.37885904"
+         rx="0.37885904"
+         y="1037.8413"
+         x="3.5355337"
+         height="8.7200232"
+         width="7.9663277"
+         id="rect3368-9-6"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4307-4-6"
+         d="m 4.0354196,1037.8348 6.6613034,0"
+         style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <g
+         transform="translate(-0.03231284,-0.10411906)"
+         id="g4307-7">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4307-4-2"
+           d="m 4.2234368,1036.1791 0,2.149 6.6621092,0 0,-2.149 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <g
+           id="g4280-6-06"
+           transform="translate(0.22665952,-0.20124145)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-65-4"
+             d="m 4.2838843,1036.8711 0.00271,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-3"
+             d="m 6.310268,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4676);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-7"
+             d="m 8.3247769,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4678);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-6-2"
+             d="m 10.321136,1036.8768 -0.03736,1.9965"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4680);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <g
+           transform="translate(0.10038992,-4.1451644e-5)"
+           id="g4322-1">
+          <g
+             transform="translate(0.12626957,-0.20518724)"
+             id="g4280-6-6-9">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-4"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(2.1280666,-0.20518757)"
+             id="g4280-6-0-6">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-64"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-1"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(4.1251721,-0.20518757)"
+             id="g4280-6-0-1-3">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-3"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(6.1329846,-0.20518757)"
+             id="g4280-6-0-1-7-5">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-4-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-2-6"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(-3.0320902,1.1849966)">
+      <rect
+         ry="0.37885904"
+         rx="0.37885904"
+         y="1037.8413"
+         x="3.5355337"
+         height="8.7200232"
+         width="7.9663277"
+         id="rect3368-9"
+         style="opacity:1;fill:url(#linearGradient4362);fill-opacity:1;stroke:url(#linearGradient4184-2);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4307">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4307-4"
+           d="m 4.2234368,1036.1791 0,2.149 6.6621092,0 0,-2.149 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <g
+           id="g4280-6"
+           transform="translate(0.22665952,-0.20124145)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-65"
+             d="m 4.2838843,1036.8711 0.00271,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-38);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7"
+             d="m 6.310268,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2"
+             d="m 8.3247769,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-6"
+             d="m 10.321136,1036.8768 -0.03736,1.9965"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <g
+           transform="translate(0.10038992,-4.1451644e-5)"
+           id="g4322">
+          <g
+             transform="translate(0.12626957,-0.20518724)"
+             id="g4280-6-6">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(2.1280666,-0.20518757)"
+             id="g4280-6-0">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(4.1251721,-0.20518757)"
+             id="g4280-6-0-1">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(6.1329846,-0.20518757)"
+             id="g4280-6-0-1-7">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-4"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-2"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4196-9);stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4188-0"
+       width="3.9724209"
+       height="2.0450788"
+       x="2.5104542"
+       y="1041.853"
+       rx="0"
+       ry="0" />
+  </g>
+</svg>

--- a/ua/org.eclipse.ui.cheatsheets/plugin.xml
+++ b/ua/org.eclipse.ui.cheatsheets/plugin.xml
@@ -45,7 +45,7 @@
          point="org.eclipse.ui.views">
       <view
             name="%CHEAT_SHEETS"
-            icon="$nl$/icons/view16/cheatsheet_view.png"
+            icon="$nl$/icons/view16/cheatsheet_view.svg"
             category="org.eclipse.help.ui"
             fastViewWidthRatio="0.5"
             class="org.eclipse.ui.internal.cheatsheets.views.CheatSheetView"
@@ -170,10 +170,10 @@
          point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.ui.cheatsheets.openCheatSheet"
-            icon="$nl$/icons/view16/cheatsheet_view.png"/>
+            icon="$nl$/icons/view16/cheatsheet_view.svg"/>
       <image
             commandId="org.eclipse.ui.cheatsheets.openCheatSheetURL"
-            icon="$nl$/icons/view16/cheatsheet_view.png"/>
+            icon="$nl$/icons/view16/cheatsheet_view.svg"/>
    </extension>
     <extension
     	point="org.eclipse.ui.bindings">
@@ -212,7 +212,7 @@
    <extension
          point="org.eclipse.help.base.searchParticipant">
       <searchParticipant
-            icon="$nl$/icons/view16/cheatsheet_view.png"
+            icon="$nl$/icons/view16/cheatsheet_view.svg"
             id="org.eclipse.ui.cheatsheets"
             name="%searchParticipant.name"
             participant="org.eclipse.ui.internal.cheatsheets.CheatsheetSearchParticipant"/>
@@ -221,11 +221,11 @@
          point="org.eclipse.ui.cheatsheets.cheatSheetContent">
       <taskEditor
             class="org.eclipse.ui.internal.cheatsheets.composite.views.CheatsheetTaskEditor"
-            icon="$nl$/icons/obj16/cheatsheet_task.png"
+            icon="$nl$/icons/obj16/cheatsheet_task.svg"
             id="cheatsheet"/>
       <taskExplorer
             class="org.eclipse.ui.internal.cheatsheets.composite.explorer.TreeTaskExplorer"
-            icon="$nl$/icons/elcl16/tree_explorer.png"
+            icon="$nl$/icons/elcl16/tree_explorer.svg"
             id="tree"
             name="Tree"/>
    </extension>

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
@@ -129,89 +129,89 @@ public class CheatSheetPlugin extends AbstractUIPlugin {
 
 	@Override
 	protected void initializeImageRegistry(ImageRegistry reg) {
-		IPath path = ICONS_PATH.append(T_OBJ).append("cheatsheet_obj.png");//$NON-NLS-1$
+		IPath path = ICONS_PATH.append(T_OBJ).append("cheatsheet_obj.svg");//$NON-NLS-1$
 		ImageDescriptor imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_OBJ, imageDescriptor);
 
-		path = ICONS_PATH.append(T_OBJ).append("skip_status.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("skip_status.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_SKIP, imageDescriptor);
 
-		path = ICONS_PATH.append(T_OBJ).append("complete_status.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("complete_status.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_COMPLETE, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("linkto_help.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("linkto_help.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_HELP, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("start_cheatsheet.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("start_cheatsheet.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_START, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("restart_cheatsheet.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("restart_cheatsheet.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_RESTART, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("start_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("start_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_BUTTON_START, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("skip_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("skip_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_BUTTON_SKIP, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("complete_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("complete_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_BUTTON_COMPLETE, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("restart_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("restart_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_ITEM_BUTTON_RESTART, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("return_to_start.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("return_to_start.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_RETURN, imageDescriptor);
 
-		path = ICONS_PATH.append(T_OBJ).append("error.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("error.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.ERROR, imageDescriptor);
 
 		// Images used by composites
 
-		path = ICONS_PATH.append(T_OBJ).append("composite_obj.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("composite_obj.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_OBJ, imageDescriptor);
 
-		path = ICONS_PATH.append(T_OBJ).append("information.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("information.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.INFORMATION, imageDescriptor);
 
-		path = ICONS_PATH.append(T_OBJ).append("warning.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_OBJ).append("warning.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.WARNING, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("start_ccs_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("start_ccs_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_TASK_START, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("skip_ccs_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("skip_ccs_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_TASK_SKIP, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("review_ccs_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("review_ccs_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_TASK_REVIEW, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("goto_ccs_task.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("goto_ccs_task.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_GOTO_TASK, imageDescriptor);
 
-		path = ICONS_PATH.append(T_ELCL).append("restart_all.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_ELCL).append("restart_all.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.COMPOSITE_RESTART_ALL, imageDescriptor);
 
-		path = ICONS_PATH.append(T_VIEW).append("cheatsheet_view.png");//$NON-NLS-1$
+		path = ICONS_PATH.append(T_VIEW).append("cheatsheet_view.svg");//$NON-NLS-1$
 		imageDescriptor = createImageDescriptor(getPlugin().getBundle(), path);
 		reg.put(ICheatSheetResource.CHEATSHEET_VIEW, imageDescriptor);
 	}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
@@ -65,7 +65,6 @@ public class CheatSheetPlugin extends AbstractUIPlugin {
 	public static final IPath ICONS_PATH = IPath.fromOSString("$nl$/icons/"); //$NON-NLS-1$
 	public static final String T_OBJ = "obj16/"; //$NON-NLS-1$
 	public static final String T_ELCL = "elcl16/"; //$NON-NLS-1$
-	public static final String T_DLCL = "dlcl16/"; //$NON-NLS-1$
 	public static final String T_VIEW = "view16/"; //$NON-NLS-1$
 
 	/**

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/ResetTaskAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/ResetTaskAction.java
@@ -36,7 +36,7 @@ public class ResetTaskAction extends Action {
 	public ResetTaskAction(ICompositeCheatSheetTask task) {
 		this.task = (AbstractTask) task;
 		this.setText(Messages.COMPOSITE_MENU_RESET);
-		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("return_to_start.png");//$NON-NLS-1$
+		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("return_to_start.svg");//$NON-NLS-1$
 		ImageDescriptor restartImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
 		this.setImageDescriptor(restartImage);
 	}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/RestartAllAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/RestartAllAction.java
@@ -31,7 +31,7 @@ public class RestartAllAction extends Action {
 	public RestartAllAction(ICompositeCheatSheet model) {
 		this.model = model;
 		this.setText(Messages.RESTART_ALL_MENU);
-		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("restart_all.png");//$NON-NLS-1$
+		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("restart_all.svg");//$NON-NLS-1$
 		ImageDescriptor restartImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
 		this.setImageDescriptor(restartImage);
 	}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/SkipAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/SkipAction.java
@@ -24,7 +24,7 @@ import org.eclipse.ui.internal.provisional.cheatsheets.ICompositeCheatSheetTask;
 
 public class SkipAction extends Action {
 
-	private static final String SKIP_CCS_TASK_GIF = "skip_ccs_task.png"; //$NON-NLS-1$
+	private static final String SKIP_CCS_TASK_GIF = "skip_ccs_task.svg"; //$NON-NLS-1$
 	private final AbstractTask task;
 
 	public SkipAction(ICompositeCheatSheetTask task) {

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/StartAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/StartAction.java
@@ -24,7 +24,7 @@ import org.eclipse.ui.internal.provisional.cheatsheets.ICompositeCheatSheetTask;
 
 public class StartAction extends Action {
 	private final AbstractTask task;
-	private static final String START_CCS_TASK_GIF = "start_ccs_task.png"; //$NON-NLS-1$
+	private static final String START_CCS_TASK_GIF = "start_ccs_task.svg"; //$NON-NLS-1$
 
 	public StartAction(ICompositeCheatSheetTask task) {
 		this.task = (AbstractTask) task;

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
@@ -106,7 +106,7 @@ public class TreeLabelProvider extends LabelProvider {
 	 */
 	private ImageSet createImages(String kind) {
 		ImageSet images = new ImageSet();
-		ImageDescriptor desc = getPredefinedImageDescriptor(kind, true);
+		ImageDescriptor desc = getPredefinedImageDescriptor(kind);
 		if (desc == null) {
 			desc = TaskEditorManager.getInstance().getImageDescriptor(kind);
 		}
@@ -134,7 +134,7 @@ public class TreeLabelProvider extends LabelProvider {
 		return images;
 	}
 
-	private ImageDescriptor getPredefinedImageDescriptor(String kind, boolean isEnabled) {
+	private ImageDescriptor getPredefinedImageDescriptor(String kind) {
 		String filename;
 		if (ICompositeCheatsheetTags.CHEATSHEET_TASK_KIND.equals(kind)) {
 			filename = "cheatsheet_task.svg"; //$NON-NLS-1$
@@ -147,13 +147,7 @@ public class TreeLabelProvider extends LabelProvider {
 		} else {
 			return null;
 		}
-		String iconPath =  "$nl$/icons/"; //$NON-NLS-1$
-		if (isEnabled) {
-			iconPath += CheatSheetPlugin.T_OBJ;
-		} else {
-			iconPath += CheatSheetPlugin.T_DLCL;
-		}
-		iconPath += filename;
+		String iconPath = "$nl$/icons/" + CheatSheetPlugin.T_OBJ + filename; //$NON-NLS-1$
 		return createImageDescriptor(iconPath);
 	}
 
@@ -165,18 +159,7 @@ public class TreeLabelProvider extends LabelProvider {
 	}
 
 	private void createDisabledImage(String kind, int state, ImageSet images, Image baseImage) {
-		// The four images for task_set, task_sequence, task_choice and cheatsheet_task can be found
-		// in icons/dlcl16.
-		// TODO extend the extension point to allow disabled images to be specified.
-		//if
-
-		ImageDescriptor desc = getPredefinedImageDescriptor(kind, false);
-		Image disabledImage;
-		if (desc != null) {
-			disabledImage = desc.createImage();
-		} else {
-			disabledImage = createGrayedImage(baseImage);
-		}
+		Image disabledImage = createGrayedImage(baseImage);
 		images.put(state, disabledImage);
 	}
 

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
@@ -115,18 +115,18 @@ public class TreeLabelProvider extends LabelProvider {
 			images.put(ICompositeCheatSheetTask.NOT_STARTED, baseImage);
 
 			createImageWithOverlay(ICompositeCheatSheetTask.IN_PROGRESS,
-					"$nl$/icons/ovr16/task_in_progress.png", //$NON-NLS-1$
+					"$nl$/icons/ovr16/task_in_progress.svg", //$NON-NLS-1$
 					images,
 					desc);
 			createImageWithOverlay(ICompositeCheatSheetTask.SKIPPED,
-					"$nl$/icons/ovr16/task_skipped.png", //$NON-NLS-1$
+					"$nl$/icons/ovr16/task_skipped.svg", //$NON-NLS-1$
 					images,
 					desc);
 			createDisabledImage(kind, BLOCKED,
 					images,
 					baseImage);
 			createImageWithOverlay(ICompositeCheatSheetTask.COMPLETED,
-					"$nl$/icons/ovr16/task_complete.png", //$NON-NLS-1$
+					"$nl$/icons/ovr16/task_complete.svg", //$NON-NLS-1$
 					images,
 					desc);
 
@@ -137,13 +137,13 @@ public class TreeLabelProvider extends LabelProvider {
 	private ImageDescriptor getPredefinedImageDescriptor(String kind, boolean isEnabled) {
 		String filename;
 		if (ICompositeCheatsheetTags.CHEATSHEET_TASK_KIND.equals(kind)) {
-			filename = "cheatsheet_task.png"; //$NON-NLS-1$
+			filename = "cheatsheet_task.svg"; //$NON-NLS-1$
 		} else if (ITaskGroup.SET.equals(kind)) {
-			filename = "task_set.png"; //$NON-NLS-1$
+			filename = "task_set.svg"; //$NON-NLS-1$
 		} else if (ITaskGroup.CHOICE.equals(kind)) {
-			filename = "task_choice.png"; //$NON-NLS-1$
+			filename = "task_choice.svg"; //$NON-NLS-1$
 		} else if (ITaskGroup.SEQUENCE.equals(kind)) {
-			filename = "task_sequence.png"; //$NON-NLS-1$
+			filename = "task_sequence.svg"; //$NON-NLS-1$
 		} else {
 			return null;
 		}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetExpandRestoreAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetExpandRestoreAction.java
@@ -34,7 +34,7 @@ public class CheatSheetExpandRestoreAction extends Action {
 		super(title);
 		this.viewer = viewer;
 
-		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("collapse_expand_all.png");//$NON-NLS-1$
+		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("collapse_expand_all.svg");//$NON-NLS-1$
 		collapseImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
 		path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_DLCL).append("collapse_expand_all.png");//$NON-NLS-1$
 		disabledImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetExpandRestoreAction.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetExpandRestoreAction.java
@@ -28,7 +28,6 @@ public class CheatSheetExpandRestoreAction extends Action {
 	private boolean collapsed = false;
 
 	private final ImageDescriptor collapseImage;
-	private final ImageDescriptor disabledImage;
 
 	public CheatSheetExpandRestoreAction(String title, boolean initValue, CheatSheetViewer viewer) {
 		super(title);
@@ -36,9 +35,6 @@ public class CheatSheetExpandRestoreAction extends Action {
 
 		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("collapse_expand_all.svg");//$NON-NLS-1$
 		collapseImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
-		path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_DLCL).append("collapse_expand_all.png");//$NON-NLS-1$
-		disabledImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
-		setDisabledImageDescriptor(disabledImage);
 		setImageDescriptor(collapseImage);
 		setCollapsed(initValue);
 	}

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetHelpPart.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetHelpPart.java
@@ -66,7 +66,7 @@ public class CheatSheetHelpPart extends AbstractFormPart implements IHelpPart {
 	 * @param tbm the toolbar to contribute to
 	 */
 	private void contributeToToolBar(IToolBarManager tbm) {
-		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("collapseall.png");//$NON-NLS-1$
+		IPath path = CheatSheetPlugin.ICONS_PATH.append(CheatSheetPlugin.T_ELCL).append("collapseall.svg");//$NON-NLS-1$
 		ImageDescriptor collapseImage = CheatSheetPlugin.createImageDescriptor(CheatSheetPlugin.getPlugin().getBundle(), path);
 		CheatSheetExpandRestoreAction expandRestoreAction = new CheatSheetExpandRestoreAction(Messages.COLLAPSE_ALL_BUT_CURRENT_TOOLTIP, false, viewer);
 		expandRestoreAction.setToolTipText(Messages.COLLAPSE_ALL_BUT_CURRENT_TOOLTIP);


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.ui.cheatsheets`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.