### PR TITLE
Add SWT PDE contribution activity pattern binding

### DIFF
--- a/platform/org.eclipse.sdk/plugin.xml
+++ b/platform/org.eclipse.sdk/plugin.xml
@@ -129,6 +129,12 @@
             activityId="org.eclipse.plugInDevelopment"
             pattern="org\.eclipse\.pde/.*">
       </activityPatternBinding>
+
+      <activityPatternBinding
+            activityId="org.eclipse.plugInDevelopment"
+            pattern="org\.eclipse\.swt\.tools.*">
+      </activityPatternBinding>
+      
       <activityPatternBinding
             activityId="org.eclipse.debugSupport"
             pattern="org\.eclipse\.debug\.ui/.*">


### PR DESCRIPTION
This filters all contributions from org.eclipse.swt.tools.* bundles if "Plugin Development" activity is disabled.

Requires
https://github.com/eclipse-platform/eclipse.platform.ui/pull/2967 to filter also SWT Tools "e4" contributions.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1869