### PR TITLE
Introduce `TerminalViewId` instead of nullable `id` and `secondaryId`

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/TerminalViewId.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/TerminalViewId.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
+ * This program and the accompanying materials are made available under the terms
+ * of the Eclipse Public License 2.0 which accompanies this distribution, and is
+ * available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Wind River Systems - initial API and implementation
+ * Max Weninger (Wind River) - [361363] [TERMINALS] Implement "Pin&Clone" for the "Terminals" view
+ * Alexander Fedorov (ArSysOp) - further evolution
+ *******************************************************************************/
+package org.eclipse.terminal.view.ui;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Encapsulates the pair of mandatory primary terminal view id and optional secondary id
+ *
+ * @see IUIConstants#ID
+ * @see IViewReference#getSecondaryId()
+ */
+public record TerminalViewId(String primary, Optional<String> secondary) {
+
+	public TerminalViewId() {
+		this(IUIConstants.ID);
+	}
+
+	public TerminalViewId(String primary) {
+		this(primary, Optional.empty());
+	}
+
+	public TerminalViewId(String primary, String secondary) {
+		this(primary, Optional.ofNullable(secondary));
+	}
+
+	public TerminalViewId next() {
+		return new TerminalViewId(primary, nextSecondaryId(primary));
+	}
+
+	private static String nextSecondaryId(String primary) {
+		Map<String, IViewReference> terminalViews = new HashMap<>();
+		int maxNumber = 0;
+		for (IViewReference ref : viewReferences()) {
+			if (ref.getId().equals(primary)) {
+				if (ref.getSecondaryId() != null) {
+					terminalViews.put(ref.getSecondaryId(), ref);
+					int scondaryIdInt = Integer.parseInt(ref.getSecondaryId());
+					if (scondaryIdInt > maxNumber) {
+						maxNumber = scondaryIdInt;
+					}
+				} else {
+					// add the one with secondaryId == null with 0 by default
+					terminalViews.put(Integer.toString(0), ref);
+				}
+			}
+		}
+		if (terminalViews.size() == 0) {
+			return null;
+		}
+
+		int i = 0;
+		for (; i < maxNumber; i++) {
+			String secondaryIdStr = Integer.toString(i);
+			if (!terminalViews.keySet().contains(secondaryIdStr)) {
+				// found a free slot
+				if (i == 0) {
+					return null;
+				}
+				return Integer.toString(i);
+			}
+		}
+		// add a new one
+		return Integer.toString(i + 1);
+	}
+
+	private static List<IViewReference> viewReferences() {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return Collections.emptyList();
+		}
+		return Optional.of(PlatformUI.getWorkbench()).map(IWorkbench::getActiveWorkbenchWindow)
+				.map(IWorkbenchWindow::getActivePage).map(IWorkbenchPage::getViewReferences).map(Arrays::asList)
+				.orElseGet(Collections::emptyList);
+	}
+
+}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/handler/NewTerminalViewHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/handler/NewTerminalViewHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2015, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,14 +8,14 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.internal.handler;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.terminal.view.ui.IUIConstants;
+import org.eclipse.terminal.view.ui.TerminalViewId;
 import org.eclipse.terminal.view.ui.internal.UIPlugin;
-import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 
 /**
  * New Terminal View handler implementation
@@ -24,9 +24,7 @@ public class NewTerminalViewHandler extends AbstractTriggerCommandHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		ITerminalConsoleViewManager consoleManager = UIPlugin.getConsoleManager();
-		String secondaryId = consoleManager.getNextTerminalSecondaryId(IUIConstants.ID);
-		consoleManager.showConsoleView(IUIConstants.ID, secondaryId);
+		UIPlugin.getConsoleManager().showConsoleView(new TerminalViewId().next());
 
 		triggerCommand("org.eclipse.terminal.view.ui.command.launchToolbar", null); //$NON-NLS-1$
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ITerminalConsoleViewManager.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ITerminalConsoleViewManager.java
@@ -10,6 +10,7 @@
  * Wind River Systems - initial API and implementation
  * Max Weninger (Wind River) - [361363] [TERMINALS] Implement "Pin&Clone" for the "Terminals" view
  * Christoph Läubrich - extract to interface
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.launcher;
 
@@ -21,6 +22,7 @@ import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.ITerminalsView;
+import org.eclipse.terminal.view.ui.TerminalViewId;
 import org.eclipse.ui.IViewPart;
 
 public interface ITerminalConsoleViewManager {
@@ -30,50 +32,37 @@ public interface ITerminalConsoleViewManager {
 	 * <p>
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 *
-	 * @param id The terminals console view id or <code>null</code> to show the default terminals console view.
-	 * @param secondaryId The terminal console secondary id, which may be <code>null</code> which is the secondary id of
-	 *        the first terminal view opened. To specify reuse of most recent terminal view use special value of
-	 *        {@link ITerminalsConnectorConstants#LAST_ACTIVE_SECONDARY_ID}.
+	 * @param tvid The terminals console view id. To specify reuse of most recent terminal view use special value of
+	 *        {@link ITerminalsConnectorConstants#LAST_ACTIVE_SECONDARY_ID} for its secondary part.
 	 *
 	 * @return an {@link Optional} describing the console view instance if available or an empty {@link Optional} otherwise.
 	 */
