### PR TITLE
Make service trackers instance scoped in terminal.view.ui

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
@@ -14,7 +14,6 @@ package org.eclipse.terminal.connector.local.activator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.utils.ScopedEclipsePreferences;
 import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
@@ -27,17 +26,13 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 public class UIPlugin extends AbstractUIPlugin {
 	// The shared instance
-	private static UIPlugin plugin;
+	private static volatile UIPlugin plugin;
 	// The scoped preferences instance
 	private static volatile ScopedEclipsePreferences scopedPreferences;
 	// The trace handler instance
 	private static volatile TraceHandler traceHandler;
 
-	/**
-	 * The constructor
-	 */
-	public UIPlugin() {
-	}
+	private ServiceTracker<ILaunchDelegateManager, ILaunchDelegateManager> launchDelegateServiceTracker;
 
 	/**
 	 * Returns the shared instance
@@ -83,6 +78,8 @@ public class UIPlugin extends AbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
+		launchDelegateServiceTracker = new ServiceTracker<>(context, ILaunchDelegateManager.class, null);
+		launchDelegateServiceTracker.open();
 		plugin = this;
 	}
 
@@ -121,25 +118,11 @@ public class UIPlugin extends AbstractUIPlugin {
 		return getDefault().getImageRegistry().getDescriptor(key);
 	}
 
-	private static ServiceTracker<ITerminalService, ITerminalService> terminalServiceTracker;
-
-	public static synchronized ITerminalService getTerminalService() {
-		if (terminalServiceTracker == null) {
-			terminalServiceTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(),
-					ITerminalService.class, null);
-			terminalServiceTracker.open();
-		}
-		return terminalServiceTracker.getService();
-	}
-
-	private static ServiceTracker<ILaunchDelegateManager, ILaunchDelegateManager> launchDelegateServiceTracker;
-
 	public static synchronized ILaunchDelegateManager getLaunchDelegateManager() {
-		if (launchDelegateServiceTracker == null) {
-			launchDelegateServiceTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(),
-					ILaunchDelegateManager.class, null);
-			launchDelegateServiceTracker.open();
+		UIPlugin plugin = getDefault();
+		if (plugin == null) {
+			return null;
 		}
-		return launchDelegateServiceTracker.getService();
+		return plugin.launchDelegateServiceTracker.getService();
 	}
 }

--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -222,7 +222,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 		}
 
 		// Get the terminal service
-		ITerminalService terminal = UIPlugin.getTerminalService();
+		ITerminalService terminal = getTerminalService();
 		// If not available, we cannot fulfill this request
 		if (terminal != null) {
 			terminal.openConsole(properties, done);

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessConnector.java
@@ -209,7 +209,7 @@ public class ProcessConnector extends AbstractStreamsConnector {
 			// Save the shell so the error message can have somewhere to display
 			Shell shell = control.getShell();
 			// Lookup the tab item
-			UIPlugin.getConsoleManager().findConsole(control).ifPresent(Widget::dispose);
+			getConsoleViewManager().findConsole(control).ifPresent(Widget::dispose);
 			// Get the error message from the exception
 			String msg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : ""; //$NON-NLS-1$
 			Assert.isNotNull(msg);

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/ProcessLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/ProcessLauncherDelegate.java
@@ -47,7 +47,7 @@ public class ProcessLauncherDelegate extends AbstractLauncherDelegate {
 		Assert.isNotNull(properties);
 
 		// Get the terminal service
-		ITerminalService terminal = UIPlugin.getTerminalService();
+		ITerminalService terminal = getTerminalService();
 		// If not available, we cannot fulfill this request
 		if (terminal != null) {
 			terminal.openConsole(properties, done);

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/UIPlugin.java
@@ -16,12 +16,9 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.utils.TraceHandler;
-import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -115,28 +112,6 @@ public class UIPlugin extends AbstractUIPlugin {
 
 	public static void log(IStatus status) {
 		getDefault().getLog().log(status);
-	}
-
-	private static ServiceTracker<ITerminalService, ITerminalService> serviceTracker;
-
-	public static synchronized ITerminalService getTerminalService() {
-		if (serviceTracker == null) {
-			serviceTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(), ITerminalService.class,
-					null);
-			serviceTracker.open();
-		}
-		return serviceTracker.getService();
-	}
-
-	private static ServiceTracker<ITerminalConsoleViewManager, ITerminalConsoleViewManager> consoleManagerTracker;
-
-	public static synchronized ITerminalConsoleViewManager getConsoleManager() {
-		if (consoleManagerTracker == null) {
-			consoleManagerTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(),
-					ITerminalConsoleViewManager.class, null);
-			consoleManagerTracker.open();
-		}
-		return consoleManagerTracker.getService();
 	}
 
 }

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/activator/UIPlugin.java
@@ -16,7 +16,6 @@ import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jsch.core.IJSchService;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.terminal.connector.ssh.connector.SshConnection;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -143,14 +142,4 @@ public class UIPlugin extends AbstractUIPlugin {
 		return getDefault().getImageRegistry().getDescriptor(key);
 	}
 
-	private static ServiceTracker<ITerminalService, ITerminalService> serviceTracker;
-
-	public static synchronized ITerminalService getTerminalService() {
-		if (serviceTracker == null) {
-			serviceTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(), ITerminalService.class,
-					null);
-			serviceTracker.open();
-		}
-		return serviceTracker.getService();
-	}
 }

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/connector/SshConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/connector/SshConnector.java
@@ -22,12 +22,12 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.connector.NullSettingsStore;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 
 import com.jcraft.jsch.ChannelShell;
 import com.jcraft.jsch.JSch;
 
-public class SshConnector extends TerminalConnectorImpl {
+public class SshConnector extends AbstractTerminalConnector {
 	private OutputStream fOutputStream;
 	private InputStream fInputStream;
 	private JSch fJsch;

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
@@ -22,7 +22,6 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
-import org.eclipse.terminal.connector.ssh.activator.UIPlugin;
 import org.eclipse.terminal.connector.ssh.connector.ISshSettings;
 import org.eclipse.terminal.connector.ssh.connector.SshSettings;
 import org.eclipse.terminal.connector.ssh.controls.SshWizardConfigurationPanel;
@@ -68,7 +67,7 @@ public class SshLauncherDelegate extends AbstractLauncherDelegate {
 		}
 
 		// Get the terminal service
-		ITerminalService terminal = UIPlugin.getTerminalService();
+		ITerminalService terminal = getTerminalService();
 		// If not available, we cannot fulfill this request
 		if (terminal != null) {
 			terminal.openConsole(properties, done);

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/activator/UIPlugin.java
@@ -15,11 +15,9 @@ package org.eclipse.terminal.connector.telnet.activator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -105,14 +103,4 @@ public class UIPlugin extends AbstractUIPlugin {
 		return getDefault().getImageRegistry().getDescriptor(key);
 	}
 
-	private static ServiceTracker<ITerminalService, ITerminalService> serviceTracker;
-
-	public static synchronized ITerminalService getTerminalService() {
-		if (serviceTracker == null) {
-			serviceTracker = new ServiceTracker<>(getDefault().getBundle().getBundleContext(), ITerminalService.class,
-					null);
-			serviceTracker.open();
-		}
-		return serviceTracker.getService();
-	}
 }

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/connector/TelnetConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/connector/TelnetConnector.java
@@ -33,9 +33,9 @@ import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.connector.NullSettingsStore;
 import org.eclipse.terminal.connector.TerminalState;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 
-public class TelnetConnector extends TerminalConnectorImpl {
+public class TelnetConnector extends AbstractTerminalConnector {
 
 	static final class TelnetOutputStream extends FilterOutputStream {
 		final static byte CR = 13;

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
@@ -22,7 +22,6 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
-import org.eclipse.terminal.connector.telnet.activator.UIPlugin;
 import org.eclipse.terminal.connector.telnet.connector.TelnetSettings;
 import org.eclipse.terminal.connector.telnet.controls.TelnetWizardConfigurationPanel;
 import org.eclipse.terminal.connector.telnet.nls.Messages;
@@ -67,7 +66,7 @@ public class TelnetLauncherDelegate extends AbstractLauncherDelegate {
 		}
 
 		// Get the terminal service
-		ITerminalService terminal = UIPlugin.getTerminalService();
+		ITerminalService terminal = getTerminalService();
 		// If not available, we cannot fulfill this request
 		if (terminal != null) {
 			terminal.openConsole(properties, done);

--- a/terminal/bundles/org.eclipse.terminal.control/schema/connectors.exsd
+++ b/terminal/bundles/org.eclipse.terminal.control/schema/connectors.exsd
@@ -52,10 +52,10 @@
          <attribute name="class" type="string" use="required">
             <annotation>
                <documentation>
-                  A class extending TerminalConnectorImpl
+                  A class extending AbstractTerminalConnector
                </documentation>
                <appInfo>
-                  <meta.attribute kind="java" basedOn="org.eclipse.terminal.connector.provider.TerminalConnectorImpl:"/>
+                  <meta.attribute kind="java" basedOn="org.eclipse.terminal.connector.provider.AbstractTerminalConnector:"/>
                </appInfo>
             </annotation>
          </attribute>

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/ITerminalConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/ITerminalConnector.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
 import java.util.Optional;
 
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.control.ITerminalViewControl;
 
 /**
@@ -29,9 +29,9 @@ import org.eclipse.terminal.control.ITerminalViewControl;
  * <code>org.eclipse.terminal.control.connectors</code> extension point. This
  * class gives access to the static markup of a terminal connector extension as
  * well as providing the lifecycle management for the dynamically loaded
- * {@link TerminalConnectorImpl} instance, which performs the actual
+ * {@link AbstractTerminalConnector} instance, which performs the actual
  * communications. This pattern allows for lazy initialization, bundle
- * activation and class loading of the actual {@link TerminalConnectorImpl}
+ * activation and class loading of the actual {@link AbstractTerminalConnector}
  * instance.
  *
  * Clients can get terminal connector instances from the
@@ -61,7 +61,7 @@ public interface ITerminalConnector extends IAdaptable {
 	boolean isHidden();
 
 	/**
-	 * @return true if the {@link TerminalConnectorImpl} has been initialized.
+	 * @return true if the {@link AbstractTerminalConnector} has been initialized.
 	 * If there was an initialization error, {@link #getInitializationErrorMessage()}
 	 * returns the error message.
 	 */

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/TerminalConnectorExtension.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/TerminalConnectorExtension.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.RegistryFactory;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.internal.connector.TerminalConnector;
 
 /**
@@ -40,7 +40,7 @@ public class TerminalConnectorExtension {
 		}
 		String hidden = config.getAttribute("hidden"); //$NON-NLS-1$
 		boolean isHidden = hidden != null ? Boolean.parseBoolean(hidden) : false;
-		TerminalConnector.Factory factory = () -> (TerminalConnectorImpl) config.createExecutableExtension("class"); //$NON-NLS-1$
+		TerminalConnector.Factory factory = () -> (AbstractTerminalConnector) config.createExecutableExtension("class"); //$NON-NLS-1$
 		return new TerminalConnector(factory, id, name, isHidden);
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/provider/AbstractTerminalConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/provider/AbstractTerminalConnector.java
@@ -27,7 +27,7 @@ import org.eclipse.terminal.connector.TerminalState;
  * extension point.
  *
  */
-public abstract class TerminalConnectorImpl {
+public abstract class AbstractTerminalConnector {
 
 	/**
 	 * The TerminalControl associated with this connector.

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/connector/TerminalConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/connector/TerminalConnector.java
@@ -26,7 +26,7 @@ import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.TerminalState;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.internal.control.impl.TerminalMessages;
 
 /**
@@ -35,7 +35,7 @@ import org.eclipse.terminal.internal.control.impl.TerminalMessages;
  *
  * It provides all terminal connector functions that can be provided by static
  * markup without loading the actual implementation class. The actual
- * {@link TerminalConnectorImpl} implementation class is lazily loaded by the
+ * {@link AbstractTerminalConnector} implementation class is lazily loaded by the
  * provided {@link TerminalConnector.Factory} interface when needed. class, and
  * delegates to the actual implementation when needed. The following methods can
  * be called without initializing the contributed implementation class:
@@ -50,7 +50,7 @@ import org.eclipse.terminal.internal.control.impl.TerminalMessages;
  */
 public class TerminalConnector implements ITerminalConnector {
 	/**
-	 * Creates an instance of TerminalConnectorImpl. This is used to lazily load
+	 * Creates an instance of {@link AbstractTerminalConnector}. This is used to lazily load
 	 * classed defined in extensions.
 	 *
 	 */
@@ -62,7 +62,7 @@ public class TerminalConnector implements ITerminalConnector {
 		 * @return a Connector
 		 * @throws Exception
 		 */
-		TerminalConnectorImpl makeConnector() throws Exception;
+		AbstractTerminalConnector makeConnector() throws Exception;
 	}
 
 	/**
@@ -84,7 +84,7 @@ public class TerminalConnector implements ITerminalConnector {
 	/**
 	 * The connector
 	 */
-	private TerminalConnectorImpl fConnector;
+	private AbstractTerminalConnector fConnector;
 	/**
 	 * If the initialization of the class specified in the extension fails,
 	 * this variable contains the error
@@ -100,7 +100,7 @@ public class TerminalConnector implements ITerminalConnector {
 	 * Constructor for the terminal connector.
 	 *
 	 * @param terminalConnectorFactory Factory for lazily instantiating the
-	 *            TerminalConnectorImpl when needed.
+	 *            {@link AbstractTerminalConnector} when needed.
 	 * @param id terminal connector ID. The connector is publicly known under
 	 *            this ID.
 	 * @param name translatable name to display the connector in the UI.
@@ -137,14 +137,14 @@ public class TerminalConnector implements ITerminalConnector {
 		return fHidden;
 	}
 
-	private TerminalConnectorImpl getConnectorImpl() {
+	private AbstractTerminalConnector getConnectorImpl() {
 		if (!isInitialized()) {
 			try {
 				fConnector = fTerminalConnectorFactory.makeConnector();
 				fConnector.initialize();
 			} catch (Exception e) {
 				fException = e;
-				fConnector = new TerminalConnectorImpl() {
+				fConnector = new AbstractTerminalConnector() {
 					@Override
 					public void connect(ITerminalControl control) {
 						// super.connect(control);
@@ -241,7 +241,7 @@ public class TerminalConnector implements ITerminalConnector {
 
 	@Override
 	public <T> T getAdapter(Class<T> adapter) {
-		TerminalConnectorImpl connector = null;
+		AbstractTerminalConnector connector = null;
 		if (isInitialized()) {
 			connector = getConnectorImpl();
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
@@ -29,6 +29,7 @@ import org.eclipse.terminal.view.core.ITerminalTabListener;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IUIConstants;
 import org.eclipse.terminal.view.ui.TerminalViewId;
+import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
 import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.service.component.annotations.Activate;
@@ -58,6 +59,8 @@ public class TerminalService implements ITerminalService {
 	public static final int TAB_DISPOSED = 1;
 
 	private final ITerminalConsoleViewManager consoleViewManager;
+
+	private ILaunchDelegateManager launchDelegateManager;
 
 	/**
 	 * Common terminal service runnable implementation.
@@ -90,8 +93,10 @@ public class TerminalService implements ITerminalService {
 	}
 
 	@Activate
-	public TerminalService(@Reference ITerminalConsoleViewManager consoleViewManager) {
+	public TerminalService(@Reference ITerminalConsoleViewManager consoleViewManager,
+			@Reference ILaunchDelegateManager launchDelegateManager) {
 		this.consoleViewManager = consoleViewManager;
+		this.launchDelegateManager = launchDelegateManager;
 	}
 
 	@Override
@@ -242,7 +247,7 @@ public class TerminalService implements ITerminalService {
 		Assert.isNotNull(properties);
 		return Optional.of(properties).map(map -> map.get(ITerminalsConnectorConstants.PROP_DELEGATE_ID))
 				.filter(String.class::isInstance).map(String.class::cast)
-				.flatMap(id -> UIPlugin.getLaunchDelegateManager().findLauncherDelegate(id, false))
+				.flatMap(id -> launchDelegateManager.findLauncherDelegate(id, false))
 				.map(d -> d.createTerminalConnector(properties)).orElse(null);
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/AbstractLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/AbstractLauncherDelegate.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.internal.Messages;
 import org.eclipse.terminal.view.ui.internal.UIPlugin;
@@ -135,5 +136,9 @@ public abstract class AbstractLauncherDelegate extends PlatformObject implements
 	protected String getDefaultTerminalTitle(Map<String, Object> properties) {
 		String title = (String) properties.get(ITerminalsConnectorConstants.PROP_TITLE);
 		return title != null ? title : null;
+	}
+
+	protected ITerminalService getTerminalService() {
+		return UIPlugin.getTerminalService();
 	}
 }

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/AbstractStreamsConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/AbstractStreamsConnector.java
@@ -16,14 +16,16 @@ import java.io.OutputStream;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.terminal.connector.ITerminalControl;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.view.core.ITerminalServiceOutputStreamMonitorListener;
+import org.eclipse.terminal.view.ui.internal.UIPlugin;
+import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.services.IDisposable;
 
 /**
  * Streams connector implementation.
  */
-public abstract class AbstractStreamsConnector extends TerminalConnectorImpl {
+public abstract class AbstractStreamsConnector extends AbstractTerminalConnector {
 	// Reference to the stdin monitor
 	private InputStreamMonitor stdInMonitor;
 	// Reference to the stdout monitor
@@ -196,6 +198,10 @@ public abstract class AbstractStreamsConnector extends TerminalConnectorImpl {
 	@Override
 	public OutputStream getTerminalToRemoteStream() {
 		return stdInMonitor;
+	}
+
+	protected ITerminalConsoleViewManager getConsoleViewManager() {
+		return UIPlugin.getConsoleManager();
 	}
 
 }

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalConnectorFactoryTest.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalConnectorFactoryTest.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.TerminalState;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.control.TerminalTitleRequestor;
 
 import junit.framework.TestCase;
@@ -118,7 +118,7 @@ public class TerminalConnectorFactoryTest extends TestCase {
 		}
 	}
 
-	static class ConnectorMock extends TerminalConnectorImpl {
+	static class ConnectorMock extends AbstractTerminalConnector {
 
 		public boolean fEcho;
 		public int fWidth;
@@ -175,7 +175,7 @@ public class TerminalConnectorFactoryTest extends TestCase {
 		return makeTerminalConnector(new ConnectorMock());
 	}
 
-	protected TerminalConnector makeTerminalConnector(final TerminalConnectorImpl mock) {
+	protected TerminalConnector makeTerminalConnector(final AbstractTerminalConnector mock) {
 		TerminalConnector c = new TerminalConnector(() -> mock, "xID", "xName", false);
 		return c;
 	}

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalConnectorTest.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalConnectorTest.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.TerminalState;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.control.TerminalTitleRequestor;
 import org.eclipse.terminal.internal.connector.TerminalConnector.Factory;
 
@@ -119,7 +119,7 @@ public class TerminalConnectorTest extends TestCase {
 		}
 	}
 
-	static class ConnectorMock extends TerminalConnectorImpl {
+	static class ConnectorMock extends AbstractTerminalConnector {
 
 		public boolean fEcho;
 		public int fWidth;
@@ -173,14 +173,14 @@ public class TerminalConnectorTest extends TestCase {
 	}
 
 	static class SimpleFactory implements Factory {
-		final TerminalConnectorImpl fConnector;
+		final AbstractTerminalConnector fConnector;
 
-		public SimpleFactory(TerminalConnectorImpl connector) {
+		public SimpleFactory(AbstractTerminalConnector connector) {
 			fConnector = connector;
 		}
 
 		@Override
-		public TerminalConnectorImpl makeConnector() throws Exception {
+		public AbstractTerminalConnector makeConnector() throws Exception {
 			// TODO Auto-generated method stub
 			return fConnector;
 		}

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/speedtest/SpeedTestConnector.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/speedtest/SpeedTestConnector.java
@@ -24,10 +24,10 @@ import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.connector.NullSettingsStore;
 import org.eclipse.terminal.connector.TerminalState;
-import org.eclipse.terminal.connector.provider.TerminalConnectorImpl;
+import org.eclipse.terminal.connector.provider.AbstractTerminalConnector;
 import org.eclipse.terminal.control.TerminalTitleRequestor;
 
-public class SpeedTestConnector extends TerminalConnectorImpl {
+public class SpeedTestConnector extends AbstractTerminalConnector {
 	final SpeedTestSettings fSettings = new SpeedTestSettings();
 	InputStream fInputStream;
 	OutputStream fOutputStream;


### PR DESCRIPTION
Currently service trackers are using a static field, what could lead to wrong behavior when the bundle is restarted.

This now converts the tracker to instance fields to account for bundle restarts and clears up an unnecessary static reference in `TerminalService`.

FYI @ruspl-afed 