### PR TITLE
Test Variations of the Eclipse Icon

### DIFF
--- a/platform/org.eclipse.sdk/eclipse16.svg
+++ b/platform/org.eclipse.sdk/eclipse16.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 1.3617021 1.3617021"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse16.svg"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.3906251"
+     inkscape:cy="5.2343751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1682"
+     inkscape:window-height="1033"
+     inkscape:window-x="220"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 0.40346119,0.84984676 H 0.21424145 c 0.0250542,0.0911041 0.0715448,0.17275664 0.13960955,0.24492124 0.10850978,0.1150391 0.23898823,0.1724809 0.39157083,0.1724809 0.0305008,0 0.0600526,-0.00242 0.0887563,-0.00699 C 0.94910676,1.2418648 1.0497284,1.186783 1.1359419,1.0947681 1.2044471,1.022627 1.2512661,0.94095104 1.2765119,0.84984685 H 1.1997235 1.0874392 Z"
+       id="path2" />
+    <path
+       d="m 0.29912249,0.57740797 h -0.0988478 c -0.003616,0.0230246 -0.00608,0.0465284 -0.007199,0.0706312 h 0.1174827 0.0589335 0.85066471 0.077648 c -0.00113,-0.0241028 -0.00359,-0.0476066 -0.00724,-0.0706312"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       d="m 0.19307616,0.71362698 c 0.001119,0.0241148 0.003571,0.0476186 0.007199,0.0706312 h 0.10276911 0.0778961 0.83227843 0.077365 c 0.00364,-0.0230126 0.00612,-0.0465164 0.00726,-0.0706312"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133164" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 1.2765345,0.51180881 C 1.2513112,0.42045308 1.2044808,0.33841738 1.1359418,0.26574966 1.0499544,0.17459763 0.94961507,0.11991109 0.83505943,0.1015106 0.80608483,0.0968525 0.77623933,0.0944056 0.74542233,0.0944056 c -0.1525826,0 -0.28307238,0.05712998 -0.39157084,0.17134289 -0.0680866,0.0726676 -0.11460096,0.1547034 -0.13964335,0.24605915"
+       id="path10" />
+    <path
+       d="m 0.16022485,0.68085105 c 0,-0.30935886 0.21917824,-0.56640322 0.50430771,-0.61161389 -0.007074,-2.7553e-4 -0.0141825,-5.7502e-4 -0.0213245,-5.7502e-4 -0.31996972,0 -0.57937867,0.2740912 -0.57937867,0.61218891 0,0.33810975 0.25939765,0.61218895 0.57937867,0.61218895 0.007165,0 0.0142729,-2.875e-4 0.0213697,-5.63e-4 C 0.37940309,1.2472663 0.16022485,0.9902219 0.16022485,0.68085105 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       style="fill:#f7941e;stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.6480272 C 1.1195384,0.6238166 1.1156884,0.60020499 1.1099524,0.577396 H 0.38093999 c -0.005741,0.022797 -0.009594,0.0464086 -0.0114477,0.0706312 z"
+       id="path37"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_1_);stroke-width:0.133164" />
+    <path
+       d="M 1.1213884,0.71362698 H 0.36950362 c 0.001853,0.0242106 0.005684,0.0478222 0.0114364,0.0706312 H 1.1099633 c 0.00574,-0.022809 0.00957,-0.0464206 0.011425,-0.0706312 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_2_);stroke-width:0.133164" />
+    <path
+       d="m 0.745446,1.080823 c 0.15139629,0 0.2818975,-0.0945544 0.3419949,-0.23097701 H 0.4034511 C 0.46354855,0.98626865 0.59404972,1.080823 0.745446,1.080823 Z"
+       id="path51"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_3_);stroke-width:0.133164" />
+    <path
+       d="M 0.31377957,0.71362698 H 0.36897247 1.122801 1.22183 1.297059 c 5.198e-4,-0.0104342 8.137e-4,-0.0209402 8.137e-4,-0.0315181 0,-0.0114404 -3.956e-4,-0.022785 -0.00101,-0.0340817 H 1.2218182 1.1227897 0.36896118 0.30986951 0.19307616 c -6.1025e-4,0.0112847 -0.001006,0.0226413 -0.001006,0.0340817 0,0.0105779 2.9382e-4,0.0210839 8.1365e-4,0.0315181 z"
+       id="path55"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 0.40124746,0.51180818 H 0.21419728 c -0.006148,0.0213595 -0.0101142,0.04327 -0.0139225,0.0655998 h 0.096339 0.0820322 0.73092182 0.103515 0.073986 c -0.00382,-0.0223178 -0.00874,-0.0442283 -0.014872,-0.0655998"
+       id="path57"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+    <path
+       d="M 1.2160096,0.7842462 H 1.1124947 0.38158413 0.30347328 0.20026344 c 0.003707,0.0223178 0.007922,0.0442164 0.0139677,0.0655998 h 0.18993187 0.68575279 0.1125781 0.073319 c 0.00603,-0.0213714 0.010905,-0.04327 0.014623,-0.0655998 z"
+       id="path59"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.133164" />
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse16_1.0px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse16_1.0px_space.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 1.3617021 1.3617021"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse16_new.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.0110565,0,0,-0.01443215,-0.70798348,6.6552053)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.01105612,0,0,-0.01443459,-0.70795157,6.6623016)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="5.9609375"
+     inkscape:cy="6.1796875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 0.40346119,0.84984676 H 0.21424145 c 0.0250542,0.0911041 0.0715448,0.17275664 0.13960955,0.24492124 0.10850978,0.1150391 0.23898823,0.1724809 0.39157083,0.1724809 0.0305008,0 0.0600526,-0.00242 0.0887563,-0.00699 C 0.94910676,1.2418648 1.0497284,1.186783 1.1359419,1.0947681 1.2044471,1.022627 1.2512661,0.94095104 1.2765119,0.84984685 H 1.1997235 1.0874392 Z"
+       id="path2" />
+    <path
+       d="m 0.30800961,0.55320594 h -0.0967113 c -0.003538,0.0277386 -0.005949,0.0560544 -0.007043,0.085092 h 0.1149434 0.0576597 0.83227819 0.07597 c -0.00111,-0.0290375 -0.00351,-0.0573534 -0.00708,-0.085092"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.144573" />
+    <path
+       d="m 0.20425531,0.72340424 c 0.001095,0.0290569 0.003494,0.0573776 0.007043,0.0851064 h 0.10054431 0.0762098 0.81426078 0.07569 c 0.00356,-0.0277288 0.00599,-0.0560495 0.0071,-0.0851064"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.144583" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 1.2765345,0.51180881 C 1.2513112,0.42045308 1.2044808,0.33841738 1.1359418,0.26574966 1.0499544,0.17459763 0.94961507,0.11991109 0.83505943,0.1015106 0.80608483,0.0968525 0.77623933,0.0944056 0.74542233,0.0944056 c -0.1525826,0 -0.28307238,0.05712998 -0.39157084,0.17134289 -0.0680866,0.0726676 -0.11460096,0.1547034 -0.13964335,0.24605915"
+       id="path10" />
+    <path
+       d="m 0.16022485,0.68085105 c 0,-0.30935886 0.21917824,-0.56640322 0.50430771,-0.61161389 -0.007074,-2.7553e-4 -0.0141825,-5.7502e-4 -0.0213245,-5.7502e-4 -0.31996972,0 -0.57937867,0.2740912 -0.57937867,0.61218891 0,0.33810975 0.25939765,0.61218895 0.57937867,0.61218895 0.007165,0 0.0142729,-2.875e-4 0.0213697,-5.63e-4 C 0.37940309,1.2472663 0.16022485,0.9902219 0.16022485,0.68085105 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       style="fill:#f7941e;stroke-width:0.133164" />
+    <path
+       d="m 1.1125028,0.63828348 c -0.00181,-0.0291674 -0.00558,-0.0576132 -0.011189,-0.085092 H 0.38805869 c -0.005617,0.0274644 -0.009387,0.0559101 -0.0112003,0.085092 z"
+       id="path37"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_1_);stroke-width:0.144573" />
+    <path
+       d="M 1.1124709,0.72340424 H 0.37686337 c 0.001813,0.0291723 0.005561,0.0576229 0.0111888,0.0851064 H 1.1012931 c 0.00562,-0.0274835 0.00936,-0.055934 0.011178,-0.0851064 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_2_);stroke-width:0.144583" />
+    <path
+       d="m 0.745446,1.080823 c 0.15139629,0 0.2818975,-0.0945544 0.3419949,-0.23097701 H 0.4034511 C 0.46354855,0.98626865 0.59404972,1.080823 0.745446,1.080823 Z"
+       id="path51"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_3_);stroke-width:0.133164" />
+    <path
+       d="M 0.31377957,0.72340424 H 0.36897247 1.122801 1.22183 1.297059 c 5.198e-4,-0.0135369 8.137e-4,-0.0271669 8.137e-4,-0.0408902 0,-0.0148423 -3.956e-4,-0.0295603 -0.00101,-0.0442161 H 1.2218182 1.1227897 0.36896118 0.30986951 0.19307616 c -6.1025e-4,0.0146403 -0.001006,0.0293739 -0.001006,0.0442161 0,0.0137233 2.9382e-4,0.0273534 8.1365e-4,0.0408902 z"
+       id="path55"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.151676" />
+    <path
+       d="M 0.40124746,0.4680851 H 0.21419728 c -0.006148,0.0277109 -0.0101142,0.0561367 -0.0139225,0.0851064 h 0.096339 0.0820322 0.73092182 0.103515 0.073986 C 1.2832488,0.5242373 1.2783288,0.4958116 1.2721968,0.4680851"
+       id="path57"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.151676" />
+    <path
+       d="M 1.2160096,0.80851062 H 1.1124947 0.38158413 0.30347328 0.20026344 c 0.003707,0.0289542 0.007922,0.0573645 0.0139677,0.0851064 h 0.18993187 0.68575279 0.1125781 0.073319 c 0.00603,-0.0277263 0.010905,-0.0561367 0.014623,-0.0851064 z"
+       id="path59"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.151676" />
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse16_1.25px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse16_1.25px_space.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 1.3617021 1.3617021"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse16_new2.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.01023297,0,0,-0.01804017,-0.60403912,8.1487865)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.01023314,0,0,-0.01804323,-0.60406428,8.1576624)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.01130076,0,0,-0.01197951,-0.73931565,5.6424167)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="6.1015625"
+     inkscape:cy="6.4921875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 0.40346119,0.84984676 H 0.21424145 c 0.0250542,0.0911041 0.0715448,0.17275664 0.13960955,0.24492124 0.10850978,0.1150391 0.23898823,0.1724809 0.39157083,0.1724809 0.0305008,0 0.0600526,-0.00242 0.0887563,-0.00699 C 0.94910676,1.2418648 1.0497284,1.186783 1.1359419,1.0947681 1.2044471,1.022627 1.2512661,0.94095104 1.2765119,0.84984685 H 1.1997235 1.0874392 Z"
+       id="path2" />
+    <path
+       d="m 0.31488625,0.52129465 h -0.0951883 c -0.003482,0.0346732 -0.005855,0.0700679 -0.006932,0.10636491 h 0.11313324 0.0567517 0.81917131 0.074774 c -0.00109,-0.0362968 -0.00345,-0.0716917 -0.00697,-0.10636491"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.160359" />
+    <path
+       d="m 0.21276595,0.73404254 c 0.001078,0.0363211 0.003439,0.071722 0.006932,0.10638298 h 0.0989612 0.0750099 0.80144015 0.074498 c 0.0035,-0.034661 0.0059,-0.0700619 0.00699,-0.10638298"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.160371" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#2c2255;stroke-width:0.133163"
+       d="M 1.2765345,0.51180881 C 1.2513112,0.42045308 1.2044808,0.33841738 1.1359418,0.26574966 1.0499544,0.17459763 0.94961507,0.11991109 0.83505943,0.1015106 0.80608483,0.0968525 0.77623933,0.0944056 0.74542233,0.0944056 c -0.1525826,0 -0.28307238,0.05712998 -0.39157084,0.17134289 -0.0680866,0.0726676 -0.11460096,0.1547034 -0.13964335,0.24605915"
+       id="path10" />
+    <path
+       d="m 0.16022485,0.68085105 c 0,-0.30935886 0.21917824,-0.56640322 0.50430771,-0.61161389 -0.007074,-2.7553e-4 -0.0141825,-5.7502e-4 -0.0213245,-5.7502e-4 -0.31996972,0 -0.57937867,0.2740912 -0.57937867,0.61218891 0,0.33810975 0.25939765,0.61218895 0.57937867,0.61218895 0.007165,0 0.0142729,-2.875e-4 0.0213697,-5.63e-4 C 0.37940309,1.2472663 0.16022485,0.9902219 0.16022485,0.68085105 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       style="fill:#f7941e;stroke-width:0.133164" />
+    <path
+       d="m 1.0808509,0.62764148 c -0.00167,-0.0364592 -0.00516,-0.0720164 -0.010356,-0.1063649 H 0.41036599 c -0.005199,0.0343305 -0.008688,0.0698876 -0.010366,0.1063649 z"
+       id="path37"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_1_);stroke-width:0.155501" />
+    <path
+       d="M 1.080851,0.73404254 H 0.39999999 c 0.001678,0.0364654 0.005147,0.0720286 0.010356,0.10638298 H 1.0705052 c 0.0052,-0.0343544 0.00866,-0.0699175 0.010346,-0.10638298 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_2_);stroke-width:0.155516" />
+    <path
+       d="m 0.745446,1.080823 c 0.15139629,0 0.2818975,-0.0945544 0.3419949,-0.23097701 H 0.4034511 C 0.46354855,0.98626865 0.59404972,1.080823 0.745446,1.080823 Z"
+       id="path51"
+       inkscape:connector-curvature="0"
+       style="fill:url(#SVGID_3_);stroke-width:0.133164" />
+    <path
+       d="M 0.31377957,0.73404262 H 0.36897247 1.122801 1.22183 1.297059 c 5.198e-4,-0.0169211 8.137e-4,-0.0339587 8.137e-4,-0.0511128 0,-0.0185529 -3.956e-4,-0.0369504 -0.00101,-0.0552702 H 1.2218182 1.1227897 0.36896118 0.30986951 0.19307616 c -6.1025e-4,0.0183004 -0.001006,0.0367174 -0.001006,0.0552702 0,0.0171541 2.9382e-4,0.0341918 8.1365e-4,0.0511128 z"
+       id="path55"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.169579" />
+    <path
+       d="M 0.41118835,0.41489361 H 0.22623728 c -0.006079,0.0346386 -0.010001,0.0701709 -0.0137663,0.10638298 H 0.30772888 0.38884048 1.1115598 1.213913 1.287069 C 1.283299,0.48508389 1.278429,0.44955169 1.272363,0.41489361"
+       id="path57"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.168624" />
+    <path
+       d="M 1.2039679,0.83807476 H 1.1029543 0.38970525 0.31348185 0.21276595 c 0.003617,0.0369924 0.007731,0.0732901 0.0136302,0.10873373 H 0.41173854 1.080921 1.1907788 1.2623258 c 0.00588,-0.0354237 0.010641,-0.0717215 0.01427,-0.10873373 z"
+       id="path59"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;stroke-width:0.169359" />
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse32.svg
+++ b/platform/org.eclipse.sdk/eclipse32.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 2.7234042 2.7234042"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse32.svg"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="28.90625"
+     inkscape:cy="20.46875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="translate(0.0638289,0.06866286)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.53441529,1.0861532 H 0.33671982 c -0.007232,0.046049 -0.01216,0.093057 -0.014398,0.1412623 H 0.55728708 0.675154 2.3764823 2.5317782 c -0.00226,-0.048206 -0.00718,-0.095213 -0.01448,-0.1412623"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266328" />
+      <path
+         d="m 0.32232277,1.358591 c 0.002238,0.04823 0.007142,0.095237 0.014398,0.1412623 h 0.20553809 0.1557921 1.66455584 0.1547299 c 0.00728,-0.046025 0.01224,-0.093033 0.01452,-0.1412623"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266328" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="m 2.1789461,1.2273915 c -0.0037,-0.048421 -0.0114,-0.095644 -0.022872,-0.1412623 H 0.69805019 c -0.011482,0.045594 -0.019188,0.092817 -0.0228954,0.1412623 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.266328" />
+      <path
+         d="M 2.1789461,1.358591 H 0.67517746 c 0.003706,0.048421 0.011368,0.095644 0.0228728,0.1412623 H 2.1560959 c 0.01148,-0.045618 0.01914,-0.092841 0.02285,-0.1412623 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.266328" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.358591 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.020868 0.00163,-0.04188 0.00163,-0.063036 0,-0.022881 -7.912e-4,-0.04557 -0.00202,-0.068163 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.022569 -0.002012,0.045283 -0.002012,0.068163 0,0.021156 5.8764e-4,0.042168 0.001627,0.063036 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+      <path
+         d="M 0.7386651,0.95495366 H 0.36456498 C 0.35226899,0.99767263 0.34433659,1.0414936 0.33672,1.0861532 H 0.52939788 0.69346217 2.1553049 2.3623348 2.5103067 c -0.00764,-0.044636 -0.01748,-0.0884566 -0.029744,-0.13119954"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+      <path
+         d="M 2.3681883,1.4998294 H 2.1611587 0.69933847 0.54311687 0.33669732 c 0.007414,0.044635 0.015844,0.088433 0.0279354,0.1311995 H 0.7444962 2.1160009 2.341157 2.4877949 c 0.01206,-0.042743 0.02181,-0.08654 0.029246,-0.1311995 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse32_1.0px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse32_1.0px_space.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 2.7234042 2.7234042"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse32_new.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02211299,0,0,-0.02886428,-1.4797953,13.24174)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02211223,0,0,-0.02886916,-1.4797315,13.255932)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="11.65625"
+     inkscape:cy="7.03125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="translate(0.0638289,0.06866286)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.55218952,1.0377491 H 0.35876704 c -0.007076,0.055477 -0.011898,0.1121088 -0.014086,0.1701839 H 0.57456771 0.68988703 2.3544424 2.5063823 c -0.00222,-0.058075 -0.00702,-0.1147067 -0.01416,-0.1701839"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.289146" />
+      <path
+         d="m 0.34468105,1.3781455 c 0.00219,0.058114 0.006988,0.1147551 0.014086,0.1702127 h 0.2010885 0.1524195 1.62852055 0.1513799 c 0.00712,-0.055458 0.01198,-0.1120989 0.0142,-0.1702127"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.289166" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="M 2.1611749,1.2079041 C 2.1575549,1.1495693 2.1500149,1.0926778 2.1387969,1.0377202 H 0.71228758 c -0.011234,0.054929 -0.018774,0.1118201 -0.0224006,0.1701839 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.289146" />
+      <path
+         d="M 2.1611111,1.3781455 H 0.68989695 c 0.003626,0.058345 0.011122,0.1152457 0.0223776,0.1702127 H 2.1387555 c 0.01124,-0.054967 0.01872,-0.1118679 0.022356,-0.1702127 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.289166" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.3781455 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.027074 0.00163,-0.054334 0.00163,-0.08178 0,-0.029685 -7.912e-4,-0.059121 -0.00202,-0.088432 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.029281 -0.002012,0.058748 -0.002012,0.088432 0,0.027446 5.8764e-4,0.054707 0.001627,0.08178 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+      <path
+         d="M 0.7386651,0.86750755 H 0.36456498 C 0.35226899,0.92292932 0.34433659,0.97978088 0.33672,1.0377202 H 0.52939788 0.69346217 2.1553049 2.3623348 2.5103067 C 2.5026667,0.9798119 2.4928267,0.92296052 2.4805627,0.86750755"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+      <path
+         d="M 2.3681883,1.5483582 H 2.1611587 0.69933847 0.54311687 0.33669732 c 0.007414,0.057908 0.015844,0.1147289 0.0279354,0.1702127 H 0.7444962 2.1160009 2.341157 2.4877949 c 0.01206,-0.055453 0.02181,-0.1122734 0.029246,-0.1702127 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse32_1.25px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse32_1.25px_space.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 2.7234042 2.7234042"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse32_new2.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02046593,0,0,-0.03608032,-1.2719068,16.2289)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02046627,0,0,-0.03608644,-1.2719571,16.246652)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="6.2976698"
+     inkscape:cy="10.363534"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="translate(0.0638289,0.06866286)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.56594279,0.97392659 H 0.37556631 c -0.006964,0.0693463 -0.01171,0.14013571 -0.013864,0.21272971 H 0.58796866 0.70147199 2.3398136 2.4893615 c -0.00218,-0.072594 -0.0069,-0.1433833 -0.01394,-0.21272971"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.320718" />
+      <path
+         d="m 0.36170232,1.3994221 c 0.002156,0.072642 0.006878,0.1434439 0.013864,0.2127658 H 0.5734886 0.7235083 2.3263876 2.4753835 c 0.007,-0.069322 0.0118,-0.1401237 0.01398,-0.2127658"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.320742" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="M 2.0978711,1.1866201 C 2.0945311,1.1137018 2.0875511,1.0425874 2.0771591,0.97389045 H 0.75690215 c -0.010398,0.068661 -0.017376,0.13977515 -0.020732,0.21272965 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.311002" />
+      <path
+         d="M 2.0978713,1.3994221 H 0.73617016 c 0.003356,0.072931 0.010294,0.1440571 0.020712,0.2127658 H 2.0771797 c 0.0104,-0.068709 0.01732,-0.1398349 0.020692,-0.2127658 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.311032" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.3994223 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.033842 0.00163,-0.067917 0.00163,-0.1022256 0,-0.037106 -7.912e-4,-0.073901 -0.00202,-0.1105403 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.036601 -0.002012,0.073435 -0.002012,0.1105403 0,0.034308 5.8764e-4,0.068384 0.001627,0.1022256 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.339158" />
+      <path
+         d="M 0.75854687,0.76112464 H 0.38864496 c -0.012158,0.0692772 -0.020002,0.14034171 -0.0275326,0.21276583 h 0.19051568 0.1622231 1.44543776 0.2047063 0.1463119 c -0.00754,-0.0723854 -0.01728,-0.14344971 -0.029412,-0.21276583"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.337248" />
+      <path
+         d="M 2.344105,1.6074864 H 2.1420779 0.7155807 0.56313399 0.36170232 c 0.007234,0.073985 0.015462,0.1465801 0.0272604,0.2174673 H 0.75964725 2.0980113 2.3177268 2.4608207 c 0.01176,-0.070847 0.021282,-0.1434429 0.02854,-0.2174673 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.338718" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse48.svg
+++ b/platform/org.eclipse.sdk/eclipse48.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 4.0851063 4.0851063"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse48.svg"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse48.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="28.90625"
+     inkscape:cy="20.46875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="matrix(1.4999984,0,0,1.4999984,0.09574543,0.10299636)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.53441529,1.0861532 H 0.33671982 c -0.007232,0.046049 -0.01216,0.093057 -0.014398,0.1412623 H 0.55728708 0.675154 2.3764823 2.5317782 c -0.00226,-0.048206 -0.00718,-0.095213 -0.01448,-0.1412623"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266328" />
+      <path
+         d="m 0.32232277,1.358591 c 0.002238,0.04823 0.007142,0.095237 0.014398,0.1412623 h 0.20553809 0.1557921 1.66455584 0.1547299 c 0.00728,-0.046025 0.01224,-0.093033 0.01452,-0.1412623"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266328" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="m 2.1789461,1.2273915 c -0.0037,-0.048421 -0.0114,-0.095644 -0.022872,-0.1412623 H 0.69805019 c -0.011482,0.045594 -0.019188,0.092817 -0.0228954,0.1412623 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.266328" />
+      <path
+         d="M 2.1789461,1.358591 H 0.67517746 c 0.003706,0.048421 0.011368,0.095644 0.0228728,0.1412623 H 2.1560959 c 0.01148,-0.045618 0.01914,-0.092841 0.02285,-0.1412623 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.266328" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.358591 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.020868 0.00163,-0.04188 0.00163,-0.063036 0,-0.022881 -7.912e-4,-0.04557 -0.00202,-0.068163 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.022569 -0.002012,0.045283 -0.002012,0.068163 0,0.021156 5.8764e-4,0.042168 0.001627,0.063036 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+      <path
+         d="M 0.7386651,0.95495366 H 0.36456498 C 0.35226899,0.99767263 0.34433659,1.0414936 0.33672,1.0861532 H 0.52939788 0.69346217 2.1553049 2.3623348 2.5103067 c -0.00764,-0.044636 -0.01748,-0.0884566 -0.029744,-0.13119954"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+      <path
+         d="M 2.3681883,1.4998294 H 2.1611587 0.69933847 0.54311687 0.33669732 c 0.007414,0.044635 0.015844,0.088433 0.0279354,0.1311995 H 0.7444962 2.1160009 2.341157 2.4877949 c 0.01206,-0.042743 0.02181,-0.08654 0.029246,-0.1311995 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.266328" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse48_1.0px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse48_1.0px_space.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 4.0851063 4.0851063"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse48_new.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02211299,0,0,-0.02886428,-1.4797953,13.24174)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02211223,0,0,-0.02886916,-1.4797315,13.255932)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="-18.1875"
+     inkscape:cy="-4.9375"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="matrix(1.4999984,0,0,1.4999984,0.09574543,0.10299636)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.55218952,1.0377491 H 0.35876704 c -0.007076,0.055477 -0.011898,0.1121088 -0.014086,0.1701839 H 0.57456771 0.68988703 2.3544424 2.5063823 c -0.00222,-0.058075 -0.00702,-0.1147067 -0.01416,-0.1701839"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.289146" />
+      <path
+         d="m 0.34468105,1.3781455 c 0.00219,0.058114 0.006988,0.1147551 0.014086,0.1702127 h 0.2010885 0.1524195 1.62852055 0.1513799 c 0.00712,-0.055458 0.01198,-0.1120989 0.0142,-0.1702127"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.289166" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="M 2.1611749,1.2079041 C 2.1575549,1.1495693 2.1500149,1.0926778 2.1387969,1.0377202 H 0.71228758 c -0.011234,0.054929 -0.018774,0.1118201 -0.0224006,0.1701839 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.289146" />
+      <path
+         d="M 2.1611111,1.3781455 H 0.68989695 c 0.003626,0.058345 0.011122,0.1152457 0.0223776,0.1702127 H 2.1387555 c 0.01124,-0.054967 0.01872,-0.1118679 0.022356,-0.1702127 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.289166" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.3781455 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.027074 0.00163,-0.054334 0.00163,-0.08178 0,-0.029685 -7.912e-4,-0.059121 -0.00202,-0.088432 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.029281 -0.002012,0.058748 -0.002012,0.088432 0,0.027446 5.8764e-4,0.054707 0.001627,0.08178 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+      <path
+         d="M 0.7386651,0.86750755 H 0.36456498 C 0.35226899,0.92292932 0.34433659,0.97978088 0.33672,1.0377202 H 0.52939788 0.69346217 2.1553049 2.3623348 2.5103067 C 2.5026667,0.9798119 2.4928267,0.92296052 2.4805627,0.86750755"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+      <path
+         d="M 2.3681883,1.5483582 H 2.1611587 0.69933847 0.54311687 0.33669732 c 0.007414,0.057908 0.015844,0.1147289 0.0279354,0.1702127 H 0.7444962 2.1160009 2.341157 2.4877949 c 0.01206,-0.055453 0.02181,-0.1122734 0.029246,-0.1702127 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.303352" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/eclipse48_1.25px_space.svg
+++ b/platform/org.eclipse.sdk/eclipse48_1.25px_space.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 4.0851063 4.0851063"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="eclipse48_new2.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="eclipse16_new.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1978">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(0.02046593,0,0,-0.03608032,-1.2719068,16.2289)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop32" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(0.02046627,0,0,-0.03608644,-1.2719571,16.246652)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop39" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(0.02260151,0,0,-0.023959,-1.5424596,11.216164)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop46" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4675"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5762"
+       x2="131.3853"
+       y2="432.21109"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4671" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4682"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.5752"
+       x2="131.3853"
+       y2="432.21011"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4678" />
+      <stop
+         offset="0.872"
+         style="stop-color:#2C2255"
+         id="stop4680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689"
+       gradientUnits="userSpaceOnUse"
+       x1="131.3853"
+       y1="358.57709"
+       x2="131.3853"
+       y2="432.2084"
+       gradientTransform="matrix(1,0,0,-1,0,793)">
+      <stop
+         offset="0.3033"
+         style="stop-color:#473788"
+         id="stop4685" />
+      <stop
+         offset="0.8631"
+         style="stop-color:#2C2255"
+         id="stop4687" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-4.0216698"
+     inkscape:cy="12.59534"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showguides="false"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2674"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="matrix(1.4999984,0,0,1.4999984,0.09574543,0.10299636)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 0.74309256,1.6310304 H 0.36465332 c 0.0501084,0.1822081 0.14308951,0.3455131 0.27921892,0.4898422 0.21701942,0.230078 0.47797616,0.3449615 0.78314116,0.3449615 0.061002,0 0.1201051,-0.00484 0.1775125,-0.01398 C 1.834383,2.415066 2.0356262,2.3049024 2.2080531,2.1208728 2.3450634,1.9765907 2.4387013,1.8132388 2.4891929,1.6310306 H 2.3356162 2.1110477 Z"
+         id="path2" />
+      <path
+         d="M 0.56594279,0.97392659 H 0.37556631 c -0.006964,0.0693463 -0.01171,0.14013571 -0.013864,0.21272971 H 0.58796866 0.70147199 2.3398136 2.4893615 c -0.00218,-0.072594 -0.0069,-0.1433833 -0.01394,-0.21272971"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.320718" />
+      <path
+         d="m 0.36170232,1.3994221 c 0.002156,0.072642 0.006878,0.1434439 0.013864,0.2127658 H 0.5734886 0.7235083 2.3263876 2.4753835 c 0.007,-0.069322 0.0118,-0.1401237 0.01398,-0.2127658"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.320742" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#2c2255;stroke-width:0.266326"
+         d="M 2.4892381,0.95495492 C 2.4387915,0.77224357 2.3451308,0.60817228 2.2080529,0.46283693 2.0360782,0.28053299 1.8353996,0.17115998 1.6062885,0.13435902 c -0.057949,-0.009316 -0.1176401,-0.01421 -0.1792741,-0.01421 -0.305165,0 -0.56614439,0.11425988 -0.78314118,0.34268556 C 0.50770011,0.6081697 0.41467145,0.77224119 0.3645867,0.95495258"
+         id="path10" />
+      <path
+         d="m 0.25662019,1.2930392 c 0,-0.61871734 0.4383562,-1.13280574 1.00861481,-1.22322702 -0.014148,-5.5106e-4 -0.028365,-0.00115 -0.042649,-0.00115 -0.63993904,0 -1.15875661,0.54818205 -1.15875661,1.22437702 0,0.6762191 0.51879497,1.2243771 1.15875661,1.2243771 0.01433,0 0.028546,-5.75e-4 0.042739,-0.00113 C 0.69497639,2.425869 0.25662019,1.9117805 0.25662019,1.2930392 Z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#f7941e;stroke-width:0.266328" />
+      <path
+         d="M 2.0978711,1.1866201 C 2.0945311,1.1137018 2.0875511,1.0425874 2.0771591,0.97389045 H 0.75690215 c -0.010398,0.068661 -0.017376,0.13977515 -0.020732,0.21272965 z"
+         id="path37"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_1_);stroke-width:0.311002" />
+      <path
+         d="M 2.0978713,1.3994221 H 0.73617016 c 0.003356,0.072931 0.010294,0.1440571 0.020712,0.2127658 H 2.0771797 c 0.0104,-0.068709 0.01732,-0.1398349 0.020692,-0.2127658 z"
+         id="path44"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_2_);stroke-width:0.311032" />
+      <path
+         d="m 1.4270617,2.0929826 c 0.3027924,0 0.5637947,-0.1891087 0.6839894,-0.4619537 H 0.74307238 C 0.8632672,1.903874 1.1242694,2.0929826 1.4270617,2.0929826 Z"
+         id="path51"
+         inkscape:connector-curvature="0"
+         style="fill:url(#SVGID_3_);stroke-width:0.266328" />
+      <path
+         d="M 0.56372943,1.3994223 H 0.67411516 2.1817713 2.3798291 2.530287 c 0.00104,-0.033842 0.00163,-0.067917 0.00163,-0.1022256 0,-0.037106 -7.912e-4,-0.073901 -0.00202,-0.1105403 H 2.3798055 2.1817487 0.67409258 0.55590932 0.32232277 c -0.00122,0.036601 -0.002012,0.073435 -0.002012,0.1105403 0,0.034308 5.8764e-4,0.068384 0.001627,0.1022256 z"
+         id="path55"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.339158" />
+      <path
+         d="M 0.75854687,0.76112464 H 0.38864496 c -0.012158,0.0692772 -0.020002,0.14034171 -0.0275326,0.21276583 h 0.19051568 0.1622231 1.44543776 0.2047063 0.1463119 c -0.00754,-0.0723854 -0.01728,-0.14344971 -0.029412,-0.21276583"
+         id="path57"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.337248" />
+      <path
+         d="M 2.344105,1.6074864 H 2.1420779 0.7155807 0.56313399 0.36170232 c 0.007234,0.073985 0.015462,0.1465801 0.0272604,0.2174673 H 0.75964725 2.0980113 2.3177268 2.4608207 c 0.01176,-0.070847 0.021282,-0.1434429 0.02854,-0.2174673 z"
+         id="path59"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke-width:0.338718" />
+    </g>
+  </g>
+</svg>

