### PR TITLE
[Debug] Externalize hardcoded strings for consistency and reuse

### DIFF
--- a/debug/org.eclipse.core.variables/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.core.variables/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.variables; singleton:=true
-Bundle-Version: 3.6.600.qualifier
+Bundle-Version: 3.6.700.qualifier
 Bundle-Activator: org.eclipse.core.variables.VariablesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/ContributedValueVariable.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/ContributedValueVariable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -88,10 +88,10 @@ public class ContributedValueVariable extends StringVariable implements IValueVa
 						if (object instanceof IValueVariableInitializer initializer) {
 							initializer.initialize(this);
 						} else {
-							VariablesPlugin.logMessage(NLS.bind("Unable to initialize variable {0} - initializer must be an instance of IValueVariableInitializer.", getName()), null); //$NON-NLS-1$
+							VariablesPlugin.logMessage(NLS.bind(VariablesMessages.VarInitFailDueNonIValueVariable, getName()), null);
 						}
 					} catch (CoreException e) {
-						VariablesPlugin.logMessage(NLS.bind("Unable to initialize variable {0}", getName()), e); //$NON-NLS-1$
+						VariablesPlugin.logMessage(NLS.bind(VariablesMessages.VarInitFail, getName()), e);
 					}
 				}
 			} else {

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/DynamicVariable.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/DynamicVariable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -43,19 +43,19 @@ public class DynamicVariable extends StringVariable implements IDynamicVariable 
 		if (fResolver == null) {
 			String name = getConfigurationElement().getAttribute("resolver"); //$NON-NLS-1$
 			if (name == null) {
-				throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind("Contributed context variable {0} must specify a resolver.", getName()), null)); //$NON-NLS-1$
+				throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind(VariablesMessages.VarMissingResolver, getName()), null));
 			}
 			Object object = getConfigurationElement().createExecutableExtension("resolver"); //$NON-NLS-1$
 			if (object instanceof IDynamicVariableResolver) {
 				fResolver = (IDynamicVariableResolver)object;
 			} else {
-				throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind("Contributed context variable resolver for {0} must be an instance of IContextVariableResolver.", getName()), null)); //$NON-NLS-1$
+				throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind(VariablesMessages.VarResolverNotIContextVariableResolver, getName()), null));
 			}
 		}
 		try {
 			return fResolver.resolveValue(this, argument);
 		} catch (RuntimeException e) {
-			throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind("Error while evaluating variable {0}.", getName()), e)); //$NON-NLS-1$
+			throw new CoreException(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, NLS.bind(VariablesMessages.VarEvalError, getName()), e));
 		}
 	}
 

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/StringVariableManager.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/StringVariableManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -126,7 +126,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 		 */
 		@Override
 		public void handleException(Throwable exception) {
-			IStatus status = new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, "An exception occurred during string variable change notification", exception); //$NON-NLS-1$
+			IStatus status = new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), VariablesPlugin.INTERNAL_ERROR, VariablesMessages.StringVarExceptionOnChange, exception);
 			VariablesPlugin.log(status);
 		}
 
@@ -223,7 +223,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 		for (IConfigurationElement element : elements) {
 			String name= element.getAttribute(ATTR_NAME);
 			if (name == null) {
-				VariablesPlugin.logMessage(NLS.bind("Variable extension missing required 'name' attribute: {0}", element.getDeclaringExtension().getLabel()), null); //$NON-NLS-1$
+				VariablesPlugin.logMessage(NLS.bind(VariablesMessages.StringVarMissingNameExt, element.getDeclaringExtension().getLabel()), null);
 				continue;
 			}
 			String description= element.getAttribute(ATTR_DESCRIPTION);
@@ -231,7 +231,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			Object old = fDynamicVariables.put(variable.getName(), variable);
 			if (old != null) {
 				DynamicVariable oldVariable = (DynamicVariable)old;
-				VariablesPlugin.logMessage(NLS.bind("Dynamic variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from bundle ''{2}''", //$NON-NLS-1$
+				VariablesPlugin.logMessage(NLS.bind(VariablesMessages.StringVarExtOverridesOnBundles,
 						element.getDeclaringExtension().getContributor().getName(), oldVariable.getName(), oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()), null);
 			}
 		}
@@ -246,7 +246,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 		for (IConfigurationElement element : elements) {
 			String name= element.getAttribute(ATTR_NAME);
 			if (name == null) {
-				VariablesPlugin.logMessage(NLS.bind("Variable extension missing required 'name' attribute: {0}", element.getDeclaringExtension().getLabel()), null); //$NON-NLS-1$
+				VariablesPlugin.logMessage(NLS.bind(VariablesMessages.StringVarMissingNameExt, element.getDeclaringExtension().getLabel()), null);
 				continue;
 			}
 			String description= element.getAttribute(ATTR_DESCRIPTION);
@@ -256,7 +256,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			Object old = fValueVariables.put(name, variable);
 			if (old != null) {
 				StringVariable oldVariable = (StringVariable)old;
-				VariablesPlugin.logMessage(NLS.bind("Contributed variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from  bundle ''{2}''", //$NON-NLS-1$
+				VariablesPlugin.logMessage(NLS.bind(VariablesMessages.StringVarContExtOverridesOnBundles,
 						element.getDeclaringExtension().getContributor().getName(), oldVariable.getName(), oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()), null);
 			}
 		}
@@ -282,11 +282,11 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			parser.setErrorHandler(new DefaultHandler());
 			root = parser.parse(stream).getDocumentElement();
 		} catch (Exception e) {
-			VariablesPlugin.logMessage("An exception occurred while loading persisted value variables.", e); //$NON-NLS-1$
+			VariablesPlugin.logMessage(VariablesMessages.StringVarExceptionOnLoad, e);
 			return;
 		}
 		if (!root.getNodeName().equals(VALUE_VARIABLES_TAG)) {
-			VariablesPlugin.logMessage("Invalid format encountered while loading persisted value variables.", null); //$NON-NLS-1$
+			VariablesPlugin.logMessage(VariablesMessages.StringVarInvalidFormat, null);
 			return;
 		}
 		NodeList list= root.getChildNodes();
@@ -295,7 +295,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
 				Element element= (Element) node;
 				if (!element.getNodeName().equals(VALUE_VARIABLE_TAG)) {
-					VariablesPlugin.logMessage(NLS.bind("Invalid XML element encountered while loading value variables: {0}", node.getNodeName()), null); //$NON-NLS-1$
+					VariablesPlugin.logMessage(NLS.bind(VariablesMessages.StringVarInvalidXML, node.getNodeName()), null);
 					continue;
 				}
 				String name= element.getAttribute(NAME_TAG);
@@ -312,7 +312,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 						existing.setValue(value);
 					}
 				} else {
-					VariablesPlugin.logMessage("Invalid variable entry encountered while loading value variables. Variable name is null.", null); //$NON-NLS-1$
+					VariablesPlugin.logMessage(VariablesMessages.StringVarNameNull, null);
 				}
 			}
 		}
