### PR TITLE
Improve Copying Watch Expressions 

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyExpressionsToClipboardActionDelegate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyExpressionsToClipboardActionDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2017 Bachmann electronic GmbH and others.
+ *  Copyright (c) 2017, 2025 Bachmann electronic GmbH and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,15 +10,17 @@
  *
  *  Contributors:
  *     Bachmann electronic GmbH - initial API and implementation
+ *     IBM Corporation - Exclude Expression UI values while copying
  *******************************************************************************/
 package org.eclipse.debug.internal.ui.actions.expressions;
 
+import org.eclipse.debug.internal.core.WatchExpression;
+import org.eclipse.debug.internal.ui.DebugUIMessages;
 import org.eclipse.debug.internal.ui.viewers.model.VirtualCopyToClipboardActionDelegate;
 
 public class CopyExpressionsToClipboardActionDelegate extends VirtualCopyToClipboardActionDelegate {
 
 	private static final String QUOTE = "\""; //$NON-NLS-1$
-
 	@Override
 	protected String trimLabel(String rawLabel) {
 		String label = super.trimLabel(rawLabel);
@@ -30,6 +32,32 @@ public class CopyExpressionsToClipboardActionDelegate extends VirtualCopyToClipb
 		}
 		if (label.endsWith(QUOTE)) {
 			label = label.substring(0, label.length() - 1);
+		}
+		return label;
+	}
+
+	@Override
+	protected String exludeLabels(Object itemData, String label) {
+		if (itemData instanceof WatchExpression watchExp) {
+			if (watchExp.isPending() || watchExp.hasErrors()) {
+				if (label.equals(DebugUIMessages.DefaultLabelProvider_12)
+						|| label.contains(DebugUIMessages.DefaultLabelProvider_13)) {
+					return null;
+				}
+			}
+			if (!watchExp.isEnabled()) {
+				if (label.equals(DebugUIMessages.DefaultLabelProvider_15)) {
+					return null;
+				}
+				if (label.contains(DebugUIMessages.DefaultLabelProvider_15)) {
+					int index = label.lastIndexOf(DebugUIMessages.DefaultLabelProvider_15);
+					if (index != -1) {
+						label = label.substring(0, index)
+								+ label.substring(index + DebugUIMessages.DefaultLabelProvider_15.length());
+					}
+				}
+			}
+			return label;
 		}
 		return label;
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/VirtualCopyToClipboardActionDelegate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/VirtualCopyToClipboardActionDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2013 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -146,7 +146,8 @@ public class VirtualCopyToClipboardActionDelegate extends AbstractDebugActionDel
 		String[] labels = (String[]) item.getData(VirtualItem.LABEL_KEY);
 		if(labels != null && labels.length > 0) {
 			for (String label : labels) {
-				String text = trimLabel(label);
+				String text = exludeLabels(item.getData(), label);
+				text = trimLabel(text);
 				if (text != null && !text.equals(IInternalDebugCoreConstants.EMPTY_STRING)) {
 					buffer.append(text);
 				}
@@ -171,6 +172,19 @@ public class VirtualCopyToClipboardActionDelegate extends AbstractDebugActionDel
 		return label.trim();
 	}
 
+	/**
+	 * Excludes unwanted labels from the selected item
+	 *
+	 * @param itemData Selected object
+	 * @param label    Current label
+	 * @return filtered label or null if label or item is null
+	 */
+	protected String exludeLabels(Object itemData, String label) {
+		if (itemData == null || label == null) {
+			return null;
+		}
+		return label;
+	}
 	private static class ItemsToCopyVirtualItemValidator implements IVirtualItemValidator {
 
 		Set<VirtualItem> fItemsToCopy = Collections.EMPTY_SET;
@@ -367,4 +381,5 @@ public class VirtualCopyToClipboardActionDelegate extends AbstractDebugActionDel
 	public void runWithEvent(IAction action, Event event) {
 		run(action);
 	}
+
 }


### PR DESCRIPTION
This PR improves the behavior when copying a watch expression, preventing unwanted UI label text from being included in the clipboard. It ensures that only the intended expression is copied, enhancing usability and providing a cleaner, more consistent debugging experience.

<img width="580" height="247" alt="(disabled)" src="https://github.com/user-attachments/assets/354ba1a6-68f2-4ae4-9cd6-1530fb1975c2" />





Currently copying the expressions will generate this result in Clipboard - Making users to manually remove the labels
```
stringVal + " a "	sadsd a	
stringVal + " a "	(disabled)	
invalidS + "e"	<error(s)_during_the_evaluation> (disabled)	
spd2	(pending)	
"(disabled)"	(disabled)	
Add new expression		

```

With this change - 
```
stringVal + " a "	sadsd a	
stringVal + " a "		
invalidS + "e"		
spd2		
"(disabled)"		
Add new expression	
```	