### PR TITLE
[Debug] Prompt when launching debug session with 'Skip All Breakpoints' enabled

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2017 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -302,6 +302,11 @@ public class DebugUIMessages extends NLS {
 	public static String ExpressionManagerContentProvider_1;
 
 	public static String LaunchShortcutAction_combineLaunchShortcutName;
+
+	public static String skipBreakpointWarningTitle;
+	public static String skipBreakpointWarningLabel;
+	public static String skipBreakpointWarningToggle1;
+	public static String skipBreakpointWarningToggle2;
 
 	static {
 		// load message values from bundle file

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2017 IBM Corporation and others.
+#  Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -288,3 +288,8 @@ WorkingDirectoryBlock_Exception_occurred_reading_configuration___15=Exception oc
 ExpressionManagerContentProvider_1=Add new expression
 
 LaunchShortcutAction_combineLaunchShortcutName={0} ({1})
+
+skipBreakpointWarningTitle = Breakpoints set to skip
+skipBreakpointWarningLabel = Breakpoints are disabled due to 'Skip All Breakpoints' being active. Debugger will continue without stopping.
+skipBreakpointWarningToggle1 = Do not show this warning
+skipBreakpointWarningToggle2 = Disable `Skip All Breakpoints`

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
@@ -56,6 +56,7 @@ public class DebugUIPreferenceInitializer extends AbstractPreferenceInitializer 
 		prefs.setDefault(IDebugPreferenceConstants.PREF_PROMPT_REMOVE_ALL_EXPRESSIONS, true);
 		prefs.setDefault(IDebugPreferenceConstants.PREF_PROMPT_DISABLE_ALL_BREAKPOINTS, true);
 		prefs.setDefault(IDebugPreferenceConstants.PREF_PROMPT_ENABLE_ALL_BREAKPOINTS, true);
+		prefs.setDefault(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT, true);
 
 		/**
 		 * Context launching preferences. Appear on the the Launching preference page

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IInternalDebugUIConstants.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IInternalDebugUIConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -466,5 +466,12 @@ public interface IInternalDebugUIConstants {
 	 * @since 3.12
 	 */
 	int BREAKPOINT_SORTING_ORDER_CREATION_TIME = 1;
+
+	/**
+	 * Boolean preference prompting Skip All Breakpoints option is enabled on
+	 * launching in debug mode
+	 *
+	 */
+	String PREF_SKIP_ALL_BREAKPOINTS_PROMPT = IDebugUIConstants.PLUGIN_ID + ".DisableSkipAllBreakpointsOnLaunch"; //$NON-NLS-1$
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencePage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencePage.java
@@ -67,6 +67,8 @@ public class DebugPreferencePage extends FieldEditorPreferencePage implements IW
 		addField(new BooleanFieldEditor(IDebugPreferenceConstants.PREF_PROMPT_REMOVE_ALL_TRIGGER_BREAKPOINTS, DebugPreferencesMessages.DebugPreferencePage_31, SWT.NONE, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(IDebugPreferenceConstants.PREF_PROMPT_DISABLE_ALL_BREAKPOINTS,
 				DebugPreferencesMessages.DebugPreferencePage_32, SWT.NONE, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT,
+				DebugPreferencesMessages.DebugPreferencePage_PromptSkipBreakpoints, SWT.NONE, getFieldEditorParent()));
 
 		SWTFactory.createHorizontalSpacer(getFieldEditorParent(), 2);
 		ColorFieldEditor mem= new ColorFieldEditor(IDebugUIConstants.PREF_CHANGED_DEBUG_ELEMENT_COLOR, DebugPreferencesMessages.DebugPreferencePage_4, getFieldEditorParent());

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2020 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -217,6 +217,10 @@ public class DebugPreferencesMessages extends NLS {
 	public static String DebugPreferencePage_5;
 
 	public static String RunDebugPropertiesPage_0;
+	public static String LaunchingPreferencePage_43;
 
+	public static String skipBreakpointWarningTitle;
+
+	public static String DebugPreferencePage_PromptSkipBreakpoints;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,7 @@ DebugPreferencePage_31=&Prompt for confirmation when removing all triggerpoints
 DebugPreferencePage_32=&Prompt for confirmation when disabling all breakpoints
 DebugPreferencePage_5=Prompt for confirmation when deleting all e&xpressions
 DebugPreferencePage_showValuesInline=Show debug values &inline on text editors (Experimental)
+DebugPreferencePage_PromptSkipBreakpoints=Show warning when launching in debug mode with 'Skip Breakpoints' enabled
 
 LaunchingPreferencePage_1=&Build (if required) before launching
 LaunchingPreferencePage_2=Save required dirty editors before launching
@@ -95,6 +96,7 @@ LaunchingPreferencePage_40=Launch Operation
 LaunchingPreferencePage_41=La&unch the previously launched application
 LaunchingPreferencePage_confirm_0=Prompt for confirmation when removin&g a configuration from the launch history
 LaunchingPreferencePage_42=Termin&ate and relaunch while launching (Press 'Shift' to toggle during launch from menu and toolbar)
+LaunchingPreferencePage_43=Show prompt to indicate whether skip all breakpoints feature is enabled or not on Debug launch
 
 ProcessPropertyPage_Command_Line__1=Co&mmand Line:
 ProcessPropertyPage_0=Run-&at time:
@@ -171,3 +173,4 @@ DefaultLaunchConfigurationsPropertiesPage_9=Delete selected launch configuration
 DefaultLaunchConfigurationsPropertiesPage_11=Select Configuration Type
 DefaultLaunchConfigurationsPropertiesPage_12=&Select the type of configuration to create:
 RunDebugPropertiesPage_0=There was a problem trying to edit {0}
+

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/LaunchingPreferencePage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/LaunchingPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2016 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -52,6 +52,7 @@ public class LaunchingPreferencePage extends FieldEditorPreferencePage implement
 	private Button fLaunchLastIfNotLaunchable;
 	private Button fCheckParent;
 	private Button fTerminatAndRelaunch;
+	private Button fSkipAllBreakpointsPrompt;
 
 	/**
 	 * The default constructor
@@ -171,6 +172,8 @@ public class LaunchingPreferencePage extends FieldEditorPreferencePage implement
 		fLaunchLastIfNotLaunchable = SWTFactory.createRadioButton(space, DebugPreferencesMessages.LaunchingPreferencePage_41);
 
 		fTerminatAndRelaunch = SWTFactory.createCheckButton(group, DebugPreferencesMessages.LaunchingPreferencePage_42, null, false, 1);
+		fSkipAllBreakpointsPrompt = SWTFactory.createCheckButton(group,
+				DebugPreferencesMessages.LaunchingPreferencePage_43, null, true, 1);
 
 		// initialize the buttons
 		boolean value = getPreferenceStore().getBoolean(IInternalDebugUIConstants.PREF_USE_CONTEXTUAL_LAUNCH);
@@ -201,6 +204,8 @@ public class LaunchingPreferencePage extends FieldEditorPreferencePage implement
 		fLaunchLastIfNotLaunchable.setEnabled(value);
 		value = getPreferenceStore().getDefaultBoolean(IInternalDebugUIConstants.PREF_TERMINATE_AND_RELAUNCH_LAUNCH_ACTION);
 		fTerminatAndRelaunch.setSelection(value);
+		value = getPreferenceStore().getDefaultBoolean(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT);
+		fSkipAllBreakpointsPrompt.setSelection(value);
 		super.performDefaults();
 	}
 
@@ -210,6 +215,8 @@ public class LaunchingPreferencePage extends FieldEditorPreferencePage implement
 		getPreferenceStore().setValue(IInternalDebugUIConstants.PREF_LAUNCH_PARENT_PROJECT, fCheckParent.getSelection());
 		getPreferenceStore().setValue(IInternalDebugUIConstants.PREF_LAUNCH_LAST_IF_NOT_LAUNCHABLE, fLaunchLastIfNotLaunchable.getSelection());
 		getPreferenceStore().setValue(IInternalDebugUIConstants.PREF_TERMINATE_AND_RELAUNCH_LAUNCH_ACTION, fTerminatAndRelaunch.getSelection());
+		getPreferenceStore().setValue(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT,
+				fSkipAllBreakpointsPrompt.getSelection());
 		return super.performOk();
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/DebugUITools.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/DebugUITools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -92,6 +92,7 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
@@ -974,6 +975,14 @@ public class DebugUITools {
 		} catch (CoreException e) {
 			DebugUIPlugin.log(e);
 		}
+		boolean breakpointsDisabled = DebugPlugin.getDefault().getBreakpointManager().isEnabled();
+		boolean showWarningPrompt = DebugUIPlugin.getDefault().getPreferenceStore()
+				.getBoolean(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT);
+		if (!breakpointsDisabled && showWarningPrompt && mode.contains("debug")) { //$NON-NLS-1$
+			SkipBreakpointsWarning showWarning = new SkipBreakpointsWarning(DebugUIPlugin.getShell());
+			Display display = DebugUIPlugin.getStandardDisplay();
+			display.syncExec(() -> showWarning.open());
+		}
 		if (launchInBackground) {
 			DebugUIPlugin.launchInBackground(configuration, mode);
 		} else {
@@ -1372,5 +1381,5 @@ public class DebugUITools {
 		}
 		return null;
 	}
-
 }
+

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/SkipBreakpointsWarning.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/SkipBreakpointsWarning.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.ui;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.internal.ui.DebugUIMessages;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Provides warning prompt dialog
+ *
+ * @since 3.19
+ */
+public class SkipBreakpointsWarning extends Dialog {
+
+	protected SkipBreakpointsWarning(Shell parentShell) {
+		super(parentShell);
+	}
+
+	Button disableWarning;
+
+	Button disableSkipAllBreakpoints;
+
+	@Override
+	protected void configureShell(Shell newShell) {
+		super.configureShell(newShell);
+		newShell.setText(DebugUIMessages.skipBreakpointWarningTitle);
+	}
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Composite container = (Composite) super.createDialogArea(parent);
+		GridLayout layout = new GridLayout(1, false);
+		layout.marginTop = 10;
+		layout.marginLeft = 10;
+		layout.marginRight = 10;
+		layout.verticalSpacing = 10;
+		container.setLayout(layout);
+
+		Label messageLabel = new Label(container, SWT.WRAP);
+		messageLabel.setText(DebugUIMessages.skipBreakpointWarningLabel);
+		GridData messageData = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		messageData.widthHint = 410;
+		messageLabel.setLayoutData(messageData);
+
+		disableWarning = new Button(container, SWT.CHECK);
+		disableWarning.setText(DebugUIMessages.skipBreakpointWarningToggle1);
+
+		GridData data = new GridData(SWT.NONE);
+		data.verticalIndent = 20;
+		data.horizontalAlignment = GridData.BEGINNING;
+		disableWarning.setLayoutData(data);
+
+		disableSkipAllBreakpoints = new Button(container, SWT.CHECK);
+		disableSkipAllBreakpoints.setText(DebugUIMessages.skipBreakpointWarningToggle2);
+		disableSkipAllBreakpoints.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+		return container;
+	}
+
+	@Override
+	protected void createButtonsForButtonBar(Composite parent) {
+		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+		createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+	}
+
+	@Override
+	protected void buttonPressed(int buttonId) {
+		if (IDialogConstants.OK_ID == buttonId) {
+			if (disableWarning.getSelection()) {
+				DebugUIPlugin.getDefault().getPreferenceStore()
+						.setValue(IInternalDebugUIConstants.PREF_SKIP_ALL_BREAKPOINTS_PROMPT, false);
+			}
+			if (disableSkipAllBreakpoints.getSelection()) {
+				DebugPlugin.getDefault().getBreakpointManager().setEnabled(true);
+			}
+			okPressed();
+		} else if (IDialogConstants.CANCEL_ID == buttonId) {
+			cancelPressed();
+		}
+	}
+
+	@Override
+	protected Point getInitialSize() {
+		return new Point(450, 250);
+	}
+
+	@Override
+	public boolean close() {
+		disableWarning.dispose();
+		disableSkipAllBreakpoints.dispose();
+		return super.close();
+	}
+
+}


### PR DESCRIPTION
This pull request introduces a warning dialog that appears when a user attempts to start a debug session while the "Skip All Breakpoints" option is enabled. The goal is to prevent confusion caused by breakpoints being silently ignored, which often leads users to believe the debugger is malfunctioning. 
eg https://www.reddit.com/r/eclipse/comments/13zt4ll/debugger_not_working/
eg https://bugs.eclipse.org/bugs/show_bug.cgi?id=578000

The popup will provide option to disable the warning forever (which can be enabled later on from Run/Debug settings) and option disable skip
<img width="475" height="266" alt="image" src="https://github.com/user-attachments/assets/a1c17deb-8f64-46ca-a5a9-6990cd77a526" />

<img width="691" height="627" alt="image" src="https://github.com/user-attachments/assets/21127259-ac40-4a3d-a350-42d89add1008" />
<br>
This will be helpful for new users who may not understand the debug settings and could get confused when breakpoints don’t work as expected.

<br>

https://github.com/user-attachments/assets/c13ff93f-d543-44c0-b4c6-ce97a0abba94

