### PR TITLE
Remove usages of deprecated fastViewWidthRatio

### DIFF
--- a/ant/org.eclipse.ant.ui/plugin.xml
+++ b/ant/org.eclipse.ant.ui/plugin.xml
@@ -38,7 +38,6 @@
             name="%View.antView"
             icon="$nl$/icons/full/eview16/ant_view.svg"
             category="org.eclipse.ant.ui.views"
-            fastViewWidthRatio="0.40"
             class="org.eclipse.ant.internal.ui.views.AntView"
             id="org.eclipse.ant.ui.views.AntView">
       </view>

--- a/debug/org.eclipse.unittest.ui/plugin.xml
+++ b/debug/org.eclipse.unittest.ui/plugin.xml
@@ -10,7 +10,6 @@
             name="%View.label"
             icon="$nl$/icons/full/eview16/unit.png"
             category="org.eclipse.debug.ui"
-            fastViewWidthRatio="0.40"
             class="org.eclipse.unittest.internal.ui.TestRunnerViewPart"
             id="org.eclipse.unittest.ui.ResultView">
       </view>

--- a/team/bundles/org.eclipse.team.ui/plugin.xml
+++ b/team/bundles/org.eclipse.team.ui/plugin.xml
@@ -292,7 +292,6 @@
       <view
             name="%SyncView.name"
             icon="$nl$/icons/full/eview16/synch_synch.svg"
-            fastViewWidthRatio="0.25"
             category="org.eclipse.team.ui"
             allowMultiple="true"
             class="org.eclipse.team.internal.ui.synchronize.SynchronizeView"
@@ -308,7 +307,6 @@
     <!--  <view
             name="%CompareView.name"
             icon="$nl$/icons/full/eview16/compare_view.svg"
-            fastViewWidthRatio="0.25"
             category="org.eclipse.team.ui"
             class="org.eclipse.team.internal.ui.synchronize.CompareView"
             id="org.eclipse.team.sync.views.CompareView">

--- a/ua/org.eclipse.ui.cheatsheets/plugin.xml
+++ b/ua/org.eclipse.ui.cheatsheets/plugin.xml
@@ -47,7 +47,6 @@
             name="%CHEAT_SHEETS"
             icon="$nl$/icons/view16/cheatsheet_view.svg"
             category="org.eclipse.help.ui"
-            fastViewWidthRatio="0.5"
             class="org.eclipse.ui.internal.cheatsheets.views.CheatSheetView"
             id="org.eclipse.ui.cheatsheets.views.CheatSheetView">
       </view>


### PR DESCRIPTION
Some plugins contained definitions of fastViewWidthRatio even though that value is not read for a while and was just deprecated. This change removes those definitions.