### PR TITLE
Compare selection or editor with clipboard

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.compare.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.CompareEditorInput;
+import org.eclipse.compare.CompareUI;
+import org.eclipse.compare.IStreamContentAccessor;
+import org.eclipse.compare.ITypedElement;
+import org.eclipse.compare.structuremergeviewer.DiffNode;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.swt.dnd.Clipboard;
+import org.eclipse.swt.dnd.TextTransfer;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public class ClipboardCompare extends BaseCompareAction{
+
+	private String clipboard = "Clipboard"; //$NON-NLS-1$
+
+	@Override
+	protected void run(ISelection selection) {
+		IFile[] files = Utilities.getFiles(selection);
+		for (IFile file : files) {
+			try {
+				processComparison(file);
+			} catch (Exception e) {
+				Shell parentShell = CompareUIPlugin.getShell();
+				MessageDialog.openError(parentShell, "Comparision Failed", e.getMessage()); //$NON-NLS-1$
+			}
+		}
+	}
+	@Override
+	protected boolean isEnabled(ISelection selection) {
+		return Utilities.getFiles(selection).length == 1 && getClipboard() != null;
+	}
+
+	/**
+	 * Process comparison with selection or entire editor contents with contents in
+	 * clipboard
+	 *
+	 * @param file Editor file
+	 * @throws IOException, CoreException
+	 */
+	private void processComparison(IFile file) throws IOException, CoreException {
+		String cb = getClipboard().toString();
+		String fileName = file.getName();
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		IEditorPart editor = page.getActiveEditor();
+		final String selectionContents;
+		if (editor instanceof ITextEditor txtEditor) {
+			ISelection selection = txtEditor.getSelectionProvider().getSelection();
+			if (selection instanceof ITextSelection textSelection) {
+				selectionContents = textSelection.getText();
+				if (selectionContents.isEmpty()) {
+					String fileContents = new String(file.getContents().readAllBytes(), file.getCharset());
+					showComparison(fileContents, fileName, cb);
+				} else {
+					showComparison(selectionContents, fileName, cb);
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Shows comparison result
+	 *
+	 * @param source            Either selection from current editor or entire
+	 *                          editor if no selection
+	 * @param fileName          Editor file name
+	 * @param clipboardContents Contents in clipboard
+	 */
+	private void showComparison(String source, String fileName, String clipboardContents) {
+		class ClipboardTypedElement implements ITypedElement, IStreamContentAccessor {
+			private final String name;
+			private final String content;
+
+			public ClipboardTypedElement(String name, String content) {
+				this.name = name;
+				this.content = content;
+			}
+
+			@Override
+			public String getName() {
+				return name;
+			}
+
+			@Override
+			public Image getImage() {
+				return null;
+			}
+
+			@Override
+			public String getType() {
+				return null;
+			}
+
+			@Override
+			public InputStream getContents() throws CoreException {
+				return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+			}
+
+		}
+		CompareConfiguration config = new CompareConfiguration();
+		config.setLeftLabel(fileName);
+		config.setRightLabel(clipboard);
+		config.setLeftEditable(true);
+		config.setRightEditable(true);
+		CompareEditorInput compareInput = new CompareEditorInput(config) {
+			@Override
+			protected Object prepareInput(IProgressMonitor monitor)
+					throws InvocationTargetException, InterruptedException {
+				return new DiffNode(new ClipboardTypedElement(fileName, source),
+						new ClipboardTypedElement(clipboard, clipboardContents));
+
+			}
+		};
+		CompareUI.openCompareEditor(compareInput);
+	}
+
+	/**
+	 * Returns Clipboard Object or null if there is nothing in clipboard
+	 *
+	 * @returns Clipboard Object or null
+	 */
+	private Object getClipboard() {
+		Clipboard clip = new Clipboard(Display.getDefault());
+		return clip.getContents(TextTransfer.getInstance());
+	}
+
+}

--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2016 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -97,6 +97,9 @@ CompareWithOtherResource.tooltip= Open the 'Compare With' Dialog
 
 CompareWithHistoryAction.label= &Local History...
 CompareWithHistoryAction.tooltip= Compare the Selected Resource with Local History
+
+CompareWithClipboardAction.label= Clipboard
+CompareWithClipboardAction.tooltip= Compare the selection or entire contents in editor with contents in clipboard
 
 ReplaceWithMenu.label= Rep&lace With
 

--- a/team/bundles/org.eclipse.compare/plugin.xml
+++ b/team/bundles/org.eclipse.compare/plugin.xml
@@ -310,6 +310,14 @@
             </separator>
          </menu>
          <action
+               label="%CompareWithClipboardAction.label"
+               tooltip="%CompareWithClipboardAction.tooltip"
+               class="org.eclipse.compare.internal.ClipboardCompare"
+               menubarPath="compareWithMenu/compareWithGroup"
+               enablesFor="1"
+               id="compareWithClipboard ">
+         </action>
+         <action
                label="%CompareWithHistoryAction.label"
                tooltip="%CompareWithHistoryAction.tooltip"
                class="org.eclipse.compare.internal.CompareWithEditionAction"


### PR DESCRIPTION
This feature will allow users to compare either the selected text or the entire editor content against the current clipboard contents.
<br>
<img width="719" alt="image" src="https://github.com/user-attachments/assets/1be8ea04-06a1-4e3f-afe9-163ad03ff2f8" />
<br>
If users want to just compare just a selection in an editor, select the section and choose _Compare with-> Clipboard_
(I had changes copied..)

https://github.com/user-attachments/assets/38d38751-1cd2-4c88-80f2-6d2f329744b7


<br>

https://github.com/user-attachments/assets/fc0d271b-fa47-4585-83cc-d19daabe7443



<br>
If User want to compare entire Editor, either select all or select None and choose _Compare with-> Clipboard_

https://github.com/user-attachments/assets/1d6d9f67-2e00-48c7-8f45-a5fbba2ba5c9


