### PR TITLE
Add UI to select if a terminal session should be allocated

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
@@ -48,6 +48,10 @@ public class LaunchConfigurationsMessages extends NLS {
 	public static String CommonTab_20;
 	public static String CommonTab_21;
 	public static String CommonTab_22;
+
+	public static String CommonTab_23;
+
+	public static String CommonTab_24;
 	public static String CommonTab_3;
 	public static String CommonTab_4;
 	public static String CommonTab_5;
@@ -65,6 +69,8 @@ public class LaunchConfigurationsMessages extends NLS {
 	public static String CommonTab_AttributeLabel_LaunchInBackground;
 	public static String CommonTab_AttributeLabel_FavoriteGroups;
 	public static String CommonTab_AttributeLabel_TerminateDescendants;
+
+	public static String CommonTab_disable_console_input;
 
 	public static String CompileErrorProjectPromptStatusHandler_0;
 	public static String CompileErrorProjectPromptStatusHandler_1;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
@@ -41,6 +41,8 @@ CommonTab_2=Defa&ult - inherited from project and workspace ({0})
 CommonTab_22=Use &system encoding ({0})
 CommonTab_20=Variables...
 CommonTab_21=&Merge standard and error output (disables coloring of error output)
+CommonTab_23=Allocate Terminal
+CommonTab_24=&Allocate text console
 CommonTab_3=Oth&er
 CommonTab_4=Standard Input and Output
 CommonTab_5=&Allocate console (necessary for input)
@@ -57,6 +59,7 @@ CommonTab_AttributeLabel_AppendToFile=Append to file
 CommonTab_AttributeLabel_LaunchInBackground=Launch in background
 CommonTab_AttributeLabel_FavoriteGroups=Favorite groups
 CommonTab_AttributeLabel_TerminateDescendants=&Terminate child-processes if terminating the launched process
+CommonTab_disable_console_input=Disable Input/Output
 
 CompileErrorPromptStatusHandler_0=Errors in Workspace
 CompileErrorPromptStatusHandler_1=Errors exist in a required project. Continue launch?


### PR DESCRIPTION
Currently the user only has the option to choose to allocate a (text)console or not.

This now adds a new option to allocate a terminal session for a run if the platforms terminal bundle is installed.

![grafik](https://github.com/user-attachments/assets/b9acfa69-1d50-459b-810c-af361bb4bf70)

See
- https://github.com/eclipse-platform/eclipse.platform/pull/1762