### PR TITLE
Import com.jcraft.jsch packages #958

### DIFF
--- a/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
@@ -7,10 +7,10 @@ Bundle-Activator: org.eclipse.jsch.internal.core.JSchCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- com.jcraft.jsch;bundle-version="[0.1.50,1.0.0)",
  org.eclipse.core.net;bundle-version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jsch.core;uses:="org.eclipse.core.runtime,com.jcraft.jsch",
  org.eclipse.jsch.internal.core;x-friends:="org.eclipse.jsch.ui"
+Import-Package: com.jcraft.jsch;version="[0.1.50,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.jsch.core

--- a/team/bundles/org.eclipse.jsch.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.jsch.ui/META-INF/MANIFEST.MF
@@ -8,12 +8,12 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.jsch.core;bundle-version="[1.2.0,2.0.0)",
- com.jcraft.jsch;bundle-version="[0.1.50,1.0.0)"
+ org.eclipse.jsch.core;bundle-version="[1.2.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.jsch.internal.ui;x-internal:=true,
  org.eclipse.jsch.internal.ui.authenticator;x-internal:=true,
  org.eclipse.jsch.internal.ui.preference;x-internal:=true,
  org.eclipse.jsch.ui;uses:="com.jcraft.jsch"
+Import-Package: com.jcraft.jsch;version="[0.1.50,3.0.0)"
 Automatic-Module-Name: org.eclipse.jsch.ui

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",
  org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.equinox.security;bundle-version="[1.4.600,2)",
  org.eclipse.ui;bundle-version="[3.207.200,4)",
- com.jcraft.jsch;bundle-version="[0.1.31,1.0.0)",
  org.eclipse.jsch.core;bundle-version="[1.5.600,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
@@ -18,7 +17,8 @@ Export-Package: org.eclipse.terminal.connector.ssh.connector;x-internal:=true,
  org.eclipse.terminal.connector.ssh.controls;x-internal:=true,
  org.eclipse.terminal.connector.ssh.launcher;x-internal:=true
 Automatic-Module-Name: org.eclipse.terminal.connector.ssh
-Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
+Import-Package: com.jcraft.jsch;version="[0.1.31,3.0.0)",
+ org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",


### PR DESCRIPTION
This removes the hard dependency to the 'com.jcraft.jsch' bundle and allows clients to switch to the 'com.github.mwiede.jsch' fork.

The original JSch bundle is no longer maintained and suffers from several problems, such as an incompatibility with modern OpenSSH versions.

Note:
- Both plugins share the same package name and can be used interchangeably.
- The current version of the mwiede fork is 2.27.2, which is why the upper bound needs to be extended.