### PR TITLE
Remove unnecessary casts

### DIFF
--- a/ua/org.eclipse.help/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_plugin_name
 Bundle-SymbolicName: org.eclipse.help; singleton:=true
-Bundle-Version: 3.10.500.qualifier
+Bundle-Version: 3.10.600.qualifier
 Bundle-Activator: org.eclipse.help.internal.HelpPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help/pom.xml
+++ b/ua/org.eclipse.help/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.help</artifactId>
-  <version>3.10.500-SNAPSHOT</version>
+  <version>3.10.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ua/org.eclipse.help/src/org/eclipse/help/internal/criteria/CriteriaDefinitionManager.java
+++ b/ua/org.eclipse.help/src/org/eclipse/help/internal/criteria/CriteriaDefinitionManager.java
@@ -107,7 +107,7 @@ public class CriteriaDefinitionManager {
 					contribution.setId(contrib[j].getId());
 					contribution.setLocale(contrib[j].getLocale());
 					ICriteriaDefinition criteria = contrib[j].getCriteriaDefinition();
-					contribution.setCriteriaDefinition(criteria instanceof CriteriaDefinition ? (CriteriaDefinition)criteria  : (CriteriaDefinition)UAElementFactory.newElement(criteria));
+					contribution.setCriteriaDefinition(criteria instanceof CriteriaDefinition ? criteria  : (CriteriaDefinition)UAElementFactory.newElement(criteria));
 					contributions.add(contribution);
 				}
 			}

--- a/ua/org.eclipse.help/src/org/eclipse/help/internal/index/IndexManager.java
+++ b/ua/org.eclipse.help/src/org/eclipse/help/internal/index/IndexManager.java
@@ -104,7 +104,7 @@ public class IndexManager {
 						contribution.setId(contrib[j].getId());
 						contribution.setLocale(contrib[j].getLocale());
 						IIndex index = contrib[j].getIndex();
-						contribution.setIndex(index instanceof Index ? (Index) index
+						contribution.setIndex(index instanceof Index ? index
 								: (Index) UAElementFactory.newElement(index));
 						contributions.add(contribution);
 					}


### PR DESCRIPTION
Otherwise cleanup https://github.com/eclipse-platform/eclipse.platform/pull/1943 will assign useless variable names to casted values