### PR TITLE
[Debug] Update breakpoint icon

### DIFF
--- a/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_obj.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_obj.svg
@@ -1,100 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="16"
-   height="16"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.0 r9654"
-   sodipodi:docname="brkp_obj.svg">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient4894">
-      <stop
-         id="stop4896"
-         offset="0"
-         style="stop-color:#b4d1e5;stop-opacity:1" />
-      <stop
-         style="stop-color:#5395be;stop-opacity:1"
-         offset="0.5"
-         id="stop4898" />
-      <stop
-         id="stop4900"
-         offset="1"
-         style="stop-color:#91bcd7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       y2="6.8716693"
-       x2="8.7378912"
-       y1="2.1550355"
-       x1="8.7378912"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4871"
-       xlink:href="#linearGradient4894"
-       inkscape:collect="always" />
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="45.254831"
-     inkscape:cx="6.3291708"
-     inkscape:cy="5.9636676"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1241"
-     inkscape:window-height="814"
-     inkscape:window-x="88"
-     inkscape:window-y="106"
-     inkscape:window-maximized="0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:snap-global="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3999" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     style="display:inline"
-     transform="translate(0,-1036.3622)">
-    <path
-       sodipodi:type="arc"
-       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:#264e72;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
-       id="path4035-4-5"
-       sodipodi:cx="8.531251"
-       sodipodi:cy="4.499999"
-       sodipodi:rx="2.8125002"
-       sodipodi:ry="2.8125002"
-       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
-       transform="matrix(1.0661147,0,0,1.0661147,-0.60287227,1039.0648)" />
-  </g>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+	<title>brkp_obj1</title>
+	<defs>
+		<image  width="8" height="7" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAHCAMAAAACh/xsAAAAAXNSR0IB2cksfwAAAHJQTFRFAAAAo+v0Cm2FG4CWHoSZHX+VB3WIJIecitnjo+v0idbiJIecF4KXY9LedOHsYM/bFoOWAAAAFYKXRdfkRNbjEoKXEH+WM8bWO9XjMcPTEICVBG6KGISZTMnXWNznS8nWCm2Fd+PtBHeFF3+UGoKXGICV4cb2wQAAACZ0Uk5TAAAjwdy+HuL////jxf///78B4P//3MT///++IOP///8cACG/273OYHiZAAAALElEQVR4nGNkYASD34wMTKxQBg8jIwNIWBBEgxgMYlARBmmQkr8sjAyKELUAf5QEjyUjbugAAAAASUVORK5CYII="/>
+	</defs>
+	<style>
+	</style>
+	<g id="layer1">
+		<use id="img1" href="#img1" x="4" y="4"/>
+	</g>
 </svg>

--- a/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_obj.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_obj.svg
@@ -1,7 +1,7 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-	<title>brkp_obj1</title>
+	<title>brkp_obj1 (3)</title>
 	<defs>
-		<image  width="8" height="7" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAHCAMAAAACh/xsAAAAAXNSR0IB2cksfwAAAHJQTFRFAAAAo+v0Cm2FG4CWHoSZHX+VB3WIJIecitnjo+v0idbiJIecF4KXY9LedOHsYM/bFoOWAAAAFYKXRdfkRNbjEoKXEH+WM8bWO9XjMcPTEICVBG6KGISZTMnXWNznS8nWCm2Fd+PtBHeFF3+UGoKXGICV4cb2wQAAACZ0Uk5TAAAjwdy+HuL////jxf///78B4P//3MT///++IOP///8cACG/273OYHiZAAAALElEQVR4nGNkYASD34wMTKxQBg8jIwNIWBBEgxgMYlARBmmQkr8sjAyKELUAf5QEjyUjbugAAAAASUVORK5CYII="/>
+		<image  width="8" height="7" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAHCAMAAAACh/xsAAAAAXNSR0IB2cksfwAAAGxQTFRFAAAAfwkNjxkfkhwjjhsgggYRlSIp2ION6Jqk14KKlSIpkBUd015t4W5+0FtqjxQeAAAAkBQd2UFX2EBWkBEbjw8XzDBG2DhQyS5Djg8ZgwMGkhYfzUhb3FNozEdafwkNfwMTjRUckBgfjhYd9aCe/gAAACR0Uk5TACPB3L4e4v///+PF////vwHg///cxP///74g4////xwhv9u9mQayeAAAAC5JREFUeJxjZGBgBIHfjAyMrFAGNyMjWFQARIMYDKJQEQYpkJK/LECeApDx5yEAf2EFaNT1xUYAAAAASUVORK5CYII="/>
 	</defs>
 	<style>
 	</style>


### PR DESCRIPTION
This PR changes the dark breakpoint icon to lighter one to provide more visibility

Before 
<img width="461" height="139" alt="image" src="https://github.com/user-attachments/assets/7353be52-fb01-4fc8-8221-01062dccc0c9" />

After
<img width="489" height="130" alt="image" src="https://github.com/user-attachments/assets/d6623dac-bfc4-42fc-b3c7-79fdc72a3307" />


Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/731