### PR TITLE
Improve and fix the markdown documentation

### DIFF
--- a/docs/.project
+++ b/docs/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.platform.docs</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/docs/.settings/org.eclipse.core.resources.prefs
+++ b/docs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/docs/API_Central.md
+++ b/docs/API_Central.md
@@ -6,15 +6,15 @@ This page is a hub to collect information about Eclipse Project APIs.
 ### API Guidelines
 
 *   [How to use the Eclipse API](http://www.eclipse.org/articles/Article-API-Use/index.html) Guidelines for using Eclipse APIs to ensure that your code will keep working as Eclipse evolves.
-*   [Evolving Java-based APIs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md) Guidelines for how to evolve Java-based APIs while maintaining compatibility with existing client code.
-*   [Javadoc](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Javadoc.md) How to write Javadoc
-*   [Provisional API Guidelines](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Provisional_API_Guidelines.md)
-*   [API Removal Process](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/ApiRemovalProcess.md)
-*   [Deprecation Policy](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Eclipse_API_Central_Deprecation_Policy.md)
-*   [Policy on use of Export-Package](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Export-Package.md)
-*   [Version Numbering](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/VersionNumbering.md) Guidelines on how to assign and evolve plug-in version numbers
-*   [Naming Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Naming_Conventions.md)  How to name things like packages, classes, and methods
-*   [Code Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Coding_Conventions.md)  How to make Java code readable
-*   [Eclipse Doc Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Eclipse_Doc_Style_Guide.md) Guide how to write Eclipse docs
+*   [Evolving Java-based APIs](Evolving-Java-based-APIs.md) Guidelines for how to evolve Java-based APIs while maintaining compatibility with existing client code.
+*   [Javadoc](Javadoc.md) How to write Javadoc
+*   [Provisional API Guidelines](Provisional_API_Guidelines.md)
+*   [API Removal Process](ApiRemovalProcess.md)
+*   [Deprecation Policy](Eclipse_API_Central_Deprecation_Policy.md)
+*   [Policy on use of Export-Package](Export-Package.md)
+*   [Version Numbering](VersionNumbering.md) Guidelines on how to assign and evolve plug-in version numbers
+*   [Naming Conventions](Naming_Conventions.md)  How to name things like packages, classes, and methods
+*   [Code Conventions](Coding_Conventions.md)  How to make Java code readable
+*   [Eclipse Doc Conventions](Eclipse_Doc_Style_Guide.md) Guide how to write Eclipse docs
 *   [User interface guidelines](https://github.com/eclipse-platform/ui-best-practices)
 

--- a/docs/ApiRemovalProcess.md
+++ b/docs/ApiRemovalProcess.md
@@ -1,6 +1,6 @@
 # API removal process
 
-See [Eclipse Project Deprecation Policy](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Eclipse_API_Central_Deprecation_Policy.md) for more information.
+See [Eclipse Project Deprecation Policy](Eclipse_API_Central_Deprecation_Policy.md) for more information.
 
 For new API planned removals use:
 

--- a/docs/Coding_Conventions.md
+++ b/docs/Coding_Conventions.md
@@ -26,7 +26,7 @@ Modifiers should be ordered as specified in the JLS and summarized in [AST#newMo
     synchronized native strictfp transient volatile
     
 
-For Javadoc conventions, see Oracle's [How to Write Doc Comments for the Javadoc Tool](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html) and [Eclipse/API_Central](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/API_Central.md).
+For Javadoc conventions, see Oracle's [How to Write Doc Comments for the Javadoc Tool](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html) and [Eclipse/API_Central](API_Central.md).
 
 For Eclipse projects, there is no policy that requires a specific coding format or style, though the Eclipse style in the formatter and cleanup is preferred. Project teams typically determine their own styles and then commit the appropriate files. One way is to commit files on a per-project basis, the other is to have a central set of files that should be imported by each committer. See [Eclipse Incubation Mailing List, 20-June-2016](https://dev.eclipse.org/mhonarc/lists/incubation/msg00141.html).
 

--- a/docs/Eclipse_API_Central_Deprecation_Policy.md
+++ b/docs/Eclipse_API_Central_Deprecation_Policy.md
@@ -4,17 +4,6 @@ Eclipse/API Central/Deprecation Policy
 This page contains Eclipse Project guidelines on API deprecation. 
 This page is maintained by the [Eclipse/PMC](https://eclipse.dev/eclipse/team-leaders.php).
 
-Contents
---------
-
-*   [1 What is Deprecation?](#What-is-Deprecation.3F)
-    *   [1.1 Process to deprecate an API](#Process-to-deprecate-an-API)
-*   [2 Identifying Deprecated API](#Identifying-Deprecated-API)
-    *   [2.1 Java API](#Java-API)
-    *   [2.2 Extension Points](#Extension-Points)
-*   [3 Removal of Deprecated API](#Removal-of-Deprecated-API)
-    *   [3.1 Third Party API](#Third-Party-API)
-
 
 What is Deprecation?
 ====================
@@ -32,7 +21,7 @@ Identifying Deprecated API
 ==========================
 
 This section describes how clients can identify what API is deprecated. 
-To identify API from non-API, see [Provisional API Guidelines](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Provisional_API_Guidelines.md)
+To identify API from non-API, see [Provisional API Guidelines](Provisional_API_Guidelines.md)
 
 Java API
 --------
@@ -54,7 +43,7 @@ Extension Points
 Elements and attributes in extension points are deprecated by setting the "Deprecated" property to true in the PDE extension point schema editor. 
 The entire extension point can be deprecated by deprecating the "extension" element, which is the top level element at the root of any contribution to the extension point.
 
-![Schema-deprecation.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/images/Schema-deprecation.png)
+![Schema-deprecation.png](images/Schema-deprecation.png)
 
 Removal of Deprecated API
 =========================

--- a/docs/Eclipse_Doc_Style_Guide.md
+++ b/docs/Eclipse_Doc_Style_Guide.md
@@ -5,17 +5,6 @@ This document gives the style conventions to be used in [Eclipse help](/Eclipse_
 The Eclipse help has the following topic types: Tutorial (Getting Started), Concept, Task, and Reference. 
 These topic types are based on the [Darwin Information Typing Architecture (DITA)](http://www.ibm.com/developerworks/library/x-dita1/) standards.
 
-Contents
---------
-
-*   [1 Topic Titles](#Topic-Titles)
-*   [2 Lists](#Lists)
-*   [3 Inline Markup](#Inline-Markup)
-*   [4 Topic Content](#Topic-Content)
-*   [5 Tables](#Tables)
-*   [6 CSS Class Summary](#CSS-Class-Summary)
-*   [7 Graphics](#Graphics)
-*   [8 Indexing](#Indexing)
 
 ### Topic Titles
 

--- a/docs/Evolving-Java-based-APIs-2.md
+++ b/docs/Evolving-Java-based-APIs-2.md
@@ -1,25 +1,8 @@
 Evolving Java-based APIs 2
 ==========================
 
-Part 2 of [Evolving\_Java-based\_APIs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md).
+Part 2 of [Evolving\_Java-based\_APIs](Evolving-Java-based-APIs.md).
 
-Contents
---------
-
-*   [1 Achieving API Binary Compatibility](#Achieving-API-Binary-Compatibility)
-    *   [1.1 Evolving API packages](#Evolving-API-packages)
-    *   [1.2 Evolving API Interfaces](#Evolving-API-Interfaces)
-        *   [1.2.1 Evolving API interfaces - API methods](#Evolving-API-interfaces---API-methods)
-        *   [1.2.2 Evolving API interfaces - API fields](#Evolving-API-interfaces---API-fields)
-        *   [1.2.3 Evolving API interfaces - API type members](#Evolving-API-interfaces---API-type-members)
-    *   [1.3 Evolving API Classes](#Evolving-API-Classes)
-        *   [1.3.1 Evolving API classes - API methods and constructors](#Evolving-API-classes---API-methods-and-constructors)
-        *   [1.3.2 Evolving API classes - API fields](#Evolving-API-classes---API-fields)
-        *   [1.3.3 Evolving API classes - API type members](#Evolving-API-classes---API-type-members)
-    *   [1.4 Evolving non-API packages](#Evolving-non-API-packages)
-    *   [1.5 Turning non-generic types and methods into generic ones](#Turning-non-generic-types-and-methods-into-generic-ones)
-    *   [1.6 Evolving annotations on API elements](#Evolving-annotations-on-API-elements)
-*   [2 Other Notes](#Other-Notes)
 
 Achieving API Binary Compatibility
 ----------------------------------
@@ -95,13 +78,13 @@ Evolving API interfaces is somewhat more straightforward than API classes since 
 | Delete element from annotation type | - | **Breaks compatibility** (6) |
 
 (0) Although adding a new method to an API interface which need not be reimplemented by Clients does not break binary compatibility, a pre-existing Client subclass of an existing implementation might still provide a pre-existing implementation of a method by this name. 
-See [Evolving Java-based APIs#Example 4 - Adding an API method](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in the preceding section for why this breaks API contract compatibility.
+See [Evolving Java-based APIs#Example 4 - Adding an API method](Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in the preceding section for why this breaks API contract compatibility.
 
 (1) Adding a new method to an API interface that is implemented by Clients (e.g., a callback, listener, or visitor interface) breaks compatibility because hypothetical pre-existing implementations do not implement the new method.
 
 (2) Adding an API field to an API interface that is implemented by Clients is dangerous in two respects:
 
-*   It may break API contract compatibility similar to [Evolving\_Java-based\_APIs#Example\_4\_-\_Adding\_an\_API\_method](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in case of name clashes.
+*   It may break API contract compatibility similar to [Evolving\_Java-based\_APIs#Example\_4\_-\_Adding\_an\_API\_method](Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in case of name clashes.
 *   It may cause linkage errors in case an instance (respectively static) field hides a static (respectively instance) field, see [JLS8 13.4.8](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.4.8). This can not happen if all field declarations follow the usual naming conventions from [JLS8 6.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.1) and classes only have API fields that are either
     *   "static final" (and hence have a name that doesn't contain any lowercase letters), or
     *   non-static and non-final (and hence have a name that contains a least one lowercase letter)
@@ -225,7 +208,7 @@ Evolving API classes is somewhat more complex than API interfaces due to the wid
 | Re-order enum constants | - | Binary compatible (8) |
 
 (0) Although adding a new method to an API class which need not be reimplemented by Clients does not break binary compatibility, a pre-existing subclass might still provide a pre-existing implementation of a method by this name. 
-See [Evolving Java-based APIs#Example 4 - Adding an API method](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in the preceding section for why this breaks API contract compatibility.
+See [Evolving Java-based APIs#Example 4 - Adding an API method](Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in the preceding section for why this breaks API contract compatibility.
 
 (1) Adding a new method to an API class that must be reimplemented by Clients breaks compatibility because pre-existing subclasses would not provide any such implementation.
 
@@ -233,7 +216,7 @@ See [Evolving Java-based APIs#Example 4 - Adding an API method](https://github.c
 
 (3) Adding an API field to an API class that is extended by Clients is dangerous in two respects:
 
-*   It may break API contract compatibility similar to [Evolving\_Java-based\_APIs#Example\_4\_-\_Adding\_an\_API\_method](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in case of name clashes.
+*   It may break API contract compatibility similar to [Evolving\_Java-based\_APIs#Example\_4\_-\_Adding\_an\_API\_method](Evolving-Java-based-APIs.md#Achieving-API-Binary-Compatibility) in case of name clashes.
 *   It may cause linkage errors in case an instance (respectively static) field hides a static (respectively instance) field, see [JLS8 13.4.8](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.4.8). This can not happen if all field declarations follow the usual naming conventions from [JLS8 6.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.1) and classes only have API fields that are either
     *   "static final" (and hence have a name that doesn't contain any lowercase letters), or
     *   non-static and non-final (and hence have a name that contains a least one lowercase letter)
@@ -390,5 +373,5 @@ Parties that declare annotation types should try to provide helpful guidance for
 Other Notes
 -----------
 
-See [Part 3](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-3.md).
+See [Part 3](Evolving-Java-based-APIs-3.md).
 

--- a/docs/Evolving-Java-based-APIs-3.md
+++ b/docs/Evolving-Java-based-APIs-3.md
@@ -1,24 +1,8 @@
 Evolving Java-based APIs 3
 ==========================
 
-Part 3 of [Evolving\_Java-based\_APIs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md).
+Part 3 of [Evolving\_Java-based\_APIs](Evolving-Java-based-APIs.md).
 
-Contents
---------
-
-*   [1 Other notes](#Other-notes)
-    *   [1.1 Data Compatibility](#Data-Compatibility)
-    *   [1.2 Standard Workarounds](#Standard-Workarounds)
-        *   [1.2.1 Deprecate and Forward](#Deprecate-and-Forward)
-        *   [1.2.2 Start over in a New Package](#Start-over-in-a-New-Package)
-        *   [1.2.3 Adding an Argument](#Adding-an-Argument)
-        *   [1.2.4 "2" Convention](#.222.22-Convention)
-        *   [1.2.5 COM Style](#COM-Style)
-        *   [1.2.6 Making Obsolete Hook Methods Final](#Making-Obsolete-Hook-Methods-Final)
-    *   [1.3 Defective API Specifications](#Defective-API-Specifications)
-    *   [1.4 A Word about Source Code Incompatibilities](#A-Word-about-Source-Code-Incompatibilities)
-    *   [1.5 Java Reflection](#Java-Reflection)
-    *   [1.6 Versioning](#Versioning)
 
 Other notes
 ===========
@@ -185,4 +169,4 @@ Versioning
 ----------
 
 It should be easy for API clients to know whether a new version of your components broke APIs or not. 
-Eclipse projects implement semantic versioning according to the [Version Numbering](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/VersionNumbering.md) specification.
+Eclipse projects implement semantic versioning according to the [Version Numbering](VersionNumbering.md) specification.

--- a/docs/Evolving-Java-based-APIs.md
+++ b/docs/Evolving-Java-based-APIs.md
@@ -4,27 +4,13 @@ Evolving Java-based APIs
 Document is currently split in 3 parts:
 
 *   Part 1: What is an API? (this page)
-*   [Part 2: Achieving API Binary Compatibility](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-2.md)
-*   [Part 3: Other Notes](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-3.md)
+*   [Part 2: Achieving API Binary Compatibility](Evolving-Java-based-APIs-2.md)
+*   [Part 3: Other Notes](Evolving-Java-based-APIs-3.md)
 
 This document is about how to evolve Java-based APIs while maintaining compatibility with existing client code. 
 Without loss of generality, we'll assume that there is a generic **Component** with a **Component API**, with one party providing the Component and controlling its API. 
 The other party, or parties, write **Client** code that use the Component's services through its API. This is a very typical arrangement.
 
-Contents
---------
-
-*   [1 API Java Elements](#API-Java-Elements)
-*   [2 API Prime Directive](#API-Prime-Directive)
-*   [3 Achieving API Contract Compatibility](#Achieving-API-Contract-Compatibility)
-    *   [3.1 Example 1 - Changing a method postcondition](#Example-1---Changing-a-method-postcondition)
-    *   [3.2 Example 2 - Changing a method precondition](#Example-2---Changing-a-method-precondition)
-    *   [3.3 Example 3 - Changing a field invariant](#Example-3---Changing-a-field-invariant)
-    *   [3.4 Example 4 - Adding an API method](#Example-4---Adding-an-API-method)
-    *   [3.5 General Rules for Contract Compatibility](#General-Rules-for-Contract-Compatibility)
-*   [4 Achieving API Binary Compatibility](#Achieving-API-Binary-Compatibility)
-*   [5 Other Notes](#Other-Notes)
-*   [6 Bundle Versioning](#Bundle-Versioning)
 
 API Java Elements
 -----------------
@@ -207,16 +193,16 @@ Whether a particular Component API change breaks or maintains contract compatibi
 Achieving API Binary Compatibility
 ----------------------------------
 
-See [Part 2](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-2.md).
+See [Part 2](Evolving-Java-based-APIs-2.md).
 
 Other Notes
 -----------
 
-See [Part 3](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-3.md).
+See [Part 3](Evolving-Java-based-APIs-3.md).
 
 Bundle Versioning
 -----------------
 
-See [Version Numbering](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/VersionNumbering.md)
+See [Version Numbering](VersionNumbering.md)
 
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,119 +1,17 @@
-# NOTE: Please move to  [The Official Eclipse FAQs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/FAQ/The_Official_Eclipse_FAQs.md)
-
-
-# THIS IS THE OLD IRC FAQ AND LOTS OF QUESTIONS AND ANSWERS ARE NOT UP TO DATE
-
-# This document is based on frequently asked questions in a older support channel of Eclipse called IRC and was located in a wiki which has been deprecreated
-# In Febr. 2024 the most outdated content has been removed or updated but if you see something which you can improve / update please send a PR for this repo
-
-
-
 IRC FAQ
-=======
+===
 
-A collection of FAQs gathered in the Eclipse [IRC](/IRC "IRC") channels. Some of them are logged, see the specific channel for details.
+This content is collection of FAQs gathered in the Eclipse IRC channels.
+Some of them are logged, see the specific channel for details.
+The content is based on frequently asked questions in an older support channel of Eclipse called IRC and was located in a wiki which has been deprecreated.
+Since February 2024 the most outdated content has been removed or updated but if you see something which you can improve or update, please send a PR for this repo.
 
-Contents
---------
+**[The Official Eclipse FAQs](FAQ/The_Official_Eclipse_FAQs.md) provides many useful details as well.**
 
-*   [1 General](#General)
-    *   [1.1 I'm new, what should I read first?](#im-new-what-should-i-read-first)
-*   [2 Installation, Startup and Runtime](#installation-startup-and-runtime)
-    *   [2.1 Where can I get Eclipse?](#Where-can-I-get-Eclipse)
-    *   [2.2 What's the difference between all the different packages like 'Eclipse IDE for Java Developers' and the 'Eclipse IDE for Java EE Developers'? What do they contain? Do they contain source code?](#whats-the-difference-between-all-the-different-packages-what-do-they-contain-do-they-contain-source-code)
-    *   [2.3 How do I verify my download? Are there any MD5 or SHA1 hashes for me to verify my download against?](#how-do-i-verify-my-download-are-there-any-md5-or-sha1-hashes-for-me-to-verify-my-download-against)
-    *   [2.4 What are all these strangely named releases?](#What-are-all-these-strangely-named-releases)
-    *   [2.5 Where can I get a list of all the Eclipse projects?](#Where-can-I-get-a-list-of-all-the-Eclipse-projects)
-    *   [2.6 Where can I get project XYZ?](#Where-can-I-get-project-XYZ)
-        *   [2.6.1 Is there a GUI Builder?](#Is-there-a-GUI-Builder)
-    *   [2.7 What is p2?](#What-is-p2)
-    *   [2.8 How do I start Eclipse?](#How-do-I-start-Eclipse)
-    *   [2.9 How do I upgrade/update Eclipse?](#how-do-i-upgradeupdate-eclipse)
-    *   [2.10 What other command line arguments are available?](#What-other-command-line-arguments-are-available)
-    *   [2.11 How do I debug Eclipse? How can I see what plug-ins are being started? Why aren't the plug-ins I installed showing up in the UI? How do I start the OSGi console?](#how-do-i-debug-eclipse-how-can-i-see-what-plug-ins-are-being-started-why-arent-the-plug-ins-i-installed-showing-up-in-the-ui-how-do-i-start-the-osgi-console)
-        *   [2.11.1 Debugging OSGi Bundle Loading Issues](#Debugging-OSGi-Bundle-Loading-Issues)
-        *   [2.11.2 Debugging Eclipse Using Eclipse](#Debugging-Eclipse-Using-Eclipse)
-            *   [2.11.2.1 Launching as an Eclipse Application using PDE](#Launching-as-an-Eclipse-Application-using-PDE)
-            *   [2.11.2.2 Attaching to a running instance](#Attaching-to-a-running-instance)
-    *   [2.12 Can I use my Eclipse workspace from an old release with a new Eclipse release?](#Can-I-use-my-Eclipse-workspace-from-an-old-release-with-a-new-Eclipse-release)
-    *   [2.13 How do I use a different workspace?](#How-do-I-use-a-different-workspace)
-    *   [2.14 When I start Eclipse it says "Workspace in use or cannot be created, choose a different one.", what should I do?](#when-i-start-eclipse-it-says-workspace-in-use-or-cannot-be-created-choose-a-different-one-what-should-i-do)
-    *   [2.15 How do I copy plugins between Eclipse installations with p2?](#How-do-I-copy-plugins-between-Eclipse-installations-with-p2)
-    *   [2.16 How do I install a plug-in with multiple dependencies?](#How-do-I-install-a-plug-in-with-multiple-dependencies.3F)
-*   [3 Crashers, Freezing, and other Major Issues](#Crashers.2C-Freezing.2C-and-other-Major-Issues)
-    *   [3.1 I'm having memory, heap, or permgen problems, what can I do?](#I.27m-having-memory.2C-heap.2C-or-permgen-problems.2C-what-can-I-do.3F)
-    *   [3.2 Eclipse seems to be hanging on startup. How can I find out why?](#Eclipse-seems-to-be-hanging-on-startup.-How-can-I-find-out-why.3F)
-    *   [3.3 Update complains that it cannot find a repository](#Update-complains-that-it-cannot-find-a-repository)
-	*	[3.4 Eclipse keeps running out of (permgen) memory when I use Oracle/Sun's Java 6 update 21 on Windows](eclipse-keeps-running-out-of-permgen-memory-when-i-use-oraclesuns-java-6-update-21-on-windows)
-	*	[3.5 After startup, i see only an empty Dialog - eclipse won't start](after-startup-i-see-only-an-empty-dialog---eclipse-wont-start)
-*   [4 Eclipse](#Eclipse)
-    *   [4.1 How do I create a project for an existing source directory?](#How-do-I-create-a-project-for-an-existing-source-directory)
-        *   [4.1.1 Option 1: Import the source into an existing project](#option-1-import-the-source-into-an-existing-project)
-        *   [4.1.2 Option 2: Create project on the existing source directory](#option-2-create-project-on-the-existing-source-directory)
-        *   [4.1.3 Option 3: Create project and link to existing source](#option-3-create-project-and-link-to-existing-source)
-    *   [4.2 Where are Eclipse's log files located?](#where-are-eclipses-log-files-located)
-    *   [4.3 I was working on a project and doing something or other does not work. Where should I start?](#I-was-working-on-a-project-and-doing-something-or-other-does-not-work.-Where-should-I-start)
-    *   [4.4 Where are Eclipse preferences stored?](#Where-are-Eclipse-preferences-stored)
-    *   [4.5 Where are update site bookmarks stored?](#Where-are-update-site-bookmarks-stored)
-    *   [4.6 Where are my Eclipse plug-ins folder?](#Where-are-my-Eclipse-plug-ins-folder)
-    *   [4.7 What's the key for ...?](#whats-the-key-for-F)
-        *   [4.7.1 How do I add my own bindings?](#How-do-I-add-my-own-bindings)
-        *   [4.7.2 Why can't I find the command I'm looking for?](#Why-cant-I-find-the-command-Im-looking-for)
-    *   [4.8 Why did Content Assist stop working?](#Why-did-Content-Assist-stop-working)
-    *   [4.9 Why won't Content Assist work for my .xyz file type?](#why-wont-content-assist-work-for-my-xyz-file-type)
-    *   [4.10 How do I manually assign a project Nature or BuildCommand?](#How-do-I-manually-assign-a-project-Nature-or-BuildCommand)
-    *   [4.11 How do I export a launch configuration?](#How-do-I-export-a-launch-configuration)
-    *   [4.12 How do I find out which workspace I currently have open?](#How-do-I-find-out-which-workspace-I-currently-have-open)
-    *   [4.13 Why is Eclipse launching the current file I have open instead of whatever I last launched?](#Why-is-Eclipse-launching-the-current-file-I-have-open-instead-of-whatever-I-last-launched)
-    *   [4.14 How do I configure Eclipse to use a black background with a white font?](#How-do-I-configure-Eclipse-to-use-a-black-background-with-a-white-font)
-    *   [4.15 Where do I find the javadoc for the Eclipse API locally? I don't always want to load stuff up in a browser.](#Where-do-I-find-the-javadoc-for-the-Eclipse-API-locally-I-dont-always-want-to-load-stuff-up-in-a-browser)
-    *   [4.16 Cut/Copy/Paste does not appear to be working properly on Linux. It's not often that I have to invoke the keyboard shortcut multiple times for it to take effect. What's the deal here?](#cutcopypaste-does-not-appear-to-be-working-properly-on-linux-its-not-often-that-i-have-to-invoke-the-keyboard-shortcut-multiple-times-for-it-to-take-effect-whats-the-deal-here)
-    *   [4.17 How do I show line numbers in the Eclipse text editor?](#How-do-I-show-line-numbers-in-the-Eclipse-text-editor)
-    *   [4.18 How do I change the colour of the highlighting marker that highlights all the occurrences of some element in the text editor?](#How-do-I-change-the-colour-of-the-highlighting-marker-that-highlights-all-the-occurrences-of-some-element-in-the-text-editor)
-    *   [4.19 How do I switch my workspace?](#How-do-I-switch-my-workspace)
-    *   [4.20 I have just installed a plug-in but I do not see any indication of it in my workspace. What do I do?](#I-have-just-installed-a-plug-in-but-I-do-not-see-any-indication-of-it-in-my-workspace-What-do-I-do)
-    *   [4.21 How do I check for the command line invocation that Eclipse used to launch an application?](#How-do-I-check-for-the-command-line-invocation-that-Eclipse-used-to-launch-an-application)
-    *   [4.22 Can projects exist outside of the workspace's folder?](#Can-projects-exist-outside-of-the-workspaceS-folder)
-    *   [4.23 How do I change the list of workspaces listed under the 'Switch Workspace' submenu?](#how-do-i-change-the-list-of-workspaces-listed-under-the-switch-workspace-submenu)
-    *   [4.24 How do I recover my saved passwords from the .keyring file?](#how-do-i-recover-my-saved-passwords-from-the-keyring-file)
-    *   [4.25 My line delimiter changes are not being persisted to the file. What's going on?](#My-line-delimiter-changes-are-not-being-persisted-to-the-file.-Whats-going-on)
-    *   [4.26 Black background color for tooltips on Linux/Ubuntu/GTK](#black-background-color-for-tooltips-on-linuxubuntugtk)
-    *   [4.27 Excessive tab folder height on Linux/Ubuntu/GTK](#excessive-tab-folder-height-on-linuxubuntugtk)
-    *   [4.28 How can I easily migrate settings and preferences between my Eclipse workspaces?](#How-can-I-easily-migrate-settings-and-preferences-between-my-Eclipse-workspaces)
-    *   [4.29 How do I swap between different programs' output in the 'Console' view? How do I open another 'Console' view?](#how-do-i-swap-between-different-programs-output-in-the-console-view-how-do-i-open-another-console-view)
-*   [5 Java Development Tools (JDT)](#Java-Development-Tools-JDT)
-    *   [5.1 The javadoc for the standard Java classes does not show up as context help. What is the problem? Should I download the javadocs?](#the-javadoc-for-the-standard-java-classes-does-not-show-up-as-context-help-what-is-the-problem-should-i-download-the-javadocs)
-        *   [5.1.1 What do you mean by 'run a JDK'?](#what-do-you-mean-by-run-a-jdk)
-        *   [5.1.2 But it still does \*not\* work! Help me!](#but-it-still-does-not-work-help-me)
-        *   [5.1.3 But I'm on MacOS X which comes with the JDK](#But-im-on-MacOS-X-which-comes-with-the-JDK)
-    *   [5.2 How do I override the environment variables that Ant uses during execution?](#How-do-I-override-the-environment-variables-that-Ant-uses-during-execution)
-    *   [5.3 Why is Content Assist not working in the Java editor? Why doesn't Eclipse recognize my .java file as a Java file?](#Why-is-Content-Assist-not-working-in-the-Java-editor-Why-doesnt-Eclipse-recognize-my-java-file-as-a-Java-file)
-    *   [5.4 How do I change the Java compiler compliance level for my workspace?](#How-do-I-change-the-Java-compiler-compliance-level-for-my-workspace)
-    *   [5.5 How do I add arguments to the Java program I am running?](#How-do-I-add-arguments-to-the-Java-program-I-am-running)
-    *   [5.6 How do I alter my package representation so that parent packages are housing child packages?](#How-do-I-alter-my-package-representation-so-that-parent-packages-are-housing-child-packages)
-    *   [5.7 I clicked on something and now I can only see the method that I am currently editing. What do I do? Did I lose my entire file?](#I-clicked-on-something-and-now-I-can-only-see-the-method-that-I-am-currently-editing-What-do-I-do-Did-I-lose-my-entire-file)
-    *   [5.8 I would like code completion to be activated as I type like how it works in Visual Studio? Can I turn this on somewhere?](#I-would-like-code-completion-to-be-activated-as-I-type-like-how-it-works-in-Visual-Studio-Can-I-turn-this-on-somewhere)
-    *   [5.9 I've been told that Eclipse has its own Java compiler, is this true? Can I use Sun's javac instead?](#Ive-been-told-that-Eclipse-has-its-own-Java-compiler-is-this-true-Can-I-use-Suns-javac-instead)
-    *   [5.10 I call System.console() in my code but null is returned. It does work in the command line though. What's going on?](#i-call-systemconsole-in-my-code-but-null-is-returned-it-does-work-in-the-command-line-though-whats-going-on)
-    *   [5.11 Why isn't my { class | jdbc driver | ... } being found?](#why-isnt-my--class--jdbc-driver----being-found)
-*   [6 PHP Development Tools (PDT)](#PHP-Development-Tools-PDT)
-    *   [6.1 When I try to create PHP project, I get an error saying "Creation of element failed.", what should I do?](#when-i-try-to-create-php-project-i-get-an-error-saying-creation-of-element-failed-what-should-i-do)
-*   [7 Plug-in Development](#Plug-in-Development)
-    *   [7.1 How do I test my plug-ins?](#How-do-I-test-my-plug-ins)
-    *   [7.2 I get an unhandled event loop exception in my console. What gives?](#I-get-an-unhandled-event-loop-exception-in-my-console-What-gives)
-    *   [7.3 A plug-in in my 'Eclipse Application' launch configuration is listed as being "out of sync", what should I do?](#a-plug-in-in-my-eclipse-application-launch-configuration-is-listed-as-being-out-of-sync-what-should-i-do)
-    *   [7.4 I added a jar to my classpath, but it's not being found! What should I do?](#i-added-a-jar-to-my-classpath-but-its-not-being-found-what-should-i-do)
-    *   [7.5 How do I find the source for a plugin?](#How-do-I-find-the-source-for-a-plugin)
-    *   [7.6 How do I edit the source for a plugin?](#How-do-I-edit-the-source-for-a-plugin)
-*   [8 SWT](#SWT)
-    *   [8.1 I cannot get the SWT widget ABC to work when I do XYZ. Could you help me?](#i-cannot-get-the-swt-widget-abc-to-work-when-i-do-xyz-could-you-help-me)
-
-General
--------
 
 ### I'm new, what should I read first?
 
-*   [The Official Eclipse FAQs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/FAQ/The_Official_Eclipse_FAQs.md")
+*   [The Official Eclipse FAQs](FAQ/The_Official_Eclipse_FAQs.md")
 
 Installation, Startup and Runtime
 ---------------------------------

--- a/docs/FAQ/FAQ_Actions_commands_operations_jobs_What_does_it_all_mean.md
+++ b/docs/FAQ/FAQ_Actions_commands_operations_jobs_What_does_it_all_mean.md
@@ -5,15 +5,6 @@ FAQ Actions, commands, operations, jobs: What does it all mean?
 
 Many terms are thrown around in Eclipse for units of functionality or behavior: runnables, actions, commands, operations, and jobs, among others. Here is a high- level view of the terms to help you keep things straight.
 
-Contents
---------
-
-*   [1 Actions](#Actions)
-*   [2 Commands](#Commands)
-*   [3 Operations](#Operations)
-*   [4 Jobs](#Jobs)
-*   [5 See Also](#See-Also)
-
 Actions
 -------
 

--- a/docs/FAQ/FAQ_How_do_I_add_Content_Assist_to_my_language_editor.md
+++ b/docs/FAQ/FAQ_How_do_I_add_Content_Assist_to_my_language_editor.md
@@ -3,14 +3,6 @@
 FAQ How do I add Content Assist to my language editor?
 ======================================================
 
-Contents
---------
-
-*   [1 If you're using the Generic and Extensible editor](#If-youre-using-the-Generic-and-Extensible-editor)
-*   [2 If you're extensing the StructuredTextEditor](#If-youre-extensing-the-StructuredTextEditor)
-*   [3 If it's your own editor](#If-its-your-own-editor)
-*   [4 Example of IContentAssistProcessor](#Example-of-IContentAssistProcessor)
-*   [5 See Also](#See-Also)
 
 If you're using the Generic and Extensible editor
 -------------------------------------------------

--- a/docs/FAQ/FAQ_How_do_I_add_actions_to_the_main_menu.md
+++ b/docs/FAQ/FAQ_How_do_I_add_actions_to_the_main_menu.md
@@ -3,19 +3,6 @@
 FAQ How do I add actions to the main menu?
 ==========================================
 
-Contents
---------
-
-*   [1 Overview](#Overview)
-*   [2 Common Menupaths](#Common-Menupaths)
-    *   [2.1 Standard Menus](#Standard-Menus)
-    *   [2.2 Standard group for adding top level menus](#Standard-group-for-adding-top-level-menus)
-    *   [2.3 Standard file actions](#Standard-file-actions)
-    *   [2.4 Most Recently Used File group](#Most-Recently-Used-File-group)
-    *   [2.5 Standard edit actions](#Standard-edit-actions)
-    *   [2.6 Standard help actions](#Standard-help-actions)
-*   [3 See Also](#See-Also)
-
 Overview
 --------
 

--- a/docs/FAQ/FAQ_How_do_I_add_hover_support_to_my_text_editor.md
+++ b/docs/FAQ/FAQ_How_do_I_add_hover_support_to_my_text_editor.md
@@ -3,14 +3,6 @@
 FAQ How do I add hover support to my text editor?
 =================================================
 
-Contents
---------
-
-*   [1 If you're using the Generic and Extensible editor](#If-yoUre-using-the-Generic-and-Extensible-editor)
-*   [2 If you're extensing the StructuredTextEditor](#If-youre-extensing-the-StructuredTextEditor)
-*   [3 If it's your own editor](#If-its-your-own-editor)
-*   [4 Example of ITextHover implementation](#Example-of-ITextHover-implementation)
-*   [5 See Also](#See-Also)
 
 If you're using the Generic and Extensible editor
 -------------------------------------------------

--- a/docs/FAQ/FAQ_How_do_I_configure_an_Eclipse_Java_project_to_use_SWT.md
+++ b/docs/FAQ/FAQ_How_do_I_configure_an_Eclipse_Java_project_to_use_SWT.md
@@ -5,26 +5,26 @@ The easiest way to configure a Java project in Eclipse to use SWT is as follows:
 
 1.  Download the SWT stable release for your Eclipse version and your operating system from [Eclipse SWT Project Page](https://www.eclipse.org/swt). For example, for Eclipse version 3.3 and Windows, select the Windows link under Releases / Stable, as shown in the screenshot below.
     
-    ![Swt web page.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Swt_web_page.png)
+    ![Swt web page.png](images/Swt_web_page.png)
     
 2.  This will download a zip file that contains our org.eclipes.swt project. (For example, for Eclipse 3.3 and Windows, the file is called swt-3.3.1.1-win32-win32-x86.zip.) Do not unzip this file. Just download it and note the directory where you saved it.
 3.  Inside Eclipse, select Import / Existing Projects into Workspace, as shown below.
     
-    ![Import wizard1.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Import_wizard1.png)
+    ![Import wizard1.png](images/Import_wizard1.png)
     
 4.  Press Next and select the option Select archive file. Browse to the zip file you just downloaded. A project called org.eclipse.swt will display in the Projects list. Make sure it is checked, as shown below, and press Finish.
     
-    ![Import wizard2.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Import_wizard2.png)
+    ![Import wizard2.png](images/Import_wizard2.png)
     
 5.  Eclipse will create the project org.eclipse.swt in your workspace. This project already has the required SWT JAR file, including source code for the SWT classes.
 6.  Select the project that will be used to develop SWT programs (for example, "MyProject) and select Project / Properties / Java Build Path.
 7.  Select the Projects tab. Press Add. The org.eclipse.swt project will display in the Select projects to add: list. Select this project by checking the box. The screen should display as shown below.
     
-    ![Required project selection.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Required_project_selection.png)
+    ![Required project selection.png](images/Required_project_selection.png)
     
 8.  Press OK to return to the Projects tab of the Java Build Path dialog. The screen should show the org.eclipse.swt project as shown below.
     
-    ![Myproject build path.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Myproject_build_path.png)
+    ![Myproject build path.png](images/Myproject_build_path.png)
     
 
 At this point, your project has access to all of the SWT packages and to the SWT source code.

--- a/docs/FAQ/FAQ_How_do_I_create_an_update_site.md
+++ b/docs/FAQ/FAQ_How_do_I_create_an_update_site.md
@@ -12,7 +12,7 @@ First create a new plugin project
 
 New -> Plug-in Development -> Plug-in Project
 
-![Plugin.jpg](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Plugin.jpg)
+![Plugin.jpg](images/Plugin.jpg)
 
 You can select a template for creating your project or even just create a blank one in case you know how things work.
 
@@ -20,7 +20,7 @@ Now you have to create your feature project.
 
 New -> Plug-in Development -> Feature Project
 
-![Feature.jpg](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Feature.jpg)
+![Feature.jpg](images/Feature.jpg)
 
 Here is the point where you link your Plugin project with your Feature Project.
 
@@ -28,7 +28,7 @@ Open the feature.xml file on your Feature project.
 
 On plugins tab click on add and select your project then save the file.
 
-![Feature-plugin.jpg](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Feature-plugin.jpg)
+![Feature-plugin.jpg](images/Feature-plugin.jpg)
 
 The last piece is the Update site project. See below
 
@@ -39,7 +39,7 @@ To create it go to
 
 New -> Plug-in Development -> Update Site Project
 
-![Site.jpg](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Site.jpg)
+![Site.jpg](images/Site.jpg)
 
 Now we just have to link the Feature project with the Update site, and you're good to go.
 
@@ -47,7 +47,7 @@ To do that, open the site.xml file on your Site project.
 
 Add Feature -> Select your project.
 
-![Site-feature.jpg](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/Site-feature.jpg)
+![Site-feature.jpg](images/Site-feature.jpg)
 
 In case you want to add a category for your feature, just click on New Category,
 

--- a/docs/FAQ/FAQ_How_do_I_find_the_active_workbench_page.md
+++ b/docs/FAQ/FAQ_How_do_I_find_the_active_workbench_page.md
@@ -22,13 +22,6 @@ Moreover the active window may not be the _appropriate_ window. On some window s
 
 To avoid getting null windows and pages, you should get your window or a page in another way.
 
-Contents
---------
-
-*   [1 Within a Workbench Part](#Within-a-Workbench-Part)
-*   [2 Within a Command Handler](#Within-a-Command-Handler)
-*   [3 Within an Action](#Within-an-Action)
-*   [4 From an IEclipseContext or IServiceLocator](#From-an-IEclipseContext-or-IServiceLocator)
 
 Within a Workbench Part
 -----------------------

--- a/docs/FAQ/FAQ_How_do_I_run_Eclipse.md
+++ b/docs/FAQ/FAQ_How_do_I_run_Eclipse.md
@@ -1,15 +1,6 @@
 FAQ How do I run Eclipse?
 =========================
 
-Contents
---------
-
-*   [1 Starting Eclipse](#Starting-Eclipse)
-*   [2 Find the JVM](#Find-the-JVM)
-*   [3 eclipse.ini](#eclipse.ini)
-*   [4 See Also:](#See-Also:)
-*   [5 User Comments](#User-Comments)
-
 Starting Eclipse
 ----------------
 

--- a/docs/FAQ/FAQ_How_do_I_set_a_conditional_breakpoint.md
+++ b/docs/FAQ/FAQ_How_do_I_set_a_conditional_breakpoint.md
@@ -12,7 +12,7 @@ Conditions can also be expressed in terms of other breakpoint attributes, such a
 It can occur that an error message is issued when a conditional breakpoint gets hit, even though the breakpoint condition appears to be syntactically correct:
   
 
-![Conditional breakpoint in java.lang.Class.PNG](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/FAQ/images/Conditional_Breakpoint_Error.PNG)  
+![Conditional breakpoint in java.lang.Class.PNG](images/Conditional_Breakpoint_Error.PNG)  
 
   
 
@@ -20,7 +20,7 @@ This can happen if you are setting a breakpoint in a class whose class file does
 
 In the **Variables** view of the debugger, the argument will appear as `arg`_n_, and that placeholder name can actually also be used in the conditional expression for the breakpoint. So, instead of using the variable name `className` in your conditional expression, you simply use the placeholder `arg0`:
 
-![Conditional breakpoint in java.lang.Class.PNG](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/FAQ/images/Conditional_breakpoint_in_java.lang.Class.PNG)  
+![Conditional breakpoint in java.lang.Class.PNG](images/Conditional_breakpoint_in_java.lang.Class.PNG)  
 
 
   

--- a/docs/FAQ/FAQ_How_do_I_upgrade_Eclipse.md
+++ b/docs/FAQ/FAQ_How_do_I_upgrade_Eclipse.md
@@ -3,20 +3,6 @@ FAQ How do I upgrade Eclipse IDE?
 
 (Redirected from [FAQ How do I upgrade Eclipse?](/index.php?title=FAQ_How_do_I_upgrade_Eclipse%3F&redirect=no "FAQ How do I upgrade Eclipse?"))
 
-Contents
---------
-
-*   [1 Upgrading existing Eclipse IDE and Installed Features to newer release](#Upgrading-existing-Eclipse-IDE-and-Installed-Features-to-newer-release)
-*   [2 Always enable major upgrades](#Always-enable-major-upgrades)
-*   [3 Beta-testing milestones and release candidates](#Beta-testing-milestones-and-release-candidates)
-*   [4 Fresh install](#Fresh-install)
-*   [5 Windows specifics](#Windows-specifics)
-*   [6 Older versions (deprecated)](#Older-versions-.28deprecated.29)
-    *   [6.1 Upgrading from previous versions to Neon (4.6) is NOT supported](#Upgrading-from-previous-versions-to-Neon-.284.6.29-is-NOT-supported)
-    *   [6.2 Upgrading from Ganymede (3.4)](#Upgrading-from-Ganymede-.283.4.29)
-    *   [6.3 Upgrading from Europa (3.3) and below](#Upgrading-from-Europa-.283.3.29-and-below)
-    *   [6.4 Upgrading Other Features](#Upgrading-Other-Features)
-*   [7 See Also:](#See-Also:)
 
 Upgrading existing Eclipse IDE and Installed Features to newer release
 ----------------------------------------------------------------------

--- a/docs/FAQ/FAQ_Pages_parts_sites_windows_What_is_all_this_stuff.md
+++ b/docs/FAQ/FAQ_Pages_parts_sites_windows_What_is_all_this_stuff.md
@@ -13,7 +13,7 @@ The main body of a workbench window is represented by the _workbench page_, whic
 
 Parts interact with the rest of the window via their _site_. The site is not a visible entity but simply an API mechanism to separate the methods that operate on the view from the methods that operate on controls and services outside the view. This allows the workbench implementers to add new features to the sites without breaking all the plug-ins that implement the parts. Figure 9.1 Spider graph shows how a view (ContentOutline) and an editor (WelcomeEditor) each has its own site, which is hosted by a page, inside a workbench window, owned by the workbench.
 
-![FAQ views.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/FAQ/images/FAQ_views.png)
+![FAQ views.png](images/FAQ_views.png)
 
 **Figure 9.1**  Spider diagram of site parts
 

--- a/docs/FAQ/FAQ_What_is_a_JDOM.md
+++ b/docs/FAQ/FAQ_What_is_a_JDOM.md
@@ -1,7 +1,7 @@
 FAQ What is a JDOM?
 ===================
 
-![Warning2.png](https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/images/Warning2.png)
+![Warning2.png](images/Warning2.png)
 
 **JDT's JDOM has been superseded by the [DOM/AST](https://help.eclipse.org/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/dom/AST.html), and should no longer be used.**  
 

--- a/docs/FAQ/FAQ_What_is_a_Quick_Fix.md
+++ b/docs/FAQ/FAQ_What_is_a_Quick_Fix.md
@@ -9,12 +9,12 @@ Quick Fixes can be used to make typing much faster. Let's assume that you are us
 
 The JDT can detect syntax errors but is also smart enough to guess what you could do to correct the problem. As can be seen in Figure 3.2, the JDT can create the class for us with a single mouse click.
 
-![](https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/images/120px-Quickfix1.jpg)
+![](images/120px-Quickfix1.jpg)
 
 
 A major tenet of Extreme Programming is to write test cases first. In other words, use cases are specified first; then the implementation is provided. Quick Fixes help in this process. For instance, we start using our Rook class as if it has a move method. Of course, the editor will complain and place a marker next to the reference to the nonexistent method. However, the editor also guesses what we want to do with the method (Figure 3.3).
 
-![](https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/images/120px-Quickguess1.jpg)
+![](images/120px-Quickguess1.jpg)
 
 
 In a similar fashion, Quick Fixes can be used to add fields to classes, add parameters to methods, help with unhandled exceptions, and generate local variable declarations. Quick Fixes are designed to allow you to continue the creative process of designing API while using it, a major component of Extreme Programming.

--- a/docs/FAQ/FAQ_What_is_a_viewer.md
+++ b/docs/FAQ/FAQ_What_is_a_viewer.md
@@ -16,7 +16,7 @@ A viewer is created by first creating an SWT widget, constructing the viewer on 
 
 In general, JFace viewers allow you to create a model-view-controller (MVC) architecture. The view is the underlying SWT widget, the model is specified by the framework user, and the JFace viewer and its associated components form the controller. The viewer input is a model element that seeds the population of the viewer.
 
-![](https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/images/Package_explorer.jpg)
+![](images/Package_explorer.jpg)
 
 JDT Package Explorer
 

--- a/docs/FAQ/FAQ_What_is_a_wizard.md
+++ b/docs/FAQ/FAQ_What_is_a_wizard.md
@@ -5,7 +5,7 @@ FAQ What is a wizard?
 
 A wizard is a series of pages that guide a user through a complex task. **Back** and **Next** buttons allow the user to move forward and backward through the pages. Typically, each page collects a piece of information; when the user clicks the **Finish** button, the information is used to perform a task. At any time before clicking **Finish**, the user can cancel the task, which should undo any side effects of the steps completed so far.
 
-![](https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/images/New_class_wizard.png)
+![](images/New_class_wizard.png)
 
 New Class wizard
 

--- a/docs/FAQ/FAQ_What_is_the_difference_between_a_command_and_an_action.md
+++ b/docs/FAQ/FAQ_What_is_the_difference_between_a_command_and_an_action.md
@@ -7,13 +7,6 @@ Since you have come this far, you probably already understand that Actions and C
 
 The action framework is proven, tightly integrated and fairly easy to program. So, why change?
 
-Contents
---------
-
-*   [1 Actions](#Actions)
-*   [2 Commands](#Commands)
-*   [3 References](#References)
-*   [4 See Also:](#See-Also:)
 
 Actions
 -------

--- a/docs/FAQ/FAQ_Where_can_I_find_more_information_on_SWT.md
+++ b/docs/FAQ/FAQ_Where_can_I_find_more_information_on_SWT.md
@@ -1,16 +1,6 @@
 FAQ Where can I find more information on SWT?
 =============================================
 
-Contents
---------
-
-- [FAQ Where can I find more information on SWT?](#faq-where-can-i-find-more-information-on-swt)
-  - [Contents](#contents)
-  - [Books](#books)
-  - [Websites](#websites)
-  - [Articles](#articles)
-  - [Discussion forums](#discussion-forums)
-  - [See Also](#see-also)
 
 Books
 -----

--- a/docs/FAQ/The_Official_Eclipse_FAQs.md
+++ b/docs/FAQ/The_Official_Eclipse_FAQs.md
@@ -5,38 +5,6 @@ The Official Eclipse FAQs
 
 Note that this FAQ is updated less frequently than [this FAQ](../FAQ.md "IRC FAQ"). You may find your answer there before it makes its way here.
 
-Contents
---------
-
-- [The Official Eclipse FAQs](#the-official-eclipse-faqs)
-  - [Contents](#contents)
-  - [Part I -- The Eclipse Ecosystem](#part-i----the-eclipse-ecosystem)
-    - [The Eclipse Community](#the-eclipse-community)
-    - [Getting Started](#getting-started)
-    - [Java Development in Eclipse](#java-development-in-eclipse)
-    - [Plug-In Development Environment](#plug-in-development-environment)
-  - [Part II -- The Rich Client Platform](#part-ii----the-rich-client-platform)
-    - [All about Plug-ins](#all-about-plug-ins)
-    - [Runtime Facilities](#runtime-facilities)
-    - [Standard Widget Toolkit (SWT)](#standard-widget-toolkit-swt)
-    - [JFace](#jface)
-    - [Generic Workbench](#generic-workbench)
-    - [Perspectives and Views](#perspectives-and-views)
-    - [Generic Editors](#generic-editors)
-    - [Actions, Commands, and Activities](#actions-commands-and-activities)
-    - [Building Your Own Application](#building-your-own-application)
-    - [Productizing an Eclipse Offering](#productizing-an-eclipse-offering)
-  - [Part III -- The Eclipse IDE Platform](#part-iii----the-eclipse-ide-platform)
-    - [Text Editors](#text-editors)
-    - [Help, Search, and Compare](#help-search-and-compare)
-    - [Workspace and Resources API](#workspace-and-resources-api)
-    - [Workbench IDE](#workbench-ide)
-    - [Implementing Support for Your Own Language](#implementing-support-for-your-own-language)
-      - [The language already has parsers, compilers, and other services](#the-language-already-has-parsers-compilers-and-other-services)
-      - [This is a DSL of your own](#this-is-a-dsl-of-your-own)
-      - [Legacy](#legacy)
-    - [Java Development Tool API](#java-development-tool-api)
-    - [Acknowledgement](#acknowledgement)
 
 Part I -- The Eclipse Ecosystem
 -------------------------------

--- a/docs/How_to_add_things_to_the_Eclipse_doc.md
+++ b/docs/How_to_add_things_to_the_Eclipse_doc.md
@@ -1,14 +1,6 @@
 How to add things to the Eclipse doc
 ====================================
 
-Contents
---------
-
-*   [1 Adding new plug-ins and dependencies](#Adding-new-plug-ins-and-dependencies)
-*   [2 Adding new API packages](#Adding-new-API-packages)
-*   [3 Adding new extension points](#Adding-new-extension-points)
-*   [4 JDT and PDE docs](#JDT-and-PDE-docs)
-*   [5 Missing API docs](#Missing-API-docs)
 
 Adding new plug-ins and dependencies
 ------------------------------------

--- a/docs/Naming_Conventions.md
+++ b/docs/Naming_Conventions.md
@@ -1,23 +1,6 @@
 Naming Conventions
 ==================
 
-Contents
---------
-
-*   [1 General](#General)
-    *   [1.1 Eclipse Workspace Projects](#Eclipse-Workspace-Projects)
-    *   [1.2 Java Packages](#Java-Packages)
-    *   [1.3 API Packages](#API-Packages)
-    *   [1.4 Internal Implementation Packages](#Internal-Implementation-Packages)
-    *   [1.5 Test Suite Packages](#Test-Suite-Packages)
-    *   [1.6 Examples Packages](#Examples-Packages)
-    *   [1.7 Additional rules](#Additional-rules)
-*   [2 Classes and Interfaces](#Classes-and-Interfaces)
-*   [3 Methods](#Methods)
-*   [4 Variables](#Variables)
-*   [5 Constants](#Constants)
-*   [6 Plug-ins and Extension Points](#Plug-ins-and-Extension-Points)
-*   [7 System Files and Settings](#System-Files-and-Settings)
 
 General
 -------
@@ -104,7 +87,7 @@ The names of API packages need to make sense to the ISV.
 The number of different packages that the ISV needs to remember should be small, since a profusion of API packages can make it difficult for ISVs to know which packages they need to import. 
 Within an API package, all public classes and interfaces are considered API. 
 The names of API packages should not contain internal, tests, or examples to avoid confusion with the scheme for naming non-API packages. 
-Consult [Eclipse/API Central](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Provisional_API_Guidelines.md) for more detailed information on choosing and naming API elements.
+Consult [Eclipse/API Central](Provisional_API_Guidelines.md) for more detailed information on choosing and naming API elements.
 
 ### Internal Implementation Packages
 

--- a/docs/Progress_Reporting.md
+++ b/docs/Progress_Reporting.md
@@ -5,15 +5,6 @@ Progress Reporting
 
 _by Henrik Lindberg_ - originally posted on [Eclipse by Planatery Transitions](https://henrik-eclipse.blogspot.com/2009/05/progress-monitor-patterns.html)
 
-Contents
---------
-
-*   [1 Problem](#Problem)
-*   [2 Antipattern](#Antipattern)
-*   [3 Good pattern](#Good-pattern)
-*   [4 Good pattern - regular loop](#Good-pattern---regular-loop)
-*   [5 Rules of Thumb](#Rules-of-Thumb)
-
 Problem
 -------
 

--- a/docs/Provisional_API_Guidelines.md
+++ b/docs/Provisional_API_Guidelines.md
@@ -1,19 +1,6 @@
 Eclipse API and Provisional Guidelines
 ======================================
 
-Contents
---------
-
-*   [1 Overview](#Overview)
-*   [2 Before the API freeze](#Before-the-API-freeze)
-    *   [2.1 Package naming](#Package-naming)
-    *   [2.2 Bundle manifest](#Bundle-manifest)
-    *   [2.3 Javadoc](#Javadoc)
-*   [3 After the API freeze](#After-the-API-freeze)
-    *   [3.1 Package naming](#Package-naming-2)
-    *   [3.2 Bundle manifest](#Bundle-manifest-2)
-    *   [3.3 Javadoc](#Javadoc-2)
-*   [4 Changing provisional APIs](#Changing-provisional-APIs)
 
 Overview
 --------
@@ -32,7 +19,7 @@ Definition of terms used in this document:
 
 A package must be exported via the MANIFEST.MF to be considered API.
 However, any package that does contain the segment "internal" and which has not set the x-internal or the x-friends directive in the MANIFEST.MF is not API. 
-See [Naming Conventions](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Naming_Conventions.md) for details)
+See [Naming Conventions](Naming_Conventions.md) for details)
 
 **Internal API**
 

--- a/docs/Status_Handling_Best_Practices.md
+++ b/docs/Status_Handling_Best_Practices.md
@@ -3,30 +3,6 @@
 Status Handling Best Practices
 ==============================
 
-Contents
---------
-
-*   [1 Introduction](#Introduction)
-*   [2 Messages](#Messages)
-    *   [2.1 Message content](#Message-content)
-    *   [2.2 Provide additional information in your message](#Provide-additional-information-in-your-message)
-    *   [2.3 Attempt to use a unique identifier](#Attempt-to-use-a-unique-identifier)
-    *   [2.4 Developing messages in eclipse: using the NLS.bind method](#developing-messages-in-eclipse-using-the-nlsbind-method)
-*   [3 About logging and Error Dialog](#About-logging-and-Error-Dialog)
-    *   [3.1 The concept of a LogRecord](#The-concept-of-a-LogRecord)
-    *   [3.2 Best practices for logging](#Best-practices-for-logging)
-*   [4 The Eclipse IStatus](#The-Eclipse-IStatus)
-    *   [4.1 Calling the Status API](#Calling-the-Status-API)
-    *   [4.2 Implementing your own Status](#Implementing-your-own-Status)
-*   [5 The Eclipse 3.3 Status handler framework](#the-eclipse-33-status-handler-framework)
-*   [6 Using the new Eclipse status handler API](#Using-the-new-Eclipse-status-handler-API)
-    *   [6.1 Calling the StatusManager handle method](#Calling-the-StatusManager-handle-method)
-*   [7 Developing a StatusHandler](#Developing-a-StatusHandler)
-    *   [7.1 Implementing the handle method](#Implementing-the-handle-method)
-*   [8 Developing an ErrorSupportProvider](#Developing-an-ErrorSupportProvider)
-    *   [8.1 Registering your ErrorSupportProvider](#Registering-your-ErrorSupportProvider)
-    *   [8.2 Implementing the createSupportArea method](#Implementing-the-createSupportArea-method)
-    *   [8.3 The flow](#The-flow)
 
 Introduction
 ============

--- a/docs/VersionNumbering.md
+++ b/docs/VersionNumbering.md
@@ -1,30 +1,6 @@
 Version Numbering
 =================
 
-Contents
---------
-
-*   [1 Guidelines on versioning plug-ins](#Guidelines-on-versioning-plug-ins)
-    *   [1.1 When to change the major segment](#When-to-change-the-major-segment)
-    *   [1.2 When to change the minor segment](#When-to-change-the-minor-segment)
-    *   [1.3 When to change the service segment](#When-to-change-the-service-segment)
-    *   [1.4 Overall example](#Overall-example)
-    *   [1.5 When to change the qualifier segment](#When-to-change-the-qualifier-segment)
-    *   [1.6 Plug-ins with no API](#Plug-ins-with-no-API)
-    *   [1.7 Versioning plug-ins that wrap external libraries](#Versioning-plug-ins-that-wrap-external-libraries)
-*   [2 How to specify plug-in requirements](#How-to-specify-plug-in-requirements)
-    *   [2.1 How to specify versions when plug-ins re-export other plug-ins](#How-to-specify-versions-when-plug-ins-re-export-other-plug-ins)
-    *   [2.2 How to version packages](#How-to-version-packages)
-    *   [2.3 Which version to use in Javadoc tags](#Which-version-to-use-in-Javadoc-tags)
-*   [3 Versioning features](#Versioning-features)
-    *   [3.1 To require features or to require bundles](#To-require-features-or-to-require-bundles)
-        *   [3.1.1 Require bundles](#Require-bundles)
-        *   [3.1.2 Require features](#Require-features)
-    *   [3.2 Feature includes](#Feature-includes)
-    *   [3.3 Patch features](#Patch-features)
-*   [4 API Baseline in API Tools](#API-Baseline-in-API-Tools)
-*   [5 pom.xml Versions](#pom.xml-Versions)
-*   [6 Further reading](#Further-reading)
 
 Guidelines on versioning plug-ins
 ---------------------------------
@@ -44,14 +20,14 @@ Each segment captures a different intent:
 
 The major segment number must be increased when a plug-in makes breaking changes to its API. 
 When the major segment is changed the minor and service segments are reset to 0. 
-See [Evolving Java-based APIs](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md) for details on what constitutes a breaking change.
+See [Evolving Java-based APIs](Evolving-Java-based-APIs.md) for details on what constitutes a breaking change.
 
 **Example**: From the version 2.2.7, an incompatible change would lead to 3.0.0. By definition, such changes should not be made when working in a maintenance stream.
 
 ### When to change the minor segment
 
 The minor segment number must be incremented when a plug-in changes in an "externally visible" way. 
-Examples of externally visible changes include [binary compatible API changes](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-2.md) or an increased minimum Java version via the Bundle-RequiredExecutionEnvironment header in the MANIFEST.MF, significant performance changes, major code rework, adding a new extension point, changing files with a somewhat unclear API status (e.g. changing icons from gif to png), etc. Another way to know when this version number should be changed is by exclusion: it should indicate changes that are neither bug fixes (indicated by the service segment) nor breaking API changes (indicated by the major segment). When the minor segment is changed, the service segment is reset to 0.
+Examples of externally visible changes include [binary compatible API changes](Evolving-Java-based-APIs-2.md) or an increased minimum Java version via the Bundle-RequiredExecutionEnvironment header in the MANIFEST.MF, significant performance changes, major code rework, adding a new extension point, changing files with a somewhat unclear API status (e.g. changing icons from gif to png), etc. Another way to know when this version number should be changed is by exclusion: it should indicate changes that are neither bug fixes (indicated by the service segment) nor breaking API changes (indicated by the major segment). When the minor segment is changed, the service segment is reset to 0.
 
 **Example**: From the version 2.2.7, a minor change would lead to 2.3.0.
 
@@ -84,7 +60,7 @@ This example shows how the version of a plug-in reacts to changes (indicated in 
      - 1.1.1
      The plug-in ships as 1.1.1
 
-![Plugin Versioning Figure 1](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/docs/images/Plugin-versioning-fig1.jpg)
+![Plugin Versioning Figure 1](images/Plugin-versioning-fig1.jpg)
 
 ### When to change the qualifier segment
 
@@ -251,7 +227,7 @@ If you use an older version as API Baseline, you will miss some API problems.
 Further reading
 ---------------
 
-*   See [Evolving Java-based APIs Part 1](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs.md)
-*   See [Evolving Java-based APIs Part 2](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-2.md)
-*   See [Evolving Java-based APIs Part 3](https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/Evolving-Java-based-APIs-3.md)
+*   See [Evolving Java-based APIs Part 1](Evolving-Java-based-APIs.md)
+*   See [Evolving Java-based APIs Part 2](Evolving-Java-based-APIs-2.md)
+*   See [Evolving Java-based APIs Part 3](Evolving-Java-based-APIs-3.md)
 


### PR DESCRIPTION
- Add a .project file to `docs` folder  for a project named `org.eclipse.platform.docs`
- Remove internal table of content entries.
- Fix broken links and avoid absolute raw and self links.