### PR TITLE
Move util `Env` class closer to its single usage

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessConnector.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/ProcessConnector.java
@@ -35,11 +35,11 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.connector.NullSettingsStore;
 import org.eclipse.terminal.connector.TerminalState;
+import org.eclipse.terminal.connector.process.internal.Env;
 import org.eclipse.terminal.connector.process.internal.Messages;
 import org.eclipse.terminal.connector.process.internal.ProcessMonitor;
 import org.eclipse.terminal.connector.process.internal.UIPlugin;
 import org.eclipse.terminal.view.core.ILineSeparatorConstants;
-import org.eclipse.terminal.view.core.utils.Env;
 import org.eclipse.terminal.view.ui.streams.AbstractStreamsConnector;
 
 /**

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/Env.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/Env.java
@@ -9,7 +9,7 @@
  * Contributors:
  * Wind River Systems - initial API and implementation
  *******************************************************************************/
-package org.eclipse.terminal.view.core.utils;
+package org.eclipse.terminal.connector.process.internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
`Env` class is partially copied from CDT and has very limited usage. Therefore, it should not be a part of API and it is better to move it to internal package, closer to its single usage.