### PR TITLE
fix: do not verify proxy data during initialization

### DIFF
--- a/team/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/ProxyType.java
+++ b/team/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/ProxyType.java
@@ -543,10 +543,7 @@ public class ProxyType implements INodeChangeListener, IPreferenceChangeListener
 	}
 
 	public void initialize() {
-		// On mac, the system proxy configuration is set by the JVM automatically
-		boolean isMac = "macosx".equals(System.getProperty("osgi.os"));  //$NON-NLS-1$//$NON-NLS-2$
-		int verify = isMac ? DO_NOT_VERIFY : VERIFY_EMPTY;
-		updateSystemProperties(getProxyData(verify));
+		updateSystemProperties(getProxyData(DO_NOT_VERIFY));
 		preferenceManager.addNodeChangeListener(PREF_PROXY_DATA_NODE, this);
 		preferenceManager.addPreferenceChangeListener(getPreferenceNode(), this);
 	}


### PR DESCRIPTION
as it produces `System property {0} has been set to {1} by an external source. This value will be overwritten using the values from the preferences` when the user sets the system properties to avoid the info message `System property {0} is not set but should be {1}`

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1951