### PR TITLE
Implement Word and Line Selection in Terminal View

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/VirtualCanvas.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/VirtualCanvas.java
@@ -335,7 +335,7 @@ public abstract class VirtualCanvas extends Canvas {
 		return getVerticalBar().isVisible();
 	}
 
-	protected void serVerticalBarVisible(boolean showVScrollBar) {
+	protected void setVerticalBarVisible(boolean showVScrollBar) {
 		ScrollBar vertical = getVerticalBar();
 		vertical.setVisible(showVScrollBar);
 		vertical.setSelection(0);


### PR DESCRIPTION
Implemented word/line selection for the terminal view similar to the behavior eclipse already has in the console / editors. 
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2126 

What it does:
- Double‑click selects a word, dragging after that extends by whole words.
-  Triple‑click selects a line, dragging after that extends by whole lines

**This is my first time developing something in the eclipse platform, so please bear with me :)** 