### PR TITLE
Depend on Lucene using the Import-Package header

### DIFF
--- a/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -42,11 +42,29 @@ Export-Package: org.apache.lucene.demo.html;x-internal:=true,
 Require-Bundle: org.eclipse.ant.core;bundle-version="[3.2.200,4.0.0)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)";visibility:=reexport,
- org.eclipse.core.net;bundle-version="[1.2.200,2.0.0)",
- org.apache.lucene.analysis-common;bundle-version="[10.0.0,11.0.0)",
- org.apache.lucene.core;bundle-version="[10.0.0,11.0.0)",
- org.apache.lucene.analysis-smartcn;bundle-version="[10.0.0,11.0.0)"
-Import-Package: org.eclipse.equinox.http.jetty;resolution:=optional
+ org.eclipse.core.net;bundle-version="[1.2.200,2.0.0)"
+Import-Package: org.apache.lucene.analysis;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.br;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.cjk;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.cn.smart;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.core;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.cz;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.de;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.el;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.en;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.fr;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.miscellaneous;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.nl;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.ru;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.standard;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.tokenattributes;version="[10.0.0,11.0.0)",
+ org.apache.lucene.analysis.util;version="[10.0.0,11.0.0)",
+ org.apache.lucene.document;version="[10.0.0,11.0.0)",
+ org.apache.lucene.index;version="[10.0.0,11.0.0)",
+ org.apache.lucene.search;version="[10.0.0,11.0.0)",
+ org.apache.lucene.store;version="[10.0.0,11.0.0)",
+ org.apache.lucene.util;version="[10.0.0,11.0.0)",
+ org.eclipse.equinox.http.jetty;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.help.base

--- a/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/AnalyzerDescriptor.java
+++ b/ua/org.eclipse.help.base/src/org/eclipse/help/internal/search/AnalyzerDescriptor.java
@@ -14,14 +14,21 @@
  *******************************************************************************/
 package org.eclipse.help.internal.search;
 
-import org.apache.lucene.analysis.*;
-import org.eclipse.core.runtime.*;
-import org.eclipse.help.internal.base.*;
-import org.osgi.framework.*;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.cn.smart.SmartChineseAnalyzer;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.help.internal.base.HelpBasePlugin;
+import org.osgi.annotation.bundle.Referenced;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
 
 /**
  * Text Analyzer Descriptor. Encapsulates Lucene Analyzer
  */
+@Referenced(SmartChineseAnalyzer.class)
 public class AnalyzerDescriptor {
 
 	private Analyzer luceneAnalyzer;

--- a/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -11,12 +11,15 @@ Require-Bundle: org.eclipse.help.ui,
  org.eclipse.ui.intro.universal,
  org.eclipse.ui.forms,
  org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100",
- org.apache.lucene.core;bundle-version="9.4.2",
  org.eclipse.equinox.http.registry;bundle-version="1.3.100"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org
 Import-Package: javax.servlet;version="3.1.0",
  javax.servlet.http;version="3.1.0",
+ org.apache.lucene.index;version="[10.0.0,11.0.0)",
+ org.apache.lucene.search;version="[10.0.0,11.0.0)",
+ org.apache.lucene.store;version="[10.0.0,11.0.0)",
+ org.apache.lucene.util;version="[10.0.0,11.0.0)",
  org.assertj.core.api,
  org.junit.jupiter.api,
  org.junit.jupiter.api.function,

--- a/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: User Assistance Test
 Bundle-SymbolicName: org.eclipse.ua.tests;singleton:=true
-Bundle-Version: 3.7.200.qualifier
+Bundle-Version: 3.7.300.qualifier
 Require-Bundle: org.eclipse.help.ui,
  org.eclipse.help.webapp,
  org.eclipse.test.performance,

--- a/ua/org.eclipse.ua.tests/pom.xml
+++ b/ua/org.eclipse.ua.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.ua.tests</artifactId>
-  <version>3.7.200-SNAPSHOT</version>
+  <version>3.7.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Using the Import-Header entries allows consumers to contribute their own Lucene bundles, without having to match the symbolic name defined by Orbit.