### PR TITLE
Fix Add to run/debug favorite not showing in launchconfiguration's context menu

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IDebugHelpContextIds.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IDebugHelpContextIds.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -81,6 +81,7 @@ public interface IDebugHelpContextIds {
 	String DEBUG_TOOLBAR_VIEW_ACTION = PREFIX + "debug_toolbar_view_action_context"; //$NON-NLS-1$
 	String DEBUG_TOOLBAR_WINDOW_ACTION = PREFIX + "debug_toolbar_window_action_context"; //$NON-NLS-1$
 	String DEBUG_TOOLBAR_BOTH_ACTION = PREFIX + "debug_toolbar_both_action_context"; //$NON-NLS-1$
+	String ADD_LAUNCH_CONFIGURATION_TO_FAV_ACTION = PREFIX + "Add_launch_configuration_to_favorites_action_context"; //$NON-NLS-1$
 
 	// Views
 	String DEBUG_VIEW = PREFIX + "debug_view_context"; //$NON-NLS-1$

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
@@ -253,5 +253,6 @@ public class ActionMessages extends NLS {
 	public static String EnableAllBreakpointsAction_1;
 	public static String EnableAllBreakpointsAction_3;
 	public static String BreakpointLabelDialog;
+	public static String RemoveFromFavoritesAction;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
@@ -16,6 +16,7 @@
 AddToFavoritesAction_1=Add to {0} &Favorites
 AddToFavoritesAction_2=Error
 AddToFavoritesAction_3=Unable to add to favorites.
+RemoveFromFavoritesAction=Remove from {0} Favorites
 
 ChangeVariableValue_errorDialogMessage=Setting the value failed.
 ChangeVariableValue_errorDialogTitle=Setting Value


### PR DESCRIPTION
This PR fixes` Add to run/debug favorite` context option not showing in launch contexts and updates execution to toggle removal/addition based on launch favorite lists. This will enable users to quickly add or remove launch favorites without going to `Organize favourites...` menu

<img width="304" height="534" alt="image" src="https://github.com/user-attachments/assets/7cae4037-bb7a-4c32-beb9-454c47ee1c1d" />
<img width="305" height="558" alt="image" src="https://github.com/user-attachments/assets/8bc82329-baac-45e1-b298-b2d3879d0a68" />

https://github.com/user-attachments/assets/0b58a1c4-a92f-463d-b2e6-2ac594f3a9d0



