### PR TITLE
Eliminate the nested platform.jar from org.eclipse.platform

### DIFF
--- a/platform/org.eclipse.platform/.classpath
+++ b/platform/org.eclipse.platform/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="bin-intro" path="src-intro"/>
+	<classpathentry kind="src" output="bin" path="src-intro"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/platform/org.eclipse.platform/META-INF/MANIFEST.MF
+++ b/platform/org.eclipse.platform/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform; singleton:=true
 Bundle-Version: 4.38.0.qualifier
-Bundle-ClassPath: platform.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.intro;bundle-version="[3.2.0,4.0.0)",

--- a/platform/org.eclipse.platform/build.properties
+++ b/platform/org.eclipse.platform/build.properties
@@ -30,8 +30,8 @@ bin.includes = about.html,\
                plugin.properties,\
                splash.png,\
                intro/,\
-               platform.jar,\
                META-INF/,\
+               .,\
                narrow_book.css,\
                disabled_book.css,\
                book.css,\
@@ -50,9 +50,9 @@ bin.includes = about.html,\
                org.eclipse.ui.intro.universal.solstice/,\
                keys/, \
                icons/
+source.. = src-intro
+output.. = bin
 src.includes = about.html
-source.platform.jar = src-intro/
-output.platform.jar = bin-intro/
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 tycho.pomless.parent = ../../


### PR DESCRIPTION
- I believe this remains like this for historical purposes when there was also a startup.jar in that bundle.