### PR TITLE
Fix IllegalArgumentException with duplicate natures

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -581,7 +582,7 @@ public class ProjectDescription extends ModelObject implements IProjectDescripti
 			return true;
 		}
 		// has natures changed?
-		if (!Set.of(natures).equals(Set.of(description.natures))) {
+		if (!new HashSet<>(Arrays.asList(natures)).equals(new HashSet<>(Arrays.asList(description.natures)))) {
 			return true;
 		}
 		// has buildspec changed?

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -167,6 +167,30 @@ public class NatureTest {
 		assertHasEnabledNature(NATURE_SNOW);
 	}
 
+	/**
+	 * Tests that duplicate natures in the project description don't cause
+	 * IllegalArgumentException. This is a regression test for a bug where
+	 * Set.of() was used which throws on duplicates.
+	 */
+	@Test
+	public void testDuplicateNatures() throws Throwable {
+		createInWorkspace(project);
+
+		// Set initial nature
+		setNatures(project, new String[] { NATURE_SIMPLE }, false);
+		assertHasEnabledNature(NATURE_SIMPLE);
+
+		// Try to set natures with a duplicate - this should not throw IllegalArgumentException
+		// The duplicate should be handled gracefully (deduplication happens automatically)
+		IProjectDescription desc = project.getDescription();
+		desc.setNatureIds(new String[] { NATURE_SIMPLE, NATURE_SIMPLE });
+		// This should not throw IllegalArgumentException when hasPrivateChanges is called
+		project.setDescription(desc, IResource.KEEP_HISTORY, createTestMonitor());
+		
+		// After deduplication, only one instance of the nature should remain
+		assertHasEnabledNature(NATURE_SIMPLE);
+	}
+
 	@Test
 	public void testNatureLifecyle() throws Throwable {
 		createInWorkspace(project);


### PR DESCRIPTION
Changed ProjectDescription.hasPrivateChanges() to use HashSet instead of Set.of() to handle duplicate natures gracefully. Set.of() throws IllegalArgumentException on duplicates, but HashSet tolerates them and correctly compares nature sets.

Also added test case testDuplicateNatures() to ensure this regression doesn't occur again.

Derived from here:
- https://github.com/eclipse-platform/eclipse.platform/pull/2183