### PR TITLE
Set terminal bundle versions to 1.0 and import package API

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/META-INF/MANIFEST.MF
@@ -2,24 +2,30 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.connector.local;singleton:=true
-Bundle-Version: 4.9.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.connector.local.activator.UIPlugin
 Bundle-Vendor: %providerName
-Import-Package: org.eclipse.cdt.utils.pty;mandatory:=native
+Import-Package: org.eclipse.cdt.utils.pty;mandatory:=native,
+ org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.connector.process;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces.constants;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.preferences;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.tracing;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.panels;version="[1.0.0,2.0.0)"
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",
  org.eclipse.core.resources;bundle-version="[3.22.200,4)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.core.variables;bundle-version="[3.6.500,4)",
  org.eclipse.debug.ui;bundle-version="[3.18.800,4)",
- org.eclipse.terminal.view.core;bundle-version="[4.10.400,5)",
- org.eclipse.terminal.view.ui;bundle-version="[4.11.600,5)",
- org.eclipse.terminal.connector.process;bundle-version="[4.9.200,5)",
- org.eclipse.terminal.control;bundle-version="[5.6.0,6.0.0)",
  org.eclipse.ui;bundle-version="[3.207.200,4)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.terminal.connector.local.activator;x-internal:=true,
- org.eclipse.terminal.connector.local.controls,
- org.eclipse.terminal.connector.local.launcher
+ org.eclipse.terminal.connector.local.controls;version="1.0.0",
+ org.eclipse.terminal.connector.local.launcher;version="1.0.0"
 Automatic-Module-Name: org.eclipse.terminal.connector.local

--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.local.activator.UIPlugin;
 import org.eclipse.terminal.connector.local.controls.LocalWizardConfigurationPanel;
@@ -50,7 +51,6 @@ import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanelContainer;
 import org.eclipse.terminal.view.ui.interfaces.IMementoHandler;
 import org.eclipse.terminal.view.ui.interfaces.IPreferenceKeys;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 import org.eclipse.ui.ISelectionService;
 import org.eclipse.ui.PlatformUI;
@@ -60,7 +60,6 @@ import org.osgi.framework.Bundle;
 /**
  * Serial launcher delegate implementation.
  */
-@SuppressWarnings("restriction")
 public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 
 	private final IMementoHandler mementoHandler = new LocalMementoHandler();
@@ -109,7 +108,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 		// Initialize the local terminal working directory.
 		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR)) {
 			// By default, start the local terminal in the users home directory
-			String initialCwd = org.eclipse.terminal.view.ui.activator.UIPlugin.getScopedPreferences()
+			String initialCwd = IPreferenceKeys.getPreferences()
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_INITIAL_CWD);
 			String cwd = null;
 			if (initialCwd == null || IPreferenceKeys.PREF_INITIAL_CWD_USER_HOME.equals(initialCwd)
@@ -280,8 +279,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 			}
 		}
 		if (shell == null) {
-			shell = org.eclipse.terminal.view.ui.activator.UIPlugin.getScopedPreferences()
-					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX);
+			shell = IPreferenceKeys.getPreferences().getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX);
 			if (shell == null || "".equals(shell)) { //$NON-NLS-1$
 				if (System.getenv("SHELL") != null && !"".equals(System.getenv("SHELL").trim())) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					shell = System.getenv("SHELL").trim(); //$NON-NLS-1$
@@ -316,7 +314,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 
 		String arguments = (String) properties.get(ITerminalsConnectorConstants.PROP_PROCESS_ARGS);
 		if (arguments == null && !Platform.OS_WIN32.equals(Platform.getOS())) {
-			arguments = org.eclipse.terminal.view.ui.activator.UIPlugin.getScopedPreferences()
+			arguments = IPreferenceKeys.getPreferences()
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX_ARGS);
 		}
 
@@ -397,7 +395,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 		Assert.isTrue(image != null || process != null);
 
 		// Construct the terminal settings store
