### PR TITLE
Add filter field and sort launches based on type in Add to favorite dialog

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
@@ -307,4 +307,6 @@ public class LaunchConfigurationsMessages extends NLS {
 	public static String SelectLaunchOptionsDialog_3;
 	public static String SelectLaunchOptionsDialog_4;
 
+	public static String SelectFavTypeToFilter;
+
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
@@ -284,3 +284,4 @@ SelectLaunchersDialog_2=This dialog allows you to specify which launcher to use 
 SelectLaunchersDialog_4=<a href="ws">Change Workspace Settings...</a>
 SelectLaunchersDialog_5=Description
 SelectLaunchersDialog_launchers=Launc&hers:
+SelectFavTypeToFilter= Type to filter

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/SelectFavoritesDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/SelectFavoritesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.debug.internal.ui.launchConfigurations;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
@@ -24,15 +25,23 @@ import org.eclipse.debug.internal.ui.AbstractDebugCheckboxSelectionDialog;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.IDebugHelpContextIds;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.model.WorkbenchViewerComparator;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Text;
 
 /**
- * This dialog is used to select one or more launch configurations to add to your favorites
+ * This dialog is used to select one or more launch configurations to add to
+ * your favorites
  *
  * @since 3.3.0
  */
@@ -46,7 +55,8 @@ public class SelectFavoritesDialog extends AbstractDebugCheckboxSelectionDialog 
 		public Object[] getElements(Object inputElement) {
 			ILaunchConfiguration[] all = null;
 			try {
-				all = LaunchConfigurationManager.filterConfigs(DebugPlugin.getDefault().getLaunchManager().getLaunchConfigurations());
+				all = LaunchConfigurationManager
+						.filterConfigs(DebugPlugin.getDefault().getLaunchManager().getLaunchConfigurations());
 			} catch (CoreException e) {
 				DebugUIPlugin.log(e);
 				return new ILaunchConfiguration[0];
@@ -60,14 +70,31 @@ public class SelectFavoritesDialog extends AbstractDebugCheckboxSelectionDialog 
 			}
 			list.removeAll(fCurrentFavoriteSet);
 			Object[] objs = list.toArray();
-			new WorkbenchViewerComparator().sort(getCheckBoxTableViewer(), objs);
+			Arrays.sort(objs, (o1, o2) -> {
+				if (o1 instanceof ILaunchConfiguration launch1 && o2 instanceof ILaunchConfiguration launch2) {
+					try {
+						String type1 = launch1.getType().getName();
+						String type2 = launch2.getType().getName();
+						int cmp = type1.compareToIgnoreCase(type2);
+						if (cmp != 0) {
+							return cmp;
+						}
+						return launch1.getName().compareToIgnoreCase(launch2.getName());
+					} catch (CoreException e) {
+						DebugUIPlugin.log(e);
+					}
+				}
+				return 0;
+			});
 			return objs;
 		}
 
 		@Override
-		public void dispose() {}
+		public void dispose() {
+		}
 		@Override
-		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {}
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		}
 	}
 
 	private final LaunchHistory fHistory;
@@ -118,4 +145,33 @@ public class SelectFavoritesDialog extends AbstractDebugCheckboxSelectionDialog 
 		return LaunchConfigurationsMessages.FavoritesDialog_7;
 	}
 
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		Composite container = new Composite(parent, SWT.NONE);
+		container.setLayout(new GridLayout(1, false));
+		container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		Text filterText = new Text(container, SWT.SEARCH | SWT.CANCEL);
+		filterText.setMessage(LaunchConfigurationsMessages.SelectFavTypeToFilter);
+		filterText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+		Table table = new Table(container, SWT.BORDER | SWT.SINGLE | SWT.CHECK);
+		GridData gd = new GridData(GridData.FILL_BOTH);
+		gd.heightHint = 150;
+		gd.widthHint = 250;
+		table.setLayoutData(gd);
+		CheckboxTableViewer viewer = new CheckboxTableViewer(table);
+		ViewerFilter filter = new ViewerFilter() {
+			@Override
+			public boolean select(Viewer viewer2, Object parentElement, Object element) {
+				String search = filterText.getText().toLowerCase();
+				if (search.isEmpty())
+					return true;
+				return element.toString().toLowerCase().contains(search);
+			}
+		};
+		viewer.addFilter(filter);
+		filterText.addModifyListener(e -> viewer.refresh());
+		return viewer;
+	}
 }


### PR DESCRIPTION
This PR adds a filter field to filter the launches listed in debug/run's 'Add to favorite' dialog and sorts the launches based on launch type

https://github.com/user-attachments/assets/656d9713-1cd9-4eca-a71a-f6fdd8e4cae3


Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2113