### PR TITLE
Use public API for ProjectScope instead of internal one

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ProjectScope.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/ProjectScope.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.resources;
 
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.AbstractScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.osgi.service.prefs.Preferences;


### PR DESCRIPTION
FYI @tjwatson this now only uses one internal API that is the `org.eclipse.core.internal.preferences.EclipsePreferences` because it access the `DEFAULT_PREFERENCES_DIRNAME`, I wonder if we should simply move these to `IEclipsePreferences` ...