### PR TITLE
Do not call `WaitForMultipleObjects` with 0 as first parameter

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Natives.java
@@ -193,7 +193,7 @@ public class Win32Natives {
 	 *   <li>All of the objects are signaled, when bWaitAll is <code>true</code></li>
 	 *   <li>The timeout interval of dwMilliseconds elapses.</li>
 	 * </ul>
-	 * @param nCount The number of handles, cannot be greater than MAXIMUM_WAIT_OBJECTS.
+	 * @param nCount The number of handles, cannot be zero and cannot be greater than MAXIMUM_WAIT_OBJECTS.
 	 * @param lpHandles The array of handles to objects to be waited upon cannot contain
 	 * duplicate handles.
 	 * @param bWaitAll If <code>true</code> requires all objects to be signaled before this


### PR DESCRIPTION
The reason for this is that Microsoft's [documentation](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects#parameters) clearly states: 

> Parameters
>
> [in] nCount
>
> The number of object handles in the array pointed to by lpHandles. The maximum number of object handles is MAXIMUM_WAIT_OBJECTS. **This parameter cannot be zero.**

And this was never checked in the code. The scenario might seem unlikely but the code allows for it, which is why I added a simple check and improved the documentation.