### PR TITLE
Replace `Done` callback with `CompletableFuture` result

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.cdt.utils.pty.PTY;
 import org.eclipse.core.runtime.Assert;
@@ -44,7 +45,6 @@ import org.eclipse.terminal.connector.local.activator.UIPlugin;
 import org.eclipse.terminal.connector.local.controls.LocalWizardConfigurationPanel;
 import org.eclipse.terminal.connector.process.ProcessSettings;
 import org.eclipse.terminal.view.core.ILineSeparatorConstants;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalServiceOutputStreamMonitorListener;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IMementoHandler;
@@ -75,7 +75,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, ITerminalService.Done done) {
+	public CompletableFuture<?> execute(Map<String, Object> properties) {
 		Assert.isNotNull(properties);
 
 		// Set the terminal tab title
@@ -221,12 +221,10 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 				}
 			}
 		}
-
-		// Get the terminal service
-		ITerminalService terminal = getTerminalService();
-		// If not available, we cannot fulfill this request
-		if (terminal != null) {
-			terminal.openConsole(properties, done);
+		try {
+			return getTerminalService().openConsole(properties);
+		} catch (RuntimeException e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/ProcessLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/ProcessLauncherDelegate.java
@@ -13,6 +13,7 @@
 package org.eclipse.terminal.connector.process.internal;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.cdt.utils.pty.PTY;
 import org.eclipse.core.runtime.Assert;
@@ -22,7 +23,6 @@ import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.process.ProcessSettings;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalServiceOutputStreamMonitorListener;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
@@ -45,14 +45,12 @@ public class ProcessLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, ITerminalService.Done done) {
+	public CompletableFuture<?> execute(Map<String, Object> properties) {
 		Assert.isNotNull(properties);
-
-		// Get the terminal service
-		ITerminalService terminal = getTerminalService();
-		// If not available, we cannot fulfill this request
-		if (terminal != null) {
-			terminal.openConsole(properties, done);
+		try {
+			return getTerminalService().openConsole(properties);
+		} catch (RuntimeException e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/launcher/SshLauncherDelegate.java
@@ -16,6 +16,7 @@ package org.eclipse.terminal.connector.ssh.launcher;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -28,7 +29,6 @@ import org.eclipse.terminal.connector.ssh.connector.ISshSettings;
 import org.eclipse.terminal.connector.ssh.connector.SshSettings;
 import org.eclipse.terminal.connector.ssh.controls.SshWizardConfigurationPanel;
 import org.eclipse.terminal.connector.ssh.nls.Messages;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IMementoHandler;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
@@ -53,7 +53,7 @@ public class SshLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, ITerminalService.Done done) {
+	public CompletableFuture<?> execute(Map<String, Object> properties) {
 		Assert.isNotNull(properties);
 
 		// Set the terminal tab title
@@ -67,12 +67,10 @@ public class SshLauncherDelegate extends AbstractLauncherDelegate {
 		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW)) {
 			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.TRUE);
 		}
-
-		// Get the terminal service
-		ITerminalService terminal = getTerminalService();
-		// If not available, we cannot fulfill this request
-		if (terminal != null) {
-			terminal.openConsole(properties, done);
+		try {
+			return getTerminalService().openConsole(properties);
+		} catch (RuntimeException e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/launcher/TelnetLauncherDelegate.java
@@ -16,6 +16,7 @@ package org.eclipse.terminal.connector.telnet.launcher;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -27,7 +28,6 @@ import org.eclipse.terminal.connector.TerminalConnectorExtension;
 import org.eclipse.terminal.connector.telnet.connector.TelnetSettings;
 import org.eclipse.terminal.connector.telnet.controls.TelnetWizardConfigurationPanel;
 import org.eclipse.terminal.connector.telnet.nls.Messages;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IMementoHandler;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
@@ -52,7 +52,7 @@ public class TelnetLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, ITerminalService.Done done) {
+	public CompletableFuture<?> execute(Map<String, Object> properties) {
 		Assert.isNotNull(properties);
 
 		// Set the terminal tab title
@@ -66,12 +66,10 @@ public class TelnetLauncherDelegate extends AbstractLauncherDelegate {
 		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW)) {
 			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.TRUE);
 		}
-
-		// Get the terminal service
-		ITerminalService terminal = getTerminalService();
-		// If not available, we cannot fulfill this request
-		if (terminal != null) {
-			terminal.openConsole(properties, done);
+		try {
+			return getTerminalService().openConsole(properties);
+		} catch (RuntimeException e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.view.core/src/org/eclipse/terminal/view/core/ITerminalService.java
+++ b/terminal/bundles/org.eclipse.terminal.view.core/src/org/eclipse/terminal/view/core/ITerminalService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011 - 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,12 +8,12 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.core;
 
 import java.util.Map;
-
-import org.eclipse.core.runtime.IStatus;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Terminal service.
@@ -21,40 +21,28 @@ import org.eclipse.core.runtime.IStatus;
 public interface ITerminalService {
 
 	/**
-	 * Client call back interface.
-	 */
-	public interface Done {
-		/**
-		 * Called when the terminal service operation is done.
-		 *
-		 * @param status The status of the terminal service operation.
-		 */
-		public void done(IStatus status);
-	}
-
-	/**
 	 * Opens a terminal asynchronously and invokes the given callback if done.
 	 *
 	 * @param properties The terminal properties. Must not be <code>null</code>.
-	 * @param done The callback to invoke if finished or <code>null</code>.
+	 * @return the {@link CompletableFuture}
 	 */
-	public void openConsole(Map<String, Object> properties, Done done);
+	public CompletableFuture<?> openConsole(Map<String, Object> properties);
 
 	/**
-	 * Close the terminal asynchronously and invokes the given callback if done.
+	 * Close the terminal asynchronously.
 	 *
 	 * @param properties The terminal properties. Must not be <code>null</code>.
-	 * @param done The callback to invoke if finished or <code>null</code>.
+	 * @return the {@link CompletableFuture}
 	 */
-	public void closeConsole(Map<String, Object> properties, Done done);
+	public CompletableFuture<?> closeConsole(Map<String, Object> properties);
 
 	/**
 	 * Terminate (disconnect) the terminal asynchronously and invokes the given callback if done.
 	 *
 	 * @param properties The terminal properties. Must not be <code>null</code>.
-	 * @param done The callback to invoke if finished or <code>null</code>.
+	 * @return the {@link CompletableFuture}
 	 */
-	public void terminateConsole(Map<String, Object> properties, Done done);
+	public CompletableFuture<?> terminateConsole(Map<String, Object> properties);
 
 	/**
 	 * Register the given listener to receive notifications about terminal events.

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/Messages.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/Messages.java
@@ -65,6 +65,7 @@ public class Messages extends NLS {
 	public static String AbstractConfigurationPanel_encoding_custom_title;
 	public static String AbstractConfigurationPanel_encoding_custom_message;
 	public static String AbstractConfigurationPanel_encoding_custom_error;
+	public static String AbstractLauncherDelegate_e_no_terminal_service;
 
 	public static String ConsoleManager_e_cannot_create_console;
 	public static String ConsoleManager_e_no_active_page;

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/Messages.properties
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/Messages.properties
@@ -27,6 +27,7 @@ AbstractConfigurationPanel_encoding_custom=Other...
 AbstractConfigurationPanel_encoding_custom_title=Other...
 AbstractConfigurationPanel_encoding_custom_message=Please enter the name of the encoding to use for the terminal.
 AbstractConfigurationPanel_encoding_custom_error=Unsupported encoding. Please enter the name of a supported encoding.
+AbstractLauncherDelegate_e_no_terminal_service=Terminal service is not available
 ConsoleManager_e_cannot_create_console=Cannot create console
 ConsoleManager_e_no_active_page=No active workbench page
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/dialogs/LaunchTerminalSettingsDialog.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/dialogs/LaunchTerminalSettingsDialog.java
@@ -20,8 +20,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.TrayDialog;
@@ -41,7 +43,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.terminal.connector.ITerminalConnector;
-import org.eclipse.terminal.view.core.ITerminalService.Done;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
 import org.eclipse.terminal.view.ui.IExternalExecutablesProperties;
 import org.eclipse.terminal.view.ui.internal.IContextHelpIds;
@@ -530,7 +531,7 @@ public class LaunchTerminalSettingsDialog extends TrayDialog {
 				}
 
 				@Override
-				public void execute(Map<String, Object> properties, Done done) {
+				public CompletableFuture<IStatus> execute(Map<String, Object> properties) {
 					throw new UnsupportedOperationException();
 				}
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/local/showin/DynamicContributionItems.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/local/showin/DynamicContributionItems.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
@@ -127,8 +128,11 @@ public class DynamicContributionItems extends CompoundContributionItem implement
 				}
 				properties.put(ITerminalsConnectorConstants.PROP_TRANSLATE_BACKSLASHES_ON_PASTE,
 						Boolean.valueOf(translate));
-
-				delegate.execute(properties, null);
+				try {
+					delegate.execute(properties);
+				} catch (Exception e) {
+					ILog.get().error(e.getMessage(), e);
+				}
 			}
 		};
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsViewMementoHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsViewMementoHandler.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.terminal.control.ITerminalViewControl;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
@@ -186,7 +187,8 @@ public class TerminalsViewMementoHandler {
 				delegate.map(d -> d.getAdapter(IMementoHandler.class))
 						.ifPresent(mh -> mh.restoreState(connection, properties));
 				// Restore the terminal connection
-				delegate.ifPresent(d -> d.execute(properties, null));
+				delegate.ifPresent(d -> executeDelegate(properties, d));
+
 			}
 		}
 	}
@@ -195,6 +197,14 @@ public class TerminalsViewMementoHandler {
 		return Optional.of(properties).map(map -> map.get(ITerminalsConnectorConstants.PROP_DELEGATE_ID))
 				.filter(String.class::isInstance).map(String.class::cast)
 				.flatMap(id -> UIPlugin.getLaunchDelegateManager().findLauncherDelegate(id, false));
+	}
+
+	private void executeDelegate(Map<String, Object> properties, ILauncherDelegate delegate) {
+		try {
+			delegate.execute(properties);
+		} catch (Exception e) {
+			ILog.get().error(e.getMessage(), e);
+		}
 	}
 
 	private Optional<IMementoHandler> mementoHandler(ILauncherDelegate delegate) {

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/AbstractLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/AbstractLauncherDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.launcher;
 
@@ -138,7 +139,15 @@ public abstract class AbstractLauncherDelegate extends PlatformObject implements
 		return title != null ? title : null;
 	}
 
-	protected ITerminalService getTerminalService() {
-		return UIPlugin.getTerminalService();
+	/**
+	 * Get the terminal service
+	 *
+	 * @return an instance of {@link ITerminalService}
+	 *
+	 */
+	protected final ITerminalService getTerminalService() {
+		ITerminalService service = UIPlugin.getTerminalService();
+		Assert.isNotNull(service, Messages.AbstractLauncherDelegate_e_no_terminal_service);
+		return service;
 	}
 }

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ILauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/launcher/ILauncherDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,17 +8,18 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.launcher;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IExecutableExtension;
 import org.eclipse.terminal.connector.ITerminalConnector;
-import org.eclipse.terminal.view.core.ITerminalService;
 
 /**
  * Terminal launcher delegate.
@@ -84,9 +85,9 @@ public interface ILauncherDelegate extends IExecutableExtension, IAdaptable {
 	 * Execute the terminal launch.
 	 *
 	 * @param properties The properties. Must not be <code>null</code>.
-	 * @param done The callback or <code>null</code>.
+	 * @return the {@link CompletableFuture}
 	 */
-	public void execute(Map<String, Object> properties, ITerminalService.Done done);
+	public CompletableFuture<?> execute(Map<String, Object> properties);
 
 	/**
 	 * Creates the terminal connector for this launcher delegate based on

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/StreamsLauncherDelegate.java
@@ -15,6 +15,7 @@ package org.eclipse.terminal.view.ui.streams;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -22,10 +23,8 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
-import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.ITerminalServiceOutputStreamMonitorListener;
 import org.eclipse.terminal.view.core.ITerminalsConnectorConstants;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.terminal.view.ui.launcher.AbstractLauncherDelegate;
 import org.eclipse.terminal.view.ui.launcher.IConfigurationPanel;
 import org.eclipse.terminal.view.ui.launcher.IConfigurationPanelContainer;
@@ -46,14 +45,12 @@ public class StreamsLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, ITerminalService.Done done) {
+	public CompletableFuture<?> execute(Map<String, Object> properties) {
 		Assert.isNotNull(properties);
-
-		// Get the terminal service
-		ITerminalService terminal = UIPlugin.getTerminalService();
-		// If not available, we cannot fulfill this request
-		if (terminal != null) {
-			terminal.openConsole(properties, done);
+		try {
+			return getTerminalService().openConsole(properties);
+		} catch (RuntimeException e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
 


### PR DESCRIPTION
Currently `null` is tolerated as a callback for a number of terminal-related operations. The introduced empty implementation `NOOP` allows to prohibit `null` as a callback argument.