### PR TITLE
Add Support for Expression Context Pinning

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.23.200.qualifier
+Bundle-Version: 3.24.0.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/IWatchExpression.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/IWatchExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -93,5 +93,32 @@ public interface IWatchExpression extends IErrorReportingExpression {
 	 * @param enabled whether this expression should be enabled
 	 */
 	void setEnabled(boolean enabled);
+
+	/**
+	 * Sets a user preferred context for expression evaluation
+	 *
+	 * @param context
+	 * @since 3.24
+	 */
+	public default void setPinnedContext(IDebugElement context) {
+	}
+
+	/**
+	 * Returns the pinned context for the given expression
+	 *
+	 * @return returns pinned <code>IDebugElement</code>
+	 * @since 3.24
+	 */
+	public default IDebugElement getPinnedContext() {
+		return null;
+	}
+
+	/**
+	 * Removes attached custom context
+	 *
+	 * @since 3.24
+	 */
+	public default void removePinnedContext() {
+	}
 
 }

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/WatchExpression.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/WatchExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IDebugElement;
 import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.debug.core.model.IWatchExpression;
 import org.eclipse.debug.core.model.IWatchExpressionDelegate;
@@ -39,6 +40,7 @@ public class WatchExpression implements IWatchExpression {
 	protected IDebugElement fCurrentContext;
 	private boolean fEnabled= true;
 	private boolean fPending= false;
+	private IDebugElement fPinnedContext;
 
 	/**
 	 * Creates a new watch expression with the given expression
@@ -299,6 +301,33 @@ public class WatchExpression implements IWatchExpression {
 			return new String[0];
 		}
 		return fResult.getErrorMessages();
+	}
+
+	/**
+	 * @see org.eclipse.debug.core.model.IWatchExpression#setPinnedContext(IDebugElement)
+	 */
+	@Override
+	public void setPinnedContext(IDebugElement context) {
+		fPinnedContext = context;
+	}
+
+	/**
+	 * @see org.eclipse.debug.core.model.IWatchExpression#getPinnedContext()
+	 */
+	@Override
+	public IDebugElement getPinnedContext() {
+		if (fPinnedContext instanceof IStackFrame) {
+			return fPinnedContext;
+		}
+		return null;
+	}
+
+	/**
+	 * @see org.eclipse.debug.core.model.IWatchExpression#removePinnedContext()
+	 */
+	@Override
+	public void removePinnedContext() {
+		fPinnedContext = null;
 	}
 
 }

--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -422,3 +422,7 @@ breakpointLabel.label= Label
 breakpointLabel.tooltip= Provide a custom label to quickly identify breakpoint
 breakpointLabelCommand = EditBreakpointLabel
 breakpointLabelCommand.description = Opens inline editor to change breakpoint label
+
+
+PinExpressionWithCurrentAction.label=Pin Evaluation Context
+PinExpressionWithCurrentAction.tooltip=Pin current evaluation stackframe for this expression

--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -1306,6 +1306,19 @@
                id="org.eclipse.debug.ui.watchExpressionActions.EditWatchExpression">
          </action>
       </viewerContribution>
