### PR TITLE
[RelEng] Update qualifier of o.e.help.webapp during release preparation

### DIFF
--- a/prepareNextDevCycle.sh
+++ b/prepareNextDevCycle.sh
@@ -26,6 +26,7 @@ if [ ! -f splash.png ] || [ ! -f eclipse_lg.png ] || [ ! -f eclipse_lg@2x.png ];
 	exit 1
 fi
 
+# Update splash-screen
 mv -f futureSplashScreens/splash_${NEXT_RELEASE_NAME}.png splash.png
 if [ -f 'futureSplashScreens/eclipse_lg.png' ]; then
 	# About-dialog image is usally the same for multiple releases
@@ -35,3 +36,11 @@ fi
 popd
 
 git commit --all --message "Splash Screen for ${NEXT_RELEASE_VERSION} (${NEXT_RELEASE_NAME})"
+
+
+# Enforce qualifier update in 'org.eclipse.help.webapp'
+sed -i '2,$ d' 'ua/org.eclipse.help.webapp/forceQualifierUpdate.txt'
+echo "Qualifier update for ${NEXT_RELEASE_VERSION} stream" >> 'ua/org.eclipse.help.webapp/forceQualifierUpdate.txt'
+
+git commit --all --message "Qualifier update of eclipse.help.webapp for ${NEXT_RELEASE_VERSION}"
+


### PR DESCRIPTION
As noted in https://github.com/eclipse-platform/eclipse.platform/pull/2134#issuecomment-3238274564, the `o.e.help.webapp` project currently needs a qualifier update during preparation of a new release cycle as the content of the generated jsp files changes then.
This extends the individual release preparation script for this repo do apply that update.

As it would be even better to avoid qualifier updates (and thus version updates), without content change I tried to investigate where the content of the differing generated files has changed. Comparing the class files respectively the java source files from which they are compiled, showed that for example `org/eclipse/help/internal/webapp/jsp/advanced/advanced_jsp.java` contains the following lines:
```
  private static java.util.Map<java.lang.String,java.lang.Long> _jspx_dependants;

  static {
    _jspx_dependants = new java.util.HashMap<java.lang.String,java.lang.Long>(1);
    _jspx_dependants.put("/advanced/header.jsp", Long.valueOf(1688504300120L));
  }
```
and the value put for the `/advanced/header.jsp` has changed.

But I don't know how that value is computed and how a change just because of a parent version change could be prevented?
If anybody has an idea and knows how we could enhance the build, please let me know, since I would be happy to avoid an enforced qualifier update.