### PR TITLE
Remove reference to non-existent disabled icons in org.eclipse.help.ui

### DIFF
--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/IHelpUIConstants.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/IHelpUIConstants.java
@@ -50,8 +50,6 @@ public interface IHelpUIConstants {
 	public static final String IMAGE_HIGHLIGHT = "elcl16/highlight.svg"; //$NON-NLS-1$
 	public static final String IMAGE_MAGNIFY = "elcl16/magnify_font.svg"; //$NON-NLS-1$
 	public static final String IMAGE_REDUCE = "elcl16/reduce_font.svg"; //$NON-NLS-1$
-	public static final String IMAGE_D_MAGNIFY = "dlcl16/magnify_font.svg"; //$NON-NLS-1$
-	public static final String IMAGE_D_REDUCE = "dlcl16/reduce_font.svg"; //$NON-NLS-1$
 	public static final String IMAGE_COLLAPSE_ALL = "elcl16/collapseall.svg"; //$NON-NLS-1$
 	public static final String IMAGE_CLOSE = "elcl16/close.svg"; //$NON-NLS-1$
 	public static final String IMAGE_CLOSE_HOT = "elcl16/close_hot.svg"; //$NON-NLS-1$

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
@@ -305,8 +305,6 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 		magnifyAction.setText(Messages.BrowserPart_magnifyTooltip);
 		magnifyAction.setImageDescriptor(HelpUIResources
 				.getImageDescriptor(IHelpUIConstants.IMAGE_MAGNIFY));
-		magnifyAction.setDisabledImageDescriptor(HelpUIResources
-				.getImageDescriptor(IHelpUIConstants.IMAGE_D_MAGNIFY));
 
 		reduceAction = new Action() {
 
@@ -319,8 +317,6 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 		reduceAction.setText(Messages.BrowserPart_reduceTooltip);
 		reduceAction
 				.setImageDescriptor(HelpUIResources.getImageDescriptor(IHelpUIConstants.IMAGE_REDUCE));
-		reduceAction.setDisabledImageDescriptor(HelpUIResources
-				.getImageDescriptor(IHelpUIConstants.IMAGE_D_REDUCE));
 		menuManager.add(new Separator());
 		menuManager.add(reduceAction);
 		menuManager.add(magnifyAction);


### PR DESCRIPTION
The paths to disabled icons have recently been replaced with paths to SVGs even though they do not exist. This change completely removes the usage of explicitly disabled icons and replaces it with on-the-fly generated disabled icons.