### PR TITLE
Add FreeBSD platforms' build.

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.project
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.project
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.core.filesystem.freebsd.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.settings/org.eclipse.core.resources.prefs
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.settings/org.eclipse.core.runtime.prefs
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %fragmentName
+Bundle-SymbolicName: org.eclipse.core.filesystem.freebsd.aarch64;singleton:=true
+Bundle-Version: 1.2.400.qualifier
+Bundle-Vendor: %providerName
+Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)"
+Bundle-Localization: fragment
+Eclipse-PlatformFilter: (& (osgi.os=freebsd) (osgi.arch=aarch64))

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/about.html
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/build.properties
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/build.properties
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (c) 2014, 2025 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+bin.includes = META-INF/,\
+               about.html,\
+               os/,\
+               fragment.properties
+src.includes = about.html
+generateSourceBundle=false

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/fragment.properties
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/fragment.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2014, 2025 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+fragmentName = Core File System for FreeBSD Aarch64 bit
+providerName = Eclipse.org

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.aarch64/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+ 
+  Contributors:
+     Igor Fedorenko - initial implementation
+     Tue Ton - support for FreeBSD
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.platform</groupId>
+    <artifactId>eclipse.platform.resources</artifactId>
+    <version>4.36.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>org.eclipse.core.filesystem.freebsd.aarch64</artifactId>
+  <version>1.2.400-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <profiles>
+    <profile>
+      <id>build-natives</id>
+      <activation>
+        <property>
+          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
+          <name>native</name>
+          <value>gtk.freebsd.aarch64</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>natives</id>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target>
+                    <exec executable="gmake" newenvironment="false" dir="../org.eclipse.core.filesystem/natives/unix/freebsd/"/>
+                    <mkdir dir="os/freebsd/aarch64/"/>
+                    <copy todir="os/freebsd/aarch64/">
+                      <fileset dir="../org.eclipse.core.filesystem/natives/unix/freebsd/">
+                        <include name="libunixfile_*.so"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.project
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.project
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.core.filesystem.freebsd.x86_64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.settings/org.eclipse.core.resources.prefs
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.settings/org.eclipse.core.runtime.prefs
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %fragmentName
+Bundle-SymbolicName: org.eclipse.core.filesystem.freebsd.x86_64; singleton:=true
+Bundle-Version: 1.2.400.qualifier
+Bundle-Vendor: %providerName
+Fragment-Host: org.eclipse.core.filesystem;bundle-version="[1.7.200,2.0.0)"
+Bundle-Localization: fragment
+Eclipse-PlatformFilter: (& (osgi.os=freebsd) (osgi.arch=x86_64))

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/about.html
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/build.properties
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/build.properties
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (c) 2005, 2025 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+bin.includes = META-INF/,\
+               about.html,\
+               os/,\
+               fragment.properties
+src.includes = about.html
+generateSourceBundle=false

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/fragment.properties
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/fragment.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2005, 2025 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+fragmentName = Core File System for FreeBSD X86_64
+providerName = Eclipse.org

