### PR TITLE
Import fragments in the feature to reflect p2.inf in bundles

### DIFF
--- a/terminal/features/org.eclipse.platform.terminal.feature/feature.xml
+++ b/terminal/features/org.eclipse.platform.terminal.feature/feature.xml
@@ -17,6 +17,15 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.eclipse.cdt.core.linux.x86_64"  filter="(&amp;(osgi.os=linux)(osgi.arch=x86_64))"/>
+      <import plugin="org.eclipse.cdt.core.linux.ppc64le" filter="(&amp;(osgi.os=linux)(osgi.arch=ppc64le))"/>
+      <import plugin="org.eclipse.cdt.core.linux.aarch64" filter="(&amp;(osgi.os=linux)(osgi.arch=aarch64))"/>
+      <import plugin="org.eclipse.cdt.core.macosx"        filter="(osgi.os=macosx)"/>
+      <import plugin="org.eclipse.cdt.core.win32.x86_64"  filter="(&amp;(osgi.os=win32)(osgi.arch=x86_64))"/>
+      <import plugin="org.eclipse.cdt.core.win32.aarch64" filter="(&amp;(osgi.os=win32)(osgi.arch=aarch64))"/>
+   </requires>
+
    <plugin
          id="org.eclipse.tm.terminal.control"
          version="0.0.0"/>


### PR DESCRIPTION
Currently we have for the bundles that require the native fragments a p2.inf to pull them in. This does not work in the IDE as PDE has no way to understand P2 metadata that is possibly not present (e.g. when consumed from a target platform).

This now adds requires/import to the feature to get the same effect when using the feature in an IDE launch without explicitly require to depend on a strict version.

Thanks to https://github.com/eclipse-pde/eclipse.pde/pull/1825 this now work without getting some warnings on each launch and will improve user experience when using this feature.