### PR TITLE
Replace disabled PNGs with runtime disablement in org.eclipse.debug.ui 

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -241,7 +241,6 @@
                definitionId="org.eclipse.debug.ui.commands.ToggleBreakpoint"
                label="%ToggleBreakpointAction.label"
                icon="$nl$/icons/full/obj16/brkp_obj.svg"
-               disabledIcon="$nl$/icons/full/obj16/brkpd_obj.png"
                helpContextId="toggle_breakpoint_action_context"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RetargetToggleBreakpointAction"
                menubarPath="org.eclipse.ui.run/lineBreakpointBeforeGroup"
@@ -250,7 +249,6 @@
          <action
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RemoveAllBreakpointsAction"
                definitionId="org.eclipse.debug.ui.commands.RemoveAllBreakpoints"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_all_co.png"
                helpContextId="remove_all_breakpoints_action_context"
                icon="$nl$/icons/full/elcl16/rem_all_co.svg"
                id="org.eclipse.debug.ui.actions.RemoveAllBreakpoints"
@@ -273,7 +271,6 @@
                definitionId="org.eclipse.debug.ui.commands.ToggleMethodBreakpoint"
                label="%ToggleMethodBreakpointAction.label"
                icon="$nl$/icons/full/obj16/brkp_obj.svg"
-               disabledIcon="$nl$/icons/full/obj16/brkpd_obj.png"
                helpContextId="toggle_method_breakpoint_action_context"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RetargetMethodBreakpointAction"
                menubarPath="org.eclipse.ui.run/lineBreakpointAfterGroup"
@@ -283,7 +280,6 @@
                definitionId="org.eclipse.debug.ui.commands.ToggleWatchpoint"
                label="%ToggleWatchpointAction.label"
                icon="$nl$/icons/full/obj16/readwrite_obj.svg"
-               disabledIcon="$nl$/icons/full/obj16/readwrite_obj_disabled.png"
                helpContextId="toggle_watchpoint_action_context"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RetargetWatchpointAction"
                menubarPath="org.eclipse.ui.run/lineBreakpointAfterGroup"
@@ -293,7 +289,6 @@
                definitionId="org.eclipse.debug.ui.commands.ToggleLineBreakpoint"
                label="%ToggleLineBreakpointAction.label"
                icon="$nl$/icons/full/obj16/brkp_obj.svg"
-               disabledIcon="$nl$/icons/full/obj16/brkpd_obj.png"
                helpContextId="toggle_line_breakpoint_action_context"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RetargetToggleLineBreakpointAction"
                menubarPath="org.eclipse.ui.run/lineBreakpointAfterGroup"
@@ -328,7 +323,6 @@
                id="org.eclipse.debug.ui.actions.ToggleStepFilters"
                class="org.eclipse.debug.internal.ui.commands.actions.ToggleStepFiltersCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.ToggleStepFilters"
-               disabledIcon="$nl$/icons/full/dlcl16/stepbystep_co.png"
                icon="$nl$/icons/full/elcl16/stepbystep_co.svg"
                helpContextId="org.eclipse.debug.ui.step_with_filters_action_context"
                label="%StepWithFiltersAction.label"
@@ -353,7 +347,6 @@
                class="org.eclipse.debug.internal.ui.actions.RetargetRunToLineAction"
                definitionId="org.eclipse.debug.ui.commands.RunToLine"
                helpContextId="run_to_line_action_context"
-               disabledIcon="$nl$/icons/full/dlcl16/runtoline_co.png"
                icon="$nl$/icons/full/elcl16/runtoline_co.svg"
                label="%RunToLine.label"
                menubarPath="org.eclipse.ui.run/emptyStepGroup"
@@ -364,7 +357,6 @@
                id="org.eclipse.debug.ui.actions.StepReturn"
                class="org.eclipse.debug.internal.ui.commands.actions.StepReturnCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.StepReturn"
-               disabledIcon="$nl$/icons/full/dlcl16/stepreturn_co.png"
                icon="$nl$/icons/full/elcl16/stepreturn_co.svg"
                helpContextId="step_return_action_context"
                label="%StepReturnAction.label"
@@ -376,7 +368,6 @@
                id="org.eclipse.debug.ui.actions.StepOver"
                class="org.eclipse.debug.internal.ui.commands.actions.StepOverCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.StepOver"
-               disabledIcon="$nl$/icons/full/dlcl16/stepover_co.png"
                icon="$nl$/icons/full/elcl16/stepover_co.svg"
                helpContextId="step_over_action_context"
                label="%StepOverAction.label"
@@ -388,7 +379,6 @@
                id="org.eclipse.debug.ui.actions.StepInto"
                class="org.eclipse.debug.internal.ui.commands.actions.StepIntoCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.StepInto"
-               disabledIcon="$nl$/icons/full/dlcl16/stepinto_co.png"
                icon="$nl$/icons/full/elcl16/stepinto_co.svg"
                helpContextId="step_into_action_context"
                label="%StepIntoAction.label"
@@ -400,7 +390,6 @@
                id="org.eclipse.debug.ui.actions.toolbar.Disconnect"
                class="org.eclipse.debug.internal.ui.commands.actions.DisconnectCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.Disconnect"
-               disabledIcon="$nl$/icons/full/dlcl16/disconnect_co.png"
                icon="$nl$/icons/full/elcl16/disconnect_co.svg"
                helpContextId="disconnect_action_context"
                label="%Disconnect.label"
@@ -412,7 +401,6 @@
                id="org.eclipse.debug.ui.actions.Terminate"
                class="org.eclipse.debug.internal.ui.commands.actions.TerminateCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.Terminate"