-		ISettingsStore store = new SettingsStore();
+		ISettingsStore store = new InMemorySettingsStore();
 
 		// Construct the process settings
 		ProcessSettings processSettings = new ProcessSettings();
@@ -414,8 +412,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 
 		if (properties.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_MERGE_ENVIRONMENT)) {
 			Object value = properties.get(ITerminalsConnectorConstants.PROP_PROCESS_MERGE_ENVIRONMENT);
-			processSettings
-					.setMergeWithNativeEnvironment(value instanceof Boolean b ? b.booleanValue() : false);
+			processSettings.setMergeWithNativeEnvironment(value instanceof Boolean b ? b.booleanValue() : false);
 		}
 
 		// And save the settings to the store

--- a/terminal/bundles/org.eclipse.terminal.connector.process/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/META-INF/MANIFEST.MF
@@ -2,23 +2,33 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.connector.process;singleton:=true
-Bundle-Version: 4.10.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.connector.process.activator.UIPlugin
 Bundle-Vendor: %providerName
 Import-Package: org.eclipse.cdt.utils.pty;mandatory:=native,
- org.eclipse.cdt.utils.spawner;mandatory:=native
+ org.eclipse.cdt.utils.spawner;mandatory:=native,
+ org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.internal.emulator,
+ org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces.constants;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.tracing;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.manager;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.nls,
+ org.eclipse.terminal.view.ui.streams;version="[1.0.0,2.0.0)"
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",
  org.eclipse.core.resources;bundle-version="[3.22.200,4)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
- org.eclipse.terminal.view.core;bundle-version="[4.10.400,5)",
- org.eclipse.terminal.view.ui;bundle-version="[4.11.600,5)",
- org.eclipse.terminal.control;bundle-version="[5.6.0,6.0.0)",
  org.eclipse.ui;bundle-version="[3.207.200,4)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
-Export-Package: org.eclipse.terminal.connector.process,
+Export-Package: org.eclipse.terminal.connector.process;version="1.0.0",
  org.eclipse.terminal.connector.process.activator;x-internal:=true,
- org.eclipse.terminal.connector.process.help,
+ org.eclipse.terminal.connector.process.help;version="1.0.0",
  org.eclipse.terminal.connector.process.nls;x-internal:=true
 Automatic-Module-Name: org.eclipse.terminal.connector.process

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessLauncherDelegate.java
@@ -17,6 +17,7 @@ import org.eclipse.cdt.utils.pty.PTY;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.terminal.view.core.interfaces.ITerminalService;
@@ -24,13 +25,11 @@ import org.eclipse.terminal.view.core.interfaces.ITerminalServiceOutputStreamMon
 import org.eclipse.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanelContainer;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 
 /**
  * Process launcher delegate implementation.
  */
