### PR TITLE
Exclude docs folder and README.md from Github build trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,14 @@ concurrency:
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
Every change to the existing repository triggers a build that is pretty much pointless and expensive for a doc change that literally has no impact on the actual content being built.
With this change documentation changes are excluded.

Using documentation from
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths

Fixes #2095