-               disabledIcon="$nl$/icons/full/dlcl16/terminate_co.png"
                icon="$nl$/icons/full/elcl16/terminate_co.svg"
                helpContextId="terminate_action_context"
                label="%TerminateAction.label"
@@ -424,7 +412,6 @@
                id="org.eclipse.debug.ui.actions.Suspend"
                class="org.eclipse.debug.internal.ui.commands.actions.SuspendCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.Suspend"
-               disabledIcon="$nl$/icons/full/dlcl16/suspend_co.png"
                icon="$nl$/icons/full/elcl16/suspend_co.svg"
                helpContextId="suspend_action_context"
                label="%SuspendAction.label"
@@ -436,7 +423,6 @@
                id="org.eclipse.debug.ui.actions.Resume"
                class="org.eclipse.debug.internal.ui.commands.actions.ResumeCommandActionDelegate"
                definitionId="org.eclipse.debug.ui.commands.Resume"
-               disabledIcon="$nl$/icons/full/dlcl16/resume_co.png"
                icon="$nl$/icons/full/elcl16/resume_co.svg"
                helpContextId="resume_action_context"
                label="%ResumeAction.label"
@@ -476,7 +462,6 @@
          </action>
          <action
                class="org.eclipse.debug.internal.ui.actions.RunAsAction"
-               disabledIcon="$nl$/icons/full/dtool16/run_exc.png"
                helpContextId="run_with_configuration_action_context"
                icon="$nl$/icons/full/etool16/run_exc.svg"
                id="org.eclipse.debug.internal.ui.actions.RunWithConfigurationAction"
@@ -496,7 +481,6 @@
                id="org.eclipse.debug.ui.actions.DebugLast"
                class="org.eclipse.debug.internal.ui.actions.DebugLastAction"
                definitionId="org.eclipse.debug.ui.commands.DebugLast"
-               disabledIcon="$nl$/icons/full/dlcl16/debuglast_co.png"
                icon="$nl$/icons/full/elcl16/debuglast_co.svg"
                helpContextId="debug_last_action_context"
                label="%ContextLaunchingDebugMenu.name"
@@ -506,7 +490,6 @@
                id="org.eclipse.debug.ui.actions.RunLast"
                class="org.eclipse.debug.internal.ui.actions.RunLastAction"
                definitionId="org.eclipse.debug.ui.commands.RunLast"
-               disabledIcon="$nl$/icons/full/dlcl16/runlast_co.png"
                icon="$nl$/icons/full/elcl16/runlast_co.svg"
                helpContextId="run_last_action_context"
                label="%ContextLaunchingRunMenu.name"
@@ -516,7 +499,6 @@
                id="org.eclipse.debug.internal.ui.actions.RunDropDownAction"
                toolbarPath="org.eclipse.debug.ui.launchActionSet/debug"
                class="org.eclipse.debug.internal.ui.actions.RunToolbarAction"
-               disabledIcon="$nl$/icons/full/dtool16/run_exc.png"
                icon="$nl$/icons/full/etool16/run_exc.svg"
                helpContextId="run_action_context"
                label="%RunDropDownAction.label"
@@ -532,7 +514,6 @@
          </action>
          <action
                class="org.eclipse.debug.internal.ui.actions.DebugAsAction"
-               disabledIcon="$nl$/icons/full/dtool16/debug_exc.png"
                helpContextId="debug_with_configuration_action_context"
                icon="$nl$/icons/full/etool16/debug_exc.svg"
                id="org.eclipse.debug.internal.ui.actions.DebugWithConfigurationAction"
@@ -552,7 +533,6 @@
                id="org.eclipse.debug.internal.ui.actions.DebugDropDownAction"
                toolbarPath="org.eclipse.debug.ui.launchActionSet/debug"
                class="org.eclipse.debug.internal.ui.actions.DebugToolbarAction"
-               disabledIcon="$nl$/icons/full/dtool16/debug_exc.png"
                icon="$nl$/icons/full/etool16/debug_exc.svg"
                helpContextId="debug_action_context"
                label="%DebugDropDownAction.label"
@@ -578,7 +558,6 @@
                id="org.eclipse.debug.internal.ui.actions.ProfileDropDownAction"
                toolbarPath="org.eclipse.debug.ui.launchActionSet/debug"
                class="org.eclipse.debug.internal.ui.actions.ProfileToolbarAction"
-               disabledIcon="$nl$/icons/full/dtool16/profile_exc.png"
                icon="$nl$/icons/full/etool16/profile_exc.svg"
                helpContextId="profile_action_context"
                label="%ProfileDropDownAction.label"
@@ -599,7 +578,6 @@
                class="org.eclipse.debug.internal.ui.actions.ProfileAsAction"
                menubarPath="org.eclipse.ui.run/profileGroup"
                icon="$nl$/icons/full/etool16/profile_exc.svg"
-               disabledIcon="$nl$/icons/full/dtool16/profile_exc.png"
                id="org.eclipse.debug.internal.ui.actions.ProfileWithConfigurationAction">
          </action>
          <action
@@ -614,7 +592,6 @@
                id="org.eclipse.debug.ui.actions.ProfileLast"
                class="org.eclipse.debug.internal.ui.actions.ProfileLastAction"
                definitionId="org.eclipse.debug.ui.commands.ProfileLast"
-               disabledIcon="$nl$/icons/full/dtool16/profile_exc.png"
                icon="$nl$/icons/full/etool16/profile_exc.svg"
                helpContextId="profile_last_action_context"
                label="%ProfileLastAction.label"
