### PR TITLE
Revert "Both command.id and override.command should't reference a command id"

### DIFF
--- a/ua/org.eclipse.ui.intro.quicklinks/schema/quicklinks.exsd
+++ b/ua/org.eclipse.ui.intro.quicklinks/schema/quicklinks.exsd
@@ -64,7 +64,7 @@ The Quicklinks is experimental component and is not yet considered API.
                   The command identifier to be invoked.  The command can also be a serialized command to encode command parameters (see ParameterizedCommand#serialize() for details).
                </documentation>
                <appinfo>
-                  <meta.attribute kind="identifier"/>
+                  <meta.attribute kind="identifier" basedOn="org.eclipse.ui.commands/command/@id"/>
                </appinfo>
             </annotation>
          </attribute>
@@ -218,7 +218,7 @@ If &quot;close&quot; then the Welcome/Intro will be closed.
                   The command identifier as referenced in a &amp;lt;quicklink&amp;gt; element.  The command can also be a serialized command to encode command parameters (see ParameterizedCommand#serialize() for details).  The command may include simple &apos;*&apos; wildcards to match any substring.  For example, &lt;code&gt;org.eclipse.ui.newWizard*&lt;/code&gt; will match any &quot;New&quot; wizard definitions.
                </documentation>
                <appinfo>
-                  <meta.attribute kind="identifier"/>
+                  <meta.attribute kind="identifier" basedOn="org.eclipse.ui.commands/command/@id"/>
                </appinfo>
             </annotation>
          </attribute>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform#2011