### PR TITLE
Use workspace root modification rule when removing all breakpoints

### DIFF
--- a/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.core; singleton:=true
-Bundle-Version: 3.23.200.qualifier
+Bundle-Version: 3.23.300.qualifier
 Bundle-Activator: org.eclipse.debug.core.DebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
When removing breakpoints, its possible that another job is accessing the breakpoint marker. This can result in an exception, since removing a breakpoint will also remove the marker.

This change moves breakpoint removal code in a job that holds a workspace root modification rule, if the current thread does not hold a matching rule.

Fixes: #2217