### PR TITLE
Convert terminal test suites from JUnit3/4 to JUnit5

### DIFF
--- a/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
+++ b/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Export-Package: org.eclipse.terminal.internal.connector;x-internal:=true,
  org.eclipse.terminal.model,
  org.eclipse.terminal.test
 Import-Package: org.junit.jupiter.api;version="[5.9.3,6.0.0)",
- org.junit.jupiter.api.function;version="[5.9.3,6.0.0)"
+ org.junit.jupiter.api.function;version="[5.9.3,6.0.0)",
+ org.junit.platform.suite.api;version="[1.9.3,2.0.0)"
 Automatic-Module-Name: org.eclipse.terminal.test

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/emulator/AllTestSuite.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/emulator/AllTestSuite.java
@@ -12,27 +12,17 @@
  *******************************************************************************/
 package org.eclipse.terminal.internal.emulator;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Terminal emulator test cases.
  * Runs in emulator package to allow access to default visible items.
  */
-public class AllTestSuite extends TestCase {
-	public AllTestSuite() {
-		super(null);
-	}
-
-	public AllTestSuite(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite(AllTestSuite.class.getName());
-		suite.addTestSuite(VT100EmulatorBackendTest.class);
-		return suite;
-	}
+@Suite
+@SelectClasses({ //
+		VT100EmulatorBackendTest.class, //
+})
+public class AllTestSuite {
 
 }

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/model/AllTestSuite.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/model/AllTestSuite.java
@@ -12,36 +12,26 @@
  *******************************************************************************/
 package org.eclipse.terminal.internal.model;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Internal Terminal Model test cases.
  * Runs in internal model package to allow access to default visible items.
  */
-public class AllTestSuite extends TestCase {
-	public AllTestSuite() {
-		super(null);
-	}
-
-	public AllTestSuite(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite(AllTestSuite.class.getName());
-		suite.addTestSuite(SnapshotChangesTest.class);
-		suite.addTestSuite(SynchronizedTerminalTextDataTest.class);
-		suite.addTestSuite(TerminalTextDataFastScrollTest.class);
-		suite.addTestSuite(TerminalTextDataFastScrollMaxHeightTest.class);
-		suite.addTestSuite(TerminalTextDataPerformanceTest.class);
-		suite.addTestSuite(TerminalTextDataSnapshotTest.class);
-		suite.addTestSuite(TerminalTextDataSnapshotWindowTest.class);
-		suite.addTestSuite(TerminalTextDataStoreTest.class);
-		suite.addTestSuite(TerminalTextDataTest.class);
-		suite.addTestSuite(TerminalTextDataWindowTest.class);
-		return suite;
-	}
+@Suite
+@SelectClasses({ //
+		SnapshotChangesTest.class, //
+		SynchronizedTerminalTextDataTest.class, //
+		TerminalTextDataFastScrollTest.class, //
+		TerminalTextDataFastScrollMaxHeightTest.class, //
+		TerminalTextDataPerformanceTest.class, //
+		TerminalTextDataSnapshotTest.class, //
+		TerminalTextDataSnapshotWindowTest.class, //
+		TerminalTextDataStoreTest.class, //
+		TerminalTextDataTest.class, //
+		TerminalTextDataWindowTest.class, //
+})
+public class AllTestSuite {
 
 }

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/model/AllTestSuite.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/model/AllTestSuite.java
@@ -12,29 +12,18 @@
  *******************************************************************************/
 package org.eclipse.terminal.model;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Public Terminal Model test cases.
  * Runs in internal model package to allow access to default visible items.
  */
-public class AllTestSuite extends TestCase {
-	public AllTestSuite() {
-		super(null);
-	}
-
-	public AllTestSuite(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite(AllTestSuite.class.getName());
-		suite.addTest(new JUnit4TestAdapter(TerminalColorUITest.class));
-		suite.addTestSuite(StyleTest.class);
-		return suite;
-	}
+@Suite
+@SelectClasses({ //
+		TerminalColorUITest.class, //
+		StyleTest.class, //
+})
+public class AllTestSuite {
 
 }

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/test/AutomatedPluginTestSuite.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/test/AutomatedPluginTestSuite.java
@@ -13,27 +13,17 @@
 
 package org.eclipse.terminal.test;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Master Test Suite to run all Terminal plug-in tests.
  */
-public class AutomatedPluginTestSuite extends TestCase {
-	/**
-	 * Call each AllTestSuite class from each of the test packages.
-	 */
-	public static Test suite() {
-		TestSuite suite = new TestSuite(AutomatedPluginTestSuite.class.getName());
-		//These tests require Eclipse Platform to be up
-		suite.addTestSuite(org.eclipse.terminal.internal.connector.TerminalConnectorPluginTest.class);
-		suite.addTestSuite(org.eclipse.terminal.internal.connector.TerminalConnectorFactoryTest.class);
-
-		//These tests must run as plain JUnit because they require access
-		//to "package" protected methods
-		//suite.addTest(AutomatedTestSuite.suite());
-		return suite;
-	}
+@Suite
+@SelectClasses({ //
+		org.eclipse.terminal.internal.connector.TerminalConnectorPluginTest.class, //
+		org.eclipse.terminal.internal.connector.TerminalConnectorFactoryTest.class, //
+})
+public class AutomatedPluginTestSuite {
 
 }

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/test/AutomatedTestSuite.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/test/AutomatedTestSuite.java
@@ -12,35 +12,22 @@
  *******************************************************************************/
 package org.eclipse.terminal.test;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Master test suite to run all terminal unit tests.
  */
-public class AutomatedTestSuite extends TestCase {
+@Suite
+@SelectClasses({ //
+		org.eclipse.terminal.internal.emulator.AllTestSuite.class, //
+		org.eclipse.terminal.internal.model.AllTestSuite.class, //
+		org.eclipse.terminal.model.AllTestSuite.class, //
+		org.eclipse.terminal.internal.connector.TerminalConnectorTest.class, //
+		org.eclipse.terminal.internal.connector.TerminalToRemoteInjectionOutputStreamTest.class, //
+})
+public class AutomatedTestSuite {
 
 	public static final String PI_TERMINAL_TESTS = "org.eclipse.terminal.test"; //$NON-NLS-1$
 
-	public AutomatedTestSuite() {
-		super(null);
-	}
-
-	public AutomatedTestSuite(String name) {
-		super(name);
-	}
-
-	/**
-	 * Call each AllTestSuite class from each of the test packages.
-	 */
-	public static Test suite() {
-		TestSuite suite = new TestSuite(AutomatedTestSuite.class.getName());
-		suite.addTest(org.eclipse.terminal.internal.emulator.AllTestSuite.suite());
-		suite.addTest(org.eclipse.terminal.internal.model.AllTestSuite.suite());
-		suite.addTest(org.eclipse.terminal.model.AllTestSuite.suite());
-		suite.addTestSuite(org.eclipse.terminal.internal.connector.TerminalConnectorTest.class);
-		suite.addTestSuite(org.eclipse.terminal.internal.connector.TerminalToRemoteInjectionOutputStreamTest.class);
-		return suite;
-	}
 }


### PR DESCRIPTION
This commit converts the following terminal test suite classes from JUnit3/4 to JUnit5:
- AutomatedTestSuite.java: Converted from JUnit3 TestCase with suite() method to JUnit5 @Suite/@SelectClasses
- AutomatedPluginTestSuite.java: Converted from JUnit3 TestCase with suite() method to JUnit5 @Suite/@SelectClasses
- terminal.internal.emulator.AllTestSuite.java: Converted from JUnit3 TestCase with suite() method to JUnit5 @Suite/@SelectClasses
- terminal.internal.model.AllTestSuite.java: Converted from JUnit3 TestCase with suite() method to JUnit5 @Suite/@SelectClasses
- terminal.model.AllTestSuite.java: Converted from JUnit3 TestCase/JUnit4TestAdapter to JUnit5 @Suite/@SelectClasses

Updated MANIFEST.MF to include org.junit.platform.suite.api import for JUnit5 suite annotations.

All tests (336) continue to pass after the conversion. The migration follows the pattern of replacing:
- extends TestCase with plain classes
- static Test suite() methods with @Suite and @SelectClasses annotations
- suite.addTestSuite() calls with class references in @SelectClasses
- JUnit4TestAdapter usage with direct class references

The test functionality remains identical, only the test runner framework has been modernized.