### PR TITLE
Fix javadoc errors

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.tests.ui; singleton:=true
-Bundle-Version: 3.12.0.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-ClassPath: anttestsui.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
@@ -372,7 +372,6 @@ public abstract class AbstractAntUITest {
 	 *
 	 * @param buildFileName
 	 *            build file to launch
-	 * @see ProjectCreationDecorator
 	 */
 	protected ILaunchConfiguration getLaunchConfiguration(String buildFileName) {
 		IFile file = getJavaProject().getProject().getFolder("launchConfigurations").getFile(buildFileName + ".launch"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUIPerformanceTests.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUIPerformanceTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2004, 2008 IBM Corporation and others.
+ *  Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -21,9 +21,7 @@ import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
 /**
- * Performance Test suite for the Ant UI. All of the tests in this suite rely on
- * the setup that occurs in the ProjectCreationDecorator suite. It must always
- * run before any of the other test suites.
+ * Performance Test suite for the Ant UI.
  */
 @Suite
 @SelectClasses({ OpenAntEditorTest.class, OpenLaunchConfigurationDialogTests.class, SeparateVMTests.class })


### PR DESCRIPTION
Even if it's javadoc plugin failure in tests bundle, it's better to remove references to non-existing classes.
```
org.apache.maven.reporting.MavenReportException:
Exit code: 1
/home/jenkins/agent/workspace/eclipse.platform_PR-1828/ant/org.eclipse.ant.tests.ui/test
plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java:375:
error: reference not found
	 * @see ProjectCreationDecorator
	        ^
1 error
```