### PR TITLE
Force qualifier updateorg.eclipse.compare.core for split packages

### DIFF
--- a/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Pick up new signing certificate (same as bug 466408)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190