### PR TITLE
Add Eclipse logo SVGs to build.properties

### DIFF
--- a/platform/org.eclipse.platform/build.properties
+++ b/platform/org.eclipse.platform/build.properties
@@ -17,6 +17,9 @@ bin.includes = about.html,\
                about.properties,\
                eclipse_lg.png,\
                eclipse_lg@2x.png,\
+               eclipse16.svg,\
+               eclipse32.svg,\
+               eclipse48.svg,\
                eclipse16.png,\
                eclipse32.png,\
                eclipse48.png,\

--- a/platform/org.eclipse.sdk/build.properties
+++ b/platform/org.eclipse.sdk/build.properties
@@ -15,6 +15,9 @@ bin.includes = about.html,\
                about.ini,\
                about.mappings,\
                about.properties,\
+               eclipse16.svg,\
+               eclipse32.svg,\
+               eclipse48.svg,\
                eclipse16.png,\
                eclipse32.png,\
                eclipse48.png,\


### PR DESCRIPTION
The recently added Eclispe logo SVGs have not been added to the build.properties to make the deployed binary bundle also contain them. This change adds them accordingly.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2327