### PR TITLE
Reduce noise in the build

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
--XX:+PrintFlagsFinal


### PR DESCRIPTION
Printing the flags didn't help fixing the OOMs for months so it's time to reduce this noise in the output.