### PR TITLE
Add constant for "Open Terminal on Selection" command id

### DIFF
--- a/debug/org.eclipse.debug.terminal/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.terminal/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.debug.terminal;singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Version: 1.0.0.qualifier
 Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.control;version="[1.0.0,2.0.0)"
+ org.eclipse.terminal.control;version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.view.ui;version="[1.0.0,2.0.0)"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.debug.core;bundle-version="3.23.0",
  org.eclipse.cdt.core.native;bundle-version="[6.4.0,7.0.0)",

--- a/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/TerminalConsoleFactory.java
+++ b/debug/org.eclipse.debug.terminal/src/org/eclipse/debug/terminal/ui/TerminalConsoleFactory.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.debug.terminal.ui;
 
@@ -19,6 +20,7 @@ import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.terminal.connector.ITerminalConnector;
+import org.eclipse.terminal.view.ui.CommandIds;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.console.ConsolePlugin;
@@ -38,7 +40,7 @@ public class TerminalConsoleFactory implements IConsoleFactory {
 		if (commandService == null || handlerService == null) {
 			return;
 		}
-		Command command = commandService.getCommand("org.eclipse.terminal.view.ui.command.launchConsole");
+		Command command = commandService.getCommand(CommandIds.COMMAND_LAUNCHCONSOLE);
 		if (command == null) {
 			return;
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/CommandIds.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/CommandIds.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ArSysOp and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alexander Fedorov (ArSysOp) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.terminal.view.ui;
+
+/**
+ * Commands declared with "org.eclipse.ui.commands" extension point
+ */
+public interface CommandIds {
+
+	/**
+	 * "Open Terminal on Selection" command id
+	 */
+	String COMMAND_LAUNCHCONSOLE = "org.eclipse.terminal.view.ui.command.launchConsole"; //$NON-NLS-1$
+
+}


### PR DESCRIPTION
The "Open Terminal on Selection" command is referenced from another bundle by its string identifier. The new constant is introduced to put this String value under API control.