### PR TITLE
Prefer view id constant from `IUIConstants`

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/listeners/WorkbenchPartListener.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/listeners/WorkbenchPartListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,12 +8,14 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.internal.listeners;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.terminal.view.ui.IUIConstants;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
@@ -51,7 +53,7 @@ public class WorkbenchPartListener implements IPartListener2 {
 
 	@Override
 	public void partActivated(IWorkbenchPartReference partRef) {
-		if ("org.eclipse.terminal.view.ui.TerminalsView".equals(partRef.getId())) { //$NON-NLS-1$
+		if (IUIConstants.ID.equals(partRef.getId())) {
 			IWorkbenchPart part = partRef.getPart(false);
 			if (part != null && part.getSite() != null) {
 				IContextService service = part.getSite().getService(IContextService.class);
@@ -69,7 +71,7 @@ public class WorkbenchPartListener implements IPartListener2 {
 
 	@Override
 	public void partDeactivated(IWorkbenchPartReference partRef) {
-		if ("org.eclipse.terminal.view.ui.TerminalsView".equals(partRef.getId())) { //$NON-NLS-1$
+		if (IUIConstants.ID.equals(partRef.getId())) {
 			IWorkbenchPart part = partRef.getPart(false);
 			if (part != null && part.getSite() != null) {
 				IContextService service = part.getSite().getService(IContextService.class);


### PR DESCRIPTION
There is an API constant for terminal view id, it is better to use it instead of hard-coded string literals.