### PR TITLE
Add a warning if join is called and JobManager is suspended

### DIFF
--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobManager.java
@@ -1005,6 +1005,13 @@ public class JobManager implements IJobManager, DebugOptionsListener {
 			}
 			//don't join a waiting or sleeping job when suspended (deadlock risk)
 			if (suspended && state != Job.RUNNING) {
+				String pluginId = JobOSGiUtils.getDefault().getBundleId(job);
+				if (pluginId == null) {
+					pluginId = JobManager.PI_JOBS;
+				}
+				RuntimeLog.log(new Status(IStatus.WARNING, pluginId, 0,
+						NLS.bind(JobMessages.JobManager_suspended_problem, job.getName()),
+						new IllegalStateException()));
 				return true;
 			}
 			//it's an error for a job to join itself

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobMessages.java
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/JobMessages.java
@@ -22,6 +22,8 @@ import org.eclipse.osgi.util.NLS;
 public class JobMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.core.internal.jobs.messages"; //$NON-NLS-1$
 
+	public static String JobManager_suspended_problem;
+
 	// Job Manager and Locks
 	public static String jobs_blocked0;
 	public static String jobs_blocked1;

--- a/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/messages.properties
+++ b/runtime/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/messages.properties
@@ -14,6 +14,7 @@
 ### Runtime jobs plugin messages
 
 ### Job Manager and Locks
+JobManager_suspended_problem=Join was called on job \"{0}\" while JobManager is suspended, this will not work as expected\!
 jobs_blocked0=The user operation is waiting for background work to complete.
 jobs_blocked1=The user operation is waiting for \"{0}\" to complete.
 jobs_unblocked=The user operation is not waiting anymore.


### PR DESCRIPTION
Currently there is a situation that is really hard to notice but quite dangerous results. When the `JobManager` is suspended and one calls `join()` on a Job this is a no-op and it returns silently without even try to wait for the job as it could lead to deadlocks. Code using join in such situation will likely fail in an random way depending on if the job has already finished fast enough.

This now adds a warning whenever this situation occurs to having a chance to be noticed and mitigated.

I tested this with starting a Workbench and didn't see such code yet in platform anymore, but if I revert the recent fix in PDE about suspended jobs I see this message:

```
!ENTRY org.eclipse.core.jobs 2 2 2025-07-25 12:50:34.630
!MESSAGE Join was called on job "Initializing plug-in models" while JobManager is suspended, this will not work as expected!
!STACK 0
java.lang.IllegalStateException
	at org.eclipse.core.internal.jobs.JobManager.join(JobManager.java:1014)
	at org.eclipse.core.internal.jobs.InternalJob.join(InternalJob.java:359)
	at org.eclipse.core.runtime.jobs.Job.join(Job.java:531)
	at org.eclipse.pde.internal.core.RequiredPluginsInitializer.setupClasspath(RequiredPluginsInitializer.java:142)
	at org.eclipse.pde.internal.core.RequiredPluginsInitializer.initialize(RequiredPluginsInitializer.java:131)
	at org.eclipse.jdt.internal.core.JavaModelManager.initializeContainer(JavaModelManager.java:3223)
	at org.eclipse.jdt.internal.core.JavaModelManager.getClasspathContainer(JavaModelManager.java:2150)
	at org.eclipse.jdt.core.JavaCore.getClasspathContainer(JavaCore.java:3976)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3159)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3323)
	at org.eclipse.jdt.internal.core.JavaProject.getResolvedClasspath(JavaProject.java:2437)
	at org.eclipse.jdt.internal.core.ExternalFolderChange.updateExternalFoldersIfNecessary(ExternalFolderChange.java:40)
	at org.eclipse.jdt.internal.core.ChangeClasspathOperation.classpathChanged(ChangeClasspathOperation.java:59)
	at org.eclipse.jdt.internal.core.SetContainerOperation.executeOperation(SetContainerOperation.java:118)
	at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:751)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2457)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2482)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:821)
	at org.eclipse.jdt.internal.core.JavaModelManager.getClasspathContainer(JavaModelManager.java:2153)
	at org.eclipse.jdt.core.JavaCore.getClasspathContainer(JavaCore.java:3976)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3159)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3323)
	at org.eclipse.jdt.internal.core.JavaProject.getResolvedClasspath(JavaProject.java:2437)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.getRawClasspathEntry(PackageFragmentRoot.java:616
```

So it seems we are safe in general but of course there might be more code that is affected by the problem and now has a chance to be discovered. Also during development if one introduce such problematic code it is possible to see and react directly.