### PR TITLE
Don't run into NPE while hiding Breakpoints view

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/DefaultBreakpointsViewInput.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/elements/adapters/DefaultBreakpointsViewInput.java
@@ -69,4 +69,16 @@ public class DefaultBreakpointsViewInput {
 		return super.equals(arg0);
 	}
 
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("DefaultBreakpointsViewInput ["); //$NON-NLS-1$
+		if (fContext != null) {
+			builder.append("context="); //$NON-NLS-1$
+			builder.append(fContext);
+		}
+		builder.append("]"); //$NON-NLS-1$
+		return builder.toString();
+	}
+
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ChildrenUpdate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ChildrenUpdate.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.debug.internal.ui.viewers.model;
 
+import java.util.Objects;
+
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IChildrenUpdate;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IElementContentProvider;
@@ -205,19 +207,27 @@ public class ChildrenUpdate extends ViewerUpdateMonitor implements IChildrenUpda
 
 	@Override
 	protected boolean doEquals(ViewerUpdateMonitor update) {
-		return
-			update instanceof ChildrenUpdate &&
-			((ChildrenUpdate)update).getOffset() == getOffset() &&
-			((ChildrenUpdate)update).getLength() == getLength() &&
-			getViewerInput().equals(update.getViewerInput()) &&
-			getElementPath().equals(update.getElementPath());
+		if (!(update instanceof ChildrenUpdate other)) {
+			return false;
+		}
+		boolean offsetAndLengthOK = other.getOffset() == getOffset() && other.getLength() == getLength();
+		if (!offsetAndLengthOK) {
+			return false;
+		}
+		Object viewerInput = getViewerInput();
+		if (!Objects.equals(viewerInput, other.getViewerInput())) {
+			return false;
+		}
+		return getElementPath().equals(other.getElementPath());
 	}
 
 	@Override
 	protected int doHashCode() {
-		return (int)Math.pow(
-			(getClass().hashCode() + getViewerInput().hashCode() + getElementPath().hashCode()) * (getOffset() + 2),
-			getLength() + 2);
+		Object viewerInput = getViewerInput();
+		int inputBits = viewerInput != null ? viewerInput.hashCode() : 0;
+		int result = (int) Math.pow(
+				(getClass().hashCode() + inputBits + getElementPath().hashCode()) * (getOffset() + 2), getLength() + 2);
+		return result;
 	}
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ViewerInputUpdate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ViewerInputUpdate.java
@@ -143,6 +143,35 @@ public class ViewerInputUpdate extends Request implements IViewerInputUpdate {
 		return fViewerInput;
 	}
 
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("ViewerInputUpdate ["); //$NON-NLS-1$
+		builder.append("inputElement="); //$NON-NLS-1$
+		builder.append(fInputElement);
+		builder.append(", "); //$NON-NLS-1$
+		if (fContext != null) {
+			builder.append("context="); //$NON-NLS-1$
+			builder.append(fContext);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (fSource != null) {
+			builder.append("source="); //$NON-NLS-1$
+			builder.append(fSource);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (fViewerInput != null) {
+			builder.append("viewerInput="); //$NON-NLS-1$
+			builder.append(fViewerInput);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (fRequestor != null) {
+			builder.append("requestor="); //$NON-NLS-1$
+			builder.append(fRequestor);
+		}
+		builder.append("]"); //$NON-NLS-1$
+		return builder.toString();
+	}
 
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ViewerUpdateMonitor.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/ViewerUpdateMonitor.java
@@ -21,7 +21,10 @@ import org.eclipse.debug.internal.ui.viewers.AsynchronousSchedulingRuleFactory;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IElementContentProvider;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IPresentationContext;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ITreeModelViewer;
+import org.eclipse.debug.internal.ui.viewers.model.provisional.IViewerInputUpdate;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IViewerUpdate;
+import org.eclipse.debug.internal.ui.viewers.model.provisional.ViewerInputService;
+import org.eclipse.debug.internal.ui.views.variables.VariablesView;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.swt.widgets.Display;
 
@@ -87,7 +90,15 @@ public abstract class ViewerUpdateMonitor extends Request implements IViewerUpda
 		fContext = context;
 		// Bug 380288: Catch and log a race condition where the viewer input is null.
 		if (viewerInput == null) {
-			DebugUIPlugin.log(new NullPointerException("Input to viewer update should not be null")); //$NON-NLS-1$
+			if (!(context.getPart() instanceof VariablesView view)) {
+				DebugUIPlugin.log(new NullPointerException("Input to viewer update should not be null")); //$NON-NLS-1$
+			} else {
+				IViewerInputUpdate viewerUpdate = view.getLastViewerUpdate();
+				if (viewerUpdate == null || viewerUpdate.getElement() != ViewerInputService.NULL_INPUT) {
+					DebugUIPlugin.log(new NullPointerException(
+							"Input element in viewer update should not be null: " + viewerUpdate)); //$NON-NLS-1$
+				}
+			}
 		}
 		fViewerInput = viewerInput;
 		fElementContentProvider = elementContentProvider;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/DebugModelPresentationContext.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/DebugModelPresentationContext.java
@@ -43,4 +43,16 @@ public class DebugModelPresentationContext extends PresentationContext {
 		return fPresentation;
 	}
 
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("DebugModelPresentationContext ["); //$NON-NLS-1$
+		if (fPresentation != null) {
+			builder.append("presentation="); //$NON-NLS-1$
+			builder.append(fPresentation);
+		}
+		builder.append("]"); //$NON-NLS-1$
+		return builder.toString();
+	}
+
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/variables/VariablesView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/variables/VariablesView.java
@@ -154,6 +154,12 @@ public class VariablesView extends AbstractDebugView implements IDebugContextLis
 	private static final String CSS_VARIABLES_VIEWER_ID = "VariablesViewer"; //$NON-NLS-1$
 
 	/**
+	 * Viewer update object used during
+	 * {@link #viewerInputUpdateComplete(IViewerInputUpdate)}
+	 */
+	private IViewerInputUpdate lastViewerUpdate;
+
+	/**
 	 * Selection provider wrapping an exchangeable active selection provider. Sends
 	 * out a selection changed event when the active selection provider changes.
 	 * Forwards all selection changed events of the active selection provider.
@@ -294,7 +300,12 @@ public class VariablesView extends AbstractDebugView implements IDebugContextLis
 	 */
 	private final IViewerInputRequestor fRequester = update -> {
 		if (!update.isCanceled()) {
-			viewerInputUpdateComplete(update);
+			lastViewerUpdate = update;
+			try {
+				viewerInputUpdateComplete(update);
+			} finally {
+				lastViewerUpdate = null;
+			}
 		}
 	};
 
@@ -440,6 +451,15 @@ public class VariablesView extends AbstractDebugView implements IDebugContextLis
 	protected void viewerInputUpdateComplete(IViewerInputUpdate update) {
 		setViewerInput(update.getInputElement());
 		updateAction(FIND_ACTION);
+	}
+
+	/**
+	 * @return Viewer update object being processed during
+	 *         {@link #viewerInputUpdateComplete(IViewerInputUpdate)}, {@code null}
+	 *         otherwise
+	 */
+	public final IViewerInputUpdate getLastViewerUpdate() {
+		return lastViewerUpdate;
 	}
 
 	/**


### PR DESCRIPTION
`VariablesView.becomesHidden()` is setting
`ViewerInputService.NULL_INPUT` which sets the `IViewerInputUpdate` "input element" to null and so the viewer input for `Breakpoints` view to null.

This is expected case, however the code in `ViewerUpdateMonitor` and in `ChildrenUpdate` was not prepared to that valid use case and runs into NPE or reports errors in case where no error happens.

To fix (and add more error context for possible remaining input issues), let the `VariablesView` provide last used `IViewerInputUpdate` object so it can be used by `ViewerUpdateMonitor`, and let the `ChildrenUpdate` code be aware about viewer input element being null (which is documented as possible value at `ViewerUpdateMonitor.getViewerInput()`).

Additionally implemented `toString()` in all related objects that can be set in `ViewerInputUpdate`, so the data can be provided in the error reported by `ViewerUpdateMonitor` for all remaining use cases with "null" input.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2150