### PR TITLE
Enable quality gate for javadoc issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,10 +37,11 @@ pipeline {
 					recordIssues enabledForFailure: true, publishAllIssues:false, ignoreQualityGate:true,
 						tools: [
 							eclipse(name: 'Compiler', pattern: '**/target/compilelogs/*.xml'),
+							javaDoc(),
 							issues(name: 'API Tools', id: 'apitools', pattern: '**/target/apianalysis/*.xml')
 						],
 						qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
-					recordIssues enabledForFailure: true, publishAllIssues:false, tools: [mavenConsole(), javaDoc()]
+					recordIssues enabledForFailure: true, publishAllIssues:false, tools: [mavenConsole()]
 				}
 			}
 		}


### PR DESCRIPTION
An effort to make Jenkins complain about javadoc issues like the fixed with https://github.com/eclipse-platform/eclipse.platform/pull/1826 at the time of introducing them.