### PR TITLE
Fix javadoc params in AbstractSearchProcessor

### DIFF
--- a/ua/org.eclipse.help.base/src/org/eclipse/help/search/AbstractSearchProcessor.java
+++ b/ua/org.eclipse.help.base/src/org/eclipse/help/search/AbstractSearchProcessor.java
@@ -71,8 +71,8 @@ public abstract class AbstractSearchProcessor {
 	 * @param originalQuery The original query before any changes made by
 	 *                      {@link #preSearch(String)}.
 	 * @param results       The results of the executed query.
-	 * @param results       The locale.
-	 * @param results       The set scopes (might be {@code null}).
+	 * @param locale        The locale.
+	 * @param scopes        The set scopes (might be {@code null}).
 	 *
 	 * @return The modified results, or {@code null} for no changes.
 	 *


### PR DESCRIPTION
Wrong with the initial contribution
https://github.com/eclipse-platform/eclipse.platform/pull/1725