+       <viewerContribution
+            targetID="org.eclipse.debug.ui.ExpressionView"
+            id="org.eclipse.debug.ui.WatchExpressionActions22">
+          <action
+               label="%PinExpressionWithCurrentAction.label"
+               helpContextId="pin_current_evaluation_context"
+               class="org.eclipse.debug.internal.ui.actions.expressions.PinWatchContextAction"
+               tooltip="%PinExpressionWithCurrentAction.tooltip"
+               menubarPath="additions"
+               enablesFor="1"
+               id="org.eclipse.debug.ui.watchExpressionActions.PinCurrentContext">
+         </action>
+      </viewerContribution>
       <viewerContribution
             targetID="org.eclipse.debug.ui.ExpressionView"
             id="org.eclipse.debug.ui.WatchExpressionActions">

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
@@ -254,5 +254,7 @@ public class ActionMessages extends NLS {
 	public static String EnableAllBreakpointsAction_3;
 	public static String BreakpointLabelDialog;
 	public static String RemoveFromFavoritesAction;
+	public static String ExpressionsPinContext;
+	public static String ExpressionsRemovePin;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
@@ -238,3 +238,6 @@ VirtualFindAction_1=Unable to locate {0} in viewer
 ToggleBreakpointsTargetManager_defaultToggleTarget_name = Default
 ToggleBreakpointsTargetManager_defaultToggleTarget_description = Default
 BreakpointLabelDialog=Provide a custom label, or blank for the default label
+
+ExpressionsRemovePin=Remove Pinned Context
+ExpressionsPinContext=Pin Evaluation Context

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/PinWatchContextAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/PinWatchContextAction.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.internal.ui.actions.expressions;
+
+import java.util.Iterator;
+
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.debug.core.DebugEvent;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.IDebugEventSetListener;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.model.IDebugElement;
+import org.eclipse.debug.core.model.IExpression;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IThread;
+import org.eclipse.debug.core.model.IWatchExpression;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.actions.ActionMessages;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IActionDelegate2;
+import org.eclipse.ui.IViewActionDelegate;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchPage;
+
+/*
+ * Associates the current stack frame with this expression, allowing its evaluation
+ * result to remain accessible across different debug contexts.
+ */
+public class PinWatchContextAction implements IViewActionDelegate, IDebugEventSetListener, IActionDelegate2 {
+
+	/**
+	 * Finds the currently selected context in the UI.
+	 *
+	 * @return the current debug context
+	 */
+	protected IDebugElement getContext() {
+		IAdaptable object = DebugUITools.getDebugContext();
+		IDebugElement context = null;
+		if (object instanceof IDebugElement iDebugElement) {
+			context = iDebugElement;
+		} else if (object instanceof ILaunch iLaunch) {
+			context = iLaunch.getDebugTarget();
+		}
+		return context;
+	}
+
+	protected IStructuredSelection getCurrentSelection() {
+		IWorkbenchPage page = DebugUIPlugin.getActiveWorkbenchWindow().getActivePage();
+		if (page != null) {
+			ISelection selection = page.getSelection();
+			if (selection instanceof IStructuredSelection sel) {
+				return sel;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @see org.eclipse.ui.IActionDelegate#run(org.eclipse.jface.action.IAction)
+	 */
+	@Override
+	public void run(IAction action) {
+		IDebugElement context = getContext();
+		for (Iterator<?> iter = getCurrentSelection().iterator(); iter.hasNext();) {
+			if (iter.next() instanceof IWatchExpression expression) {
+				if (expression.getPinnedContext() != null) {
+					expression.removePinnedContext();
+					expression.setExpressionContext(context);
+					action.setText(ActionMessages.ExpressionsPinContext);
+				} else {
+					expression.setPinnedContext(context);
+					action.setText(ActionMessages.ExpressionsRemovePin);
+				}
+				if (expression.isEnabled()) {
+					expression.evaluate();
+				}
+			}
+		}
+	}
+
+	@Override
+	public void selectionChanged(IAction action, ISelection selection) {
+
+		IDebugElement debugElement = getContext();
+		if (debugElement == null) {
+			action.setEnabled(false);
+			return;
+		} else {
+			action.setEnabled(true);
+		}
+		if (getCurrentSelection() == null) {
+			return;
+		}
+		for (Object select : getCurrentSelection()) {
+			if (select instanceof IWatchExpression expression) {
+				if (expression.getPinnedContext() != null) {
+					action.setText(ActionMessages.ExpressionsRemovePin);
+				} else {
+					action.setText(ActionMessages.ExpressionsPinContext);
+				}
+			} else {
+				action.setEnabled(false);
+			}
+
+		}
+
+	}
+
+	@Override
+	public void handleDebugEvents(DebugEvent[] events) {
+		for (DebugEvent event : events) {
+			if (event.getSource() instanceof IThread thread && thread.isTerminated()) {
+				for (IExpression exp : DebugPlugin.getDefault().getExpressionManager().getExpressions()) {
+					if (exp instanceof IWatchExpression expression && expression.getPinnedContext() != null) {
+						if (expression.getPinnedContext() instanceof IStackFrame frame && frame.isTerminated()) {
+							expression.removePinnedContext();
+							expression.setExpressionContext(getContext());
+						}
+					}
+				}
+
+			}
+		}
+
+	}
+
+	@Override
+	public void init(IViewPart view) {
+		DebugPlugin.getDefault().addDebugEventListener(this);
+
+	}
+
+	@Override
+	public void init(IAction action) {
+	}
+
+	@Override
+	public void dispose() {
+		DebugPlugin.getDefault().removeDebugEventListener(this);
+	}
+
+	@Override
+	public void runWithEvent(IAction action, Event event) {
+		run(action);
+	}
+
+}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/model/elements/ExpressionLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/model/elements/ExpressionLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2014 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,10 @@ import org.eclipse.debug.core.model.IWatchExpression;
 import org.eclipse.debug.internal.ui.DebugUIMessages;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IPresentationContext;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.TreePath;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 
 /**
@@ -161,6 +164,21 @@ protected String getLabel(TreePath elementPath, IPresentationContext context, St
 			return getValueText(null, value, context);
 		}
 		return null;
+	}
+
+	@Override
+	protected FontData getFontData(TreePath elementPath, IPresentationContext presentationContext, String columnId)
+			throws CoreException {
+		Object element = elementPath.getLastSegment();
+		if (element instanceof IWatchExpression watchExp) {
+			if (watchExp.getPinnedContext() != null) {
+				var fontNew = JFaceResources.getFontDescriptor(IDebugUIConstants.PREF_VARIABLE_TEXT_FONT)
+						.getFontData()[0];
+				return new FontData(fontNew.getName(), fontNew.getHeight(),
+						fontNew.getStyle() ^ (SWT.BOLD | SWT.ITALIC));
+			}
+		}
+		return JFaceResources.getFontDescriptor(IDebugUIConstants.PREF_VARIABLE_TEXT_FONT).getFontData()[0];
 	}
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/update/DefaultWatchExpressionModelProxy.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/update/DefaultWatchExpressionModelProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2011 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -113,8 +113,13 @@ public class DefaultWatchExpressionModelProxy extends DefaultExpressionModelProx
 					}
 				}
 				IWatchExpression expression = (IWatchExpression)getExpression();
-				if (expression != null){
-					expression.setExpressionContext(context);
+				if (expression != null) {
+					IDebugElement pinnedContext = expression.getPinnedContext();
+					if (pinnedContext != null) {
+						expression.setExpressionContext(pinnedContext);
+					} else {
+						expression.setExpressionContext(context);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR introduces a new feature in the Expressions view that allows expressions to be pinned to a specific stack frame, ensuring their values remain visible and consistent even when switching between threads or stack frames or even launches. This enhancement improves the debugging experience by preventing frequent `<error on evaluation>` issues (if one wishes to see the variables/expressions again) and enables developers to track and compare expressions or variables (by watch) across different contexts more effectively.

<img width="660" height="389" alt="image" src="https://github.com/user-attachments/assets/2d7d176d-702b-4a53-afa9-b6929dbeeb67" />
<br><br>
Pinned expressions will be highlighted with Bold and italics 
<img width="464" height="105" alt="image" src="https://github.com/user-attachments/assets/aaa8303e-42ee-4942-9101-80ae741b8865" />
<br><br>
This can be removed/unpinned manually or will be removed/unpinned if context not available
<img width="435" height="380" alt="image" src="https://github.com/user-attachments/assets/e8abbb10-9fd7-4ae3-a734-26432575a1e1" />


https://github.com/user-attachments/assets/63e68e0a-3a8a-4ab2-8bd3-951098a9cd33

(apologies for the poor video quality - had to compress the size below 10 MB)