-@SuppressWarnings("restriction")
 public class ProcessLauncherDelegate extends AbstractLauncherDelegate {
 
 	@Override
@@ -89,7 +88,7 @@ public class ProcessLauncherDelegate extends AbstractLauncherDelegate {
 		Assert.isTrue(image != null || process != null);
 
 		// Construct the terminal settings store
-		ISettingsStore store = new SettingsStore();
+		ISettingsStore store = new InMemorySettingsStore();
 
 		// Construct the process settings
 		ProcessSettings processSettings = new ProcessSettings();
@@ -106,8 +105,7 @@ public class ProcessLauncherDelegate extends AbstractLauncherDelegate {
 
 		if (properties.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_MERGE_ENVIRONMENT)) {
 			value = properties.get(ITerminalsConnectorConstants.PROP_PROCESS_MERGE_ENVIRONMENT);
-			processSettings
-					.setMergeWithNativeEnvironment(value instanceof Boolean b ? b.booleanValue() : false);
+			processSettings.setMergeWithNativeEnvironment(value instanceof Boolean b ? b.booleanValue() : false);
 		}
 
 		// And save the settings to the store

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessSettings.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessSettings.java
@@ -14,13 +14,12 @@ package org.eclipse.terminal.connector.process;
 import org.eclipse.cdt.utils.pty.PTY;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.terminal.connector.ISettingsStore;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.view.core.interfaces.ITerminalServiceOutputStreamMonitorListener;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 
 /**
  * Process connector settings implementation.
  */
-@SuppressWarnings("restriction")
 public class ProcessSettings {
 	// Reference to the process image
 	private String image;
@@ -271,14 +270,14 @@ public class ProcessSettings {
 				.parseBoolean(store.get("MergeWithNativeEnvironment", Boolean.FALSE.toString())); //$NON-NLS-1$
 		lineSeparator = store.get("LineSeparator", null); //$NON-NLS-1$
 		workingDir = store.get("WorkingDir", null); //$NON-NLS-1$
-		if (store instanceof SettingsStore) {
-			process = (Process) ((SettingsStore) store).getSettings().get("Process"); //$NON-NLS-1$
-			pty = (PTY) ((SettingsStore) store).getSettings().get("PTY"); //$NON-NLS-1$
-			stdoutListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((SettingsStore) store).getSettings()
-					.get("StdOutListeners"); //$NON-NLS-1$
-			stderrListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((SettingsStore) store).getSettings()
-					.get("StdErrListeners"); //$NON-NLS-1$
-			environment = (String[]) ((SettingsStore) store).getSettings().get("Environment"); //$NON-NLS-1$
+		if (store instanceof InMemorySettingsStore) {
+			process = (Process) ((InMemorySettingsStore) store).getSettings().get("Process"); //$NON-NLS-1$
+			pty = (PTY) ((InMemorySettingsStore) store).getSettings().get("PTY"); //$NON-NLS-1$
+			stdoutListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((InMemorySettingsStore) store)
+					.getSettings().get("StdOutListeners"); //$NON-NLS-1$
+			stderrListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((InMemorySettingsStore) store)
+					.getSettings().get("StdErrListeners"); //$NON-NLS-1$
+			environment = (String[]) ((InMemorySettingsStore) store).getSettings().get("Environment"); //$NON-NLS-1$
 		}
 	}
 
@@ -295,12 +294,12 @@ public class ProcessSettings {
 		store.put("MergeWithNativeEnvironment", Boolean.toString(mergeWithNativeEnvironment)); //$NON-NLS-1$
 		store.put("LineSeparator", lineSeparator); //$NON-NLS-1$
 		store.put("WorkingDir", workingDir); //$NON-NLS-1$
-		if (store instanceof SettingsStore) {
-			((SettingsStore) store).getSettings().put("Process", process); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("PTY", pty); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("StdOutListeners", stdoutListeners); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("StdErrListeners", stderrListeners); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("Environment", environment); //$NON-NLS-1$
+		if (store instanceof InMemorySettingsStore) {
+			((InMemorySettingsStore) store).getSettings().put("Process", process); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("PTY", pty); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("StdOutListeners", stdoutListeners); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("StdErrListeners", stderrListeners); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("Environment", environment); //$NON-NLS-1$
 		}
 	}
 }

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
@@ -2,15 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.connector.ssh;singleton:=true
-Bundle-Version: 4.9.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.connector.ssh.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.equinox.security;bundle-version="[1.4.600,2)",
- org.eclipse.terminal.view.core;bundle-version="[4.11.0,5.0.0)",
- org.eclipse.terminal.view.ui;bundle-version="[4.12.0,5.0.0)",
- org.eclipse.terminal.control;bundle-version="[5.6.100,6.0.0)",
  org.eclipse.ui;bundle-version="[3.207.200,4)",
  com.jcraft.jsch;bundle-version="[0.1.31,1.0.0)",
  org.eclipse.jsch.core;bundle-version="[1.5.600,2.0.0)"
@@ -23,3 +20,12 @@ Export-Package: org.eclipse.terminal.connector.ssh.activator;x-internal:=true,
  org.eclipse.terminal.connector.ssh.launcher,
  org.eclipse.terminal.connector.ssh.nls;x-internal:=true
 Automatic-Module-Name: org.eclipse.terminal.connector.ssh
+Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces.constants;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.tracing;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.panels;version="[1.0.0,2.0.0)"

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.ssh.connector.ISshSettings;
 import org.eclipse.terminal.connector.ssh.connector.SshSettings;
@@ -31,13 +32,11 @@ import org.eclipse.terminal.view.core.interfaces.constants.ITerminalsConnectorCo
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanelContainer;
 import org.eclipse.terminal.view.ui.interfaces.IMementoHandler;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 
 /**
  * SSH launcher delegate implementation.
  */
-@SuppressWarnings("restriction")
 public class SshLauncherDelegate extends AbstractLauncherDelegate {
 	// The SSH terminal connection memento handler
 	private final IMementoHandler mementoHandler = new SshMementoHandler();
@@ -100,8 +99,7 @@ public class SshLauncherDelegate extends AbstractLauncherDelegate {
 			DateFormat format = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
 			String date = format.format(new Date(System.currentTimeMillis()));
 			if (port != null && Integer.valueOf(port).intValue() != ISshSettings.DEFAULT_SSH_PORT) {
-				return NLS.bind(Messages.SshLauncherDelegate_terminalTitle_port,
-						user, host, port, date);
+				return NLS.bind(Messages.SshLauncherDelegate_terminalTitle_port, user, host, port, date);
 			}
 			return NLS.bind(Messages.SshLauncherDelegate_terminalTitle, user, host, date);
 		}
@@ -155,7 +153,7 @@ public class SshLauncherDelegate extends AbstractLauncherDelegate {
 		}
 
 		// Construct the ssh settings store
-		ISettingsStore store = new SettingsStore();
+		ISettingsStore store = new InMemorySettingsStore();
 
 		// Construct the telnet settings
 		SshSettings sshSettings = new SshSettings();

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/META-INF/MANIFEST.MF
@@ -2,15 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.connector.telnet;singleton:=true
-Bundle-Version: 4.9.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.connector.telnet.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.equinox.security;bundle-version="[1.4.600,2)",
- org.eclipse.terminal.view.core;bundle-version="[4.10.400,5)",
- org.eclipse.terminal.view.ui;bundle-version="[4.11.600,5)",
- org.eclipse.terminal.control;bundle-version="[5.6.0,6.0.0)",
  org.eclipse.ui;bundle-version="[3.207.200,4)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
@@ -21,3 +18,12 @@ Export-Package: org.eclipse.terminal.connector.telnet.activator;x-internal:=true
  org.eclipse.terminal.connector.telnet.launcher,
  org.eclipse.terminal.connector.telnet.nls;x-internal:=true
 Automatic-Module-Name: org.eclipse.terminal.connector.telnet
+Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.interfaces.constants;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.core.tracing;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.interfaces;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui.panels;version="[1.0.0,2.0.0)"

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.telnet.connector.TelnetSettings;
 import org.eclipse.terminal.connector.telnet.controls.TelnetWizardConfigurationPanel;
@@ -30,13 +31,11 @@ import org.eclipse.terminal.view.core.interfaces.constants.ITerminalsConnectorCo
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanelContainer;
 import org.eclipse.terminal.view.ui.interfaces.IMementoHandler;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 
 /**
  * Telnet launcher delegate implementation.
  */
-@SuppressWarnings("restriction")
 public class TelnetLauncherDelegate extends AbstractLauncherDelegate {
 	// The Telnet terminal connection memento handler
 	private final IMementoHandler mementoHandler = new TelnetMementoHandler();
@@ -141,7 +140,7 @@ public class TelnetLauncherDelegate extends AbstractLauncherDelegate {
 		}
 
 		// Construct the terminal settings store
-		ISettingsStore store = new SettingsStore();
+		ISettingsStore store = new InMemorySettingsStore();
 
 		// Construct the telnet settings
 		TelnetSettings telnetSettings = new TelnetSettings();

--- a/terminal/bundles/org.eclipse.terminal.control/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.control/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.control; singleton:=true
-Bundle-Version: 5.6.100.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.internal.control.impl.TerminalPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/InMemorySettingsStore.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/InMemorySettingsStore.java
@@ -9,22 +9,21 @@
  * Contributors:
  * Wind River Systems - initial API and implementation
  *******************************************************************************/
-package org.eclipse.terminal.view.ui.internal;
+package org.eclipse.terminal.connector;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.terminal.connector.ISettingsStore;
 
 /**
  * Simple default Terminal settings store implementation keeping the settings
  * within memory.
  */
-public class SettingsStore implements ISettingsStore {
+public class InMemorySettingsStore implements ISettingsStore {
 	private final Map<String, Object> settings = new HashMap<>();
 
-	public SettingsStore() {
+	public InMemorySettingsStore() {
 	}
 
 	/**

--- a/terminal/bundles/org.eclipse.terminal.view.core/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.view.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.view.core;singleton:=true
-Bundle-Version: 4.11.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.view.core.activator.CoreBundleActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",

--- a/terminal/bundles/org.eclipse.terminal.view.ui/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.view.ui;singleton:=true
-Bundle-Version: 4.12.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.terminal.view.ui.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
@@ -10,12 +10,11 @@ Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.22.0,4.0.0)";resolution:=optional,
  org.eclipse.core.variables;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.18.0,4.0.0)";resolution:=optional,
- org.eclipse.terminal.view.core;bundle-version="[4.11.0,5.0.0)",
- org.eclipse.terminal.control;bundle-version="[5.6.0,6.0.0)",
  org.eclipse.ui;bundle-version="[3.207.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.22.0,4.0.0)";resolution:=optional,
  org.eclipse.ui.editors;bundle-version="[3.20.0,4.0.0)";resolution:=optional,
- org.eclipse.text;bundle-version="[3.14.0,4.0.0)";resolution:=optional
+ org.eclipse.text;bundle-version="[3.14.0,4.0.0)";resolution:=optional,
+ org.eclipse.terminal.view.core;bundle-version="[1.0.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
@@ -41,3 +40,8 @@ Export-Package: org.eclipse.terminal.view.ui.actions;version="1.0.0",
  org.eclipse.terminal.view.ui.tabs;version="1.0.0",
  org.eclipse.terminal.view.ui.view;version="1.0.0"
 Automatic-Module-Name: org.eclipse.terminal.view.ui
+Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.control;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.control.actions;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.model;version="[1.0.0,2.0.0)"

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/interfaces/IPreferenceKeys.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/interfaces/IPreferenceKeys.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.interfaces;
 
+import org.eclipse.terminal.view.core.preferences.ScopedEclipsePreferences;
+import org.eclipse.terminal.view.ui.activator.UIPlugin;
+
 /**
  * Terminal plug-in preference key definitions.
  *
@@ -67,4 +70,9 @@ public interface IPreferenceKeys {
 	 */
 	public final String PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX_ARGS = PREF_TERMINAL
 			+ ".localTerminalDefaultShellUnixArgs"; //$NON-NLS-1$
+
+	static ScopedEclipsePreferences getPreferences() {
+		return UIPlugin.getScopedPreferences();
+	}
+
 }

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsLauncherDelegate.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.terminal.view.core.interfaces.ITerminalService;
@@ -25,7 +26,6 @@ import org.eclipse.terminal.view.core.interfaces.ITerminalServiceOutputStreamMon
 import org.eclipse.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.interfaces.IConfigurationPanelContainer;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 
 /**
@@ -78,7 +78,7 @@ public class StreamsLauncherDelegate extends AbstractLauncherDelegate {
 				.get(ITerminalsConnectorConstants.PROP_STDERR_LISTENERS);
 
 		// Construct the terminal settings store
-		ISettingsStore store = new SettingsStore();
+		ISettingsStore store = new InMemorySettingsStore();
 
 		// Construct the streams settings
 		StreamsSettings streamsSettings = new StreamsSettings();

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsSettings.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsSettings.java
@@ -16,8 +16,8 @@ import java.io.OutputStream;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.terminal.connector.ISettingsStore;
+import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.view.core.interfaces.ITerminalServiceOutputStreamMonitorListener;
-import org.eclipse.terminal.view.ui.internal.SettingsStore;
 
 /**
  * Streams connector settings implementation.
@@ -174,13 +174,13 @@ public class StreamsSettings {
 		Assert.isNotNull(store);
 		localEcho = Boolean.parseBoolean(store.get("LocalEcho", Boolean.FALSE.toString())); //$NON-NLS-1$
 		lineSeparator = store.get("LineSeparator", null); //$NON-NLS-1$
-		if (store instanceof SettingsStore) {
-			stdin = (OutputStream) ((SettingsStore) store).getSettings().get("stdin"); //$NON-NLS-1$
-			stdout = (InputStream) ((SettingsStore) store).getSettings().get("stdout"); //$NON-NLS-1$
-			stderr = (InputStream) ((SettingsStore) store).getSettings().get("stderr"); //$NON-NLS-1$
-			stdoutListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((SettingsStore) store).getSettings()
+		if (store instanceof InMemorySettingsStore) {
+			stdin = (OutputStream) ((InMemorySettingsStore) store).getSettings().get("stdin"); //$NON-NLS-1$
+			stdout = (InputStream) ((InMemorySettingsStore) store).getSettings().get("stdout"); //$NON-NLS-1$
+			stderr = (InputStream) ((InMemorySettingsStore) store).getSettings().get("stderr"); //$NON-NLS-1$
+			stdoutListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((InMemorySettingsStore) store).getSettings()
 					.get("StdOutListeners"); //$NON-NLS-1$
-			stderrListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((SettingsStore) store).getSettings()
+			stderrListeners = (ITerminalServiceOutputStreamMonitorListener[]) ((InMemorySettingsStore) store).getSettings()
 					.get("StdErrListeners"); //$NON-NLS-1$
 		}
 	}
@@ -194,12 +194,12 @@ public class StreamsSettings {
 		Assert.isNotNull(store);
 		store.put("LocalEcho", Boolean.toString(localEcho)); //$NON-NLS-1$
 		store.put("LineSeparator", lineSeparator); //$NON-NLS-1$
-		if (store instanceof SettingsStore) {
-			((SettingsStore) store).getSettings().put("stdin", stdin); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("stdout", stdout); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("stderr", stderr); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("StdOutListeners", stdoutListeners); //$NON-NLS-1$
-			((SettingsStore) store).getSettings().put("StdErrListeners", stderrListeners); //$NON-NLS-1$
+		if (store instanceof InMemorySettingsStore) {
+			((InMemorySettingsStore) store).getSettings().put("stdin", stdin); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("stdout", stdout); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("stderr", stderr); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("StdOutListeners", stdoutListeners); //$NON-NLS-1$
+			((InMemorySettingsStore) store).getSettings().put("StdErrListeners", stderrListeners); //$NON-NLS-1$
 		}
 	}
 }

--- a/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
+++ b/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.terminal.test;singleton:=true
-Bundle-Version: 4.6.100.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="[4.13.2,5)",
- org.eclipse.terminal.control;bundle-version="[5.6.0,6.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.ui;bundle-version="[3.207.200,4)",
- org.opentest4j;bundle-version="[1.3.0,2)"
+ org.opentest4j;bundle-version="[1.3.0,2)",
+ org.eclipse.terminal.control;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.terminal.internal.connector;x-internal:=true,
  org.eclipse.terminal.internal.emulator;x-internal:=true,


### PR DESCRIPTION
FYI @merks @HannesWell this now makes use of exported package to ensure no internal API is required to implement extensions. There is only one exception where the NLS of another bundle is reused but this should be cleared out later.

The package structure sometimes look a bit more nested / overengineered in some places (e.g. `org.eclipse.terminal.view.core` / `org.eclipse.terminal.view.core.interfaces` / `org.eclipse.terminal.view.core.interfaces.constants` ... ) but this is also something for another PR.