### PR TITLE
Make `org.eclipse.terminal.view.core.utils` subsystem-internal

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -108,7 +108,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 		// Initialize the local terminal working directory.
 		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR)) {
 			// By default, start the local terminal in the users home directory
-			String initialCwd = IPreferenceKeys.getPreferences()
+			String initialCwd = UIPlugin.getScopedPreferences()
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_INITIAL_CWD);
 			String cwd = null;
 			if (initialCwd == null || IPreferenceKeys.PREF_INITIAL_CWD_USER_HOME.equals(initialCwd)
@@ -277,7 +277,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 			}
 		}
 		if (shell == null) {
-			shell = IPreferenceKeys.getPreferences().getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX);
+			shell = UIPlugin.getScopedPreferences().getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX);
 			if (shell == null || "".equals(shell)) { //$NON-NLS-1$
 				if (System.getenv("SHELL") != null && !"".equals(System.getenv("SHELL").trim())) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					shell = System.getenv("SHELL").trim(); //$NON-NLS-1$
@@ -312,7 +312,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 
 		String arguments = (String) properties.get(ITerminalsConnectorConstants.PROP_PROCESS_ARGS);
 		if (arguments == null && !Platform.OS_WIN32.equals(Platform.getOS())) {
-			arguments = IPreferenceKeys.getPreferences()
+			arguments = UIPlugin.getScopedPreferences()
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX_ARGS);
 		}
 

--- a/terminal/bundles/org.eclipse.terminal.view.core/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.view.core/META-INF/MANIFEST.MF
@@ -12,5 +12,10 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.terminal.view.core;version="1.0.0",
  org.eclipse.terminal.view.core.internal;x-internal:=true,
- org.eclipse.terminal.view.core.utils;version="1.0.0"
+ org.eclipse.terminal.view.core.utils;version="1.0.0";
+  x-friends:="org.eclipse.terminal.connector.local,
+   org.eclipse.terminal.connector.ssh,
+   org.eclipse.terminal.connector.telnet,
+   org.eclipse.terminal.connector.process,
+   org.eclipse.terminal.view.ui"
 Automatic-Module-Name: org.eclipse.terminal.view.core

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/IPreferenceKeys.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/IPreferenceKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -9,11 +9,9 @@
  * Contributors:
  * Wind River Systems - initial API and implementation
  * Dirk Fauth <dirk.fauth@googlemail.com> - Bug 460496
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui;
-
-import org.eclipse.terminal.view.core.utils.ScopedEclipsePreferences;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 
 /**
  * Terminal plug-in preference key definitions.
@@ -70,9 +68,5 @@ public interface IPreferenceKeys {
 	 */
 	public final String PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX_ARGS = PREF_TERMINAL
 			+ ".localTerminalDefaultShellUnixArgs"; //$NON-NLS-1$
-
-	static ScopedEclipsePreferences getPreferences() {
-		return UIPlugin.getScopedPreferences();
-	}
 
 }


### PR DESCRIPTION
The API package `org.eclipse.terminal.view.core.utils` may be converted to subsystem-internal, since types it provides has questionable value outside the scope of terminal subsystem implementation.