@@ -787,7 +764,6 @@
                id="org.eclipse.debug.ui.debugview.toolbar.removeAllTerminated"
                toolbarPath="threadGroup"
                class="org.eclipse.debug.internal.ui.actions.RemoveAllTerminatedAction"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_all_co.png"
                icon="$nl$/icons/full/elcl16/rem_all_co.svg"
                helpContextId="remove_all_terminated_action_context"
                label="%RemoveAllTerminatedAction.label"
@@ -797,7 +773,6 @@
                id="org.eclipse.debug.ui.debugview.toolbar.collapseAll"
                toolbarPath="threadGroup"
                class="org.eclipse.debug.internal.ui.actions.LaunchCollapseAllAction"
-               disabledIcon="$nl$/icons/full/dlcl16/collapseall.png"
                icon="$nl$/icons/full/elcl16/collapseall.svg"
                helpContextId="collapse_all_action_context"
                label="%CollapseAllAction.label"
@@ -813,7 +788,6 @@
                id="org.eclipse.debug.ui.breakpointsView.toolbar.removeAll"
                toolbarPath="breakpointGroup"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RemoveAllBreakpointsAction"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_all_co.png"
                icon="$nl$/icons/full/elcl16/rem_all_co.svg"
                helpContextId="remove_all_breakpoints_action_context"
                label="%RemoveAllAction.label"
@@ -824,7 +798,6 @@
                definitionId="org.eclipse.ui.edit.delete"
                toolbarPath="breakpointGroup"
                class="org.eclipse.debug.internal.ui.actions.breakpoints.RemoveBreakpointAction"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_co.png"
                icon="$nl$/icons/full/elcl16/rem_co.svg"
                helpContextId="remove_breakpoint_action_context"
                label="%RemoveAction.label"
@@ -912,7 +885,6 @@
                id="org.eclipse.debug.ui.expresssionsView.toolbar.removeAll"
                toolbarPath="expressionGroup"
                class="org.eclipse.debug.internal.ui.actions.expressions.RemoveAllExpressionsAction"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_all_co.png"
                icon="$nl$/icons/full/elcl16/rem_all_co.svg"
                helpContextId="remove_all_expressions_action_context"
                label="%RemoveAllAction.label"
@@ -923,7 +895,6 @@
                toolbarPath="expressionGroup"
                definitionId="org.eclipse.ui.edit.delete"
                class="org.eclipse.debug.internal.ui.actions.expressions.RemoveExpressionAction"
-               disabledIcon="$nl$/icons/full/dlcl16/rem_co.png"
                icon="$nl$/icons/full/elcl16/rem_co.svg"
                helpContextId="remove_expression_action_context"
                label="%RemoveAction.label"
@@ -968,7 +939,6 @@
                toolbarPath="additions"
                tooltip="%NewMemoryViewAction.tooltip"/>
          <action
-               disabledIcon="$nl$/icons/full/dlcl16/var_cntnt_prvdr.png"
                toolbarPath="MemoryMonitorsGroup"
                label="%ToggleMemoryMonitorsPaneAction.name"
                tooltip="%ToggleMemoryMonitorsPaneAction.tooltip"
@@ -977,7 +947,6 @@
                style="toggle"
                id="org.eclipse.debug.ui.togglemonitors"/>
          <action
-               disabledIcon="$nl$/icons/full/dlcl16/synced.png"
                toolbarPath="RenderingPanesGroup"
                label="%LinkRenderingPanesAction.name"
                tooltip="%LinkRenderingPanesAction.tooltip"
@@ -994,7 +963,6 @@
                style="push"
                tooltip="%TableRenderingPrefActionName"/>
          <action
-               disabledIcon="$nl$/icons/full/dlcl16/det_pane_right.png"
                toolbarPath="RenderingPanesGroup"
                label="%ToggleSplitPaneAction.name"
                tooltip="%ToggleSplitPaneAction.tooltip"
@@ -1004,7 +972,6 @@
                id="org.eclipse.debug.ui.togglesplitpane"/>
          <action
                class="org.eclipse.debug.internal.ui.views.memory.SwitchMemoryBlockAction"
-               disabledIcon="$nl$/icons/full/dlcl16/display_selected_mb.png"
                helpContextId="switchMemoryBlockAction_context"
                icon="$nl$/icons/full/elcl16/display_selected_mb.svg"
                id="org.eclipse.debug.ui.switchMemoryBlock"
@@ -2279,56 +2246,45 @@ M4 = Platform-specific fourth key
   	<extension point="org.eclipse.ui.commandImages">
        <image
           commandId="org.eclipse.debug.ui.commands.ToggleStepFilters"
-          icon="$nl$/icons/full/elcl16/stepbystep_co.svg"
-          disabledIcon="$nl$/icons/full/dlcl16/stepbystep_co.png"/>
+          icon="$nl$/icons/full/elcl16/stepbystep_co.svg" />
        <image
              commandId="org.eclipse.debug.ui.commands.StepInto"
-             disabledIcon="$nl$/icons/full/dlcl16/stepinto_co.png"
              icon="$nl$/icons/full/elcl16/stepinto_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.StepOver"
-             disabledIcon="$nl$/icons/full/dlcl16/stepover_co.png"
              icon="$nl$/icons/full/elcl16/stepover_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.StepReturn"
-             disabledIcon="$nl$/icons/full/dlcl16/stepreturn_co.png"
              icon="$nl$/icons/full/elcl16/stepreturn_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.Resume"
-             disabledIcon="$nl$/icons/full/dlcl16/resume_co.png"
              icon="$nl$/icons/full/elcl16/resume_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.Terminate"
-             disabledIcon="$nl$/icons/full/dlcl16/terminate_co.png"
              icon="$nl$/icons/full/elcl16/terminate_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.DebugLast"
