### PR TITLE
Restore natures and buildspec for project descriptions

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
@@ -411,9 +411,10 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 		try {
 			final IProject project = buildConfiguration.getProject();
 			final ICommand[] commands;
-			if (project.isAccessible())
-				commands = ((Project) project).internalGetDescription().getBuildSpec(false);
-			else
+			if (project.isAccessible()) {
+				ProjectDescription description = ((Project) project).internalGetDescription();
+				commands = description == null ? null : description.getBuildSpec(false);
+			} else
 				commands = null;
 			int work = commands == null ? 0 : commands.length;
 			monitor.beginTask(NLS.bind(Messages.events_building_1, project.getFullPath()), work);
@@ -708,6 +709,9 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 		ArrayList<BuilderPersistentInfo> oldInfos = getBuildersPersistentInfo(project);
 
 		ProjectDescription desc = ((Project) project).internalGetDescription();
+		if (desc == null) {
+			return null;
+		}
 		ICommand[] commands = desc.getBuildSpec(false);
 		if (commands.length == 0)
 			return null;
@@ -1577,7 +1581,8 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 			final ICommand[] commands;
 			if (project.isAccessible()) {
 				Set<ISchedulingRule> rules = new HashSet<>();
-				commands = ((Project) project).internalGetDescription().getBuildSpec(false);
+				ProjectDescription description = ((Project) project).internalGetDescription();
+				commands = description == null ? new ICommand[0] : description.getBuildSpec(false);
 				boolean hasNullBuildRule = false;
 				BuildContext context = new BuildContext(buildConfiguration);
 				for (int i = 0; i < commands.length; i++) {

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ModelObjectWriter.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ModelObjectWriter.java
@@ -44,7 +44,7 @@ public class ModelObjectWriter implements IModelObjectConstants {
 	 * Returns the string representing the serialized set of build triggers for
 	 * the given command
 	 */
-	private static String triggerString(BuildCommand command) {
+	static String triggerString(BuildCommand command) {
 		StringBuilder buf = new StringBuilder();
 		if (command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD))
 			buf.append(TRIGGER_AUTO).append(',');
@@ -83,7 +83,7 @@ public class ModelObjectWriter implements IModelObjectConstants {
 	/**
 	 * Returns whether the build triggers for this command should be written.
 	 */
-	private boolean shouldWriteTriggers(BuildCommand command) {
+	static boolean shouldWriteTriggers(BuildCommand command) {
 		//only write triggers if command is configurable and there exists a trigger
 		//that the builder does NOT respond to.  I.e., don't write out on the default
 		//cases to avoid dirtying .project files unnecessarily.

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -787,7 +787,11 @@ public class Project extends Container implements IProject {
 	 * @see #getActiveBuildConfig()
 	 */
 	IBuildConfiguration internalGetActiveBuildConfig() {
-		String configName = internalGetDescription().activeConfiguration;
+		ProjectDescription description = internalGetDescription();
+		if (description == null) {
+			return new BuildConfiguration(this, IBuildConfiguration.DEFAULT_CONFIG_NAME);
+		}
+		String configName = description.activeConfiguration;
 		try {
 			if (configName != null)
 				return getBuildConfig(configName);
@@ -827,6 +831,9 @@ public class Project extends Container implements IProject {
 	 */
 	public IBuildConfiguration[] internalGetReferencedBuildConfigs(String configName, boolean includeMissing) {
 		ProjectDescription description = internalGetDescription();
+		if (description == null) {
+			return new IBuildConfiguration[0];
+		}
 		IBuildConfiguration[] refs = description.getAllBuildConfigReferences(this, configName, false);
 		Collection<IBuildConfiguration> configs = new LinkedHashSet<>(refs.length);
 		for (IBuildConfiguration ref : refs) {

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.internal.events.BuildCommand;
@@ -546,6 +547,14 @@ public class ProjectDescription extends ModelObject implements IProjectDescripti
 		// Configuration level references
 		if (configRefsHaveChanges(dynamicConfigRefs, description.dynamicConfigRefs))
 			return true;
+		// has natures changed?
+		if (!Set.of(natures).equals(Set.of(description.natures))) {
+			return true;
+		}
+		// has buildspec changed?
+		if (!Objects.deepEquals(buildSpec, description.buildSpec)) {
+			return true;
+		}
 
 		return false;
 	}
@@ -978,4 +987,5 @@ public class ProjectDescription extends ModelObject implements IProjectDescripti
 		}
 		return result.toArray(new IProject[0]);
 	}
+
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescriptionReader.java
@@ -233,26 +233,31 @@ public class ProjectDescriptionReader extends DefaultHandler implements IModelOb
 			state = S_BUILD_COMMAND;
 			BuildCommand command = (BuildCommand) objectStack.peek();
 			//presence of this element indicates the builder is configurable
+			String string = charBuffer.toString();
 			command.setConfigurable(true);
 			//clear all existing values
-			command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, false);
-			command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
-			command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, false);
-			command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
+			parseBuildTriggers(command, string);
+		}
+	}
 
-			//set new values according to value in the triggers element
-			StringTokenizer tokens = new StringTokenizer(charBuffer.toString(), ","); //$NON-NLS-1$
-			while (tokens.hasMoreTokens()) {
-				String next = tokens.nextToken();
-				if (next.equalsIgnoreCase(TRIGGER_AUTO)) {
-					command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, true);
-				} else if (next.equalsIgnoreCase(TRIGGER_CLEAN)) {
-					command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, true);
-				} else if (next.equalsIgnoreCase(TRIGGER_FULL)) {
-					command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, true);
-				} else if (next.equalsIgnoreCase(TRIGGER_INCREMENTAL)) {
-					command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, true);
-				}
+	static void parseBuildTriggers(BuildCommand command, String string) {
+		command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, false);
+		command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, false);
+		command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, false);
+		command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, false);
+
+		// set new values according to value in the triggers element
+		StringTokenizer tokens = new StringTokenizer(string, ","); //$NON-NLS-1$
+		while (tokens.hasMoreTokens()) {
+			String next = tokens.nextToken();
+			if (next.equalsIgnoreCase(TRIGGER_AUTO)) {
+				command.setBuilding(IncrementalProjectBuilder.AUTO_BUILD, true);
+			} else if (next.equalsIgnoreCase(TRIGGER_CLEAN)) {
+				command.setBuilding(IncrementalProjectBuilder.CLEAN_BUILD, true);
+			} else if (next.equalsIgnoreCase(TRIGGER_FULL)) {
+				command.setBuilding(IncrementalProjectBuilder.FULL_BUILD, true);
+			} else if (next.equalsIgnoreCase(TRIGGER_INCREMENTAL)) {
+				command.setBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD, true);
 			}
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.900.qualifier
+Bundle-Version: 3.11.1000.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.37.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.900-SNAPSHOT</version>
+  <version>3.11.1000-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Currently a private project description does not store natures and builder, but these are mostly important these days.

This now also stores natures and builder specs.