@@ -489,13 +489,13 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			try {
 				variableString= getValueVariablesAsXML();
 			} catch (IOException e) {
-				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, "An exception occurred while storing launch configuration variables.", e)); //$NON-NLS-1$
+				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, VariablesMessages.StringVarLaunchExcep, e));
 				return;
 			} catch (ParserConfigurationException e) {
-				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, "An exception occurred while storing launch configuration variables.", e)); //$NON-NLS-1$
+				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, VariablesMessages.StringVarLaunchExcep, e));
 				return;
 			} catch (TransformerException e) {
-				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, "An exception occurred while storing launch configuration variables.", e)); //$NON-NLS-1$
+				VariablesPlugin.log(new Status(IStatus.ERROR, VariablesPlugin.getUniqueIdentifier(), IStatus.ERROR, VariablesMessages.StringVarLaunchExcep, e));
 				return;
 			}
 		}

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/VariablesMessages.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/VariablesMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,34 @@ public class VariablesMessages extends NLS {
 	public static String StringVariableManager_27;
 
 	public static String DynamicVariable_0;
+
+	public static String VarMissingResolver;
+
+	public static String VarResolverNotIContextVariableResolver;
+
+	public static String VarEvalError;
+
+	public static String VarInitFailDueNonIValueVariable;
+
+	public static String VarInitFail;
+
+	public static String StringVarExceptionOnChange;
+
+	public static String StringVarMissingNameExt;
+
+	public static String StringVarExtOverridesOnBundles;
+
+	public static String StringVarContExtOverridesOnBundles;
+
+	public static String StringVarExceptionOnLoad;
+
+	public static String StringVarInvalidFormat;
+
+	public static String StringVarInvalidXML;
+
+	public static String StringVarNameNull;
+
+	public static String StringVarLaunchExcep;
 
 	static {
 		// load message values from bundle file

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/VariablesMessages.properties
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/VariablesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2005 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -19,3 +19,19 @@ StringVariableManager_26=Variables with the specified names are already register
 StringVariableManager_27=Variable named {0} already registered
 
 DynamicVariable_0=Unsupported argument {0} specified for variable {1}
+VarMissingResolver=Contributed context variable {0} must specify a resolver.
+VarResolverNotIContextVariableResolver=Contributed context variable resolver for {0} must be an instance of IContextVariableResolver.
+VarEvalError=Error while evaluating variable {0}.
+
+VarInitFailDueNonIValueVariable=Unable to initialize variable {0} - initializer must be an instance of IValueVariableInitializer.
+VarInitFail=Unable to initialize variable {0}
+
+StringVarExceptionOnChange=An exception occurred during string variable change notification
+StringVarMissingNameExt=Variable extension missing required 'name' attribute: {0}
+StringVarExtOverridesOnBundles=Dynamic variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from bundle ''{2}''
+StringVarContExtOverridesOnBundles=Contributed variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from  bundle ''{2}''
+StringVarExceptionOnLoad=An exception occurred while loading persisted value variables.
+StringVarInvalidFormat=Invalid format encountered while loading persisted value variables.
+StringVarInvalidXML=Invalid XML element encountered while loading value variables: {0}
+StringVarNameNull=Invalid variable entry encountered while loading value variables. Variable name is null.
+StringVarLaunchExcep=An exception occurred while storing launch configuration variables.


### PR DESCRIPTION
Externalized strings in core.internal.variables package to eliminate redundancy and enhance code maintainability.