-             disabledIcon="$nl$/icons/full/dlcl16/debuglast_co.png"
              icon="$nl$/icons/full/elcl16/debuglast_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.RunLast"
-             disabledIcon="$nl$/icons/full/dlcl16/runlast_co.png"
              icon="$nl$/icons/full/elcl16/runlast_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.RunToLine"
-             disabledIcon="$nl$/icons/full/dlcl16/runtoline_co.png"
              icon="$nl$/icons/full/elcl16/runtoline_co.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.ToggleBreakpoint"
-             disabledIcon="$nl$/icons/full/obj16/brkpd_obj.png"
              icon="$nl$/icons/full/obj16/brkp_obj.svg">
        </image>
        <image
              commandId="org.eclipse.debug.ui.commands.Suspend"
-             disabledIcon="$nl$/icons/full/dlcl16/suspend_co.png"
              icon="$nl$/icons/full/elcl16/suspend_co.svg">
        </image>
     </extension>

--- a/debug/org.eclipse.debug.ui/schema/breakpointOrganizers.exsd
+++ b/debug/org.eclipse.debug.ui/schema/breakpointOrganizers.exsd
@@ -112,7 +112,7 @@ Organizers with the specified name will be automatically created by the Debug Pl
     class=&quot;com.example.BreakpointOrganizer&quot;
      id=&quot;com.example.BreakpointOrganizer&quot;
      label=&quot;Example Organizer&quot;
-     icon=&quot;icons/full/obj16/example_org.png&quot;/&gt;
+     icon=&quot;icons/full/obj16/example_org.svg&quot;/&gt;
 &lt;/extension&gt;
 &lt;/pre&gt;
 In the above example, the supplied factory will be included in the list of options for grouping breakpoints (&quot;Group By &gt; Example Organizer&quot;). When selected, the associated organizer will be used to categorize breakpoints.

--- a/debug/org.eclipse.debug.ui/schema/launchConfigurationTypeImages.exsd
+++ b/debug/org.eclipse.debug.ui/schema/launchConfigurationTypeImages.exsd
@@ -71,7 +71,7 @@
   &lt;launchConfigurationTypeImage
      id=&quot;com.example.FirstLaunchConfigurationTypeImage&quot;
      configTypeID=&quot;com.example.FirstLaunchConfigurationType&quot;
-     icon=&quot;icons/FirstLaunchConfigurationType.png&quot;&gt;
+     icon=&quot;icons/FirstLaunchConfigurationType.svg&quot;&gt;
   &lt;/launchConfigurationTypeImage&gt;
  &lt;/extension&gt;
 &lt;/pre&gt;

--- a/debug/org.eclipse.debug.ui/schema/launchGroups.exsd
+++ b/debug/org.eclipse.debug.ui/schema/launchGroups.exsd
@@ -140,8 +140,8 @@
      id=&quot;com.example.ExampleLaunchGroupId&quot;
      mode=&quot;run&quot;
      label=&quot;Run&quot;
-     image=&quot;icons\run.png&quot;
-     bannerImage=&quot;icons\runBanner.png&quot;&gt;
+     image=&quot;icons\run.svg&quot;
+     bannerImage=&quot;icons\runBanner.svg&quot;&gt;
   &lt;/launchGroup&gt;
  &lt;/extension&gt;
 &lt;/pre&gt;

--- a/debug/org.eclipse.debug.ui/schema/launchShortcuts.exsd
+++ b/debug/org.eclipse.debug.ui/schema/launchShortcuts.exsd
@@ -271,7 +271,7 @@ New in 3.4, clients can implement &lt;code&gt;org.eclipse.debug.ui.ILaunchShortc
  &lt;extension point=&quot;org.eclipse.debug.ui.launchShortcuts&quot;&gt;
   &lt;shortcut
     label=&quot;Java Application&quot;
-    icon=&quot;$nl$/icons/full/etool16/java_app.png&quot;
+    icon=&quot;$nl$/icons/full/etool16/java_app.svg&quot;
     helpContextId=&quot;org.eclipse.jdt.debug.ui.shortcut_local_java_application&quot;
     modes=&quot;run, debug&quot;
     class=&quot;org.eclipse.jdt.internal.debug.ui.launcher.JavaApplicationLaunchShortcut&quot;

--- a/debug/org.eclipse.debug.ui/schema/sourceContainerPresentations.exsd
+++ b/debug/org.eclipse.debug.ui/schema/sourceContainerPresentations.exsd
@@ -103,7 +103,7 @@
       &lt;sourceContainerPresentation
             browserClass=&quot;org.eclipse.debug.internal.ui.sourcelookup.browsers.ProjectSourceContainerBrowser&quot;
             containerTypeID=&quot;org.eclipse.debug.core.containerType.project&quot;
-            icon=&quot;icons/full/obj16/prj_obj.png&quot;
+            icon=&quot;icons/full/obj16/prj_obj.svg&quot;
             id=&quot;org.eclipse.debug.ui.containerPresentation.project&quot;&gt;
       &lt;/sourceContainerPresentation&gt;
    &lt;/extension&gt;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
