### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/debug/org.eclipse.debug.tests/forceQualifierUpdate.txt
+++ b/debug/org.eclipse.debug.tests/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 516076 - Fix comparator errors caused by GVT47 : Non-externalized strings in
 Bug 517740: [Launch Group] Externalisation of strings broke Group Launch UI
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3137


### PR DESCRIPTION
Changes to ecj are to remove redundant bytecode, see: eclipse-jdt/eclipse.jdt.core#3465

See: eclipse-platform/eclipse.platform.releng.aggregator#3137