### PR TITLE
Null check for org.eclipse.help.IContext

### DIFF
--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/DefaultHelpUI.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/DefaultHelpUI.java
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -333,6 +333,9 @@ public class DefaultHelpUI extends AbstractHelpUI {
 												 * If the context help has no description text and exactly one
 												 * topic, go straight to the topic and skip context help.
 												 */
+					if (context == null) {
+						return;
+					}
 					String contextText = context.getText();
 					IHelpResource[] topics = context.getRelatedTopics();
 					boolean isSingleChoiceWithoutDescription = contextText == null && topics.length == 1;


### PR DESCRIPTION
Check whether context is null or not before invoking getText()

Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/1689