### PR TITLE
Remove explicit disabled icons from org.eclipse.unittest.ui

### DIFF
--- a/debug/org.eclipse.unittest.ui/plugin.xml
+++ b/debug/org.eclipse.unittest.ui/plugin.xml
@@ -59,7 +59,6 @@
          point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.unittest.ui.history"
-            disabledIcon="icons/full/dlcl16/history_list.png"
             icon="icons/full/elcl16/history_list.png">
       </image>
    </extension>

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/CompareResultsAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/CompareResultsAction.java
@@ -38,7 +38,6 @@ public class CompareResultsAction extends Action {
 		setDescription(Messages.CompareResultsAction_description);
 		setToolTipText(Messages.CompareResultsAction_tooltip);
 
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/compare.png")); //$NON-NLS-1$
 		setImageDescriptor(Images.getImageDescriptor("elcl16/compare.png")); //$NON-NLS-1$
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IUnitTestHelpContextIds.ENABLEFILTER_ACTION);
 		fView = view;

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/EnableStackFilterAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/EnableStackFilterAction.java
@@ -36,7 +36,6 @@ public class EnableStackFilterAction extends Action {
 		setDescription(Messages.EnableStackFilterAction_action_description);
 		setToolTipText(Messages.EnableStackFilterAction_action_tooltip);
 
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/cfilter.png")); //$NON-NLS-1$
 		setImageDescriptor(Images.getImageDescriptor("elcl16/cfilter.png")); //$NON-NLS-1$
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IUnitTestHelpContextIds.ENABLEFILTER_ACTION);
 

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/Images.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/Images.java
@@ -66,10 +66,6 @@ public class Images {
 	}
 
 	private static void setImageDescriptors(IAction action, String type, String relPath) {
-		ImageDescriptor id = createImageDescriptor("d" + type, relPath, false); //$NON-NLS-1$
-		if (id != null)
-			action.setDisabledImageDescriptor(id);
-
 		ImageDescriptor descriptor = createImageDescriptor("e" + type, relPath, true); //$NON-NLS-1$
 		action.setImageDescriptor(descriptor);
 	}

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ScrollLockAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ScrollLockAction.java
@@ -33,7 +33,6 @@ public class ScrollLockAction extends Action {
 		super(Messages.ScrollLockAction_action_label);
 		fRunnerViewPart = viewer;
 		setToolTipText(Messages.ScrollLockAction_action_tooltip);
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/lock.png")); //$NON-NLS-1$
 		setImageDescriptor(Images.getImageDescriptor("elcl16/lock.png")); //$NON-NLS-1$
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IUnitTestHelpContextIds.OUTPUT_SCROLL_LOCK_ACTION);
 		setChecked(false);

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowNextFailureAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowNextFailureAction.java
@@ -29,7 +29,6 @@ public class ShowNextFailureAction extends Action {
 	 */
 	public ShowNextFailureAction(TestRunnerViewPart part) {
 		super(Messages.ShowNextFailureAction_label);
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/select_next.png")); //$NON-NLS-1$
 		setImageDescriptor(Images.getImageDescriptor("elcl16/select_next.png")); //$NON-NLS-1$
 		setToolTipText(Messages.ShowNextFailureAction_tooltip);
 		fPart = part;

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowPreviousFailureAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowPreviousFailureAction.java
@@ -29,7 +29,6 @@ public class ShowPreviousFailureAction extends Action {
 	 */
 	public ShowPreviousFailureAction(TestRunnerViewPart part) {
 		super(Messages.ShowPreviousFailureAction_label);
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/select_prev.png")); //$NON-NLS-1$
 		setImageDescriptor(Images.getImageDescriptor("elcl16/select_prev.png")); //$NON-NLS-1$
 		setToolTipText(Messages.ShowPreviousFailureAction_tooltip);
 		fPart = part;

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowStackTraceInConsoleViewAction.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/ShowStackTraceInConsoleViewAction.java
@@ -33,7 +33,6 @@ public class ShowStackTraceInConsoleViewAction extends Action {
 		setToolTipText(Messages.ShowStackTraceInConsoleViewAction_tooltip);
 
 		setImageDescriptor(Images.getImageDescriptor("elcl16/open_console.png")); //$NON-NLS-1$
-		setDisabledImageDescriptor(Images.getImageDescriptor("dlcl16/open_console.png")); //$NON-NLS-1$
 
 		fDelegate = null;
 	}


### PR DESCRIPTION
Use on-the-fly-generated disabled version of SVG-rasterized icons instead.