### PR TITLE
Update from most org.eclipse.tm.terminal.* features to org.eclipse.terminal

### DIFF
--- a/terminal/features/org.eclipse.terminal.feature/build.properties
+++ b/terminal/features/org.eclipse.terminal.feature/build.properties
@@ -1,2 +1,3 @@
 bin.includes = feature.xml,\
+               p2.inf,\
                feature.properties

--- a/terminal/features/org.eclipse.terminal.feature/p2.inf
+++ b/terminal/features/org.eclipse.terminal.feature/p2.inf
@@ -1,0 +1,6 @@
+
+# The Eclipse Terminal feature replaces a whole set of features that the TM project
+# used to provide. The granularity of the TM project is collapsed into a single
+# feature in Eclipse Terminal. For ISVs that require additional granularity they
+# are advised to provide their own features that lists their requirements
+update.matchExp=providedCapabilities.exists(pc | pc.namespace == 'org.eclipse.equinox.p2.iu' && (pc.name == 'org.eclipse.terminal.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.connector.local.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.connector.ssh.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.connector.telnet.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.control.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.feature.feature.group' || pc.name == 'org.eclipse.tm.terminal.view.feature.feature.group'))


### PR DESCRIPTION
The Eclipse Terminal feature replaces a whole set of features that the TM project used to provide. The granularity of the TM project is collapsed into a single feature in Eclipse Terminal. For ISVs that require additional granularity they are advised to provide their own features that lists their requirements

With this PR all the org.eclipse.tm.terminal.* features will update to org.eclipse.terminal (except the cdtserial and remote connectors that are now considered downstream features of the terminal). There is a cooresponding CDT terminal change to remove all the now redundant org.eclipse.tm.terminal features from future update sites.

There is precedence for handling the rename in this way, when `org.eclipse.tcf.te.terminals.feature` was renamed to `org.eclipse.tm.terminal.feature` a p2.inf entry was created to handle upgrades across the rename.

### Example

For example if you start with EPP CPP 2025-09 which has org.eclipse.tm.terminal.feature and org.eclipse.tm.terminal.connector.cdtserial.feature explicitly included in [the product file](https://github.com/eclipse-packaging/packages/blob/d889e408b0c01ffaa39766ccb2c6ad53e6c8222b/packages/org.eclipse.epp.package.cpp.product/epp.product#L238) then you end up with the following installed:

```
eclipse/features/org.eclipse.tm.terminal.connector.cdtserial.feature_12.2.0.202507250901
eclipse/features/org.eclipse.tm.terminal.connector.local.feature_12.2.0.202507240827
eclipse/features/org.eclipse.tm.terminal.connector.ssh.feature_12.2.0.202507241300
eclipse/features/org.eclipse.tm.terminal.connector.telnet.feature_12.2.0.202507241539
eclipse/features/org.eclipse.tm.terminal.control.feature_12.2.0.202507251115
eclipse/features/org.eclipse.tm.terminal.feature_12.2.0.202507251115
eclipse/features/org.eclipse.tm.terminal.view.feature_12.2.0.202507251115
```

With this PR, updating will lead you to have only the serial and eclipse terminal features:

```
eclipse/features/org.eclipse.terminal.feature_1.0.100.v20251014-2032
eclipse/features/org.eclipse.tm.terminal.connector.cdtserial.feature_12.3.0.202510141948
```

This will be presented as the following to users on check for updates:

<img width="902" height="660" alt="Screenshot From 2025-10-14 17-07-33" src="https://github.com/user-attachments/assets/0195f7c1-ccf8-4aa3-87ad-c8ddc0a35e29" />

(Note that by the time CDT release for 2025-12 the exact behavior / name of cdt serial may be updated too so this screenshot may be out of date by then)

### Testing

To test this I did

1. Build the aggregator with this change included
2. Build CDT with the corresponding update (PR link to be provided soon)
3. Unpack `eclipse-cpp-2025-09-R-linux-gtk-x86_64.tar.gz` and run Eclipse
4. Add the update sites from step 1 and step 2 to available software sites
5. Run check for updates
6. Check that the old org.eclipse.tm.terminal features are removed and the org.eclipse.terminal was installed (the latest cdtserial connector should be present/updated too)
7. Make sure terminal works

I repeated the above, using the same build output from 1, 2 to make sure a manual install of the terminal would update properly

3. Unpack `eclipse-platform-4.37-linux-gtk-x86_64.tar.gz` and run Eclipse
4. Install the Eclipse Terminal (org.eclipse.terminal)
5. Add the update sites from step 1 and step 2 to available software sites
6. Run check for updates
7. Check that the org.eclipse.terminal was updated
8. Make sure terminal works

I repeated the above, using the same build output from 1, 2 to make sure an update from a much older version works

3. Unpack `eclipse-platform-4.28-linux-gtk-x86_64.tar.gz` and run Eclipse (2 year old Eclipse)
4. Install the Eclipse TM Terminal (org.eclipse.tm.terminal)
5. Add the update sites from step 1 and step 2 to available software sites
6. Run check for updates
7. Check that the old org.eclipse.tm.terminal features are removed and the org.eclipse.terminal was installed
8. Make sure terminal works

I repeated the above, using the same build output from 1, 2 to check how p2 handles finding a newer org.eclipse.tm.terminal and a newer org.eclipse.terminal

3. Unpack `eclipse-cpp-2025-06-R-linux-gtk-x86_64.tar.gz` and run Eclipse - by using this version there is a new version of org.eclipse.tm.terminal available in https://download.eclipse.org/releases/latest (which is in available software sites by default for users of EPP)
4. Add the update sites from step 1 and step 2 to available software sites
5. Run check for updates two times - on first iteration org.eclipse.tm.terminal will be updated to latest org.eclipse.tm.terminal, and on the second it will be updated to org.eclipse.terminal
6. Check that the old org.eclipse.tm.terminal features are removed and the org.eclipse.terminal was installed (the latest cdtserial connector should be present/updated too)
7. Make sure terminal works
