### PR TITLE
Build jsps with jetty-ee8-jspc-maven-plugin

### DIFF
--- a/ua/org.eclipse.help.webapp/pom.xml
+++ b/ua/org.eclipse.help.webapp/pom.xml
@@ -23,9 +23,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-jspc-maven-plugin</artifactId>
-        <version>10.0.24</version>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
+        <version>12.0.19</version>
         <executions>
           <execution>
             <id>jspc</id>
@@ -38,8 +38,8 @@
               </jspc>
               <webAppSourceDirectory>${basedir}</webAppSourceDirectory>
               <useProvidedScope>true</useProvidedScope>
-              <sourceVersion>17</sourceVersion>
-              <targetVersion>17</targetVersion>
+              <sourceVersion>21</sourceVersion>
+              <targetVersion>21</targetVersion>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Use same jetty version that we ship with instead of old Jetty 10 jspc maven plugin.
This version finally allows to set the source/target compiler version to Java 21 to match the BREE.