-	Optional<ITerminalsView> findConsoleView(String id, String secondaryId);
-
-	/**
-	 * Return a new secondary id to use, based on the number of open terminal views.
-	 *
-	 * @param id The terminals console view id. Must not be <code>null</code>.
-	 * @return The next secondary id, or <code>null</code> if it is the first one
-	 * @since 4.1
-	 */
-	String getNextTerminalSecondaryId(String id);
+	Optional<ITerminalsView> findConsoleView(TerminalViewId tvid);
 
 	/**
 	 * Show the terminals console view specified by the given id.
 	 * <p>
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 *
-	 * @param id The terminals console view id or <code>null</code> to show the default terminals console view.
+	 * @param tvid The terminals console view id.
 	 */
-	IViewPart showConsoleView(String id, String secondaryId);
+	IViewPart showConsoleView(TerminalViewId tvid);
 
 	/**
 	 * Opens the console with the given title and connector.
 	 * <p>
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 *
-	 * @param id The terminals console view id or <code>null</code> to show the default terminals console view.
-	 * @param secondaryId The terminal console secondary id, which may be <code>null</code> which is the secondary id of
-	 *        the first terminal view opened. To specify reuse of most recent terminal view use special value of
-	 *        {@link ITerminalsConnectorConstants#LAST_ACTIVE_SECONDARY_ID}.
+	 * @param tvid The terminals console view id. To specify reuse of most recent terminal view use special value of
+	 *        {@link ITerminalsConnectorConstants#LAST_ACTIVE_SECONDARY_ID} for its secondary part.
 	 * @param title The console title. Must not be <code>null</code>.
 	 * @param encoding The terminal encoding or <code>null</code>.
 	 * @param connector The terminal connector. Must not be <code>null</code>.
 	 * @param data The custom terminal data node or <code>null</code>.
 	 * @param flags The flags controlling how the console is opened or <code>null</code> to use defaults.
 	 */
-	Widget openConsole(String id, String secondaryId, String title, String encoding, ITerminalConnector connector,
-			Object data, Map<String, Boolean> flags);
+	Widget openConsole(TerminalViewId tvid, String title, String encoding, ITerminalConnector connector, Object data,
+			Map<String, Boolean> flags);
 
 	/**
 	 * Lookup a console with the given title and the given terminal connector.
@@ -81,16 +70,14 @@ public interface ITerminalConsoleViewManager {
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 * <b>Note:</b> The method will handle unified console titles itself.
 	 *
-	 * @param id The terminals console view id or <code>null</code> to show the default terminals console view.
-	 * @param secondaryId The terminals console view secondary id or <code>null</code>.
+	 * @param tvid The terminals console view id.
 	 * @param title The console title. Must not be <code>null</code>.
 	 * @param connector The terminal connector. Must not be <code>null</code>.
 	 * @param data The custom terminal data node or <code>null</code>.
 	 *
 	 * @return An {@link Optional} describing the corresponding console tab item or <an empty optional if not found.
 	 */
-	Optional<Widget> findConsole(String id, String secondaryId, String title, ITerminalConnector connector,
-			Object data);
+	Optional<Widget> findConsole(TerminalViewId tvid, String title, ITerminalConnector connector, Object data);
 
 	/**
 	 * Lookup a console which is assigned with the given terminal control.
@@ -108,11 +95,12 @@ public interface ITerminalConsoleViewManager {
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 * <b>Note:</b> The method will handle unified console titles itself.
 	 *
+	 * @param tvid The terminals console view id.
 	 * @param title The console title. Must not be <code>null</code>.
 	 * @param connector The terminal connector. Must not be <code>null</code>.
 	 * @param data The custom terminal data node or <code>null</code>.
 	 */
-	void closeConsole(String id, String title, ITerminalConnector connector, Object data);
+	void closeConsole(TerminalViewId tvid, String title, ITerminalConnector connector, Object data);
 
 	/**
 	 * Terminate (disconnect) the console with the given title and the given terminal connector.
@@ -120,10 +108,11 @@ public interface ITerminalConsoleViewManager {
 	 * <b>Note:</b> The method must be called within the UI thread.
 	 * <b>Note:</b> The method will handle unified console titles itself.
 	 *
+	 * @param tvid The terminals console view id.
 	 * @param title The console title. Must not be <code>null</code>.
 	 * @param connector The terminal connector. Must not be <code>null</code>.
 	 * @param data The custom terminal data node or <code>null</code>.
 	 */
-	void terminateConsole(String id, String title, ITerminalConnector connector, Object data);
+	void terminateConsole(TerminalViewId tvid, String title, ITerminalConnector connector, Object data);
 
 }


### PR DESCRIPTION
Currently there is a pair of arguments in a number of signatures `String id, String secondaryId` each of which may be `null`.

Instead of this pair a new type introduced that also handles the logic of calculation for the next secondary id.

As a result the client code may be simplified to look like this: `UIPlugin.getConsoleManager().showConsoleView(new
TerminalViewId().next());`