### PR TITLE
Add SVGs to bundle org.eclipse.platform

### DIFF
--- a/platform/org.eclipse.platform/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.platform/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.platform.internal;x-internal:=true
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.platform
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/platform/org.eclipse.platform/icons/etool16/cheatsheet_view.svg
+++ b/platform/org.eclipse.platform/icons/etool16/cheatsheet_view.svg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cheatsheet_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4350">
+      <stop
+         style="stop-color:#304bb0;stop-opacity:1"
+         offset="0"
+         id="stop4352" />
+      <stop
+         style="stop-color:#897b8d;stop-opacity:1"
+         offset="1"
+         id="stop4354" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4190">
+      <stop
+         style="stop-color:#2846b3;stop-opacity:1"
+         offset="0"
+         id="stop4192" />
+      <stop
+         style="stop-color:#92808a;stop-opacity:1"
+         offset="1"
+         id="stop4194" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4170">
+      <stop
+         style="stop-color:#85c0ed;stop-opacity:1;"
+         offset="0"
+         id="stop4172" />
+      <stop
+         style="stop-color:#dbedfa;stop-opacity:1"
+         offset="1"
+         id="stop4174" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4187">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1"
+         offset="0"
+         id="stop4189" />
+      <stop
+         id="stop4201"
+         offset="0.49999079"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop4191" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4178-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4180-5"
+         offset="0"
+         style="stop-color:#7e713d;stop-opacity:1" />
+      <stop
+         id="stop4182-0"
+         offset="1"
+         style="stop-color:#b28a30;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-11.869292,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1036.755"
+       x2="20.299725"
+       y1="1052.2014"
+       x1="20.299725"
+       id="linearGradient4184-2"
+       xlink:href="#linearGradient4350"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8303571,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4326"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8839285,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4328"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.6397152,-109.42141)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4330"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4178-1"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-11.869292,0)"
+       x1="20.299725"
+       y1="1052.2014"
+       x2="20.299725"
+       y2="1036.755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4170"
+       id="linearGradient4362"
+       x1="6.5091562"
+       y1="1044.7267"
+       x2="6.5091562"
+       y2="1040.5598"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4190"
+       id="linearGradient4196-9"
+       x1="20.767859"
+       y1="1044.5051"
+       x2="20.767859"
+       y2="1041.6479"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.034189,-0.06260848)" />
+    <linearGradient
+       gradientTransform="translate(-0.18040135,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-38"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1-9"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4206-1-9-5"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.8459821,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4648"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4650"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.2346"
+       x2="3.9750192"
+       y1="1036.3827"
+       x1="3.9750192"
+       id="linearGradient4652"
+       xlink:href="#linearGradient4187"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.18040135,0)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4676"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8459821,0)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.860491,-4.2568467e-7)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4187"
+       id="linearGradient4680"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83688828,0,0,1.10534,6.5850277,-109.21828)"
+       x1="3.9750192"
+       y1="1036.3827"
+       x2="3.9750192"
+       y2="1039.2346" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="4.2696908"
+     inkscape:cy="14.238158"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-3-2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1234"
+     inkscape:window-height="964"
+     inkscape:window-x="512"
+     inkscape:window-y="347"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="layer1-3-2"
+       inkscape:label="Layer 1"
+       transform="translate(4.0074104,4.2785891)">
+      <rect
+         ry="0.37885904"
+         rx="0.37885904"
+         y="1037.8413"
+         x="3.5355337"
+         height="8.7200232"
+         width="7.9663277"
+         id="rect3368-9-6"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4340);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4307-4-6"
+         d="m 4.0354196,1037.8348 6.6613034,0"
+         style="fill:#b7d2e4;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <g
+         transform="translate(-0.03231284,-0.10411906)"
+         id="g4307-7">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4307-4-2"
+           d="m 4.2234368,1036.1791 0,2.149 6.6621092,0 0,-2.149 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <g
+           id="g4280-6-06"
+           transform="translate(0.22665952,-0.20124145)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-65-4"
+             d="m 4.2838843,1036.8711 0.00271,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4674);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-3"
+             d="m 6.310268,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4676);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-7"
+             d="m 8.3247769,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4678);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-6-2"
+             d="m 10.321136,1036.8768 -0.03736,1.9965"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4680);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <g
+           transform="translate(0.10038992,-4.1451644e-5)"
+           id="g4322-1">
+          <g
+             transform="translate(0.12626957,-0.20518724)"
+             id="g4280-6-6-9">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-4"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(2.1280666,-0.20518757)"
+             id="g4280-6-0-6">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-64"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-1"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(4.1251721,-0.20518757)"
+             id="g4280-6-0-1-3">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-3"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(6.1329846,-0.20518757)"
+             id="g4280-6-0-1-7-5">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-4-8"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-2-6"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(-3.0320902,1.1849966)">
+      <rect
+         ry="0.37885904"
+         rx="0.37885904"
+         y="1037.8413"
+         x="3.5355337"
+         height="8.7200232"
+         width="7.9663277"
+         id="rect3368-9"
+         style="opacity:1;fill:url(#linearGradient4362);fill-opacity:1;stroke:url(#linearGradient4184-2);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4307">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4307-4"
+           d="m 4.2234368,1036.1791 0,2.149 6.6621092,0 0,-2.149 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <g
+           id="g4280-6"
+           transform="translate(0.22665952,-0.20124145)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-65"
+             d="m 4.2838843,1036.8711 0.00271,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-38);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7"
+             d="m 6.310268,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2"
+             d="m 8.3247769,1036.8711 -0.044643,2.0536"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4198-7-2-6"
+             d="m 10.321136,1036.8768 -0.03736,1.9965"
+             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4206-1-9-5);stroke-width:0.96179312;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <g
+           transform="translate(0.10038992,-4.1451644e-5)"
+           id="g4322">
+          <g
+             transform="translate(0.12626957,-0.20518724)"
+             id="g4280-6-6">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(2.1280666,-0.20518757)"
+             id="g4280-6-0">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(4.1251721,-0.20518757)"
+             id="g4280-6-0-1">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+          <g
+             transform="translate(6.1329846,-0.20518757)"
+             id="g4280-6-0-1-7">
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-5-6-4"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1036.3784" />
+            <rect
+               style="opacity:1;fill:#213c65;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="rect4221-2-1-0-2"
+               width="0.99626446"
+               height="1.0021973"
+               x="3.8007526"
+               y="1038.3823" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4196-9);stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4188-0"
+       width="3.9724209"
+       height="2.0450788"
+       x="2.5104542"
+       y="1041.853"
+       rx="0"
+       ry="0" />
+  </g>
+</svg>

--- a/platform/org.eclipse.platform/plugin.xml
+++ b/platform/org.eclipse.platform/plugin.xml
@@ -107,7 +107,7 @@
                class="org.eclipse.ui.cheatsheets.CheatSheetExtensionFactory:helpMenuAction"
                menubarPath="help/group.tutorials"
                id="org.eclipse.ui.cheatsheets.actions.CheatSheetHelpMenuAction"
-               icon="$nl$/icons/etool16/cheatsheet_view.png">
+               icon="$nl$/icons/etool16/cheatsheet_view.svg">
          </action>
       </actionSet>
    </extension>


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.platform` except for the following as these are not available as SVG yet:

All svgs for icons in `images` folder.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.