### PR TITLE
Remove dependencies to removed terminal utils package

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Import-Package: org.eclipse.cdt.utils.pty;mandatory:=native,
  org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.process;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)"
 Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.400,4)",

--- a/terminal/bundles/org.eclipse.terminal.connector.process/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.process/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Import-Package: org.eclipse.cdt.utils.pty;mandatory:=native,
  org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.streams;version="[1.0.0,2.0.0)"

--- a/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.ssh/META-INF/MANIFEST.MF
@@ -21,6 +21,5 @@ Import-Package: com.jcraft.jsch;version="[0.1.31,3.0.0)",
  org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)"

--- a/terminal/bundles/org.eclipse.terminal.connector.telnet/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.connector.telnet/META-INF/MANIFEST.MF
@@ -19,6 +19,5 @@ Automatic-Module-Name: org.eclipse.terminal.connector.telnet
 Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui;version="[1.0.0,2.0.0)"


### PR DESCRIPTION
The package `org.eclipse.terminal.view.core.utils` has been removed but some bundles still import it, leading to errors. This change removes those unnecessary dependencies.

<img width="1000" height="115" alt="image" src="https://github.com/user-attachments/assets/a1495c73-0daf-4eed-8e7a-0eb81508961b" />
