### PR TITLE
Update export/import launch icons with simpler ones

### DIFF
--- a/debug/org.eclipse.debug.ui/icons/full/elcl16/export_config.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/elcl16/export_config.svg
@@ -1,294 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="16"
-   height="16"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.0 r9654"
-   sodipodi:docname="export_config_obj.svg">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient4838-07-5-1">
-      <stop
-         id="stop4840-3-2-2"
-         offset="0"
-         style="stop-color:#4177af;stop-opacity:1;" />
-      <stop
-         style="stop-color:#14518f;stop-opacity:1;"
-         offset="0.59750789"
-         id="stop4846-52-17-4" />
-      <stop
-         id="stop4842-56-0-9"
-         offset="1"
-         style="stop-color:#6ea2d8;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       y2="457.95499"
-       x2="388.63736"
-       y1="478.18777"
-       x1="388.63736"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient13741-3-5"
-       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0-5-8"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0-5-8">
-      <stop
-         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4-4-7"
-         offset="0"
-         style="stop-color:#4f9e55;stop-opacity:1" />
-      <stop
-         style="stop-color:#3c8d49;stop-opacity:1;"
-         offset="0.5"
-         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0-1-8" />
-      <stop
-         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7-6-9"
-         offset="1"
-         style="stop-color:#a4e173;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       y2="1056.2894"
-       x2="15.633883"
-       y1="1054.6906"
-       x1="16.965528"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient13743-6-7"
-       xlink:href="#linearGradient9276-9-4-7"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient9276-9-4-7">
-      <stop
-         style="stop-color:#9dd560;stop-opacity:1"
-         offset="0"
-         id="stop9278-0-5-1" />
-      <stop
-         style="stop-color:#499851;stop-opacity:1"
-         offset="1"
-         id="stop9280-5-2-6" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4838-07-5-1"
-       id="linearGradient17601"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0333065,0,0,1.0333065,-5.5682784,1021.4443)"
-       x1="5.875"
-       y1="24.6875"
-       x2="15"
-       y2="24.6875" />
-    <linearGradient
-       id="linearGradient4922-2"
-       inkscape:collect="always">
-      <stop
-         id="stop4924-3"
-         offset="0"
-         style="stop-color:#0d5c9a;stop-opacity:1" />
-      <stop
-         id="stop4926-7"
-         offset="1"
-         style="stop-color:#4077a7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       y2="1050.3622"
-       x2="6.9999828"
-       y1="1048.8934"
-       x1="8.5"
-       gradientTransform="translate(-3.9802819,-0.99114279)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient19869"
-       xlink:href="#linearGradient4922-2"
-       inkscape:collect="always" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask19970">
-      <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path19972"
-         sodipodi:cx="-6.7838054"
-         sodipodi:cy="9.7465248"
-         sodipodi:rx="4.3089318"
-         sodipodi:ry="4.3089318"
-         d="m -2.4748735,9.7465248 a 4.3089318,4.3089318 0 1 1 -8.6178635,0 4.3089318,4.3089318 0 1 1 8.6178635,0 z"
-         transform="matrix(1.2065384,0,0,1.2065384,15.710162,1030.1032)" />
-    </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter20746"
-       x="-0.24"
-       width="1.48"
-       y="-0.24"
-       height="1.48">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.3238898"
-         id="feGaussianBlur20748" />
-    </filter>
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313709"
-     inkscape:cx="16.604646"
-     inkscape:cy="1.3749919"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1147"
-     inkscape:window-height="752"
-     inkscape:window-x="1198"
-     inkscape:window-y="809"
-     inkscape:window-maximized="0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid17599" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     style="display:inline"
-     transform="translate(0,-1036.3622)">
-    <g
-       id="g17594"
-       transform="matrix(1.2065384,0,0,1.2065384,1.2248827,-221.37405)">
-      <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#3784be;stroke-width:0.50000000000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path6139"
-         sodipodi:cx="-6.7838054"
-         sodipodi:cy="9.7465248"
-         sodipodi:rx="4.3089318"
-         sodipodi:ry="4.3089318"
-         d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
-         transform="translate(12.005651,1037.2461)" />
-      <path
-         sodipodi:nodetypes="scccccscccccccccccccccsccccccccccscccccccccccccccccsccc"
-         inkscape:connector-curvature="0"
-         id="path6139-5"
-         d="m 5.216858,1042.4979 c -0.436143,0 -0.861017,0.077 -1.259342,0.1937 l 0.516653,0.6782 0.839562,1.0655 0.807271,-1.0655 0.516653,-0.6136 c -0.446184,-0.1501 -0.924009,-0.2583 -1.420797,-0.2583 z m -2.195776,0.6136 c -0.747196,0.4267 -1.348234,1.0416 -1.743705,1.8083 l 0.678108,0.097 1.323924,0.1615 -0.161454,-1.324 -0.09687,-0.7426 z m 4.391553,0 -0.09687,0.7426 -0.161454,1.324 1.356215,-0.1615 0.645817,-0.064 c -0.395006,-0.778 -0.988302,-1.409 -1.743705,-1.8405 z m -6.458166,2.5832 c -0.116895,0.3983 -0.193745,0.8232 -0.193745,1.2593 0,0.4503 0.101739,0.882 0.226036,1.2917 l 0.548944,-0.4521 1.065597,-0.8072 -1.065597,-0.8396 z m 8.524779,0.032 -0.548944,0.4198 -1.065598,0.8396 1.065598,0.8072 0.516653,0.4198 c 0.118617,-0.401 0.226036,-0.8199 0.226036,-1.2594 0,-0.4253 -0.08236,-0.8375 -0.193745,-1.227 z m -6.199839,3.0677 -1.323924,0.1614 -0.645817,0.064 c 0.395954,0.7492 0.977064,1.3565 1.711414,1.7761 l 0.09687,-0.6782 0.161454,-1.3239 z m 3.874899,0 0.161454,1.3238 0.09687,0.6782 c 0.73435,-0.4195 1.31546,-1.0269 1.711414,-1.7761 l -0.613526,-0.064 c -0.451932,-0.054 -0.905156,-0.108 -1.356215,-0.1619 z m -1.840577,0.7426 -0.839562,1.0333 -0.484362,0.6458 c 0.389576,0.1114 0.801707,0.1938 1.227051,0.1938 0.482666,0 0.95327,-0.084 1.388506,-0.226 l -0.484362,-0.6136 z"
-         style="color:#000000;fill:url(#linearGradient17601);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccccscccs"
-         inkscape:connector-curvature="0"
-         id="rect9436"
-         d="m 0.524759,1042.9675 3.79253,5.2259 c 0,0 1.216807,0.4672 1.684108,-1e-4 l 0.19297,-0.193 c 0.467299,-0.4673 -8e-6,-1.6841 -8e-6,-1.6841 z m 4.055643,3.5242 c 0.376798,-0.3768 0.991528,-0.3769 1.368362,0 0.376788,0.3767 0.376773,0.9914 -2.5e-5,1.3682 -0.376798,0.3769 -0.991507,0.3769 -1.368294,0 -0.376855,-0.3768 -0.376841,-0.9915 -4.3e-5,-1.3682 z"
-         style="color:#000000;fill:#ffffd5;fill-opacity:1;fill-rule:nonzero;stroke:#384e6e;stroke-width:0.50000000000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    </g>
-    <g
-       id="g19963"
-       mask="url(#mask19970)">
-      <g
-         transform="matrix(0.56502437,0,0,0.56502437,7.4012139,454.22542)"
-         inkscape:label="Layer 1"
-         id="layer1-0-8-7"
-         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:3.53967032999999990;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter20746)">
-        <g
-           style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:3.53967033;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g8159-2-9-9"
-           transform="translate(-8.2201167,-12.904699)">
-          <path
-             sodipodi:type="arc"
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:5.68159035;stroke-miterlimit:4;stroke-dasharray:none"
-             id="path10796-2-6-0-3-1-0"
-             sodipodi:cx="388.125"
-             sodipodi:cy="468.23718"
-             sodipodi:rx="10.625"
-             sodipodi:ry="10.625"
-             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path8117-2-7-8"
-             d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.53967033;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
-          <path
-             sodipodi:type="arc"
-             style="fill:#ffffff;stroke:#ffffff;stroke-width:5.68159035;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-             id="path10796-2-6-0-5-3-5"
-             sodipodi:cx="388.125"
-             sodipodi:cy="468.23718"
-             sodipodi:rx="10.625"
-             sodipodi:ry="10.625"
-             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
-        </g>
-      </g>
-    </g>
-    <g
-       style="display:inline"
-       id="layer1-0-8"
-       inkscape:label="Layer 1"
-       transform="matrix(0.56502437,0,0,0.56502437,7.4012139,454.22542)">
-      <g
-         transform="translate(-8.2201167,-12.904699)"
-         id="g8159-2-9"
-         style="display:inline">
-        <path
-           transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
-           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-           sodipodi:ry="10.625"
-           sodipodi:rx="10.625"
-           sodipodi:cy="468.23718"
-           sodipodi:cx="388.125"
-           id="path10796-2-6-0-3-1"
-           style="fill:url(#linearGradient13741-3-5);fill-opacity:1;stroke:none;display:inline"
-           sodipodi:type="arc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient13743-6-7);stroke-width:0.64604712;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
-           d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
-           id="path8117-2-7"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccc" />
-        <path
-           transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
-           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-           sodipodi:ry="10.625"
-           sodipodi:rx="10.625"
-           sodipodi:cy="468.23718"
-           sodipodi:cx="388.125"
-           id="path10796-2-6-0-5-3"
-           style="fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-           sodipodi:type="arc" />
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="path4920"
-       d="m 0.76971825,1047.3711 4.24999995,0 0,4.2813 z"
-       style="fill:url(#linearGradient19869);fill-opacity:1;stroke:none;display:inline" />
-  </g>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+	<defs>
+		<clipPath clipPathUnits="userSpaceOnUse" id="cp1">
+			<path d="m12.72 5.5c0 1.38-0.54 2.7-1.52 3.68-0.97 0.97-2.3 1.52-3.67 1.52-1.38 0-2.71-0.55-3.68-1.52-0.98-0.98-1.52-2.3-1.52-3.68 0-1.38 0.54-2.7 1.52-3.68 0.97-0.97 2.3-1.52 3.68-1.52 1.37 0 2.7 0.55 3.67 1.52 0.98 0.98 1.52 2.3 1.52 3.68z"/>
+		</clipPath>
+		<linearGradient id="g1" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-7.122,7.122,0,4.176,13.482)">
+			<stop offset="0" stop-color="#4f9e55"/>
+			<stop offset=".5" stop-color="#3c8d49"/>
+			<stop offset="1" stop-color="#a4e173"/>
+		</linearGradient>
+		<linearGradient id="g2" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.752,.903,-0.92,-0.766,4.343,8.498)">
+			<stop offset="0" stop-color="#9dd560"/>
+			<stop offset="1" stop-color="#499851"/>
+		</linearGradient>
+		<linearGradient id="g3" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-2.22,-2.174,1.094,-1.118,9.55,8.485)">
+			<stop offset="0" stop-color="#0d5c9a"/>
+			<stop offset="1" stop-color="#4077a7"/>
+		</linearGradient>
+	</defs>
+	<style>
+		.s0 { fill: #ffffff;stroke: #3784be;stroke-width: .6 } 
+		.s1 { fill: url(#g1) } 
+		.s2 { fill: #ffffff;stroke: url(#g2);stroke-width: .4 } 
+		.s3 { fill: none;stroke: #14733c;stroke-linecap: round;stroke-linejoin: round;stroke-width: .5 } 
+		.s4 { fill: url(#g3) } 
+	</style>
+	<g id="layer1">
+		<g id="g17594">
+			<path id="path6139" class="s0" d="m12.72 5.5c0 2.87-2.32 5.2-5.19 5.2-2.88 0-5.2-2.33-5.2-5.2 0-2.87 2.32-5.2 5.2-5.2 2.87 0 5.19 2.33 5.19 5.2z"/>
+		</g>
+		<g id="Clip-Path: g19963" clip-path="url(#cp1)">
+		</g>
+		<g id="layer1-0-8">
+			<g id="g8159-2-9">
+				<path id="path10796-2-6-0-3-1" class="s1" d="m7.74 9.98c0 2.06-1.68 3.74-3.74 3.74-2.07 0-3.74-1.68-3.74-3.74 0-2.07 1.67-3.74 3.74-3.74 2.06 0 3.74 1.67 3.74 3.74z"/>
+				<path id="path8117-2-7" class="s2" d="m2.69 7.12l3.42 2.93-3.39 2.86z"/>
+				<path id="path10796-2-6-0-5-3" class="s3" d="m7.74 9.98c0 2.06-1.68 3.74-3.74 3.74-2.07 0-3.74-1.68-3.74-3.74 0-2.07 1.67-3.74 3.74-3.74 2.06 0 3.74 1.67 3.74 3.74z"/>
+			</g>
+		</g>
+		<path id="path4920" class="s4" d="m10.29 9.24v-6.24h-6.29z"/>
+	</g>
 </svg>

--- a/debug/org.eclipse.debug.ui/icons/full/elcl16/import_config.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/elcl16/import_config.svg
@@ -1,294 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="16"
-   height="16"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.0 r9654"
-   sodipodi:docname="import_config_obj.svg">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient4838-07-5-1">
-      <stop
-         id="stop4840-3-2-2"
-         offset="0"
-         style="stop-color:#4177af;stop-opacity:1;" />
-      <stop
-         style="stop-color:#14518f;stop-opacity:1;"
-         offset="0.59750789"
-         id="stop4846-52-17-4" />
-      <stop
-         id="stop4842-56-0-9"
-         offset="1"
-         style="stop-color:#6ea2d8;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       y2="457.95499"
-       x2="388.63736"
-       y1="478.18777"
-       x1="388.63736"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient13741-3-5"
-       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0-5-8"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0-5-8">
-      <stop
-         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4-4-7"
-         offset="0"
-         style="stop-color:#4f9e55;stop-opacity:1" />
-      <stop
-         style="stop-color:#3c8d49;stop-opacity:1;"
-         offset="0.5"
-         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0-1-8" />
-      <stop
-         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7-6-9"
-         offset="1"
-         style="stop-color:#a4e173;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       y2="1056.2894"
-       x2="15.633883"
-       y1="1054.6906"
-       x1="16.965528"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient13743-6-7"
-       xlink:href="#linearGradient9276-9-4-7"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient9276-9-4-7">
-      <stop
-         style="stop-color:#9dd560;stop-opacity:1"
-         offset="0"
-         id="stop9278-0-5-1" />
-      <stop
-         style="stop-color:#499851;stop-opacity:1"
-         offset="1"
-         id="stop9280-5-2-6" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4838-07-5-1"
-       id="linearGradient17601"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0333065,0,0,1.0333065,-5.5682784,1021.4443)"
-       x1="5.875"
-       y1="24.6875"
-       x2="15"
-       y2="24.6875" />
-    <linearGradient
-       id="linearGradient4922-2"
-       inkscape:collect="always">
-      <stop
-         id="stop4924-3"
-         offset="0"
-         style="stop-color:#0d5c9a;stop-opacity:1" />
-      <stop
-         id="stop4926-7"
-         offset="1"
-         style="stop-color:#4077a7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       y2="1050.3622"
-       x2="6.9999828"
-       y1="1048.8934"
-       x1="8.5"
-       gradientTransform="matrix(1,0,0,-1,6.9999999,2100.0146)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient19869"
-       xlink:href="#linearGradient4922-2"
-       inkscape:collect="always" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask19970">
-      <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path19972"
-         sodipodi:cx="-6.7838054"
-         sodipodi:cy="9.7465248"
-         sodipodi:rx="4.3089318"
-         sodipodi:ry="4.3089318"
-         d="m -2.4748735,9.7465248 a 4.3089318,4.3089318 0 1 1 -8.6178635,0 4.3089318,4.3089318 0 1 1 8.6178635,0 z"
-         transform="matrix(1.2065384,0,0,1.2065384,15.710162,1030.1032)" />
-    </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter20746"
-       x="-0.24"
-       width="1.48"
-       y="-0.24"
-       height="1.48">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.3238898"
-         id="feGaussianBlur20748" />
-    </filter>
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313709"
-     inkscape:cx="6.0422389"
-     inkscape:cy="1.3749919"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1147"
-     inkscape:window-height="752"
-     inkscape:window-x="1198"
-     inkscape:window-y="809"
-     inkscape:window-maximized="0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid17599" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     style="display:inline"
-     transform="translate(0,-1036.3622)">
-    <g
-       id="g17594"
-       transform="matrix(1.2065384,0,0,1.2065384,1.2248827,-221.37405)">
-      <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#3784be;stroke-width:0.50000000000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path6139"
-         sodipodi:cx="-6.7838054"
-         sodipodi:cy="9.7465248"
-         sodipodi:rx="4.3089318"
-         sodipodi:ry="4.3089318"
-         d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
-         transform="translate(12.005651,1037.2461)" />
-      <path
-         sodipodi:nodetypes="scccccscccccccccccccccsccccccccccscccccccccccccccccsccc"
-         inkscape:connector-curvature="0"
-         id="path6139-5"
-         d="m 5.216858,1042.4979 c -0.436143,0 -0.861017,0.077 -1.259342,0.1937 l 0.516653,0.6782 0.839562,1.0655 0.807271,-1.0655 0.516653,-0.6136 c -0.446184,-0.1501 -0.924009,-0.2583 -1.420797,-0.2583 z m -2.195776,0.6136 c -0.747196,0.4267 -1.348234,1.0416 -1.743705,1.8083 l 0.678108,0.097 1.323924,0.1615 -0.161454,-1.324 -0.09687,-0.7426 z m 4.391553,0 -0.09687,0.7426 -0.161454,1.324 1.356215,-0.1615 0.645817,-0.064 c -0.395006,-0.778 -0.988302,-1.409 -1.743705,-1.8405 z m -6.458166,2.5832 c -0.116895,0.3983 -0.193745,0.8232 -0.193745,1.2593 0,0.4503 0.101739,0.882 0.226036,1.2917 l 0.548944,-0.4521 1.065597,-0.8072 -1.065597,-0.8396 z m 8.524779,0.032 -0.548944,0.4198 -1.065598,0.8396 1.065598,0.8072 0.516653,0.4198 c 0.118617,-0.401 0.226036,-0.8199 0.226036,-1.2594 0,-0.4253 -0.08236,-0.8375 -0.193745,-1.227 z m -6.199839,3.0677 -1.323924,0.1614 -0.645817,0.064 c 0.395954,0.7492 0.977064,1.3565 1.711414,1.7761 l 0.09687,-0.6782 0.161454,-1.3239 z m 3.874899,0 0.161454,1.3238 0.09687,0.6782 c 0.73435,-0.4195 1.31546,-1.0269 1.711414,-1.7761 l -0.613526,-0.064 c -0.451932,-0.054 -0.905156,-0.108 -1.356215,-0.1619 z m -1.840577,0.7426 -0.839562,1.0333 -0.484362,0.6458 c 0.389576,0.1114 0.801707,0.1938 1.227051,0.1938 0.482666,0 0.95327,-0.084 1.388506,-0.226 l -0.484362,-0.6136 z"
-         style="color:#000000;fill:url(#linearGradient17601);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccccscccs"
-         inkscape:connector-curvature="0"
-         id="rect9436"
-         d="m 0.524759,1042.9675 3.79253,5.2259 c 0,0 1.216807,0.4672 1.684108,-1e-4 l 0.19297,-0.193 c 0.467299,-0.4673 -8e-6,-1.6841 -8e-6,-1.6841 z m 4.055643,3.5242 c 0.376798,-0.3768 0.991528,-0.3769 1.368362,0 0.376788,0.3767 0.376773,0.9914 -2.5e-5,1.3682 -0.376798,0.3769 -0.991507,0.3769 -1.368294,0 -0.376855,-0.3768 -0.376841,-0.9915 -4.3e-5,-1.3682 z"
-         style="color:#000000;fill:#ffffd5;fill-opacity:1;fill-rule:nonzero;stroke:#384e6e;stroke-width:0.50000000000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    </g>
-    <g
-       id="g19963"
-       mask="url(#mask19970)">
-      <g
-         transform="matrix(0.56502437,0,0,0.56502437,7.4012139,454.22542)"
-         inkscape:label="Layer 1"
-         id="layer1-0-8-7"
-         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:3.53967032999999990;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter20746)">
-        <g
-           style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:3.53967033;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g8159-2-9-9"
-           transform="translate(-8.2201167,-12.904699)">
-          <path
-             sodipodi:type="arc"
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:5.68159035;stroke-miterlimit:4;stroke-dasharray:none"
-             id="path10796-2-6-0-3-1-0"
-             sodipodi:cx="388.125"
-             sodipodi:cy="468.23718"
-             sodipodi:rx="10.625"
-             sodipodi:ry="10.625"
-             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path8117-2-7-8"
-             d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.53967033;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
-          <path
-             sodipodi:type="arc"
-             style="fill:#ffffff;stroke:#ffffff;stroke-width:5.68159035;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-             id="path10796-2-6-0-5-3-5"
-             sodipodi:cx="388.125"
-             sodipodi:cy="468.23718"
-             sodipodi:rx="10.625"
-             sodipodi:ry="10.625"
-             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)" />
-        </g>
-      </g>
-    </g>
-    <g
-       style="display:inline"
-       id="layer1-0-8"
-       inkscape:label="Layer 1"
-       transform="matrix(0.56502437,0,0,0.56502437,7.4012139,454.22542)">
-      <g
-         transform="translate(-8.2201167,-12.904699)"
-         id="g8159-2-9"
-         style="display:inline">
-        <path
-           transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
-           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-           sodipodi:ry="10.625"
-           sodipodi:rx="10.625"
-           sodipodi:cy="468.23718"
-           sodipodi:cx="388.125"
-           id="path10796-2-6-0-3-1"
-           style="fill:url(#linearGradient13741-3-5);fill-opacity:1;stroke:none;display:inline"
-           sodipodi:type="arc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient13743-6-7);stroke-width:0.64604712;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
-           d="m 14.039346,1052.2494 6.0625,5.1875 -6,5.0625 z"
-           id="path8117-2-7"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccc" />
-        <path
-           transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
-           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
-           sodipodi:ry="10.625"
-           sodipodi:rx="10.625"
-           sodipodi:cy="468.23718"
-           sodipodi:cx="388.125"
-           id="path10796-2-6-0-5-3"
-           style="fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-           sodipodi:type="arc" />
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="path4920"
-       d="m 11.75,1051.6524 4.25,0 0,-4.2813 z"
-       style="fill:url(#linearGradient19869);fill-opacity:1;stroke:none;display:inline" />
-  </g>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+	<defs>
+		<clipPath clipPathUnits="userSpaceOnUse" id="cp1">
+			<path d="m12.72 5.5c0 1.38-0.54 2.7-1.52 3.68-0.97 0.97-2.3 1.52-3.67 1.52-1.38 0-2.71-0.55-3.68-1.52-0.98-0.98-1.52-2.3-1.52-3.68 0-1.38 0.54-2.7 1.52-3.68 0.97-0.97 2.3-1.52 3.68-1.52 1.37 0 2.7 0.55 3.67 1.52 0.98 0.98 1.52 2.3 1.52 3.68z"/>
+		</clipPath>
+		<linearGradient id="g1" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-7.122,7.122,0,12.176,13.482)">
+			<stop offset="0" stop-color="#4f9e55"/>
+			<stop offset=".5" stop-color="#3c8d49"/>
+			<stop offset="1" stop-color="#a4e173"/>
+		</linearGradient>
+		<linearGradient id="g2" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.752,.903,-0.92,-0.766,12.343,8.498)">
+			<stop offset="0" stop-color="#9dd560"/>
+			<stop offset="1" stop-color="#499851"/>
+		</linearGradient>
+		<linearGradient id="g3" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-2.112,-2.068,4.109,-4.196,8.281,6.266)">
+			<stop offset="0" stop-color="#0d5c9a"/>
+			<stop offset="1" stop-color="#4077a7"/>
+		</linearGradient>
+	</defs>
+	<style>
+		.s0 { fill: #ffffff;stroke: #3784be;stroke-width: .6 } 
+		.s1 { fill: url(#g1) } 
+		.s2 { fill: #ffffff;stroke: url(#g2);stroke-width: .4 } 
+		.s3 { fill: none;stroke: #14733c;stroke-linecap: round;stroke-linejoin: round;stroke-width: .5 } 
+		.s4 { fill: url(#g3) } 
+	</style>
+	<g id="layer1">
+		<g id="g17594">
+			<path id="path6139" class="s0" d="m12.72 5.5c0 2.87-2.32 5.2-5.19 5.2-2.88 0-5.2-2.33-5.2-5.2 0-2.87 2.32-5.2 5.2-5.2 2.87 0 5.19 2.33 5.19 5.2z"/>
+		</g>
+		<g id="Clip-Path: g19963" clip-path="url(#cp1)">
+		</g>
+		<g id="layer1-0-8">
+			<g id="g8159-2-9">
+				<path id="path10796-2-6-0-3-1" class="s1" d="m15.74 9.98c0 2.06-1.68 3.74-3.74 3.74-2.07 0-3.74-1.68-3.74-3.74 0-2.07 1.67-3.74 3.74-3.74 2.06 0 3.74 1.67 3.74 3.74z"/>
+				<path id="path8117-2-7" class="s2" d="m10.69 7.12l3.42 2.93-3.39 2.86z"/>
+				<path id="path10796-2-6-0-5-3" class="s3" d="m15.74 9.98c0 2.06-1.68 3.74-3.74 3.74-2.07 0-3.74-1.68-3.74-3.74 0-2.07 1.67-3.74 3.74-3.74 2.06 0 3.74 1.67 3.74 3.74z"/>
+			</g>
+		</g>
+		<path id="path4920" class="s4" d="m3 7.01h5.98v-6.03z"/>
+	</g>
 </svg>


### PR DESCRIPTION
Before 
<img width="249" height="33" alt="Screenshot 2025-10-01 at 2 18 00 PM" src="https://github.com/user-attachments/assets/1bbd711b-4b64-42be-85fa-8a01167dbcd6" />

New
Export first and Import second
<img width="243" height="36" alt="Screenshot 2025-10-01 at 2 16 49 PM" src="https://github.com/user-attachments/assets/fcf13a11-34b2-4068-b773-1386b6a721f3" />


<img width="243" height="161" alt="image" src="https://github.com/user-attachments/assets/be5ab130-9bec-4f4c-9695-3205be94c407" /> <br>
( Changed background color to white to mimic light theme)
