### PR TITLE
Fixed some eclipse.tm.terminal > eclipse.terminal move errors

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/plugin.xml
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/plugin.xml
@@ -427,11 +427,11 @@
 
       <activityPatternBinding
             activityId="org.eclipse.terminal.view.ui.activity.views"
-            pattern="org\.eclipse\.tm\.terminal\.view\.ui/org\.eclipse\.tm\.terminal\.view\.ui\.TerminalsView">
+            pattern="org\.eclipse\.terminal\.view\.ui/org\.eclipse\.terminal\.view\.ui\.TerminalsView">
       </activityPatternBinding>
       <activityPatternBinding
             activityId="org.eclipse.terminal.view.ui.activity.views"
-            pattern="org\.eclipse\.tm\.terminal\.view\.ui/org\.eclipse\.tm\.terminal\.view\.ui\.commands\.^(?!org\.eclipse\.tm\.terminal\.view\.ui\.commands\.launchToolbar).*">
+            pattern="org\.eclipse\.terminal\.view\.ui/org\.eclipse\.terminal\.view\.ui\.commands\.^(?!org\.eclipse\.terminal\.view\.ui\.commands\.launchToolbar).*">
       </activityPatternBinding>
       
       <categoryActivityBinding
@@ -477,11 +477,11 @@
 
       <activityPatternBinding
             activityId="org.eclipse.terminal.view.ui.activity.maintoolbar"
-            pattern="org\.eclipse\.tm\.terminal\.view\.ui/org\.eclipse\.tm\.terminal\.view\.ui\.toolbar">
+            pattern="org\.eclipse\.terminal\.view\.ui/org\.eclipse\.terminal\.view\.ui\.toolbar">
       </activityPatternBinding>
       <activityPatternBinding
             activityId="org.eclipse.terminal.view.ui.activity.maintoolbar"
-            pattern="org\.eclipse\.tm\.terminal\.view\.ui/org\.eclipse\.tm\.terminal\.view\.ui\.commands\.launchToolbar">
+            pattern="org\.eclipse\.terminal\.view\.ui/org\.eclipse\.terminal\.view\.ui\.command.*\.launchToolbar">
       </activityPatternBinding>
 
       <categoryActivityBinding

--- a/terminal/bundles/org.eclipse.terminal.view.ui/schema/launcherDelegates.exsd
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/schema/launcherDelegates.exsd
@@ -125,7 +125,7 @@ The terminal launcher delegate implementation class must be specified either by 
 The terminal launcher delegate implementation class must be specified either by the class attribute or the class child element!
                </documentation>
                <appinfo>
-                  <meta.attribute kind="java" basedOn="org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate:org.eclipse.tm.terminal.view.ui.interfaces.ILauncherDelegate"/>
+                  <meta.attribute kind="java" basedOn="org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate:org.eclipse.terminal.view.ui.interfaces.ILauncherDelegate"/>
                </appinfo>
             </annotation>
          </attribute>


### PR DESCRIPTION
This commit fixes activities and extension point definitions.

Follow up on f38c5a858532dcc61fb8ddb21c0ca9b753f35fe3 changes.