### PR TITLE
Rename `ILaunchDelegateManager` to `ILauncherDelegateManager`

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
@@ -16,7 +16,7 @@ import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.terminal.view.core.utils.ScopedEclipsePreferences;
 import org.eclipse.terminal.view.core.utils.TraceHandler;
-import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
+import org.eclipse.terminal.view.ui.launcher.ILauncherDelegateManager;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
@@ -32,7 +32,7 @@ public class UIPlugin extends AbstractUIPlugin {
 	// The trace handler instance
 	private static volatile TraceHandler traceHandler;
 
-	private ServiceTracker<ILaunchDelegateManager, ILaunchDelegateManager> launchDelegateServiceTracker;
+	private ServiceTracker<ILauncherDelegateManager, ILauncherDelegateManager> launchDelegateServiceTracker;
 
 	/**
 	 * Returns the shared instance
@@ -78,7 +78,7 @@ public class UIPlugin extends AbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-		launchDelegateServiceTracker = new ServiceTracker<>(context, ILaunchDelegateManager.class, null);
+		launchDelegateServiceTracker = new ServiceTracker<>(context, ILauncherDelegateManager.class, null);
 		launchDelegateServiceTracker.open();
 		plugin = this;
 	}
@@ -118,7 +118,7 @@ public class UIPlugin extends AbstractUIPlugin {
 		return getDefault().getImageRegistry().getDescriptor(key);
 	}
 
-	public static synchronized ILaunchDelegateManager getLaunchDelegateManager() {
+	public static synchronized ILauncherDelegateManager getLaunchDelegateManager() {
 		UIPlugin plugin = getDefault();
 		if (plugin == null) {
 			return null;

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/LauncherDelegateManager.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/LauncherDelegateManager.java
@@ -39,7 +39,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
+import org.eclipse.terminal.view.ui.launcher.ILauncherDelegateManager;
 import org.eclipse.terminal.view.ui.launcher.ILauncherDelegate;
 import org.eclipse.ui.ISources;
 import org.eclipse.ui.PlatformUI;
@@ -49,8 +49,8 @@ import org.osgi.service.component.annotations.Component;
 /**
  * Terminal launcher delegate manager implementation.
  */
-@Component(service = ILaunchDelegateManager.class)
-public class LauncherDelegateManager implements ILaunchDelegateManager {
+@Component(service = ILauncherDelegateManager.class)
+public class LauncherDelegateManager implements ILauncherDelegateManager {
 	// Flag to mark the extension point manager initialized (extensions loaded).
 	private boolean initialized = false;
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
@@ -31,7 +31,7 @@ import org.eclipse.terminal.view.core.ITerminalTabListener;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IUIConstants;
 import org.eclipse.terminal.view.ui.TerminalViewId;
-import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
+import org.eclipse.terminal.view.ui.launcher.ILauncherDelegateManager;
 import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.service.component.annotations.Activate;
@@ -62,7 +62,7 @@ public class TerminalService implements ITerminalService {
 
 	private final ITerminalConsoleViewManager consoleViewManager;
 
-	private ILaunchDelegateManager launchDelegateManager;
+	private ILauncherDelegateManager launchDelegateManager;
 
 	/**
 	 * Common terminal service runnable implementation.
@@ -96,7 +96,7 @@ public class TerminalService implements ITerminalService {
 
 	@Activate
 	public TerminalService(@Reference ITerminalConsoleViewManager consoleViewManager,
-			@Reference ILaunchDelegateManager launchDelegateManager) {
+			@Reference ILauncherDelegateManager launchDelegateManager) {
 		this.consoleViewManager = consoleViewManager;
 		this.launchDelegateManager = launchDelegateManager;
 	}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
@@ -34,7 +34,7 @@ import org.eclipse.terminal.view.ui.ImageConsts;
 import org.eclipse.terminal.view.ui.internal.listeners.WorkbenchWindowListener;
 import org.eclipse.terminal.view.ui.internal.view.TerminalsView;
 import org.eclipse.terminal.view.ui.internal.view.TerminalsViewMementoHandler;
-import org.eclipse.terminal.view.ui.launcher.ILaunchDelegateManager;
+import org.eclipse.terminal.view.ui.launcher.ILauncherDelegateManager;
 import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewReference;
@@ -64,7 +64,7 @@ public class UIPlugin extends AbstractUIPlugin {
 	private IWindowListener windowListener;
 
 	private ServiceTracker<ITerminalService, ITerminalService> terminalServiceTracker;
-	private ServiceTracker<ILaunchDelegateManager, ILaunchDelegateManager> launchDelegateServiceTracker;
+	private ServiceTracker<ILauncherDelegateManager, ILauncherDelegateManager> launchDelegateServiceTracker;
 	private ServiceTracker<ITerminalConsoleViewManager, ITerminalConsoleViewManager> consoleManagerTracker;
 
 	/**
@@ -113,7 +113,7 @@ public class UIPlugin extends AbstractUIPlugin {
 		super.start(context);
 		terminalServiceTracker = new ServiceTracker<>(context, ITerminalService.class, null);
 		terminalServiceTracker.open();
-		launchDelegateServiceTracker = new ServiceTracker<>(context, ILaunchDelegateManager.class, null);
+		launchDelegateServiceTracker = new ServiceTracker<>(context, ILauncherDelegateManager.class, null);
 		launchDelegateServiceTracker.open();
 		consoleManagerTracker = new ServiceTracker<>(context, ITerminalConsoleViewManager.class, null);
 		consoleManagerTracker.open();
@@ -296,7 +296,7 @@ public class UIPlugin extends AbstractUIPlugin {
 		return plugin.terminalServiceTracker.getService();
 	}
 
-	public static synchronized ILaunchDelegateManager getLaunchDelegateManager() {
+	public static synchronized ILauncherDelegateManager getLaunchDelegateManager() {
 		UIPlugin plugin = getDefault();
 		if (plugin == null) {
 			return null;

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ILauncherDelegateManager.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ILauncherDelegateManager.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jface.viewers.ISelection;
 
-public interface ILaunchDelegateManager {
+public interface ILauncherDelegateManager {
 
 	/**
 	 * Returns all contributed terminal launcher delegates.


### PR DESCRIPTION
Since this type is all about `ILauncherDelegate` and not about `ILaunchDelegate` from Debug subsystem, I believe it is better to rename it and avoid confusion.