### PR TITLE
Replace manual image instantiation of Image in AsynchronousViewer and TreeModelLabelProvider with createImage() for better scaling of icons

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
@@ -295,7 +295,7 @@ public abstract class AsynchronousViewer extends StructuredViewer implements Lis
 		}
 		Image image = fImageCache.get(descriptor);
 		if (image == null) {
-			image = new Image(getControl().getDisplay(), descriptor.getImageData());
+			image = descriptor.createImage();
 			fImageCache.put(descriptor, image);
 		}
 		return image;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
@@ -149,7 +149,7 @@ public class TreeModelLabelProvider extends ColumnLabelProvider
 		}
 		Image image = fImageCache.get(descriptor);
 		if (image == null) {
-			image = new Image(getDisplay(), descriptor.getImageData());
+			image = descriptor.createImage();
 			fImageCache.put(descriptor, image);
 		}
 		return image;


### PR DESCRIPTION
Replaced direct image creation using new Image(..., descriptor.getImageData()) with descriptor.createImage() in both AsynchronousViewer and TreeModelLabelProvider. This change ensures that icons now render sharply even at higher zoom levels (e.g., 225%).

Screenshots at 225% (I have circled in red in the first image for the icon that is being affected with the change)


<table> <tr> <td align="center" valign="top"> <img src="https://github.com/user-attachments/assets/1f7fceb2-b6ba-4e5e-b406-c17fb49f0710" /> <br/> <sub>Current Behavior</sub> </td> <td align="center" valign="top"> <img src="https://github.com/user-attachments/assets/1b2e2d44-c0ea-493a-b220-534188991cd7" /> <br/> <sub>After This Change</sub> </td> </tr> </table>

**Steps to Reproduce**
To observe the change in AsynchronousViewer, run the Memory View in Eclipse CDT. The icons are shown during debugging when a C++ application is monitored with memory watches, and the variable’s memory address changes.

While it requires some effort to set up, the change itself is minimal and self-explanatory.

Contributes to: https://github.com/vi-eclipse/Eclipse-Platform/issues/199