### PR TITLE
Add configurable elapsed time display with format customization

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2004, 2020 IBM Corporation and others.
+ *  Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@
 package org.eclipse.debug.internal.ui;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.debug.internal.ui.preferences.DebugPreferencesMessages;
 import org.eclipse.debug.internal.ui.preferences.IDebugPreferenceConstants;
 import org.eclipse.debug.internal.ui.views.memory.MemoryViewUtil;
 import org.eclipse.debug.ui.IDebugUIConstants;
@@ -84,6 +85,8 @@ public class DebugUIPreferenceInitializer extends AbstractPreferenceInitializer 
 		prefs.setDefault(IDebugPreferenceConstants.CONSOLE_TAB_WIDTH, 8);
 		prefs.setDefault(IDebugPreferenceConstants.CONSOLE_INTERPRET_CONTROL_CHARACTERS, false);
 		prefs.setDefault(IDebugPreferenceConstants.CONSOLE_INTERPRET_CR_AS_CONTROL_CHARACTER, true);
+		prefs.setDefault(IDebugPreferenceConstants.CONSOLE_ELAPSED_FORMAT,
+				DebugPreferencesMessages.ConsoleDefaultElapsedTimeFormat);
 
 		// console colors
 		setThemeBasedPreferences(prefs, false);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2020 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -218,5 +218,13 @@ public class DebugPreferencesMessages extends NLS {
 
 	public static String RunDebugPropertiesPage_0;
 
+
+	public static String ConsoleDefaultElapsedTimeFormat;
+
+	public static String ConsoleElapsedTimeLabel;
+
+	public static String ConsoleElapsedTimeToolTip;
+
+	public static Object ConsoleDisableElapsedTime;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,10 @@ ConsolePreferencePage_11=Back&ground color:
 ConsolePreferencePage_Interpret_control_characters=Interpret ASCII &control characters
 ConsolePreferencePage_Interpret_cr_as_control_character=Interpret Carriage &Return (\\r) as control character 
 ConsolePreferencePage_Enable_Word_Wrap_text=E&nable word wrap
+ConsoleElapsedTimeLabel=Elapsed Time Format (Choose 'None' to disable)
+ConsoleDefaultElapsedTimeFormat=%d:%02d:%02d
+ConsoleElapsedTimeToolTip=Supports formats like: 'H:MM:SS.mmm', 'MMm SSs', 'H:MM:SS' \nYou can also use positional parameters \n%1$ = (H)hours\n%2$ = (M)minutes\n%3$ = (S)seconds\n%4$ = (mmm)milliseconds
+ConsoleDisableElapsedTime=None
 
 DebugPreferencePage_1=General Settings for Running and Debugging.
 DebugPreferencePage_2=Re&use editor when displaying source code

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/IDebugPreferenceConstants.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/IDebugPreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -335,6 +335,7 @@ public interface IDebugPreferenceConstants {
 	 * @since 3.8
 	 */
 	String DEBUG_VIEW_TOOLBAR_HIDDEN_PERSPECTIVES = "org.eclipse.debug.ui.Debug_view.debug_toolbar_hidden_perspectives"; //$NON-NLS-1$
+	String CONSOLE_ELAPSED_FORMAT = "org.eclipse.console.elapsedTimeFormat"; //$NON-NLS-1$
 }
 
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2020 IBM Corporation and others.
+#  Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -25,8 +25,8 @@ ProcessConsole_0=<terminated> {0}
 ProcessConsole_1=[Console output redirected to file:{0}]\n
 ProcessConsole_2=[Invalid file specified for console output: {0}]\n
 ProcessConsole_3=[Invalid file specified for  stdin file: {0}]\n
-ProcessConsole_commandLabel_withStart={0} ({1} elapsed: {2})
+ProcessConsole_commandLabel_withStart={0} ({1} {2})
 ProcessConsole_commandLabel_withEnd={0} (Terminated {1})
-ProcessConsole_commandLabel_withStartEnd={0} ({1} \u2013 {2} elapsed: {3})
+ProcessConsole_commandLabel_withStartEnd={0} ({1} \u2013 {2} {3})
 ShowStandardErrorAction_0=Show Console When Standard Error Changes
 ShowStandardOutAction_0=Show Console When Standard Out Changes


### PR DESCRIPTION
This PR introduces a toggle to enable or disable the display of elapsed time in the console output in Console settings. 

Added support for customizing the format of the elapsed time, allowing users to choose from multiple display styles based on their preferences or requirements.

<img width="687" height="203" alt="image" src="https://github.com/user-attachments/assets/54d6ca11-eeca-4729-95dc-ad51e3545123" />



https://github.com/user-attachments/assets/a6f8e2dd-8bb0-4ec1-9345-d76443b5b283



fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2112