### PR TITLE
Simplify calls to Win32Monitor::setHandleValueArrays

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Monitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/refresh/win32/Win32Monitor.java
@@ -221,7 +221,7 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 			setHandleValue(createHandleValue(path, subtree, Win32Natives.FILE_NOTIFY_CHANGE_FILE_NAME | Win32Natives.FILE_NOTIFY_CHANGE_DIR_NAME | Win32Natives.FILE_NOTIFY_CHANGE_LAST_WRITE | Win32Natives.FILE_NOTIFY_CHANGE_SIZE));
 			if (isOpen()) {
 				fHandleValueToHandle.put(getHandleValue(), this);
-				setHandleValueArrays(createHandleArrays());
+				setHandleValueArrays();
 			} else {
 				close();
 			}
@@ -369,7 +369,7 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 		setPriority(Job.DECORATE);
 		setSystem(true);
 		fHandleValueToHandle = new HashMap<>(1);
-		setHandleValueArrays(createHandleArrays());
+		setHandleValueArrays();
 	}
 
 	/**
@@ -424,7 +424,7 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 	 * Win32Natives.MAXIMUM_WAIT_OBJECTS. The arrays are balanced so that they
 	 * differ in size by no more than one element.
 	 */
-	protected long[][] createHandleArrays() {
+	private long[][] createHandleArrays() {
 		long[] handles;
 		// synchronized: in order to protect the map during iteration
 		synchronized (fHandleValueToHandle) {
@@ -524,7 +524,7 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 				fHandleValueToHandle.remove(handle.getHandleValue());
 				handle.destroy();
 			}
-			setHandleValueArrays(createHandleArrays());
+			setHandleValueArrays();
 		}
 	}
 
@@ -572,8 +572,8 @@ class Win32Monitor extends Job implements IRefreshMonitor {
 		return Status.OK_STATUS;
 	}
 
-	protected void setHandleValueArrays(long[][] arrays) {
-		fHandleValueArrays = arrays;
+	private void setHandleValueArrays() {
+		fHandleValueArrays = createHandleArrays();
 	}
 
 	@Override


### PR DESCRIPTION
- Remove parameter and obtain it inside the method instead (it was always the same parameter)
- Reduce visibility of 2 methods

The reason for this is that `fHandleValueArrays` needs to be balanced (all of its rows/arrays need to be very similar in size) which means that there is currently no other possible appropriate value for it than the one generated by `createHandleArrays()` (which is why the method was being used every time to provide the input parameter: `long[][] arrays`).

This PR makes this correlation between the 2 methods more obvious thus simplifying the API while reducing the risk that callers mess up the invocation in the future.