### PR TITLE
Do not init preference with null

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/preferences/PreferencesInitializer.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/preferences/PreferencesInitializer.java
@@ -31,6 +31,6 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer {
 		IPreferenceStore prefs = UIPlugin.getScopedPreferences();
 		prefs.setDefault(IPreferenceKeys.PREF_REMOVE_TERMINATED_TERMINALS, true);
 		prefs.setDefault(IPreferenceKeys.PREF_LOCAL_TERMINAL_INITIAL_CWD, IPreferenceKeys.PREF_INITIAL_CWD_USER_HOME);
-		prefs.setDefault(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX, null);
+		prefs.setDefault(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX, ""); //$NON-NLS-1$
 	}
 }


### PR DESCRIPTION
This currently causes:

```
java.lang.NullPointerException
	at org.eclipse.core.internal.preferences.EclipsePreferences.put(EclipsePreferences.java:840)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.setDefault(ScopedPreferenceStore.java:453)
	at org.eclipse.terminal.view.ui.internal.preferences.PreferencesInitializer.initializeDefaultPreferences(PreferencesInitializer.java:34)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.preferences.PreferenceServiceRegistryHelper.runInitializer(PreferenceServiceRegistryHelper.java:289)
	at org.eclipse.core.internal.preferences.PreferenceServiceRegistryHelper.applyRuntimeDefaults(PreferenceServiceRegistryHelper.java:114)
	at org.eclipse.core.internal.preferences.PreferencesService.applyRuntimeDefaults(PreferencesService.java:338)
	at org.eclipse.core.internal.preferences.DefaultPreferences.applyRuntimeDefaults(DefaultPreferences.java:233)
	at org.eclipse.core.internal.preferences.DefaultPreferences.load(DefaultPreferences.java:288)
	at org.eclipse.core.internal.preferences.EclipsePreferences.create(EclipsePreferences.java:381)
	at org.eclipse.core.internal.preferences.EclipsePreferences.internalNode(EclipsePreferences.java:635)
	at org.eclipse.core.internal.preferences.EclipsePreferences.node(EclipsePreferences.java:771)
	at org.eclipse.core.runtime.preferences.AbstractScope.getNode(AbstractScope.java:37)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getDefaultPreferences(ScopedPreferenceStore.java:182)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getPreferenceNodes(ScopedPreferenceStore.java:211)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.internalGet(ScopedPreferenceStore.java:349)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getString(ScopedPreferenceStore.java:393)
	at org.eclipse.terminal.connector.local.launcher.LocalLauncherDelegate.execute(LocalLauncherDelegate.java:112)
	at org.eclipse.terminal.view.ui.internal.handler.LaunchTerminalCommandHandler.executeDelegate(LaunchTerminalCommandHandler.java:176)
	at org.eclipse.terminal.view.ui.internal.handler.LaunchTerminalCommandHandler.execute(LaunchTerminalCommandHandler.java:89)
```