@@ -29,6 +29,7 @@ import org.eclipse.debug.internal.core.IConfigurationElementConstants;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -50,8 +51,6 @@ public class DebugPluginImages {
 
 	// Use IPath and toOSString to build the names to ensure they have the slashes correct
 	private final static String CTOOL= ICONS_PATH + "etool16/"; //basic colors - size 16x16 //$NON-NLS-1$
-	private final static String DTOOL= ICONS_PATH + "dtool16/"; //basic colors - size 16x16 //$NON-NLS-1$
-	private final static String DLCL= ICONS_PATH + "dlcl16/"; //disabled - size 16x16 //$NON-NLS-1$
 	private final static String ELCL= ICONS_PATH + "elcl16/"; //enabled - size 16x16 //$NON-NLS-1$
 	private final static String OBJECT= ICONS_PATH + "obj16/"; //basic colors - size 16x16 //$NON-NLS-1$
 	private final static String WIZBAN= ICONS_PATH + "wizban/"; //basic colors - size 16x16 //$NON-NLS-1$
@@ -69,105 +68,102 @@ public class DebugPluginImages {
 		declareRegistryImage(IDebugUIConstants.IMG_SKIP_BREAKPOINTS, ELCL + "skip_brkp.svg"); //$NON-NLS-1$
 
 		//menus
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_CHANGE_VARIABLE_VALUE, ELCL + "changevariablevalue_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_CHANGE_VARIABLE_VALUE, DLCL + "changevariablevalue_co.png"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_CHANGE_VARIABLE_VALUE,
+				IInternalDebugUIConstants.IMG_DLCL_CHANGE_VARIABLE_VALUE, ELCL + "changevariablevalue_co.svg"); //$NON-NLS-1$
 
 		declareRegistryImage(IDebugUIConstants.IMG_LCL_CONTENT_ASSIST, ELCL + "metharg_obj.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_DLCL_CONTENT_ASSIST, DLCL + "metharg_obj.png"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_ELCL_CONTENT_ASSIST, ELCL + "metharg_obj.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_ELCL_CONTENT_ASSIST, IDebugUIConstants.IMG_DLCL_CONTENT_ASSIST,
+				ELCL + "metharg_obj.svg"); //$NON-NLS-1$
 
-		//Local toolbars
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE, ELCL + "toggledetailpane_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_UNDER, ELCL + "det_pane_under.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_RIGHT, ELCL + "det_pane_right.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_HIDE, ELCL + "det_pane_hide.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_LOCK, ELCL + "lock_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_TYPE_NAMES, ELCL + "tnames_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_DISCONNECT, ELCL + "disconnect_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_REMOVE_ALL, ELCL + "rem_all_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_REMOVE, ELCL + "rem_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_LCL_ADD, ELCL + "monitorexpression_tsk.svg"); //$NON-NLS-1$
+		// Local toolbars
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE, IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE,
+				ELCL + "toggledetailpane_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_UNDER,
+				IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_UNDER, ELCL + "det_pane_under.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_RIGHT,
+				IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_RIGHT, ELCL + "det_pane_right.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_DETAIL_PANE_HIDE,
+				IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_HIDE, ELCL + "det_pane_hide.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_LOCK, IInternalDebugUIConstants.IMG_DLCL_LOCK,
+				ELCL + "lock_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_TYPE_NAMES, IInternalDebugUIConstants.IMG_DLCL_TYPE_NAMES,
+				ELCL + "tnames_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_DISCONNECT, IInternalDebugUIConstants.IMG_DLCL_DISCONNECT,
+				ELCL + "disconnect_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_REMOVE_ALL, IInternalDebugUIConstants.IMG_DLCL_REMOVE_ALL,
+				ELCL + "rem_all_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_REMOVE, IInternalDebugUIConstants.IMG_DLCL_REMOVE,
+				ELCL + "rem_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_LCL_ADD, IInternalDebugUIConstants.IMG_DLCL_MONITOR_EXPRESSION,
+				ELCL + "monitorexpression_tsk.svg"); //$NON-NLS-1$
 
-		// disabled local toolbars
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE, DLCL + "toggledetailpane_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_UNDER, DLCL + "det_pane_under.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_RIGHT, DLCL + "det_pane_right.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_HIDE, DLCL + "det_pane_hide.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_AUTO, DLCL + "det_pane_auto.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_LOCK, DLCL + "lock_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TYPE_NAMES, DLCL + "tnames_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_SHOW_LOGICAL_STRUCTURE, DLCL + "var_cntnt_prvdr.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_COLLAPSE_ALL, DLCL + "collapseall.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TERMINATE, DLCL + "terminate_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_REMOVE_ALL, DLCL + "rem_all_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_REMOVE, DLCL + "rem_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_RUN_TO_LINE, DLCL + "runtoline_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_MONITOR_EXPRESSION, DLCL + "monitorexpression_tsk.png");  //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_REMOVE_MEMORY, DLCL + "removememory_tsk.png");  //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_RESET_MEMORY, DLCL + "memoryreset_tsk.png");  //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_COPY_VIEW_TO_CLIPBOARD, DLCL + "copyviewtoclipboard_tsk.png");  //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_PRINT_TOP_VIEW_TAB, DLCL + "printview_tsk.png");  //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DUPLICATE_CONFIG, DLCL + "copy_edit_co.png");   //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_NEW_CONFIG, DLCL + "new_con.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DELETE_CONFIG, DLCL + "rem_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_FILTER_CONFIGS, DLCL + "filter_ps.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_NEW_PROTO, DLCL + "new_proto.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_LINK_PROTO, DLCL + "link_proto.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_UNLINK_PROTO, DLCL + "unlink_proto.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_RESET_PROTO, DLCL + "reset_proto.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_DISCONNECT, DLCL + "disconnect_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_SUSPEND, DLCL + "suspend_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_RESUME, DLCL + "resume_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_STEP_RETURN, DLCL+ "stepreturn_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_STEP_OVER, DLCL + "stepover_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_STEP_INTO, DLCL + "stepinto_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TERMINATE_AND_REMOVE, DLCL + "terminate_rem_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TERMINATE_ALL, DLCL + "terminate_all_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TERMINATE_AND_RELAUNCH, DTOOL + "term_restart.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_TOGGLE_STEP_FILTERS, DLCL+"stepbystep_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_NEXT_THREAD, DLCL+"next_thread_nav.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_PREVIOUS_THREAD, DLCL+"prev_thread_nav.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_RESTART, DLCL+"restart_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_DLCL_EXPORT_CONFIG, DLCL + "export_config.png"); //$NON-NLS-1$
-
-		// enabled local toolbars
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DETAIL_PANE_AUTO, ELCL + "det_pane_auto.svg"); //$NON-NLS-1$
+		// local toolbars
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DETAIL_PANE_AUTO,
+				IInternalDebugUIConstants.IMG_DLCL_DETAIL_PANE_AUTO, ELCL + "det_pane_auto.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DEBUG_VIEW_COMPACT_LAYOUT,
 				ELCL + "debug_view_compact.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_SHOW_LOGICAL_STRUCTURE, ELCL + "var_cntnt_prvdr.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_COLLAPSE_ALL, ELCL + "collapseall.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE, ELCL + "terminate_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RUN_TO_LINE, ELCL + "runtoline_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_REMOVE_MEMORY, ELCL + "removememory_tsk.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESET_MEMORY, ELCL + "memoryreset_tsk.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_SHOW_LOGICAL_STRUCTURE,
