### PR TITLE
Add filter text to Version Control preferences

### DIFF
--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/TeamUIMessages.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/TeamUIMessages.java
@@ -631,6 +631,7 @@ public class TeamUIMessages extends NLS {
 
 	public static String ResourceMappingMergeOperation_4;
 
+	public static String VersionControl_FilterMessage;
 
 	public static String GenericHistoryView_PinCurrentHistory;
 

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/messages.properties
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/messages.properties
@@ -355,6 +355,8 @@ ResourceMappingMergeOperation_2=&Done
 ResourceMappingMergeOperation_3=Multiple potential side effects of this operation have been detected.
 ResourceMappingMergeOperation_4=Preview the merge before it is performed
 
+VersionControl_FilterMessage=type filter text
+
 CompressedFoldersModelProvider_0=&Compressed Folders
 HierarchicalModelProvider_0=&Tree
 UIProjectSetSerializationContext_0=Project {0} exists in the workspace. Overwrite {0}?


### PR DESCRIPTION
Add filter text to Version Control preferences:

Introduced a search field above the table in the Version Control tab of the Preferences page to allow filtering entries.