--- a/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/pom.xml
+++ b/resources/bundles/org.eclipse.core.filesystem.freebsd.x86_64/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+ 
+  Contributors:
+     Igor Fedorenko - initial implementation
+     Tue Ton - support for FreeBSD
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.platform</groupId>
+    <artifactId>eclipse.platform.resources</artifactId>
+    <version>4.36.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>org.eclipse.core.filesystem.freebsd.x86_64</artifactId>
+  <version>1.2.400-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <profiles>
+    <profile>
+      <id>build-natives</id>
+      <activation>
+        <property>
+          <!-- This has to be hardcoded. Profiles are not allowed to use pom defined properties :-( -->
+          <name>native</name>
+          <value>gtk.freebsd.x86_64</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>natives</id>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target>
+                    <exec executable="gmake" newenvironment="false" dir="../org.eclipse.core.filesystem/natives/unix/freebsd/"/>
+                    <mkdir dir="os/freebsd/x86_64/"/>
+                    <copy todir="os/freebsd/x86_64/">
+                      <fileset dir="../org.eclipse.core.filesystem/natives/unix/freebsd/">
+                        <include name="libunixfile_*.so"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/resources/bundles/org.eclipse.core.filesystem/natives/unix/freebsd/Makefile
+++ b/resources/bundles/org.eclipse.core.filesystem/natives/unix/freebsd/Makefile
@@ -1,0 +1,46 @@
+#******************************************************************************
+# Copyright (c) 2010, 2025 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+#******************************************************************************/
+#
+# makefile for libunixfile_1_0_0.so
+
+CORE.C = ../unixfile.c
+CORE.O = unixfile.o
+LIB_NAME = libunixfile.so
+LIB_NAME_FULL = libunixfile_1_0_0.so
+
+#Set this to be your OS type
+OS_TYPE = freebsd
+OS_ARCH ?= x86_64
+OUTPUT_DIR ?= ../../../../org.eclipse.core.filesystem.${OS_TYPE}.${OS_ARCH}/os/${OS_TYPE}/${OS_ARCH}
+
+#Set this to be the location of your JRE
+ifeq (${JAVA_HOME},)
+	JAVA_HOME = /usr/local/openjdk21
+endif
+
+JDK_INCLUDE = -I ${JAVA_HOME}/include -I ${JAVA_HOME}/include/${OS_TYPE}
+OPT_FLAGS=-O2 -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+
+core:
+	${CC} $(OPT_FLAGS) -fPIC -c $(JDK_INCLUDE) -o $(CORE.O) $(CORE.C)
+	${CC} $(OPT_FLAGS) -shared -Wl,-soname,$(LIB_NAME) -o $(LIB_NAME_FULL) $(CORE.O) -lc
+
+clean:
+	rm -f $(CORE.O) $(LIB_NAME_FULL)
+
+install: core
+	rm -f ${OUTPUT_DIR}/${LIB_NAME_FULL}
+	mkdir -p ${OUTPUT_DIR}
+	mv ${LIB_NAME_FULL} ${OUTPUT_DIR}/

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileSystem.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFileSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
  * Martin Oberhuber (Wind River) - [183137] liblocalfile for solaris-sparc
  * Martin Oberhuber (Wind River) - [184433] liblocalfile for Linux x86_64
  * Martin Oberhuber (Wind River) - [184534] get attributes from native lib
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.core.internal.filesystem.local;
 
@@ -84,6 +85,8 @@ public class LocalFileSystem extends FileSystem {
 		if (Constants.OS_WIN32.equals(os)) {
 			attributes |= EFS.ATTRIBUTE_ARCHIVE | EFS.ATTRIBUTE_HIDDEN;
 		} else if (Constants.OS_LINUX.equals(os) || (Constants.OS_SOLARIS.equals(os) && Constants.ARCH_SPARC.equals(Platform.getOSArch()))) {
+			attributes |= EFS.ATTRIBUTE_EXECUTABLE | EFS.ATTRIBUTE_SYMLINK | EFS.ATTRIBUTE_LINK_TARGET;
+		} else if (Constants.OS_FREEBSD.equals(os)) {
 			attributes |= EFS.ATTRIBUTE_EXECUTABLE | EFS.ATTRIBUTE_SYMLINK | EFS.ATTRIBUTE_LINK_TARGET;
 		} else if (Constants.OS_MACOSX.equals(os) || Constants.OS_HPUX.equals(os) || Constants.OS_QNX.equals(os)) {
 			attributes |= EFS.ATTRIBUTE_EXECUTABLE;

--- a/resources/tests/org.eclipse.core.tests.filesystem.feature/feature.xml
+++ b/resources/tests/org.eclipse.core.tests.filesystem.feature/feature.xml
@@ -20,6 +20,12 @@
    </license>
 
    <plugin
+         id="org.eclipse.core.filesystem.freebsd.x86_64"
+         os="freebsd"
+         arch="x86_64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.core.filesystem.linux.x86_64"
          os="linux"
          arch="x86_64"

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Julian Chen - fix for bug #92572, jclRM
  *     Benjamin Cabe <benjamin.cabe@anyware-tech.com> - fix for bug 265532
  *     Christoph Läubrich - remove InternalPlatform.getDefault().log (bug 55083)
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.core.internal.runtime;
 
@@ -108,7 +109,7 @@ public final class InternalPlatform {
 
 	private final ConcurrentMap<Bundle, Log> logs = new ConcurrentHashMap<>(5);
 
-	private static final String[] OS_LIST = { Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32 };
+	private static final String[] OS_LIST = { Platform.OS_FREEBSD, Platform.OS_LINUX, Platform.OS_MACOSX, Platform.OS_WIN32 };
 	private String password = ""; //$NON-NLS-1$
 	private static final String PASSWORD = "-password"; //$NON-NLS-1$
 

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Gunnar Wagenknecht <gunnar@wagenknecht.org> - Fix for bug 265445
  *     Benjamin Cabe <benjamin.cabe@anyware-tech.com> - Fix for bug 265532
  *     Lars Vogel<Lars.Vogel@vogella.com> - Bug 478768
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.core.runtime;
 
@@ -94,6 +95,13 @@ public final class Platform {
 		 */
 		public static boolean isLinux() {
 			return is(OS_LINUX);
+		}
+
+		/**
+		 * @return <code>true</code> if the current OS is FreeBSD
+		 */
+		public static boolean isFreeBSD() {
+			return is(OS_FREEBSD);
 		}
 
 		/**
@@ -260,6 +268,14 @@ public final class Platform {
 	 * @since 3.0
 	 */
 	public static final String OS_LINUX = "linux";//$NON-NLS-1$
+
+	/**
+	 * Constant string (value {@code freebsd}) indicating the platform is running on a
+	 * FreeBSD-based operating system.
+	 *
+	 * @since 4.32
+	 */
+	public static final String OS_FREEBSD = "freebsd";//$NON-NLS-1$
 
 	/**
 	 * Constant string (value {@code aix} indicating the platform is running on an

--- a/team/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/ProxyManager.java
+++ b/team/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/ProxyManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.core.internal.net;
 
@@ -21,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import org.eclipse.core.net.internal.proxy.freebsd.ProxyProviderFreeBSD;
 import org.eclipse.core.net.internal.proxy.linux.ProxyProviderLinux;
 import org.eclipse.core.net.internal.proxy.win32.ProxyProviderWin32;
 import org.eclipse.core.net.proxy.IProxyChangeEvent;
@@ -68,6 +70,7 @@ public class ProxyManager implements IProxyService, IPreferenceChangeListener {
 			String os = System.getProperty("osgi.os"); //$NON-NLS-1$
 			if (os != null) {
 				nativeProxyProvider = switch (os) {
+				case Constants.OS_FREEBSD -> new ProxyProviderFreeBSD();
 				case Constants.OS_LINUX -> new ProxyProviderLinux();
 				case Constants.OS_WIN32 -> new ProxyProviderWin32();
 				default -> null;

--- a/team/bundles/org.eclipse.core.net/src/org/eclipse/core/net/internal/proxy/freebsd/ProxyProviderFreeBSD.java
+++ b/team/bundles/org.eclipse.core.net/src/org/eclipse/core/net/internal/proxy/freebsd/ProxyProviderFreeBSD.java
@@ -1,0 +1,388 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2025 Red Hat Inc. and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *     Tue Ton - support for FreeBSD
+ *******************************************************************************/
+package org.eclipse.core.net.internal.proxy.freebsd;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.eclipse.core.internal.net.AbstractProxyProvider;
+import org.eclipse.core.internal.net.Activator;
+import org.eclipse.core.internal.net.Policy;
+import org.eclipse.core.internal.net.ProxyData;
+import org.eclipse.core.internal.net.StringUtil;
+import org.eclipse.core.net.proxy.IProxyData;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+
+/**
+ * JNA version of org.eclipse.core.internal.net.UnixProxyProvider
+ *
+ * @author jjohnstn
+ *
+ */
+public class ProxyProviderFreeBSD extends AbstractProxyProvider {
+
+	private static LibGio fLibGio;
+
+	private static Pointer proxySettings = Pointer.NULL;
+	private static Pointer httpProxySettings = Pointer.NULL;
+	private static Pointer httpsProxySettings = Pointer.NULL;
+	private static Pointer socksProxySettings = Pointer.NULL;
+	private static Pointer ftpProxySettings = Pointer.NULL;
+
+	private static final String ENABLE_GNOME = Activator.ID + ".enableGnome"; //$NON-NLS-1$
+
+	private static final String LIBRARY_NAME = "gio-2.0"; //$NON-NLS-1$
+
+	private static boolean isGnomeLibLoaded = false;
+
+	static {
+		// Load the GSettings JNI library if org.eclipse.core.net.enableGnome is specified
+		String value = System.getProperty(ENABLE_GNOME);
+		if ("".equals(value) || "true".equals(value)) { //$NON-NLS-1$ //$NON-NLS-2$
+			initializeSettings();
+		}
+	}
+
+	public ProxyProviderFreeBSD() {
+		// no initialization required
+	}
+
+	@Override
+	public IProxyData[] select(URI uri) {
+		String[] nonProxyHosts = getNonProxiedHosts();
+		if (nonProxyHosts != null) {
+			String host = uri.getHost();
+			for (String nonProxyHost : nonProxyHosts) {
+				if (StringUtil.hostMatchesFilter(host, nonProxyHost)) {
+					return new IProxyData[0];
+				}
+			}
+		}
+		IProxyData[] proxies = new IProxyData[0];
+		if (uri.getScheme() != null) {
+			ProxyData pd = getSystemProxyInfo(uri.getScheme());
+			proxies = pd != null ? new IProxyData[] { pd } : new IProxyData[0];
+		} else {
+			proxies = getProxyData();
+		}
+		if (Policy.DEBUG) {
+			Policy.debug("FreeBSDProxyProvider#select result for [" + uri + "]"); //$NON-NLS-1$ //$NON-NLS-2$
+			for (IProxyData proxy : proxies) {
+				System.out.println("	" + proxy); //$NON-NLS-1$
+			}
+		}
+		return proxies;
+	}
+
+	@Override
+	public IProxyData[] getProxyData() {
+		String[] commonTypes = new String[] { IProxyData.HTTP_PROXY_TYPE,
+				IProxyData.SOCKS_PROXY_TYPE, IProxyData.HTTPS_PROXY_TYPE };
+		return getProxyForTypes(commonTypes);
+	}
+
+	private IProxyData[] getProxyForTypes(String[] types) {
+		ArrayList<IProxyData> allData = new ArrayList<>();
+		for (String type : types) {
+			ProxyData pd = getSystemProxyInfo(type);
+			if (pd != null && pd.getHost() != null) {
+				allData.add(pd);
+			}
+		}
+		return allData.toArray(new IProxyData[0]);
+	}
+
+	@Override
+	public String[] getNonProxiedHosts() {
+		String[] npHosts;
+
+		if (Policy.DEBUG_SYSTEM_PROVIDERS)
+			Policy.debug("Getting no_proxy"); //$NON-NLS-1$
+
+		// First try the environment variable which is a URL
+		String npEnv = getEnv("no_proxy"); //$NON-NLS-1$
+		if (npEnv != null) {
+			npHosts = StringUtil.split(npEnv, new String[] { "," }); //$NON-NLS-1$
+			for (int i = 0; i < npHosts.length; i++)
+				npHosts[i] = npHosts[i].trim();
+			if (Policy.DEBUG_SYSTEM_PROVIDERS) {
+				Policy.debug("Got Env no_proxy: " + npEnv); //$NON-NLS-1$
+				debugPrint(npHosts);
+			}
+			return npHosts;
+		}
+
+		if (isGnomeLibLoaded) {
+			try {
+				npHosts = getGSettingsNonProxyHosts();
+				if (npHosts != null && npHosts.length > 0) {
+					if (Policy.DEBUG_SYSTEM_PROVIDERS) {
+						Policy.debug("Got Gnome no_proxy"); //$NON-NLS-1$
+						debugPrint(npHosts);
+					}
+					return npHosts;
+				}
+			} catch (UnsatisfiedLinkError e) {
+				// The library should be loaded, so this is a real exception
+				Activator.logError(
+						"Problem during accessing Gnome library", e); //$NON-NLS-1$
+			}
+		}
+
+		return new String[0];
+	}
+
+	// Returns null if something wrong or there is no proxy for the protocol
+	protected ProxyData getSystemProxyInfo(String protocol) {
+		ProxyData pd = null;
+		String envName = null;
+
+		if (Policy.DEBUG_SYSTEM_PROVIDERS)
+			Policy.debug("Getting proxies for: " + protocol); //$NON-NLS-1$
+
+		try {
+			// protocol schemes are ISO 8859 (ASCII)
+			protocol = protocol.toLowerCase(Locale.ENGLISH);
+
+			// First try the environment variable which is a URL
+			envName = protocol + "_proxy"; //$NON-NLS-1$
+			String proxyEnv = getEnv(envName);
+			if (Policy.DEBUG_SYSTEM_PROVIDERS)
+				Policy.debug("Got proxyEnv: " + proxyEnv); //$NON-NLS-1$
+
+			if (proxyEnv != null) {
+				int colonInd = proxyEnv.indexOf(":"); //$NON-NLS-1$
+				if (colonInd !=-1 && proxyEnv.length() > colonInd + 2 && !"//".equals(proxyEnv.substring(colonInd + 1, colonInd + 3))) { //$NON-NLS-1$
+					proxyEnv = "http://" + proxyEnv; //$NON-NLS-1$
+				}
+				URI uri = new URI(proxyEnv);
+				pd = new ProxyData(protocol);
+				pd.setHost(Objects.requireNonNull(uri.getHost(), "no host in " + proxyEnv)); //$NON-NLS-1$
+				int port = uri.getPort();
+				if (port == -1) {
+					throw new IllegalStateException("no port in " + proxyEnv); //$NON-NLS-1$
+				}
+				pd.setPort(port);
+				String userInfo = uri.getUserInfo();
+				if (userInfo != null) {
+					String user = null;
+					String password = null;
+					int pwInd = userInfo.indexOf(':');
+					if (pwInd >= 0) {
+						user = userInfo.substring(0, pwInd);
+						password = userInfo.substring(pwInd + 1);
+					} else {
+						user = userInfo;
+					}
+					pd.setUserid(user);
+					pd.setPassword(password);
+				}
+				pd.setSource("FREEBSD_ENV"); //$NON-NLS-1$
+				if (Policy.DEBUG_SYSTEM_PROVIDERS)
+					Policy.debug("Got Env proxy: " + pd); //$NON-NLS-1$
+				return pd;
+			}
+		} catch (Exception e) {
+			Activator.logError(
+					"Problem during accessing system variable: " + envName, e); //$NON-NLS-1$
+		}
+
+		if (isGnomeLibLoaded) {
+			try {
+				// Then ask Gnome
+				pd = getGSettingsProxyInfo(protocol);
+				if (pd != null) {
+					if (Policy.DEBUG_SYSTEM_PROVIDERS)
+						Policy.debug("Got Gnome proxy: " + pd); //$NON-NLS-1$
+					pd.setSource("FREEBSD_GNOME"); //$NON-NLS-1$
+					return pd;
+				}
+			} catch (UnsatisfiedLinkError e) {
+				// The library should be loaded, so this is a real exception
+				Activator.logError(
+						"Problem during accessing Gnome library", e); //$NON-NLS-1$
+			}
+		}
+
+		return null;
+	}
+
+	private static String getEnv(String env) {
+		try {
+			return System.getenv(env);
+		} catch (Throwable t) {
+			// Fall-back to running 'env' directly. Warning this is very slow...
+			// up to 200ms
+			String cmd[] = { "/bin/sh", //$NON-NLS-1$
+					"-c", //$NON-NLS-1$
+					"env | grep -i proxy" }; //$NON-NLS-1$
+			Properties props = new Properties();
+			Process proc = null;
+			try {
+				proc = Runtime.getRuntime().exec(cmd);
+				props.load(proc.getInputStream());
+			} catch (IOException e) {
+				Activator.logError(
+						"Problem during accessing system variable: " + env, e); //$NON-NLS-1$
+			} catch (IllegalArgumentException e) {
+				Activator.logError(
+						"Problem during accessing system variable: " + env, e); //$NON-NLS-1$
+			} finally {
+				if (proc != null) {
+					proc.destroy();
+				}
+			}
+			return props.getProperty(env);
+		}
+	}
+
+	private void debugPrint(String[] strs) {
+		for (int i = 0; i < strs.length; i++)
+			System.out.println(i + ": " + strs[i]); //$NON-NLS-1$
+	}
+
+	private interface LibGio extends Library {
+		Pointer g_settings_new(String schema);
+		boolean g_settings_get_boolean(Pointer settings, String key);
+		Pointer g_settings_get_string(Pointer settings, String key);
+		int g_settings_get_int(Pointer settings, String key);
+		PointerByReference g_settings_get_strv(Pointer Settings, String key);
+		void g_strfreev(PointerByReference p);
+		void g_free(Pointer p);
+	}
+
+	private static void initializeSettings() {
+		try {
+			fLibGio = Native.load(LIBRARY_NAME, LibGio.class);
+			proxySettings = fLibGio.g_settings_new ("org.gnome.system.proxy"); //$NON-NLS-1$
+			httpProxySettings = fLibGio.g_settings_new ("org.gnome.system.proxy.http"); //$NON-NLS-1$
+			httpsProxySettings = fLibGio.g_settings_new ("org.gnome.system.proxy.https"); //$NON-NLS-1$
+			socksProxySettings = fLibGio.g_settings_new ("org.gnome.system.proxy.socks"); //$NON-NLS-1$
+			ftpProxySettings = fLibGio.g_settings_new ("org.gnome.system.proxy.ftp"); //$NON-NLS-1$
+			isGnomeLibLoaded= true;
+			if (Policy.DEBUG_SYSTEM_PROVIDERS)
+				Policy.debug("Loaded " + //$NON-NLS-1$
+						System.mapLibraryName(LIBRARY_NAME) + " library"); //$NON-NLS-1$
+		} catch (UnsatisfiedLinkError e) {
+			isGnomeLibLoaded= false;
+			if (Policy.DEBUG_SYSTEM_PROVIDERS)
+				Policy.debug("Could not load library: " //$NON-NLS-1$
+						+ System.mapLibraryName(LIBRARY_NAME));
+		}
+	}
+
+	protected static ProxyData getGSettingsProxyInfo(String protocol) {
+
+		if (protocol == null) {
+			return null;
+		}
+
+		if (proxySettings == Pointer.NULL) {
+			initializeSettings();
+		}
+
+		// Everything else applies only if the system proxy mode is manual
+		// Auto-configuration is not supported
+		Pointer mode = fLibGio.g_settings_get_string(proxySettings, "mode"); //$NON-NLS-1$
+		if (!mode.getString(0).equalsIgnoreCase("manual")) { //$NON-NLS-1$
+			fLibGio.g_free(mode);
+			return null;
+		}
+		fLibGio.g_free(mode);
+
+		Pointer host;
+		int port;
+
+		switch (protocol.toLowerCase()) {
+		case "http": //$NON-NLS-1$
+			host = fLibGio.g_settings_get_string(httpProxySettings, "host"); //$NON-NLS-1$
+			port = fLibGio.g_settings_get_int(httpProxySettings, "port"); //$NON-NLS-1$
+			break;
+		case "https": //$NON-NLS-1$
+			host = fLibGio.g_settings_get_string(httpsProxySettings, "host"); //$NON-NLS-1$
+			port = fLibGio.g_settings_get_int(httpsProxySettings, "port"); //$NON-NLS-1$
+			break;
+		case "ftp": //$NON-NLS-1$
+			host = fLibGio.g_settings_get_string(ftpProxySettings, "host"); //$NON-NLS-1$
+			port = fLibGio.g_settings_get_int(ftpProxySettings, "port"); //$NON-NLS-1$
+			break;
+		case "socks": //$NON-NLS-1$
+			host = fLibGio.g_settings_get_string(socksProxySettings, "host"); //$NON-NLS-1$
+			port = fLibGio.g_settings_get_int(socksProxySettings, "port"); //$NON-NLS-1$
+			break;
+		default:
+			// Unknown/invalid proxy type
+			return null;
+		}
+
+		ProxyData proxyData = new ProxyData(protocol);
+		proxyData.setHost(host.getString(0));
+		fLibGio.g_free(host);
+		proxyData.setPort(port);
+
+		// Each proxy type is enabled only if the "host" key is non-empty and its "port" key is non-0
+		if (proxyData.getHost() == null || proxyData.getPort() == 0) {
+			return null;
+		}
+
+		if (protocol.equalsIgnoreCase("http")) { //$NON-NLS-1$
+			// Authentication applies only to http proxies
+			boolean reqAuth = fLibGio.g_settings_get_boolean(httpProxySettings, "use-authentication"); //$NON-NLS-1$
+			if (reqAuth) {
+				Pointer user = fLibGio.g_settings_get_string(httpProxySettings,	"authentication-user"); //$NON-NLS-1$
+				proxyData.setUserid(user.getString(0));
+				fLibGio.g_free(user);
+
+				Pointer password = fLibGio.g_settings_get_string(httpProxySettings,	"authentication-password"); //$NON-NLS-1$
+				proxyData.setPassword(password.getString(0));
+				fLibGio.g_free(password);
+			}
+		}
+
+		return proxyData;
+	}
+
+	protected static String[] getGSettingsNonProxyHosts() {
+		if (proxySettings == Pointer.NULL) {
+			initializeSettings();
+		}
+
+		// Everything else applies only if the system proxy mode is manual
+		// Auto-configuration is not supported
+		Pointer mode = fLibGio.g_settings_get_string(proxySettings, "mode"); //$NON-NLS-1$
+		if (!mode.getString(0).equalsIgnoreCase("manual")) { //$NON-NLS-1$
+			fLibGio.g_free(mode);
+			return null;
+		}
+		fLibGio.g_free(mode);
+
+		PointerByReference npHostsArray = fLibGio.g_settings_get_strv(proxySettings, "ignore-hosts"); //$NON-NLS-1$
+		String[] npHosts = npHostsArray.getPointer().getStringArray(0);
+
+		fLibGio.g_strfreev(npHostsArray);
+
+		return npHosts;
+	}
+
+}
+

--- a/ua/infocenter-web/infocenter-product/infocenter.product
+++ b/ua/infocenter-web/infocenter-product/infocenter.product
@@ -28,6 +28,7 @@ org.osgi.framework.bootdelegation=*
    </launcher>
 
    <vm>
+      <freebsd include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</freebsd>
       <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</linux>
       <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</macos>
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</windows>

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowserFactory.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowserFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Martin Oberhuber (Wind River) - [352077] error dialogs when just probing browser
  *     George Suaridze <suag@1c.ru> (1C-Soft LLC) - Bug 560168
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.help.ui.internal.browser.embedded;
 
@@ -66,6 +67,7 @@ public class EmbeddedBrowserFactory implements IBrowserFactory {
 	 */
 	private boolean test() {
 		if (!Constants.OS_WIN32.equalsIgnoreCase(Platform.getOS())
+				&& !Constants.OS_FREEBSD.equalsIgnoreCase(Platform.getOS())
 				&& !Constants.OS_LINUX.equalsIgnoreCase(Platform.getOS())) {
 			return false;
 		}

--- a/ua/org.eclipse.ui.intro.universal/plugin.xml
+++ b/ua/org.eclipse.ui.intro.universal/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-    Copyright (c) 2005, 2010 IBM Corporation and others.
+    Copyright (c) 2005, 2025 IBM Corporation and others.
 
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
 
     Contributors:
          IBM Corporation - initial API and implementation
+         Tue Ton - support for FreeBSD
  -->
 
 <plugin>
@@ -49,7 +50,7 @@
             <implementation
                   style="themes/shared/html/shared.css,$theme$/html/shared.css,$theme$/html/font-$fontStyle$.css,$theme$/html/$direction$.css"
                   kind="html"
-                  os="win32,linux,macosx,solaris">
+                  os="win32,linux,macosx,freebsd">
             </implementation>
             <implementation
                   kind="swt">


### PR DESCRIPTION
- part of eclipse-platform/eclipse.platform.releng.aggregator#2959
- add 2 file system modules for FreeBSD:
  `org.eclipse.core.filesystem.freebsd.aarch64` and `org.eclipse.core.filesystem.freebsd.x86_64`
- add a Makefile to compile the file system natives for FreeBSD.

To support cross-compiling from Linux to FreeBSD, for the same hardware architecture, a Docker container is made available in my fork with detailed instructions:
https://github.com/chirontt/eclipse.platform.releng.aggregator/tree/master/cje-production/dockerfiles/alpine/freebsd-cross which will be submitted to the official repo at later stage.
