### PR TITLE
Add Filter text support in Export Launch Configurations

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/WizardMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/WizardMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2008 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -46,6 +46,7 @@ public class WizardMessages extends NLS {
 	public static String ImportLaunchConfigurationsWizardPage_5;
 	public static String ImportLaunchConfigurationsWizardPage_6;
 	public static String ImportLaunchConfigurationsWizardPage_7;
+	public static String ImportLaunchTypeToFilter;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, WizardMessages.class);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/WizardMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/WizardMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2008 IBM Corporation and others.
+# Copyright (c) 2005, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -40,3 +40,4 @@ ImportLaunchConfigurationsWizardPage_4=You must select at least one configuratio
 ImportLaunchConfigurationsWizardPage_5=Import launch configurations from the local file system
 ImportLaunchConfigurationsWizardPage_6=From &Directory:
 ImportLaunchConfigurationsWizardPage_7=Brows&e...
+ImportLaunchTypeToFilter=Type filter text


### PR DESCRIPTION
This PR adds a filter text field that in Export launch configurations menu which will allows users to quickly find and select launch configurations without manually expanding all launch types or scrolling through the list.

Before : 
<img width="502" height="557" alt="Screenshot 2025-10-06 at 8 59 56 AM" src="https://github.com/user-attachments/assets/0d7e3308-c6dc-4a3c-906a-2b880bb25ed8" /> 


After :

<img width="519" height="684" alt="image" src="https://github.com/user-attachments/assets/4e0cec7d-b1fd-4015-a498-7b2f6945cb75" />

<img width="577" height="562" alt="image" src="https://github.com/user-attachments/assets/08b14e4a-0151-4659-b73f-49f7dbcc2e40" />

<img width="571" height="537" alt="image" src="https://github.com/user-attachments/assets/0784dc83-a2e2-4034-9f95-1a545cd2c562" />


