### PR TITLE
Remove unused reference to PlatformAdmin / do not use PackageAdmin

### DIFF
--- a/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
+++ b/update/org.eclipse.update.configurator/META-INF/MANIFEST.MF
@@ -2,16 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.update.configurator; singleton:=true
-Bundle-Version: 3.5.800.qualifier
+Bundle-Version: 3.5.900.qualifier
 Bundle-Activator: org.eclipse.update.internal.configurator.ConfigurationActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.update.configurator,
  org.eclipse.update.internal.configurator;x-friends:="org.eclipse.update.core",
  org.eclipse.update.internal.configurator.branding;x-friends:="org.eclipse.update.core"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
- org.eclipse.osgi;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="3.29.0"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.xml.parsers,
  org.w3c.dom,

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/FeatureEntry.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/FeatureEntry.java
@@ -13,16 +13,22 @@
  *******************************************************************************/
 package org.eclipse.update.internal.configurator;
 
-import java.net.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.update.configurator.*;
-import org.eclipse.update.internal.configurator.branding.*;
-import org.osgi.framework.*;
-import org.w3c.dom.*;
+import org.eclipse.core.runtime.IBundleGroup;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.update.configurator.IPlatformConfiguration;
+import org.eclipse.update.internal.configurator.branding.AboutInfo;
+import org.eclipse.update.internal.configurator.branding.IBundleGroupConstants;
+import org.eclipse.update.internal.configurator.branding.IProductConstants;
+import org.osgi.framework.Bundle;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 
 /**
@@ -197,7 +203,7 @@ public class FeatureEntry
 		ArrayList<Bundle> bundles = new ArrayList<>(plugins.size());
 		for (PluginEntry plugin : plugins) {
 			// get the highest version for the plugin
-			Bundle bundle = Utils.getBundle(plugin.getPluginIdentifier());
+			Bundle bundle = Platform.getBundle(plugin.getPluginIdentifier());
 			if (bundle != null) {
 				bundles.add(bundle);
 			}
@@ -357,11 +363,11 @@ public class FeatureEntry
 	}
 
 	public Bundle getDefiningBundle() {
-		return Utils.getBundle(getFeaturePluginIdentifier());
+		return Platform.getBundle(getFeaturePluginIdentifier());
 	}
 
 	public boolean hasBranding() {
 		String bundleId = getFeaturePluginIdentifier();
-		return bundleId != null && Utils.getBundle(bundleId) != null;
+		return bundleId != null && Platform.getBundle(bundleId) != null;
 	}
 }

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/branding/IniFileReader.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/branding/IniFileReader.java
@@ -28,10 +28,10 @@ import java.util.StringTokenizer;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.update.internal.configurator.Messages;
-import org.eclipse.update.internal.configurator.Utils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 
@@ -95,7 +95,7 @@ public class IniFileReader {
 		}
 
 		// attempt to locate the corresponding plugin
-		bundle = Utils.getBundle(pluginId);
+		bundle = Platform.getBundle(pluginId);
 		if (bundle == null || bundle.getState() == Bundle.UNINSTALLED || bundle.getState() == Bundle.INSTALLED) {
 			bundle = null; // make it null for other test down the road
 			String message = NLS.bind(Messages.IniFileReader_MissingDesc, featureId);


### PR DESCRIPTION
PlatformAdmin + PackageAdmin are part of the old legacy Resolver API and should not be used anymore.