### PR TITLE
Update launch config title body text based on launch mode

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
@@ -69,6 +69,7 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.jface.wizard.ProgressMonitorPart;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.ViewForm;
@@ -279,7 +280,9 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 		topComp.setLayout(topLayout);
 
 		// Set the things that TitleAreaDialog takes care of
-		setTitle(LaunchConfigurationsMessages.LaunchConfigurationDialog_Create__manage__and_run_launch_configurations_8);
+		setTitle(NLS.bind(
+				LaunchConfigurationsMessages.LaunchConfigurationDialog_Create__manage__and_run_launch_configurations_8,
+				getLaunchGroup().getMode()));
 		setMessage(LaunchConfigurationsMessages.LaunchConfigurationDialog_Ready_to_launch_2);
 		setModeLabelState();
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
@@ -94,7 +94,7 @@ LaunchConfigurationTabGroupViewer_17=Multiple launchers available - <a>Select on
 LaunchConfigurationTabGroupViewer_18=Multiple launchers available - select one to continue
 LaunchConfigurationTabGroupViewer_19=- Press the 'Import' button to import external configurations.
 
-LaunchConfigurationDialog_Create__manage__and_run_launch_configurations_8=Create, manage, and run configurations
+LaunchConfigurationDialog_Create__manage__and_run_launch_configurations_8=Create, manage, and {0} configurations
 LaunchConfigurationDialog_Discard_changes__38=Discard changes?
 LaunchConfigurationDialog_Do_you_wish_to_discard_changes_37=\nDo you wish to discard changes?\n
 LaunchConfigurationDialog_Error_19=Error


### PR DESCRIPTION
Fixes a minor UI mismatch

before :
<img width="855" height="112" alt="image" src="https://github.com/user-attachments/assets/dacb7daf-1605-4d8c-97db-45ea7db416dd" />

After :
<img width="787" height="97" alt="image" src="https://github.com/user-attachments/assets/172b2b51-c7cf-4b76-a1a0-34b570feed8d" />