--- a/platform/org.eclipse.sdk/plugin.xml
+++ b/platform/org.eclipse.sdk/plugin.xml
@@ -4,7 +4,7 @@
 
     <extension id="ide" point="org.eclipse.core.runtime.products"> 
       <product name="%productName" application="org.eclipse.ui.ide.workbench" description="%productBlurb"> 
-          <property name="windowImages" value="eclipse16.png,eclipse32.png,eclipse48.png"/> 
+          <property name="windowImages" value="eclipse16_1.0px_space.svg,eclipse32_1.0px_space.svg,eclipse32_1.0px_space.svg"/> 
           <property name="aboutImage" value="eclipse_lg.png"/> 
           <property name="aboutText" value="%productBlurb"/> 
           <property name="appName" value="Eclipse"/> 


### PR DESCRIPTION
This draft is created in the context of this [issue](https://github.com/eclipse-platform/eclipse.platform.images/issues/153#issue-3178350003) and allows analyzing different variations of the Eclipse Icon. 

How to test:
I added three different variations as SVG of the eclipse icon  in different sizes to the bundle `org,eclipse.sdk`:

- `eclipse16.svg`: Normal eclipse icon as SVG. After rendering + antialiasing the white lines in the middle of the eclipse icon look like one white block.
- `eclipse16_1.0_space.svg`: Variation of the eclipse icon where the white space and the blue lines in the middle of the icon each are 1.0px high.
- `eclipse16_1.25_space.svg`: Same as above but lines and white space are 1.25px high.

To change the currently used icons the `plugin.xml` of the bundle `org.eclipse.sdk` needs to be adjusted. The default of this draft is the 1.0px variation. The icons can be found in the top left corner of the window or in the about dialog found in the toolbar entry `Help` -> `About Eclipse IDE`. 

Screenshots can be found in the above cited issue. 