### PR TITLE
org.mortbay.jasper.apache-jsp -> org.mortbay.jasper.mortbay-apache-jsp

### DIFF
--- a/ua/infocenter-web/infocenter-product/infocenter.product
+++ b/ua/infocenter-web/infocenter-product/infocenter.product
@@ -64,7 +64,7 @@ org.osgi.framework.bootdelegation=*
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state"/>
       <plugin id="org.eclipse.osgi.util"/>
-      <plugin id="org.mortbay.jasper.apache-jsp"/>
+      <plugin id="org.mortbay.jasper.mortbay-apache-jsp"/>
    </plugins>
 
    <configurations>

--- a/ua/org.eclipse.ua.tests/pom.xml
+++ b/ua/org.eclipse.ua.tests/pom.xml
@@ -62,7 +62,7 @@
 	            </requirement>
 				<requirement>
 					<type>eclipse-plugin</type>
-					<id>org.mortbay.jasper.apache-jsp</id>
+					<id>org.mortbay.jasper.mortbay-apache-jsp</id>
 					<versionRange>0.0.0</versionRange>
 				</requirement>
 	          </extraRequirements>


### PR DESCRIPTION
- The org.mortbay.jasper.apache-jsp artifact was relocated in Maven Central and also changes its BSN.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3282