### PR TITLE
Add SVGs to org.eclipse.debug.ui.launchview

### DIFF
--- a/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Export-Package: org.eclipse.debug.ui.launchview;x-internal:=true,
 Automatic-Module-Name: org.eclipse.debug.ui.launchview
 Service-Component: OSGI-INF/org.eclipse.debug.ui.launchview.internal.impl.DebugCoreProvider.xml,
  OSGI-INF/org.eclipse.debug.ui.launchview.internal.model.LaunchViewModel.xml
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui.launchview;singleton:=true
-Bundle-Version: 1.1.700.qualifier
+Bundle-Version: 1.1.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/debug/org.eclipse.debug.ui.launchview/icons/debug_exc.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/debug_exc.svg
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="debug_exc.svg"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   version="1.1"
+   id="svg2"
+   height="16"
+   width="16">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12717-5-0-4-3"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:window-height="1005"
+     inkscape:window-width="1680"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="8.6392718"
+     inkscape:cx="8.6336562"
+     inkscape:zoom="52.125962"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       id="grid3017"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:label="alt#1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       sodipodi:nodetypes="ccc"
+       style="fill:none;stroke:url(#linearGradient3993);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 12.82579,9.4971188 1.661134,0 1.422561,1.4112212"
+       id="path12694-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       style="fill:none;stroke:url(#linearGradient12878-2-7-1-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 10,6.9999994 1.508233,-1.4917651 0.983535,-2.4e-6 0.977902,0.9889529 1.541382,0"
+       id="path12696-5"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:none;stroke:url(#linearGradient12876-4-0-6-7);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 8.497184,5.9999999 0,-1.4696695 1.0021304,-1.0554648 0,-1.4697487"
+       id="path12698-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;stroke:url(#linearGradient12868-4-7-0-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 5.516768,6.0186776 5.4903436,0.99696"
+       id="path12700-8"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:none;stroke:url(#linearGradient3813-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 6.0125902,8.501281 -1.4696698,0 -1.0554648,1.0021285 -1.4697478,0"
+       id="path12698-4-3"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       style="fill:none;stroke:url(#linearGradient3847-1);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 7.0014107,10.06109 -1.4917664,1.508234 -2.8e-6,0.983533 0.9889544,0.977904 0,1.541381"
+       id="path12696-5-5"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccc"
+       style="fill:none;stroke:url(#linearGradient3881-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 9.4588992,12.848383 0,1.661134 1.4112208,1.422562"
+       id="path12694-8-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:none;stroke:url(#linearGradient3915-6);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 6.0300382,5.4946057 1.0083225,5.5210287"
+       id="path12700-8-0"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(0,-1036.3622)"
+     style="display:inline"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       transform="matrix(0.0982715,-0.0982715,0.0982715,0.0982715,-78.62319,1042.923)"
+       d="m 444.77016,431.08047 a 11.313708,14.937631 0 1 1 -22.62742,0 11.313708,14.937631 0 1 1 22.62742,0 z"
+       sodipodi:ry="14.937631"
+       sodipodi:rx="11.313708"
+       sodipodi:cy="431.08047"
+       sodipodi:cx="433.45645"
+       id="path12648-2-2"
+       style="fill:url(#radialGradient4194);fill-opacity:1;stroke:url(#linearGradient4196);stroke-width:7.19544077;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       sodipodi:type="arc" />
+    <path
+       transform="matrix(0.19686609,-0.19686609,0.1968661,0.1968661,-161.15278,1045.6329)"
+       d="m 444.77016,431.08047 a 11.313708,14.937631 0 1 1 -22.62742,0 11.313708,14.937631 0 1 1 22.62742,0 z"
+       sodipodi:ry="14.937631"
+       sodipodi:rx="11.313708"
+       sodipodi:cy="431.08047"
+       sodipodi:cx="433.45645"
+       id="path12648-9"
+       style="fill:url(#radialGradient4192);fill-opacity:1;stroke:none;display:inline"
+       sodipodi:type="arc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path12686-5"
+       d="m 5.88715,1042.2397 5.808198,5.8082"
+       style="fill:none;stroke:url(#linearGradient4086);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    <path
+       transform="matrix(0.18984474,-0.18571766,0.18984475,0.18571767,-155.10466,1045.8163)"
+       d="m 444.77016,431.08047 a 11.313708,14.937631 0 1 1 -22.62742,0 11.313708,14.937631 0 1 1 22.62742,0 z"
+       sodipodi:ry="14.937631"
+       sodipodi:rx="11.313708"
+       sodipodi:cy="431.08047"
+       sodipodi:cx="433.45645"
+       id="path12648-1-6"
+       style="fill:none;stroke:url(#linearGradient4190);stroke-width:3.76581596999999979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       sodipodi:type="arc" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="4.931597"
+       sodipodi:start="4.5270744"
+       transform="matrix(0.18984474,-0.18571766,0.18984475,0.18571767,-155.10466,1045.8163)"
+       d="m 431.37184,416.3986 a 11.313708,14.937631 0 0 1 4.54485,0.1017"
+       sodipodi:ry="14.937631"
+       sodipodi:rx="11.313708"
+       sodipodi:cy="431.08047"
+       sodipodi:cx="433.45645"
+       id="path12648-1-6-2"
+       style="fill:#2e6a22;fill-opacity:1;stroke:#2e6a22;stroke-width:3.76581597;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       sodipodi:type="arc" />
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/edit_template.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/edit_template.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="write_obj.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302" />
+      <stop
+         id="stop5308"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7" />
+      <stop
+         id="stop5087-6"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4908-52-3-2">
+      <stop
+         style="stop-color:#986443;stop-opacity:1"
+         offset="0"
+         id="stop4910-7-2-7" />
+      <stop
+         style="stop-color:#994f1b;stop-opacity:1"
+         offset="1"
+         id="stop4912-6-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.6704"
+       x2="-8.7005796"
+       y1="1042.1598"
+       x1="-11.21119"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5173"
+       xlink:href="#linearGradient4908-52-3-2"
+       inkscape:collect="always"
+       gradientTransform="translate(20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5077-5"
+       id="linearGradient5196"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-1036.3622)"
+       x1="-0.9810437"
+       y1="1047.4242"
+       x2="1.9838035"
+       y2="1050.3188" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300"
+       id="linearGradient5306"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       id="filter5428">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.22207033"
+         id="feGaussianBlur5430" />
+    </filter>
+    <linearGradient
+       y2="1044.6704"
+       x2="-8.7005796"
+       y1="1042.1598"
+       x1="-11.21119"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5173-2"
+       xlink:href="#linearGradient4908-52-3-2-0"
+       inkscape:collect="always"
+       gradientTransform="translate(20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4908-52-3-2-0">
+      <stop
+         style="stop-color:#986443;stop-opacity:1"
+         offset="0"
+         id="stop4910-7-2-7-5" />
+      <stop
+         style="stop-color:#994f1b;stop-opacity:1"
+         offset="1"
+         id="stop4912-6-2-9-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="1.7639436"
+     inkscape:cy="11.44607"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="227"
+     inkscape:window-y="586"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:#ffffff;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;fill-opacity:1"
+       d="m 15.685953,1040.5523 -8.747594,8.7054 -5.461084,2.5938 2.59375,-5.4564 8.663811,-8.7231 c 1.269887,0.6025 2.210467,1.6169 2.951117,2.8807 z"
+       id="path5226-6-14-1-5-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient5173);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 15.685953,1040.5523 -8.747594,8.7054 -5.461084,2.5938 2.59375,-5.4564 8.663811,-8.7231 c 1.269887,0.6025 2.210467,1.6169 2.951117,2.8807 z"
+       id="path5226-6-14-1-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffcb72;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 12.75,1037.6747 -8.6875,8.7188 0.9375,0.9062 8.9375,-8.875 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875,-0.75 z"
+       id="path5424"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#e5a856;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 15.3125,1039.956 -8.78125,8.9062 0.40625,0.4063 8.75,-8.7188 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+       id="path5226-6-14-1-5-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#fbbc67;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 6.536718,1048.8567 -1.548139,-1.5456 8.939717,-8.8821 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+       id="path5226-6-14-1-5-2-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428)"
+       d="m 4.984376,1047.2528 8.937501,-8.8281"
+       id="path5426"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5196);fill-opacity:1;stroke:none;display:inline"
+       d="M 5.40625,8.6875 4.09375,10 2.6875,12.9375 l 1.375,1.28125 -0.03125,0.0625 2.9375,-1.40625 0.75,-0.75 0.1875,-2 L 5.1875,9.96875 c 0,0 0.127199,-0.74275 0.21875,-1.28125 z"
+       id="path5006"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       transform="translate(0,1036.3622)" />
+    <path
+       style="fill:url(#linearGradient5306);fill-opacity:1;stroke:none;display:inline"
+       d="m 3.25,1049.1435 c -0.211528,0.024 -0.41079,0.089 -0.5625,0.1562 l -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c 0.121601,-0.3002 0.273127,-0.8318 -0.09375,-1.2188 -0.132606,-0.1402 -0.331591,-0.1963 -0.5,-0.2187 -0.08057,-0.011 -0.138928,-0.01 -0.21875,0 z"
+       id="path5006-1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/profile_exc.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/profile_exc.svg
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="profile_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9276-9"
+       inkscape:collect="always">
+      <stop
+         id="stop9278-0"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280-5"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0"
+       id="linearGradient13741"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276-9"
+       id="linearGradient13743"
+       gradientUnits="userSpaceOnUse"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient13761"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient13837"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient13755-3">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-0"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-0"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-65" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831-8">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833-2" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755-3"
+       id="linearGradient13906"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831-8"
+       id="linearGradient13908"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13922"
+       id="linearGradient13928"
+       x1="11"
+       y1="8.5"
+       x2="16"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-9" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1051.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945"
+       xlink:href="#linearGradient13922-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-0" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1053.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-8"
+       xlink:href="#linearGradient13922-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-3" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1055.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-1"
+       xlink:href="#linearGradient13922-7"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask14146">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g14148"
+         transform="matrix(0.73426076,0,0,0.73426076,3.6725146,281.72245)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,-18.103841,1064.137)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path14150"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14152"
+           d="m 14.349242,1061.6734 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14154"
+           d="m 14.349242,1061.6734 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter14156"
+       x="-0.18"
+       width="1.36"
+       y="-0.18"
+       height="1.36">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.99291734"
+         id="feGaussianBlur14158" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="10.07386"
+     inkscape:cy="8.8274714"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="867"
+     inkscape:window-height="637"
+     inkscape:window-x="142"
+     inkscape:window-y="77"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient13761);fill-opacity:1;stroke:url(#linearGradient13837);stroke-width:0.80190598999999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path13745"
+         sodipodi:cx="26"
+         sodipodi:cy="-2"
+         sodipodi:rx="4"
+         sodipodi:ry="4"
+         d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+         transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)" />
+      <path
+         style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 53.750446,1047.7972 0,-2.0313"
+         id="path13811"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline"
+         d="m 53.750446,1047.7972 1.458408,2.3881"
+         id="path13811-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <g
+         id="g13901"
+         transform="matrix(0.73426076,0,0,0.73426076,3.6725146,281.72245)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,-18.103841,1064.137)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745-2"
+           style="fill:url(#linearGradient13906);fill-opacity:1;stroke:url(#linearGradient13908);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-4"
+           d="m 14.349242,1061.6734 0,-2.0313"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9-5"
+           d="m 14.349242,1061.6734 1.458408,2.3881"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+      <rect
+         style="fill:url(#linearGradient13928);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect13912"
+         width="5"
+         height="1"
+         x="11"
+         y="8"
+         transform="translate(8.2201163,1049.2669)" />
+      <rect
+         style="fill:url(#linearGradient13945);fill-opacity:1;stroke:none;display:inline"
+         id="rect13912-3"
+         width="5"
+         height="1"
+         x="19.220116"
+         y="1059.2668" />
+      <rect
+         style="fill:url(#linearGradient13945-8);fill-opacity:1;stroke:none;display:inline"
+         id="rect13912-1"
+         width="5"
+         height="1"
+         x="19.220116"
+         y="1061.2668" />
+      <rect
+         style="fill:url(#linearGradient13945-1);fill-opacity:1;stroke:none;display:inline"
+         id="rect13912-5"
+         width="5"
+         height="1"
+         x="19.220116"
+         y="1063.2668" />
+      <g
+         id="g14139"
+         mask="url(#mask14146)">
+        <g
+           style="display:inline;fill:#ffffff;stroke:#ffffff;filter:url(#filter14156);stroke-width:2.58418837;stroke-miterlimit:4;stroke-dasharray:none"
+           id="layer1-0-8-9"
+           inkscape:label="Layer 1"
+           transform="matrix(0.77393739,0,0,0.77393739,7.411332,246.44575)">
+          <g
+             transform="translate(-8.2201167,-12.904699)"
+             id="g8159-2-9-7"
+             style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:2.58418837;stroke-miterlimit:4;stroke-dasharray:none">
+            <path
+               transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+               d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+               sodipodi:ry="10.625"
+               sodipodi:rx="10.625"
+               sodipodi:cy="468.23718"
+               sodipodi:cx="388.125"
+               id="path10796-2-6-0-3-1-6"
+               style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:4.14792857;stroke-miterlimit:4;stroke-dasharray:none"
+               sodipodi:type="arc" />
+            <path
+               style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58418837;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+               d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
+               id="path8117-2-7-3"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccc" />
+            <path
+               transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+               d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+               sodipodi:ry="10.625"
+               sodipodi:rx="10.625"
+               sodipodi:cy="468.23718"
+               sodipodi:cx="388.125"
+               id="path10796-2-6-0-5-3-1"
+               style="fill:#ffffff;stroke:#ffffff;stroke-width:4.14792857;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+               sodipodi:type="arc" />
+          </g>
+        </g>
+      </g>
+      <g
+         transform="matrix(0.77393739,0,0,0.77393739,7.411332,246.44575)"
+         inkscape:label="Layer 1"
+         id="layer1-0-8"
+         style="display:inline">
+        <g
+           style="display:inline"
+           id="g8159-2-9"
+           transform="translate(-8.2201167,-12.904699)">
+          <path
+             sodipodi:type="arc"
+             style="fill:url(#linearGradient13741);fill-opacity:1;stroke:none;display:inline"
+             id="path10796-2-6-0-3-1"
+             sodipodi:cx="388.125"
+             sodipodi:cy="468.23718"
+             sodipodi:rx="10.625"
+             sodipodi:ry="10.625"
+             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path8117-2-7"
+             d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient13743);stroke-width:0.64604712;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+          <path
+             sodipodi:type="arc"
+             style="fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+             id="path10796-2-6-0-5-3"
+             sodipodi:cx="388.125"
+             sodipodi:cy="468.23718"
+             sodipodi:rx="10.625"
+             sodipodi:ry="10.625"
+             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/refresh.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/refresh.svg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="refresh.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5-1"
+       id="linearGradient7608-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7584-5-1">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1-2"
+       id="linearGradient7610-5-8"
+       gradientUnits="userSpaceOnUse"
+       x1="23.551146"
+       y1="1037.3622"
+       x2="23.551146"
+       y2="1045.3622" />
+    <linearGradient
+       id="linearGradient7592-1-2">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6-7" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="14.77039"
+     inkscape:cy="-0.49944469"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="665"
+     inkscape:window-y="497"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4090" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-13.086169,0.51822429)">
+      <path
+         sodipodi:nodetypes="ccssscscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-3-3);fill-opacity:1;stroke:url(#linearGradient7610-5-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 23.069359,2.3660973 0,-0.5966213 c 0,0 0.110485,-0.3756505 -0.220971,-0.243068 -0.331456,0.1325826 -0.972272,0.6629126 -1.038563,0.773398 -0.06629,0.1104855 -0.751301,0.5966214 -0.596622,0.8175923 0.15468,0.2209709 1.458408,0.066291 1.458408,0.066291 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.049623,2089.2948)">
+      <path
+         sodipodi:nodetypes="ccssscsscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <image
+       y="1052.3622"
+       x="0"
+       id="image3013"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAXZJREFU
+OI2lUj1Iw1AQ/l5wKF1MKTaDiy7F3bEu6iS0Dh0EaREnQVoc1EVEkNDgYpbSqdBBhbpVLYhDbRYR
+3Cw42UkcSgzWgqKm9uccNCHBpBX94IN3j7vvvnfvGBHhP+B+k6RIAimS4Nipr4AiCTS5cfs3B+di
+wCzudAglUaCSaHfC3GZwtjVE08ltcJ4R2/2bdo3LgzRmRI31dNBqE/BaA5qajd7BYYTmFnCRHSUA
+GHATmN15ZIU1P4VjEXC+IIoZGQAQjkXg9QWhVZ/7zyAq19nxXhHdRhXtNiEq19mREbe6X0lEBCJC
+ORUg69ka5xM85RO8LTbOZkG30zCLyqkA6bpqE3Gj+YSPVhOhZBbWhRmPp+G2QAYYEUGRBArFVwF+
+7EeCrlZwo+QwsXzPnAQ4AJjafGBKbhdQrwBdtdEDHS+1994ODBTW/QQCCEB4aQXQ73C6f4Ko/OTY
+3fYLVuYTPOmVRdvk3ei4yodJHwHAfKbh3vkbn+0qFz9A+1qMAAAAAElFTkSuQmCC
+"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/run_co.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/run_co.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="run_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientTransform="translate(20,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       id="linearGradient4744"
+       xlink:href="#linearGradient4738"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         id="stop4740"
+         offset="0"
+         style="stop-color:#8cc861;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa766;stop-opacity:1"
+         offset="0.43753415"
+         id="stop4746" />
+      <stop
+         id="stop4742"
+         offset="1"
+         style="stop-color:#c2dd97;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.314993,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       id="linearGradient4747"
+       xlink:href="#linearGradient4741"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#30825a;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#106643;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       gradientTransform="translate(15.825436,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6032"
+       xlink:href="#linearGradient4738"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       gradientTransform="translate(-5.4895565,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6034"
+       xlink:href="#linearGradient4741"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       gradientTransform="translate(15.825436,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6032-1"
+       xlink:href="#linearGradient4738-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4738-7">
+      <stop
+         id="stop4740-4"
+         offset="0"
+         style="stop-color:#8cc861;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa766;stop-opacity:1"
+         offset="0.43753415"
+         id="stop4746-0" />
+      <stop
+         id="stop4742-9"
+         offset="1"
+         style="stop-color:#c2dd97;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       gradientTransform="translate(-5.4895565,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6034-4"
+       xlink:href="#linearGradient4741-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4741-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4743-8"
+         offset="0"
+         style="stop-color:#30825a;stop-opacity:1" />
+      <stop
+         id="stop4745-2"
+         offset="1"
+         style="stop-color:#106643;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter3854"
+       x="-0.17271166"
+       width="1.3454233"
+       y="-0.18946901"
+       height="1.378938">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.79164101"
+         id="feGaussianBlur3856" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="2.7895639"
+     inkscape:cy="0.17979497"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="831"
+     inkscape:window-height="877"
+     inkscape:window-x="650"
+     inkscape:window-y="517"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9.000617,1046.9325 -6.9803119,-2.5603 -2.05187237,0 0,7.99 2.02030507,0 7.0118792,-2.5078"
+       id="path3360"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <g
+       style="display:inline;fill:#ffffff;stroke:#ffffff;filter:url(#filter3854)"
+       id="layer1-6-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.479092,0,0,0.43051303,2.2977699,599.01177)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968-5"
+         d="m -1.6770565,1039.8618 0,2.0277 0,5 0,3 0.99999995,0 9.54668705,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.12684205,-4.5004 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.20189905000000020;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="matrix(0.54671979,0,0,0.4912835,1.5927832,535.14258)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="m -1.6770565,1039.8618 0,2.0277 0,5 0,3 0.99999995,0 9.54668705,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.12684205,-4.5004 z"
+         style="fill:url(#linearGradient6032);fill-opacity:1;stroke:url(#linearGradient6034);stroke-width:2.20189905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/run_exc.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/run_exc.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="start.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientTransform="matrix(0.66159777,0,0,0.66159776,-240.06252,747.98229)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509664"
+     inkscape:cx="8.4134662"
+     inkscape:cy="1.3092525"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <sodipodi:guide
+       position="0.98332041,11.735262"
+       orientation="1,0"
+       id="guide1"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7.0600196,15.01668"
+       orientation="0,-1"
+       id="guide2"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <circle
+         style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#14733c;stroke-width:0.941048;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path10796-2-6-0"
+         cx="16.720118"
+         cy="1057.767"
+         r="7.0294762" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path8117"
+         d="m 14.220116,1052.2669 6,5.567 -5.938144,5.433 z"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.03057" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/term_restart.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/term_restart.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="term_restart.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49579832;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6642">
+      <stop
+         style="stop-color:#e83038;stop-opacity:1;"
+         offset="0"
+         id="stop6644" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(20,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.053"
+       x2="-13.936629"
+       y1="1049.9579"
+       x1="-13.936629"
+       id="linearGradient4744"
+       xlink:href="#linearGradient4738"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.314993,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.912"
+       x2="11.0625"
+       y1="1038.5497"
+       x1="11.0625"
+       id="linearGradient4747"
+       xlink:href="#linearGradient4741"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#30825a;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#106643;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4738">
+      <stop
+         id="stop4740"
+         offset="0"
+         style="stop-color:#8cc861;stop-opacity:1" />
+      <stop
+         style="stop-color:#4aa766;stop-opacity:1"
+         offset="0.43753415"
+         id="stop4746" />
+      <stop
+         id="stop4742"
+         offset="1"
+         style="stop-color:#c2dd97;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642"
+       id="linearGradient5933"
+       gradientUnits="userSpaceOnUse"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient5935"
+       gradientUnits="userSpaceOnUse"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6052">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g6054"
+         transform="matrix(0.85180709,0,0,0.85180709,-0.23923085,151.12608)">
+        <rect
+           ry="1.1490484"
+           rx="1.1490484"
+           y="1039.4933"
+           x="2.9031553"
+           height="9.9879284"
+           width="9.9436893"
+           id="rect6056"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+        <rect
+           ry="0.30935922"
+           rx="0.30935922"
+           y="1040.6334"
+           x="4.0174322"
+           height="7.6526675"
+           width="7.6892476"
+           id="rect6058"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:#ffffff;stroke:#ffffff;stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter6832"
+       x="-0.2293"
+       width="1.4586"
+       y="-0.25154783"
+       height="1.5030957">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.0510192"
+         id="feGaussianBlur6834" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="2.7879001"
+     inkscape:cy="9.1741616"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="844"
+     inkscape:window-height="794"
+     inkscape:window-x="31"
+     inkscape:window-y="14"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       id="g5929"
+       transform="matrix(0.85180709,0,0,0.85180709,-0.23923084,151.12608)">
+      <rect
+         ry="1.1490484"
+         rx="1.1490484"
+         y="1039.4933"
+         x="2.9031553"
+         height="9.9879284"
+         width="9.9436893"
+         id="rect6562"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient5933);fill-opacity:1;fill-rule:nonzero;stroke:#a81d24;stroke-width:0.60000002;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+      <rect
+         ry="0.30935922"
+         rx="0.30935922"
+         y="1040.6334"
+         x="4.0174322"
+         height="7.6526675"
+         width="7.6892476"
+         id="rect6562-9"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient5935);stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+    </g>
+    <g
+       id="g6048"
+       mask="url(#mask6052)">
+      <g
+         transform="matrix(0.61981187,0,0,0.63114696,7.7969515,387.39989)"
+         inkscape:label="Layer 1"
+         id="layer1-2-6"
+         style="display:inline;fill:#ffffff;stroke:#ffffff;filter:url(#filter6832);stroke-width:3.19767855;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.19767855;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 2.497507,1039.8618 0,2.0277 0,5 0,3 1,0 9.546687,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.126842,-4.5004 z"
+           id="rect3968-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-2"
+       inkscape:label="Layer 1"
+       transform="matrix(0.61981187,0,0,0.63114696,7.7969515,387.39989)">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3968"
+         d="m 2.497507,1039.8618 0,2.0277 0,5 0,3 1,0 9.546687,-4.5273 c 0.59227,-0.3746 0.618127,-0.6299 0,-1 l -9.126842,-4.5004 z"
+         style="fill:url(#linearGradient4744);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/terminate_all_co.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/terminate_all_co.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="terminate_all_co.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4916">
+      <stop
+         id="stop4918"
+         offset="0"
+         style="stop-color:#e85050;stop-opacity:1" />
+      <stop
+         style="stop-color:#e82030;stop-opacity:1"
+         offset="0.5"
+         id="stop4924" />
+      <stop
+         id="stop4920"
+         offset="1"
+         style="stop-color:#e83840;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4908">
+      <stop
+         style="stop-color:#c85848;stop-opacity:1"
+         offset="0"
+         id="stop4910" />
+      <stop
+         id="stop4922"
+         offset="0.5"
+         style="stop-color:#c43434;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c01020;stop-opacity:1"
+         offset="1"
+         id="stop4912" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4900">
+      <stop
+         style="stop-color:#f4adad;stop-opacity:1"
+         offset="0"
+         id="stop4902" />
+      <stop
+         style="stop-color:#f4a4a7;stop-opacity:1"
+         offset="1"
+         id="stop4904" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4892">
+      <stop
+         style="stop-color:#cd6759;stop-opacity:1"
+         offset="0"
+         id="stop4894" />
+      <stop
+         style="stop-color:#c62634;stop-opacity:1"
+         offset="1"
+         id="stop4896" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4839">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4841" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4843" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49579832;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4839"
+       id="linearGradient4845"
+       x1="26"
+       y1="1045.3622"
+       x2="24"
+       y2="1045.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4839"
+       id="linearGradient4847"
+       x1="28"
+       y1="1042.3622"
+       x2="28"
+       y2="1040.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       id="linearGradient4729-4-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4731-8-1" />
+      <stop
+         id="stop4737-8-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49579832;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4733-2-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1048.3102"
+       x2="7.5007138"
+       y1="1040.3939"
+       x1="7.5007138"
+       gradientTransform="matrix(1.0433579,0,0,1.0396531,-1.716865,-43.046209)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4865"
+       xlink:href="#linearGradient4729-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient4887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0433579,0,0,1.0396531,2.283135,-39.046151)"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4916"
+       id="linearGradient4890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0433579,0,0,1.0396531,2.283135,-39.046151)"
+       x1="8.2203207"
+       y1="1042.0864"
+       x2="8.2203207"
+       y2="1049.0878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4892"
+       id="linearGradient4898"
+       x1="8.9927311"
+       y1="1042.5375"
+       x2="8.9927311"
+       y2="1053.1179"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4900"
+       id="linearGradient4906"
+       x1="14.743395"
+       y1="1042.5375"
+       x2="14.743395"
+       y2="1053.1179"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4908"
+       id="linearGradient4914"
+       x1="14"
+       y1="1042.3622"
+       x2="14"
+       y2="1051.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-11.226687"
+     inkscape:cy="14.085504"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="1171"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-120.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       style="display:inline;stroke:url(#linearGradient4898);stroke-opacity:1;fill:url(#linearGradient4906);fill-opacity:1"
+       id="g3968-4"
+       transform="matrix(1.0433579,0,0,1.0396531,-5.382637,-46.51512)">
+      <rect
+         ry="1.1490484"
+         rx="1.1490484"
+         y="1042.83"
+         x="6.4165921"
+         height="9.9879284"
+         width="9.9436893"
+         id="rect6562-5"
+         style="font-size:13.58917427000000100px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient4906);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4898);stroke-width:0.60000001999999997;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+    </g>
+    <rect
+       ry="0.32162628"
+       rx="0.32277238"
+       y="1038.8517"
+       x="2.4747548"
+       height="7.9561195"
+       width="8.0226374"
+       id="rect6562-9-5"
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient4865);stroke-width:0.93735343;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans" />
+    <path
+       style="fill:url(#linearGradient4845);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1040.3622 2,2 0,6 -2,0 z"
+       id="rect4031"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4847);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1040.3622 8,0 0,2 -6,0 z"
+       id="rect4031-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="font-size:13.58917427000000100px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient4890);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4914);stroke-width:0.62490230999999996;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562"
+       width="10.374826"
+       height="10.383981"
+       x="5.3121653"
+       y="1041.6663"
+       rx="1.1988688"
+       ry="1.1946118" />
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient4887);stroke-width:0.93735343;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562-9"
+       width="8.0226374"
+       height="7.9561195"
+       x="6.4747548"
+       y="1042.8516"
+       rx="0.32277238"
+       ry="0.32162628" />
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/icons/terminate_co.svg
+++ b/debug/org.eclipse.debug.ui.launchview/icons/terminate_co.svg
@@ -1,0 +1,4572 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="ch_cancel.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4774">
+      <stop
+         style="stop-color:#c01020;stop-opacity:1"
+         offset="0"
+         id="stop4776" />
+      <stop
+         id="stop4782"
+         offset="0.5"
+         style="stop-color:#b83838;stop-opacity:1" />
+      <stop
+         style="stop-color:#c85848;stop-opacity:1"
+         offset="1"
+         id="stop4778" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4760">
+      <stop
+         id="stop4762"
+         offset="0"
+         style="stop-color:#e85050;stop-opacity:1" />
+      <stop
+         style="stop-color:#e83038;stop-opacity:1"
+         offset="0.49362174"
+         id="stop4764" />
+      <stop
+         id="stop4772"
+         offset="0.63784295"
+         style="stop-color:#e82030;stop-opacity:1" />
+      <stop
+         id="stop4766"
+         offset="1"
+         style="stop-color:#e83840;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4750">
+      <stop
+         id="stop4752"
+         offset="0"
+         style="stop-color:#f8b0a8;stop-opacity:1" />
+      <stop
+         style="stop-color:#f07878;stop-opacity:1"
+         offset="0.5"
+         id="stop4754" />
+      <stop
+         id="stop4756"
+         offset="1"
+         style="stop-color:#f8a8a8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6642">
+      <stop
+         style="stop-color:#e83038;stop-opacity:1;"
+         offset="0"
+         id="stop6644" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850">
+      <stop
+         id="stop13852"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801" />
+      <stop
+         id="stop13809"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090" />
+      <stop
+         id="stop12096"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001" />
+      <stop
+         id="stop12007"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971" />
+      <stop
+         id="stop11979"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689" />
+      <stop
+         id="stop11695"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150" />
+      <stop
+         id="stop11152"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130" />
+      <stop
+         id="stop11136"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856">
+      <stop
+         id="stop10858"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860" />
+      <stop
+         id="stop10862"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800" />
+      <stop
+         id="stop10806"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748">
+      <stop
+         id="stop10750"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754" />
+      <stop
+         id="stop10756"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450" />
+      <stop
+         id="stop10458"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442" />
+      <stop
+         id="stop10521"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432">
+      <stop
+         id="stop10434"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436" />
+      <stop
+         id="stop10438"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416" />
+      <stop
+         id="stop10422"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398" />
+      <stop
+         id="stop10404"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159" />
+      <stop
+         id="stop10165"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914"
+       inkscape:collect="always">
+      <stop
+         id="stop9916"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908"
+       inkscape:collect="always">
+      <stop
+         id="stop9910"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512" />
+      <stop
+         id="stop9514"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334" />
+      <stop
+         id="stop9340"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324">
+      <stop
+         id="stop9326"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328" />
+      <stop
+         id="stop9330"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314" />
+      <stop
+         id="stop9322"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9">
+      <stop
+         id="stop7561-3-3-4-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1" />
+      <stop
+         id="stop7565-8-8-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6" />
+      <stop
+         id="stop7114-9-0-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322" />
+      <stop
+         id="stop4324"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331" />
+      <stop
+         id="stop4333"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8">
+      <stop
+         id="stop7561-3-3-4-48-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7" />
+      <stop
+         id="stop7565-8-8-3-2-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7" />
+      <stop
+         id="stop7114-9-0-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258" />
+      <stop
+         id="stop3260"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267" />
+      <stop
+         id="stop3269"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2">
+      <stop
+         id="stop7561-3-3-4-48-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76" />
+      <stop
+         id="stop7565-8-8-3-2-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8" />
+      <stop
+         id="stop7114-9-0-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508" />
+      <stop
+         id="stop3510"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517" />
+      <stop
+         id="stop3519"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9" />
+      <stop
+         id="stop7114-9-0-1-4-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         id="stop4137"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         id="stop4146"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356" />
+      <stop
+         id="stop4358"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365" />
+      <stop
+         id="stop4367"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1" />
+      <stop
+         id="stop4358-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6" />
+      <stop
+         id="stop4367-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692" />
+      <stop
+         id="stop5694"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701" />
+      <stop
+         id="stop5703"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0" />
+      <stop
+         id="stop5694-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6" />
+      <stop
+         id="stop5703-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127" />
+      <stop
+         id="stop6129"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136" />
+      <stop
+         id="stop6138"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4" />
+      <stop
+         id="stop6129-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6" />
+      <stop
+         id="stop6138-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295" />
+      <stop
+         id="stop6297"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304" />
+      <stop
+         id="stop6306"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         id="stop6325"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332" />
+      <stop
+         id="stop6334"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         id="stop6353"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360" />
+      <stop
+         id="stop6362"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942" />
+      <stop
+         id="stop6944"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951" />
+      <stop
+         id="stop6953"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108" />
+      <stop
+         id="stop7110"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117" />
+      <stop
+         id="stop7119"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9"
+       id="linearGradient7692-4"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5"
+       xlink:href="#linearGradient7686-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8159-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9"
+       id="linearGradient8143-2"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3"
+       xlink:href="#linearGradient8153-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182"
+       xlink:href="#linearGradient8137-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6"
+       id="linearGradient8291-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498"
+       id="linearGradient8504"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8659"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291"
+       id="linearGradient9297"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299"
+       id="linearGradient9305"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9"
+       id="linearGradient9338-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5" />
+      <stop
+         id="stop9340-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7"
+       id="linearGradient9318"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7">
+      <stop
+         id="stop9326-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1" />
+      <stop
+         id="stop9330-5"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient9297-1"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient9305-8"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52" />
+      <stop
+         id="stop9340-23"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5" />
+      <stop
+         id="stop9322-0"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5"
+       xlink:href="#linearGradient9510-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4" />
+      <stop
+         id="stop9514-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient8697-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3"
+       id="linearGradient8703-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605"
+       id="linearGradient9962"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6"
+       id="linearGradient9964"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9"
+       id="linearGradient9966"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3"
+       id="linearGradient9968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5"
+       id="linearGradient9970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6"
+       id="linearGradient9972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0"
+       id="linearGradient9974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2"
+       id="linearGradient9976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908"
+       id="linearGradient9978"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient9980"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4"
+       id="linearGradient9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914"
+       id="linearGradient9984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332"
+       id="linearGradient9997"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312"
+       id="linearGradient9999"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510"
+       id="linearGradient10001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient10003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient10005"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5"
+       id="linearGradient10163-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7" />
+      <stop
+         id="stop10165-2"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3"
+       id="linearGradient10155-1"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6"
+       id="linearGradient10155-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10163-2"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8" />
+      <stop
+         id="stop10165-3"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10155-7"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7" />
+      <stop
+         id="stop10394"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4"
+       id="linearGradient10454-7"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4" />
+      <stop
+         id="stop10458-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2"
+       id="linearGradient10446-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9"
+       id="linearGradient10454-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3" />
+      <stop
+         id="stop10458-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1"
+       id="linearGradient10446-7"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43" />
+      <stop
+         id="stop10521-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3"
+       xlink:href="#linearGradient10448-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5" />
+      <stop
+         id="stop10458-8-0"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3"
+       xlink:href="#linearGradient10440-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2" />
+      <stop
+         id="stop10521-1-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8"
+       xlink:href="#linearGradient10448-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8" />
+      <stop
+         id="stop10458-8-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1"
+       xlink:href="#linearGradient10440-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0" />
+      <stop
+         id="stop10521-1-4"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6" />
+      <stop
+         id="stop10456-4-1-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0" />
+      <stop
+         id="stop10521-1-2-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0"
+       id="linearGradient10770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0"
+       id="linearGradient10772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748"
+       id="linearGradient10774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3"
+       id="linearGradient10776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448"
+       id="linearGradient10778"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440"
+       id="linearGradient10780"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414"
+       id="linearGradient10782"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432"
+       id="linearGradient10784"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157"
+       id="linearGradient10786"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396"
+       id="linearGradient10788"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5"
+       id="linearGradient10794"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8"
+       id="linearGradient10804-7"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2" />
+      <stop
+         id="stop10806-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1"
+       id="linearGradient10804-8"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5" />
+      <stop
+         id="stop10806-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2" />
+      <stop
+         id="stop10806-6-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2"
+       xlink:href="#linearGradient10856-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6">
+      <stop
+         id="stop10858-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7" />
+      <stop
+         id="stop10862-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8"
+       id="radialGradient11144-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7" />
+      <stop
+         id="stop11152-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7"
+       id="radialGradient11144-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9" />
+      <stop
+         id="stop11152-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6"
+       xlink:href="#linearGradient11146-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8" />
+      <stop
+         id="stop11152-8-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6"
+       xlink:href="#linearGradient10856-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3">
+      <stop
+         id="stop10858-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9" />
+      <stop
+         id="stop10862-3-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1" />
+      <stop
+         id="stop10806-6-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4"
+       id="radialGradient11268-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4" />
+      <stop
+         id="stop11152-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3"
+       id="radialGradient11270-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5" />
+      <stop
+         id="stop11152-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5"
+       id="radialGradient11272-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6" />
+      <stop
+         id="stop11152-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5"
+       id="radialGradient11274-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3" />
+      <stop
+         id="stop11152-8-8-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3"
+       xlink:href="#linearGradient10856-6-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0">
+      <stop
+         id="stop10858-0-7-6"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1" />
+      <stop
+         id="stop10862-3-3-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8" />
+      <stop
+         id="stop10806-6-8-5-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7" />
+      <stop
+         id="stop11152-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5" />
+      <stop
+         id="stop11152-8-4-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4" />
+      <stop
+         id="stop11152-6-7-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1" />
+      <stop
+         id="stop11152-8-8-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1">
+      <stop
+         id="stop10858-0-7-6-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7" />
+      <stop
+         id="stop10862-3-3-8-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0"
+       xlink:href="#linearGradient10798-1-9-3-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5" />
+      <stop
+         id="stop10806-6-8-5-3-2-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2"
+       id="radialGradient11685-7"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1"
+       id="linearGradient11693-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9" />
+      <stop
+         id="stop11695-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8"
+       id="linearGradient11894-2"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4"
+       id="linearGradient11894-5"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3" />
+      <stop
+         id="stop11979-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1" />
+      <stop
+         id="stop12096-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9" />
+      <stop
+         id="stop12007-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7"
+       id="radialGradient11685-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9"
+       id="linearGradient11693-2"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1" />
+      <stop
+         id="stop11695-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8"
+       id="radialGradient11685-3"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8"
+       id="linearGradient11693-26"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6" />
+      <stop
+         id="stop11695-6"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7" />
+      <stop
+         id="stop11979-8-6"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8" />
+      <stop
+         id="stop12096-1-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2" />
+      <stop
+         id="stop12007-1-3"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7" />
+      <stop
+         id="stop11979-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7" />
+      <stop
+         id="stop12096-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1" />
+      <stop
+         id="stop12007-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3"
+       id="radialGradient11685-2"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2"
+       id="linearGradient11693-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3" />
+      <stop
+         id="stop11695-9"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9"
+       id="radialGradient12723-3"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5"
+       id="radialGradient12739-4"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1"
+       id="linearGradient12904-2"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1" />
+      <stop
+         id="stop11152-9-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2" />
+      <stop
+         id="stop11152-8-4-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8" />
+      <stop
+         id="stop11152-6-7-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19" />
+      <stop
+         id="stop11152-8-8-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5">
+      <stop
+         id="stop10858-0-7-6-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9" />
+      <stop
+         id="stop10862-3-3-8-6"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20" />
+      <stop
+         id="stop10806-6-8-5-3-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient13850-2">
+      <stop
+         id="stop13852-4"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4" />
+      <stop
+         id="stop13809-4"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8"
+       xlink:href="#linearGradient12862-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1" />
+      <stop
+         id="stop11979-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9" />
+      <stop
+         id="stop12096-6-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9" />
+      <stop
+         id="stop12007-4-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7" />
+      <stop
+         id="stop11695-9-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5-6-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-1"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6038-4-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-3"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642"
+       id="linearGradient6648"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient4735"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#f8b0a8;stop-opacity:1"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#f07878;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8a8a8;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642-7"
+       id="linearGradient6648-1"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6642-7">
+      <stop
+         id="stop4758"
+         offset="0"
+         style="stop-color:#cb2129;stop-opacity:1;" />
+      <stop
+         style="stop-color:#bd1a21;stop-opacity:1;"
+         offset="0.75"
+         id="stop4770" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       y2="1048.1158"
+       x2="8.2203207"
+       y1="1041.1198"
+       x1="8.2203207"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4783"
+       xlink:href="#linearGradient4760"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4750"
+       id="linearGradient4748"
+       x1="18.277163"
+       y1="4.5243545"
+       x2="18.277163"
+       y2="12.6786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,1036.3622)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4774"
+       id="linearGradient4780"
+       x1="15.820688"
+       y1="1049.7999"
+       x2="15.820688"
+       y2="1039.7346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="12.963467"
+     inkscape:cy="7.0594162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3958" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient4783);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4780);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562"
+       width="10.011972"
+       height="9.9912109"
+       x="3.4962158"
+       y="1039.864"
+       rx="1.3052979"
+       ry="1.3052979" />
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient4735);stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562-9"
+       width="8.0096645"
+       height="8.0024414"
+       x="4.4926262"
+       y="1040.8654"
+       rx="0.30935922"
+       ry="0.30935922" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient4748)"
+       id="rect4740"
+       width="8.0100994"
+       height="8.0082979"
+       x="4.4903278"
+       y="1040.8599"
+       rx="0.30935922"
+       ry="0.30935922" />
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui.launchview/plugin.xml
+++ b/debug/org.eclipse.debug.ui.launchview/plugin.xml
@@ -5,7 +5,7 @@
       <e4view
             category="org.eclipse.debug.ui"
             class="org.eclipse.debug.ui.launchview.internal.view.LaunchViewImpl"
