### PR TITLE
Replacing custom logic in Help>Search results to disable icons, with Image constructor call

### DIFF
--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/EngineResultSection.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/EngineResultSection.java
@@ -34,7 +34,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -158,9 +157,9 @@ public class EngineResultSection {
 		searchResults.setImage(ISharedImages.IMG_OBJS_ERROR_TSK, PlatformUI.getWorkbench().getSharedImages()
 				.getImage(ISharedImages.IMG_OBJS_ERROR_TSK));
 		searchResults.setImage(desc.getId(), desc.getIconImage());
-		Image grayedImage = getGrayedImage(desc.getIconImage());
-		searchResults.setImage(KEY_PREFIX_GRAYED + desc.getId(), grayedImage);
-		searchResults.addDisposeListener(e -> grayedImage.dispose());
+		Image disabledImage = new Image(desc.getIconImage().getDevice(), desc.getIconImage(), SWT.IMAGE_GRAY);
+		searchResults.setImage(KEY_PREFIX_GRAYED + desc.getId(), disabledImage);
+		searchResults.addDisposeListener(e -> disabledImage.dispose());
 		searchResults.addHyperlinkListener(new IHyperlinkListener() {
 
 			@Override
@@ -307,39 +306,6 @@ public class EngineResultSection {
 			sorter.sort(null, results);
 		}
 		return results;
-	}
-
-	/**
-	 * Returns a copy of the given image but grayed and half transparent.
-	 * This gives the icon a grayed/disabled look.
-	 *
-	 * @param image the image to gray
-	 * @return the grayed image
-	 */
-	private Image getGrayedImage(Image image) {
-		// first gray the image
-		Image temp = new Image(image.getDevice(), image, SWT.IMAGE_GRAY);
-		// then add alpha to blend it 50/50 with the background
-		ImageData data = temp.getImageData();
-		ImageData maskData = data.getTransparencyMask();
-		if (maskData != null) {
-			for (int y=0;y<maskData.height;++y) {
-				for (int x=0;x<maskData.width;++x) {
-					if (maskData.getPixel(x, y) == 0) {
-						// masked; set to transparent
-						data.setAlpha(x, y, 0);
-					}
-					else {
-						// not masked; set to translucent
-						data.setAlpha(x, y, 128);
-					}
-				}
-			}
-			data.maskData = null;
-		}
-		Image grayed = new Image(image.getDevice(), data);
-		temp.dispose();
-		return grayed;
 	}
 
 	void updateResults(boolean reflow) {


### PR DESCRIPTION
### Summary

For the results displayed in `Help>Search`, Previously, icons for disabled search hits were created by custom pixel-level manipulation using `ImageData`. This approach, at high zoom levels (e.g., 225%), causes icons to appear slightly distorted, as scaling of `ImageData` is a destructive operation. This logic has now been replaced by a call to the `Image` constructor with the flag set to disabled.

---

### Screenshots at 225%

<table>
  <tr>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/1d9f6581-ad8a-4645-9bb9-6c15cca20f67" />
      <br/>
      <sub>Current Behaviour</sub>
    </td>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/f9259952-ee14-4c55-b7f1-62933ba452b7" />
      <br/>
      <sub>With This Change</sub>
    </td>
  </tr>
</table>

---

### Steps to reproduce

Testing this change directly in the runtime workspace is complicated due to conditional logic that disables icons only when the corresponding search hit is considered a **potential hit** — and a potential hit is defined as one **without any filters applied**.

To simulate the change for the purposes of this PR, the following line can be temporarily modified:

```diff
- boolean isPotentialHit = (hit instanceof SearchHit && ((SearchHit) hit).isPotentialHit());
+ boolean isPotentialHit = true;
```

File: [`EngineResultSection.java`](https://github.com/eclipse-platform/eclipse.platform/blob/master/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/EngineResultSection.java#L379)

---

### Related Issue

Contributes to: https://github.com/vi-eclipse/Eclipse-Platform/issues/199
