### PR TITLE
Mention the Eclipse-IDE GitHub page in README and Oomph configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Update provides Java interfaces like `IPlatformConfiguration`. `IPlatformConfigu
 
 Contributions are most welcome. There are many ways to contribute, from entering high quality bug reports, to contributing code or documentation changes.
 
-For a complete guide, see the [CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) page.
+For a general contributing information and a complete guide see the [Eclipse-IDE](https://github.com/eclipse-ide) developer page.<br>
+For detailed information about the contributing process of this project, see [Eclipse-Platform CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md).
 
 [![Create Eclipse Development Environment for Eclipse Platform](https://download.eclipse.org/oomph/www/setups/svg/Eclipse_Platform.svg)](
 https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/releng/org.eclipse.platform.setup/PlatformConfiguration.setup&show=true

--- a/releng/org.eclipse.platform.setup/PlatformConfiguration.setup
+++ b/releng/org.eclipse.platform.setup/PlatformConfiguration.setup
@@ -80,7 +80,7 @@
     and the API baseline is based on the most recent release.
     &lt;p>
     &lt;/p>
-    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
+    Please &lt;a href=&quot;https://github.com/eclipse-ide/.github/blob/main/CONTRIBUTING.md&quot;>read the tutorial instructions&lt;/a> for more details.
     &lt;/p>
   </description>
 </setup:Configuration>


### PR DESCRIPTION
Migrate off the `Eclipse_Platform_SDK_Provisioning` guide hosted at the deprecated wiki.

This is the first repo of the all Eclipse-SDK repos, where this change is applied, so please add your remarks here. Subsequently I'll apply it to all other repos in platform, equinox, JDT and PDE.

Once https://github.com/eclipse-ide is mentioned in all READMEs, we can remove general information from https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md that's already provided in https://github.com/eclipse-ide (and add there general information that's missing).

CC @merks 