### PR TITLE
[Win32] Fix deletion of read-only files not working with Java 25 #2178

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.11.300.qualifier
+Bundle-Version: 1.11.400.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)",

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
@@ -61,6 +61,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.osgi.util.NLS;
@@ -314,6 +315,12 @@ public class LocalFile extends FileStore {
 			} catch (AccessDeniedException e) {
 				// If the file is read only, it can't be deleted via Files.deleteIfExists()
 				// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=500306
+				// Since Java 25, just calling File#delete() is not sufficient anymore on Windows
+				// but the read-only state has to be cleared explicitly,
+				// see https://bugs.openjdk.org/browse/JDK-8355954
+				if (OS.isWindows()) {
+					target.setWritable(true);
+				}
 				if (target.delete()) {
 					infMonitor.worked();
 					return Status.OK_STATUS;


### PR DESCRIPTION
With Java 25, the behavior of File#delete() has been changed for read-only files on Windows. Previously, the operation also removed read-only files whereas now the operation fails in that case. LocalFile#delete() depends on the preexisting behavior. It ensures that read-only files are also deleted.

In order to preserve the behavior with Java 25, this change makes LocalFile#delete() explicitly remove the read-only attribute when deleting a read-only file on WIndows.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2178