### PR TITLE
Check if manager is null before accessing it

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
@@ -1256,7 +1256,11 @@ public abstract class Resource extends PlatformObject implements IResource, ICor
 		if (!isAccessible() || isVirtual()) {
 			return null;
 		}
-		return getLocalManager().attributes(this);
+		FileSystemResourceManager manager = getLocalManager();
+		if (manager == null) {
+			return null;
+		}
+		return manager.attributes(this);
 	}
 
 	/**


### PR DESCRIPTION
I observed this in a test that shut down very fast:

```
!ENTRY org.eclipse.ui.workbench 4 2 2025-07-29 18:38:22.080
!MESSAGE Problems occurred when invoking code from plug-in: "org.eclipse.ui.workbench".
!STACK 0
java.lang.NullPointerException: Cannot invoke "org.eclipse.core.internal.localstore.FileSystemResourceManager.attributes(org.eclipse.core.resources.IResource)" because the return value of "org.eclipse.core.internal.resources.Resource.getLocalManager()" is null
	at org.eclipse.core.internal.resources.Resource.getResourceAttributes(Resource.java:1259)
	at org.eclipse.ui.internal.ide.SymlinkDecorator.decorate(SymlinkDecorator.java:70)
	at org.eclipse.ui.internal.decorators.LightweightDecoratorDefinition.decorate(LightweightDecoratorDefinition.java:250)
	at org.eclipse.ui.internal.decorators.LightweightDecoratorManager$LightweightRunnable.run(LightweightDecoratorManager.java:105)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.ui.internal.decorators.LightweightDecoratorManager.decorate(LightweightDecoratorManager.java:359)
	at org.eclipse.ui.internal.decorators.LightweightDecoratorManager.getDecorations(LightweightDecoratorManager.java:345)
	at org.eclipse.ui.internal.decorators.DecorationScheduler$1.queue(DecorationScheduler.java:410)
	at org.eclipse.ui.internal.decorators.DecorationScheduler$1.run(DecorationScheduler.java:388)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

as the method allows for return `null` (and already does in some cases) it seems valid to simply return null if manager is not available instead of run into a generic exception.