-            icon="$nl$/icons/run_exc.png"
+            icon="$nl$/icons/run_exc.svg"
             id="org.eclipse.debug.ui.launchView"
             name="%LaunchView.name"
             restorable="true">

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/EditAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/EditAction.java
@@ -33,7 +33,7 @@ public class EditAction {
 		MDirectMenuItem item = MMenuFactory.INSTANCE.createDirectMenuItem();
 		item.setLabel(LaunchViewMessages.EditAction_Edit);
 		item.setObject(this);
-		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/edit_template.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/edit_template.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 		return item;
 	}
 

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchAction.java
@@ -36,9 +36,9 @@ public class LaunchAction {
 
 	static {
 		COMMON_MODE_ICONS = new TreeMap<>();
-		COMMON_MODE_ICONS.put("run", "icons/run_exc.png"); //$NON-NLS-1$//$NON-NLS-2$
-		COMMON_MODE_ICONS.put("debug", "icons/debug_exc.png"); //$NON-NLS-1$ //$NON-NLS-2$
-		COMMON_MODE_ICONS.put("profile", "icons/profile_exc.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		COMMON_MODE_ICONS.put("run", "icons/run_exc.svg"); //$NON-NLS-1$//$NON-NLS-2$
+		COMMON_MODE_ICONS.put("debug", "icons/debug_exc.svg"); //$NON-NLS-1$ //$NON-NLS-2$
+		COMMON_MODE_ICONS.put("profile", "icons/profile_exc.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 		COMMON_MODE_ICONS.put("coverage", "icons/coverage.png"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewImpl.java
@@ -153,12 +153,12 @@ public class LaunchViewImpl implements Supplier<Set<ILaunchObject>> {
 
 		MDirectMenuItem refresh = MMenuFactory.INSTANCE.createDirectMenuItem();
 		refresh.setLabel(LaunchViewMessages.LaunchView_Refresh);
-		refresh.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/refresh.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		refresh.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/refresh.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 		refresh.setObject(new RefreshHandler());
 
 		MDirectMenuItem terminateAll = MMenuFactory.INSTANCE.createDirectMenuItem();
 		terminateAll.setLabel(LaunchViewMessages.LaunchView_TerminateAll);
-		terminateAll.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/terminate_all_co.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		terminateAll.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/terminate_all_co.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 		terminateAll.setObject(new TerminateAllHandler());
 
 		viewMenu.getChildren().add(refresh);

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewLabelProvider.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/LaunchViewLabelProvider.java
@@ -27,7 +27,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 
 public class LaunchViewLabelProvider extends BaseLabelProvider implements IStyledLabelProvider {
 
-	private static final ImageDescriptor ICON_RUNNING = AbstractUIPlugin.imageDescriptorFromPlugin(LaunchViewBundleInfo.PLUGIN_ID, "icons/run_co.png"); //$NON-NLS-1$
+	private static final ImageDescriptor ICON_RUNNING = AbstractUIPlugin.imageDescriptorFromPlugin(LaunchViewBundleInfo.PLUGIN_ID, "icons/run_co.svg"); //$NON-NLS-1$
 
 	private final ImageRegistry perConfig = new ImageRegistry();
 

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/RelaunchAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/RelaunchAction.java
@@ -38,7 +38,7 @@ public class RelaunchAction {
 		item.setEnabled(isEnabled());
 		item.setObject(this);
 
-		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/term_restart.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/term_restart.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		return item;
 	}

--- a/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/TerminateAction.java
+++ b/debug/org.eclipse.debug.ui.launchview/src/org/eclipse/debug/ui/launchview/internal/view/TerminateAction.java
@@ -38,7 +38,7 @@ public class TerminateAction {
 		item.setEnabled(isEnabled());
 		item.setObject(this);
 
-		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/terminate_co.png"); //$NON-NLS-1$ //$NON-NLS-2$
+		item.setIconURI("platform:/plugin/" + LaunchViewBundleInfo.PLUGIN_ID + "/icons/terminate_co.svg"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		return item;
 	}


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.debug.ui.launchview` except for the following as these are not available as SVG yet:

coverage.svg
delete_exc.svg
favorite_star.svg

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.