### PR TITLE
Make delays depending on available processors

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -78,6 +78,19 @@ import org.eclipse.osgi.util.NLS;
  */
 public class JobManager implements IJobManager, DebugOptionsListener {
 
+
+	private static final int CORES = Runtime.getRuntime().availableProcessors();
+
+	private static final long DELAY_PRIORITY_INTERACTIVE = 0;
+
+	private static final long DELAY_PRIORITY_DECORATE = 1000 / CORES;
+
+	private static final long DELAY_PRIORITY_BUILD = 500 / CORES;
+
+	private static final long DELAY_PRIORITY_LONG = 100 / CORES;
+
+	private static final long DELAY_PRIORITY_SHORT = 50 / CORES;
+
 	private static final int NANOS_IN_MS = 1_000_000;
 
 	/**
@@ -618,18 +631,17 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 	 * tolerate waiting.
 	 */
 	private long delayFor(int priority) {
-		//these values may need to be tweaked based on machine speed
 		switch (priority) {
 			case Job.INTERACTIVE :
-				return 0L;
+				return DELAY_PRIORITY_INTERACTIVE;
 			case Job.SHORT :
-				return 50L;
+				return DELAY_PRIORITY_SHORT;
 			case Job.LONG :
-				return 100L;
+				return DELAY_PRIORITY_LONG;
 			case Job.BUILD :
-				return 500L;
+				return DELAY_PRIORITY_BUILD;
 			case Job.DECORATE :
-				return 1000L;
+				return DELAY_PRIORITY_DECORATE;
 			default :
 				Assert.isTrue(false, "Job has invalid priority: " + priority); //$NON-NLS-1$
 				return 0;


### PR DESCRIPTION
Currently we use a fixed delay for a given job priority, depending on the number of jobs running and other factors this can considerably delay some actions and make eclipse feel laggy.

This now makes these values dependent on the number of CPUs installed in the machine, as we can assume more CPUs can do the work better in parallel without additional sleep delays.

FYI @iloveeclipse @merks @vogella 

I'll keep this PR open for a few days in case someone likes to review this, but the change seem save enough as I tried to even reduce the delay always to zero and didn't see any negative effects here. In many cases (e.g. no builds or other jobs running) this is even zero in some cases as the value is multiplied with the number of running jobs. In other cases it seems even unused or only used for rescheduling purpose.