### PR TITLE
Implement word and line selection modes in TextCanvas

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextCanvas.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextCanvas.java
@@ -294,7 +294,7 @@ public class TextCanvas extends GridCanvas {
 			}
 			redraw();
 		});
-		serVerticalBarVisible(true);
+		setVerticalBarVisible(true);
 		setHorizontalBarVisible(false);
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/VirtualCanvas.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/VirtualCanvas.java
@@ -335,7 +335,7 @@ public abstract class VirtualCanvas extends Canvas {
 		return getVerticalBar().isVisible();
 	}
 
-	protected void serVerticalBarVisible(boolean showVScrollBar) {
+	protected void setVerticalBarVisible(boolean showVScrollBar) {
 		ScrollBar vertical = getVerticalBar();
 		vertical.setVisible(showVScrollBar);
 		vertical.setSelection(0);


### PR DESCRIPTION
Implemented word/line selection for the terminal view similar to the behavior eclipse already has in the console / editors.
Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2126

What it does:

- Double‑click selects a word, dragging after that extends by whole words.
- Triple‑click selects a line, dragging after that extends by whole lines
