### PR TITLE
Move `TraceHandler` to internals of `org.eclipse.terminal.view.ui`

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/activator/UIPlugin.java
@@ -15,7 +15,6 @@ package org.eclipse.terminal.connector.local.activator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.terminal.view.ui.launcher.ILauncherDelegateManager;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -27,8 +26,6 @@ import org.osgi.util.tracker.ServiceTracker;
 public class UIPlugin extends AbstractUIPlugin {
 	// The shared instance
 	private static volatile UIPlugin plugin;
-	// The trace handler instance
-	private static volatile TraceHandler traceHandler;
 
 	private ServiceTracker<ILauncherDelegateManager, ILauncherDelegateManager> launchDelegateServiceTracker;
 
@@ -51,18 +48,6 @@ public class UIPlugin extends AbstractUIPlugin {
 		return "org.eclipse.terminal.connector.local"; //$NON-NLS-1$
 	}
 
-	/**
-	 * Returns the bundles trace handler.
-	 *
-	 * @return The bundles trace handler.
-	 */
-	public static TraceHandler getTraceHandler() {
-		if (traceHandler == null) {
-			traceHandler = new TraceHandler(getUniqueIdentifier());
-		}
-		return traceHandler;
-	}
-
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
@@ -74,7 +59,6 @@ public class UIPlugin extends AbstractUIPlugin {
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
-		traceHandler = null;
 		super.stop(context);
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/src/org/eclipse/terminal/connector/process/internal/UIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2012, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.connector.process.internal;
 
@@ -16,7 +17,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -26,9 +26,6 @@ import org.osgi.framework.BundleContext;
 public class UIPlugin extends AbstractUIPlugin {
 	// The shared instance
 	private static UIPlugin plugin;
-
-	// The trace handler instance
-	private static volatile TraceHandler traceHandler;
 
 	/**
 	 * The constructor
@@ -53,18 +50,6 @@ public class UIPlugin extends AbstractUIPlugin {
 			return getDefault().getBundle().getSymbolicName();
 		}
 		return "org.eclipse.terminal.connector.process"; //$NON-NLS-1$
-	}
-
-	/**
-	 * Returns the bundles trace handler.
-	 *
-	 * @return The bundles trace handler.
-	 */
-	public static TraceHandler getTraceHandler() {
-		if (traceHandler == null) {
-			traceHandler = new TraceHandler(getUniqueIdentifier());
-		}
-		return traceHandler;
 	}
 
 	@Override

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/src/org/eclipse/terminal/connector/ssh/activator/UIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.connector.ssh.activator;
 
@@ -16,7 +17,6 @@ import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jsch.core.IJSchService;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.terminal.connector.ssh.connector.SshConnection;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
@@ -27,8 +27,6 @@ import org.osgi.util.tracker.ServiceTracker;
 public class UIPlugin extends AbstractUIPlugin {
 	// The shared instance
 	private static UIPlugin plugin;
-	// The trace handler instance
-	private static volatile TraceHandler traceHandler;
 
 	// ServiceTracker for IJschService
 	private ServiceTracker<IJSchService, IJSchService> tracker;
@@ -56,18 +54,6 @@ public class UIPlugin extends AbstractUIPlugin {
 			return getDefault().getBundle().getSymbolicName();
 		}
 		return "org.eclipse.terminal.connector.ssh"; //$NON-NLS-1$
-	}
-
-	/**
-	 * Returns the bundles trace handler.
-	 *
-	 * @return The bundles trace handler.
-	 */
-	public static TraceHandler getTraceHandler() {
-		if (traceHandler == null) {
-			traceHandler = new TraceHandler(getUniqueIdentifier());
-		}
-		return traceHandler;
 	}
 
 	//---------------------------------------------------------------------------

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/activator/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/src/org/eclipse/terminal/connector/telnet/activator/UIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -9,13 +9,13 @@
  * Contributors:
  * Wind River Systems - initial API and implementation
  * Max Weninger (Wind River) - [366374] [TERMINALS][TELNET] Add Telnet terminal support
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
 package org.eclipse.terminal.connector.telnet.activator;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -25,8 +25,6 @@ import org.osgi.framework.BundleContext;
 public class UIPlugin extends AbstractUIPlugin {
 	// The shared instance
 	private static UIPlugin plugin;
-	// The trace handler instance
-	private static volatile TraceHandler traceHandler;
 
 	/**
 	 * The constructor
@@ -51,18 +49,6 @@ public class UIPlugin extends AbstractUIPlugin {
 			return getDefault().getBundle().getSymbolicName();
 		}
 		return "org.eclipse.terminal.connector.telnet"; //$NON-NLS-1$
-	}
-
-	/**
-	 * Returns the bundles trace handler.
-	 *
-	 * @return The bundles trace handler.
-	 */
-	public static TraceHandler getTraceHandler() {
-		if (traceHandler == null) {
-			traceHandler = new TraceHandler(getUniqueIdentifier());
-		}
-		return traceHandler;
 	}
 
 	@Override

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TraceHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TraceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Wind River Systems, Inc. and others. All rights reserved.
+ * Copyright (c) 2011, 2025 Wind River Systems, Inc. and others. All rights reserved.
  * This program and the accompanying materials are made available under the terms
  * of the Eclipse Public License 2.0 which accompanies this distribution, and is
  * available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,13 +8,13 @@
  *
  * Contributors:
  * Wind River Systems - initial API and implementation
+ * Alexander Fedorov (ArSysOp) - further evolution
  *******************************************************************************/
-package org.eclipse.terminal.view.core.utils;
+package org.eclipse.terminal.view.ui.internal;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.terminal.view.core.internal.CoreBundleActivator;
 
 /**
  * Helper class to handle tracing using the platforms debug capabilities.
@@ -184,11 +184,11 @@ public class TraceHandler {
 	 * <p>
 	 * Initializes the tracing handler with the given bundle identifier.
 	 *
-	 * @param identifier The bundle identifier or <code>null</code>.
+	 * @param identifier The bundle identifier, must not be <code>null</code>.
 	 */
 	public TraceHandler(String identifier) {
-		this.identifier = identifier != null ? identifier : CoreBundleActivator.getUniqueIdentifier();
-		Assert.isNotNull(this.identifier);
+		Assert.isNotNull(identifier);
+		this.identifier = identifier;
 	}
 
 	/**

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
@@ -29,7 +29,6 @@ import org.eclipse.terminal.connector.TerminalState;
 import org.eclipse.terminal.control.ITerminalViewControl;
 import org.eclipse.terminal.view.core.ITerminalService;
 import org.eclipse.terminal.view.core.utils.ScopedEclipsePreferences;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.terminal.view.ui.internal.listeners.WorkbenchWindowListener;
 import org.eclipse.terminal.view.ui.internal.view.TerminalsView;
 import org.eclipse.terminal.view.ui.internal.view.TerminalsViewMementoHandler;


### PR DESCRIPTION
This type is not in fact used in other bundles therefore it should not be a part of API

FYI @laeubi this one looks even better to merge first