### PR TITLE
Resources / Runtime tests: Do not depend on higher-level plug-ins.

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
+++ b/resources/tests/org.eclipse.core.tests.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Resources
 Bundle-SymbolicName: org.eclipse.core.tests.resources; singleton:=true
-Bundle-Version: 3.11.1000.qualifier
+Bundle-Version: 3.11.1100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.filesystem,
  org.eclipse.core.tests.internal.alias,

--- a/resources/tests/org.eclipse.core.tests.resources/pom.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/pom.xml
@@ -18,7 +18,7 @@
     <version>4.38.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.core.tests.resources</artifactId>
-  <version>3.11.1000-SNAPSHOT</version>
+  <version>3.11.1100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -1101,9 +1101,9 @@ public class IResourceTest {
 		sourceProj.open(createTestMonitor());
 		// create a new filter.
 		if (applyResFilter) {
-			String MULTI_FILT_ID = "org.eclipse.ui.ide.multiFilter";
-			String FILT_ARG = "1.0-length-equals-false-false-10485760";
-			FileInfoMatcherDescription filterDesc = new FileInfoMatcherDescription(MULTI_FILT_ID, FILT_ARG);
+			String filterProviderId = "org.eclipse.core.resources.regexFilterMatcher";
+			String filterArguments = "foo.*";
+			FileInfoMatcherDescription filterDesc = new FileInfoMatcherDescription(filterProviderId, filterArguments);
 			int EXCL_FILE_GT = IResourceFilterDescription.EXCLUDE_ALL + IResourceFilterDescription.FILES
 					+ IResourceFilterDescription.INHERITABLE;
 			sourceProj.createFilter(EXCL_FILE_GT, filterDesc, IResource.BACKGROUND_REFRESH, createTestMonitor());

--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.21.700.qualifier
+Bundle-Version: 3.21.800.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
@@ -60,6 +60,7 @@ import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
@@ -222,11 +223,25 @@ public class PreferencesServiceTest {
 	@Test
 	public void testLookupOrder() {
 		IPreferencesService service = Platform.getPreferencesService();
-		String[] defaultOrder = new String[] {"project", //$NON-NLS-1$
+		List<String> defaultOrderList = new ArrayList<>(List.of( //
 				InstanceScope.SCOPE, //
 				ConfigurationScope.SCOPE, //
 				UserScope.SCOPE, //
-				DefaultScope.SCOPE};
+				DefaultScope.SCOPE) //
+		);
+		Bundle resourcesBundle = Platform.getBundle("org.eclipse.core.resources");
+		if (resourcesBundle != null) {
+			if (resourcesBundle.getState() == Bundle.ACTIVE) {
+				// "project" scope is added via
+				// PreferencesService.prependScopeToDefaultDefaultLookupOrder(String)
+				// by org.eclipse.core.internal.resources.Workspace, when the
+				// org.eclipse.core.resources bundle is started, which depends on
+				// the test execution environment (is the UI harness part of the
+				// launch?)
+				defaultOrderList.add(0, "project");
+			}
+		}
+		String[] defaultOrder = defaultOrderList.toArray(String[]::new);
 		String[] fullOrder = new String[] {"a", "b", "c"};
 		String[] nullKeyOrder = new String[] {"e", "f", "g"};
 		String qualifier = getUniqueString();


### PR DESCRIPTION
* PreferencesServiceTest is not deterministic but its behavior changes depending on the presence of downstream plug-in org.eclipse.core.resources. Take this into account.

* IResourceTest should not depend on downstream plug-in org.eclipse.ui.ide (even inside a downstream repository). Use a different (upstream) filter provider in the unit test instead.

These downstream plug-ins are currently only visible because Tycho adds the full-blown UI test harness to the target platform unconditionally, even if there is no such actual dependency [1]. This is a cleanup in preparation for [2].

[1] https://github.com/eclipse-tycho/tycho/issues/5349
[2] https://github.com/eclipse-tycho/tycho/pull/5362