+				IInternalDebugUIConstants.IMG_DLCL_SHOW_LOGICAL_STRUCTURE, ELCL + "var_cntnt_prvdr.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_COLLAPSE_ALL,
+				IInternalDebugUIConstants.IMG_DLCL_COLLAPSE_ALL, ELCL + "collapseall.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE, IInternalDebugUIConstants.IMG_DLCL_TERMINATE,
+				ELCL + "terminate_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RUN_TO_LINE,
+				IInternalDebugUIConstants.IMG_DLCL_RUN_TO_LINE, ELCL + "runtoline_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_REMOVE_MEMORY,
+				IInternalDebugUIConstants.IMG_DLCL_REMOVE_MEMORY, ELCL + "removememory_tsk.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESET_MEMORY,
+				IInternalDebugUIConstants.IMG_DLCL_RESET_MEMORY, ELCL + "memoryreset_tsk.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_COPY_VIEW_TO_CLIPBOARD,
-				ELCL + "copyviewtoclipboard_tsk.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_PRINT_TOP_VIEW_TAB, ELCL + "printview_tsk.svg"); //$NON-NLS-1$
+				IInternalDebugUIConstants.IMG_DLCL_COPY_VIEW_TO_CLIPBOARD, ELCL + "copyviewtoclipboard_tsk.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_PRINT_TOP_VIEW_TAB,
+				IInternalDebugUIConstants.IMG_DLCL_PRINT_TOP_VIEW_TAB, ELCL + "printview_tsk.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_HIERARCHICAL, ELCL + "hierarchicalLayout.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_FILTER_CONFIGS, ELCL + "filter_ps.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DUPLICATE_CONFIG, ELCL + "copy_edit_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEW_CONFIG, ELCL + "new_con.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DELETE_CONFIG, ELCL + "delete_config.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEW_PROTO, ELCL + "new_proto.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_LINK_PROTO, ELCL + "link_proto.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_UNLINK_PROTO, ELCL + "unlink_proto.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESET_PROTO, ELCL + "reset_proto.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_SUSPEND, ELCL + "suspend_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESUME, ELCL + "resume_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_RETURN, ELCL + "stepreturn_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_OVER, ELCL + "stepover_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_INTO, ELCL + "stepinto_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_FILTER_CONFIGS,
+				IInternalDebugUIConstants.IMG_DLCL_FILTER_CONFIGS, ELCL + "filter_ps.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DUPLICATE_CONFIG,
+				IInternalDebugUIConstants.IMG_DLCL_DUPLICATE_CONFIG, ELCL + "copy_edit_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEW_CONFIG,
+				IInternalDebugUIConstants.IMG_DLCL_NEW_CONFIG, ELCL + "new_con.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DELETE_CONFIG,
+				IInternalDebugUIConstants.IMG_DLCL_DELETE_CONFIG, ELCL + "delete_config.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEW_PROTO, IInternalDebugUIConstants.IMG_DLCL_NEW_PROTO,
+				ELCL + "new_proto.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_LINK_PROTO,
+				IInternalDebugUIConstants.IMG_DLCL_LINK_PROTO, ELCL + "link_proto.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_UNLINK_PROTO,
+				IInternalDebugUIConstants.IMG_DLCL_UNLINK_PROTO, ELCL + "unlink_proto.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESET_PROTO,
+				IInternalDebugUIConstants.IMG_DLCL_RESET_PROTO, ELCL + "reset_proto.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_SUSPEND, IInternalDebugUIConstants.IMG_DLCL_SUSPEND,
+				ELCL + "suspend_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESUME, IInternalDebugUIConstants.IMG_DLCL_RESUME,
+				ELCL + "resume_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_RETURN,
+				IInternalDebugUIConstants.IMG_DLCL_STEP_RETURN, ELCL + "stepreturn_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_OVER, IInternalDebugUIConstants.IMG_DLCL_STEP_OVER,
+				ELCL + "stepover_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STEP_INTO, IInternalDebugUIConstants.IMG_DLCL_STEP_INTO,
+				ELCL + "stepinto_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_DROP_TO_FRAME, ELCL + "drop_to_frame.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_REMOVE, ELCL + "terminate_rem_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_ALL, ELCL + "terminate_all_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_RELAUNCH, CTOOL + "term_restart.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TOGGLE_STEP_FILTERS, ELCL + "stepbystep_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_REMOVE,
+				IInternalDebugUIConstants.IMG_DLCL_TERMINATE_AND_REMOVE, ELCL + "terminate_rem_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_ALL,
+				IInternalDebugUIConstants.IMG_DLCL_TERMINATE_ALL, ELCL + "terminate_all_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_RELAUNCH,
+				IInternalDebugUIConstants.IMG_DLCL_TERMINATE_AND_RELAUNCH, CTOOL + "term_restart.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_TOGGLE_STEP_FILTERS,
+				IInternalDebugUIConstants.IMG_DLCL_TOGGLE_STEP_FILTERS, ELCL + "stepbystep_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STANDARD_OUT, ELCL + "writeout_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_STANDARD_ERR, ELCL + "writeerr_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEXT_THREAD, ELCL + "next_thread_nav.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_PREVIOUS_THREAD, ELCL + "prev_thread_nav.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESTART, ELCL + "restart_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_EXPORT_CONFIG, ELCL + "export_config.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_NEXT_THREAD,
+				IInternalDebugUIConstants.IMG_DLCL_NEXT_THREAD, ELCL + "next_thread_nav.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_PREVIOUS_THREAD,
+				IInternalDebugUIConstants.IMG_DLCL_PREVIOUS_THREAD, ELCL + "prev_thread_nav.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_RESTART, IInternalDebugUIConstants.IMG_DLCL_RESTART,
+				ELCL + "restart_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_ELCL_EXPORT_CONFIG,
+				IInternalDebugUIConstants.IMG_DLCL_EXPORT_CONFIG, ELCL + "export_config.svg"); //$NON-NLS-1$
 
 		//Object
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_LAUNCH_DEBUG, OBJECT + "ldebug_obj.svg"); //$NON-NLS-1$
@@ -185,15 +181,16 @@ public class DebugPluginImages {
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_REGISTER, OBJECT + "genericregister_obj.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_REGISTER_GROUP, OBJECT + "genericreggroup_obj.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_BREAKPOINT, OBJECT + "brkp_obj.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_OBJS_BREAKPOINT_DISABLED, OBJECT + "brkpd_obj.png"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_OBJS_BREAKPOINT_DISABLED, OBJECT + "brkpd_obj.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_BREAKPOINT_GROUP, OBJECT + "brkp_grp.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_BREAKPOINT_GROUP_DISABLED, OBJECT + "brkp_grp_disabled.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_WATCHPOINT, OBJECT + "readwrite_obj.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_OBJS_WATCHPOINT_DISABLED, OBJECT + "readwrite_obj_disabled.png"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_OBJS_WATCHPOINT_DISABLED, OBJECT + "readwrite_obj_disabled.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_ACCESS_WATCHPOINT, OBJECT + "read_obj.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_OBJS_ACCESS_WATCHPOINT_DISABLED, OBJECT + "read_obj_disabled.png"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_OBJS_ACCESS_WATCHPOINT_DISABLED, OBJECT + "read_obj_disabled.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_MODIFICATION_WATCHPOINT, OBJECT + "write_obj.svg"); //$NON-NLS-1$
-		declareRegistryImage(IDebugUIConstants.IMG_OBJS_MODIFICATION_WATCHPOINT_DISABLED, OBJECT + "write_obj_disabled.png"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_OBJS_MODIFICATION_WATCHPOINT_DISABLED,
+				OBJECT + "write_obj_disabled.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_OS_PROCESS, OBJECT + "osprc_obj.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_OS_PROCESS_TERMINATED, OBJECT + "osprct_obj.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_OBJS_EXPRESSION, OBJECT + "expression_obj.svg"); //$NON-NLS-1$
@@ -243,8 +240,8 @@ public class DebugPluginImages {
 
 		//source location
 		declareRegistryImage(IInternalDebugUIConstants.IMG_SRC_LOOKUP_MENU, ELCL + "edtsrclkup_co.svg"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_SRC_LOOKUP_MENU_DLCL, DLCL + "edtsrclkup_co.png"); //$NON-NLS-1$
-		declareRegistryImage(IInternalDebugUIConstants.IMG_SRC_LOOKUP_MENU_ELCL, ELCL + "edtsrclkup_co.svg"); //$NON-NLS-1$
+		declareRegistryImage(IInternalDebugUIConstants.IMG_SRC_LOOKUP_MENU_ELCL,
+				IInternalDebugUIConstants.IMG_SRC_LOOKUP_MENU_DLCL, ELCL + "edtsrclkup_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_SRC_LOOKUP_TAB, ELCL + "edtsrclkup_co.svg"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_ADD_SRC_LOC_WIZ, WIZBAN + "addsrcloc_wiz.png"); //$NON-NLS-1$
 		declareRegistryImage(IInternalDebugUIConstants.IMG_EDIT_SRC_LOC_WIZ, WIZBAN + "edtsrclkup_wiz.png"); //$NON-NLS-1$
@@ -276,13 +273,23 @@ public class DebugPluginImages {
 	 *				this plugin class is found (i.e. typically the packages directory)
 	 */
 	private final static void declareRegistryImage(String key, String path) {
+		declareRegistryImage(key, null, path);
+	}
+
+	private final static void declareRegistryImage(String key, String disabledKey, String path) {
 		Bundle bundle = FrameworkUtil.getBundle(DebugPluginImages.class);
+		ImageDescriptor imageDescriptor;
 		if (bundle == null) {
-			imageRegistry.put(key, ImageDescriptor.getMissingImageDescriptor());
+			imageDescriptor = ImageDescriptor.getMissingImageDescriptor();
 		} else {
-			imageRegistry.put(key,
-					ImageDescriptor.createFromURLSupplier(true,
-							() -> FileLocator.find(bundle, IPath.fromOSString(path), null)));
+			imageDescriptor = ImageDescriptor.createFromURLSupplier(true,
+					() -> FileLocator.find(bundle, IPath.fromOSString(path), null));
+		}
+		imageRegistry.put(key, imageDescriptor);
+		if (disabledKey != null) {
+			ImageDescriptor disabledImageDescriptor = ImageDescriptor.createWithFlags(imageDescriptor,
+					SWT.IMAGE_DISABLE);
+			imageRegistry.put(disabledKey, disabledImageDescriptor);
 		}
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/OpenBreakpointMarkerAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/breakpoints/OpenBreakpointMarkerAction.java
@@ -42,10 +42,8 @@ public class OpenBreakpointMarkerAction extends SelectionProviderAction {
 	public OpenBreakpointMarkerAction(ISelectionProvider selectionProvider) {
 		super(selectionProvider, ActionMessages.OpenBreakpointMarkerAction__Go_to_File_1);
 		setToolTipText(ActionMessages.OpenBreakpointMarkerAction_Go_to_File_for_Breakpoint_2);
-		ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui.ide", "icons/full/elcl16/gotoobj_tsk.png") //$NON-NLS-1$ //$NON-NLS-2$
+		ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui.ide", "icons/full/elcl16/gotoobj_tsk.svg") //$NON-NLS-1$ //$NON-NLS-2$
 				.ifPresent(this::setImageDescriptor);
-		ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui.ide", "icons/full/dlcl16/gotoobj_tsk.png") //$NON-NLS-1$ //$NON-NLS-2$
-				.ifPresent(this::setDisabledImageDescriptor);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(
 			this,
 			IDebugHelpContextIds.OPEN_BREAKPOINT_ACTION);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/IBreakpointOrganizerDelegate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/IBreakpointOrganizerDelegate.java
@@ -37,7 +37,7 @@ import org.eclipse.jface.util.IPropertyChangeListener;
  * 		class="com.example.BreakpointOrganizer"
  *      id="com.example.BreakpointOrganizer"
  *      label="Example Organizer"
- *      icon="icons/full/obj16/example_org.png"/&gt;
+ *      icon="icons/full/obj16/example_org.svg"/&gt;
  * &lt;/extension&gt;
  * </pre>
  *

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/ILaunchGroup.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/ILaunchGroup.java
@@ -30,7 +30,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
  * 			  id="com.example.ExampleLaunchGroupId"
  * 			  mode="run"
  * 			  label="Run"
- * 			  image="icons\run.png"
+ * 			  image="icons\run.svg"
  * 		&lt;/launchGroup&gt;
  * 	&lt;/extension&gt;
  * </pre>

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/ILaunchShortcut.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/ILaunchShortcut.java
@@ -40,7 +40,7 @@ import org.eclipse.ui.IEditorPart;
  *           class="org.eclipse.jdt.internal.debug.ui.launcher.JavaApplicationLaunchShortcut"
  *           description="%JavaLaunchShortcut.description"
  *           helpContextId="org.eclipse.jdt.debug.ui.shortcut_local_java_application"
- *           icon="$nl$/icons/full/etool16/java_app.png"
+ *           icon="$nl$/icons/full/etool16/java_app.svg"
  *           id="org.eclipse.jdt.debug.ui.localJavaShortcut"
  *           label="%JavaApplicationShortcut.label"
  *           modes="run, debug"&gt;

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
@@ -35,7 +35,6 @@ public interface ICompareUIConstants {
 	public static final String RETARGET_PROJECT = "eview16/compare_view.svg"; //$NON-NLS-1$
 
 	public static final String IGNORE_WHITESPACE_ENABLED = "etool16/ignorews_edit.svg"; //$NON-NLS-1$
-	public static final String IGNORE_WHITESPACE_DISABLED= "dtool16/ignorews_edit.png";	//$NON-NLS-1$
 
 	public static final String PROP_ANCESTOR_VISIBLE = PREFIX + "AncestorVisible"; //$NON-NLS-1$
 	public static final String PROP_IGNORE_ANCESTOR = PREFIX + "IgnoreAncestor"; //$NON-NLS-1$

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PreviewPatchPage2.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PreviewPatchPage2.java
@@ -170,8 +170,7 @@ public class PreviewPatchPage2 extends WizardPage {
 	private void updateActions(IStructuredSelection ss) {
 		fExcludeAction.setEnabled(false);
 		fIncludeAction.setEnabled(false);
-		for (Iterator<?> it = ss.iterator(); it.hasNext();) {
-			Object element = it.next();
+		for (Object element : ss) {
 			if (element instanceof PatchDiffNode) {
 				if (((PatchDiffNode) element).isEnabled()) {
 					fExcludeAction.setEnabled(true);
@@ -305,7 +304,6 @@ public class PreviewPatchPage2 extends WizardPage {
 		};
 		fIgnoreWhiteSpace.setChecked(false);
 		fIgnoreWhiteSpace.setToolTipText(PatchMessages.PreviewPatchPage2_IgnoreWSTooltip);
-		fIgnoreWhiteSpace.setDisabledImageDescriptor(CompareUIPlugin.getImageDescriptor(ICompareUIConstants.IGNORE_WHITESPACE_DISABLED));
 
 		fReversePatch = new Action(PatchMessages.PreviewPatchPage_ReversePatch_text){
 			@Override


### PR DESCRIPTION
In org.eclipse.debug.ui, several disabled images are still retrieved from PNGs. This change replaces those images with ones that are disabled on-the-fly. To this end, image descriptors based on the original image descriptors applying the SWT.IMAGE_DISABLE are used.

❗ Includes and thus needs to be merged after:
- https://github.com/eclipse-platform/eclipse.platform/pull/1839