### PR TITLE
UnifiedTree.isRecursiveLink() links check may silently ignore some links

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/WorkspaceResetExtension.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/WorkspaceResetExtension.java
@@ -40,7 +40,7 @@ public class WorkspaceResetExtension implements AfterEachCallback, BeforeEachCal
 	public void beforeEach(ExtensionContext context) throws Exception {
 		// Wait for any pending refresh operation, in particular from startup
 		waitForRefresh();
-		TestUtil.log(IStatus.INFO, context.getDisplayName(), "setUp");
+		TestUtil.log(IStatus.INFO, getTestName(context), "setUp");
 		assertNotNull(getWorkspace(), "Workspace was not set up");
 		FreezeMonitor.expectCompletionInAMinute();
 		waitForRefresh();
@@ -48,13 +48,23 @@ public class WorkspaceResetExtension implements AfterEachCallback, BeforeEachCal
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		TestUtil.log(IStatus.INFO, context.getDisplayName(), "tearDown");
+		TestUtil.log(IStatus.INFO, getTestName(context), "tearDown");
 		try {
 			restoreCleanWorkspace();
 		} finally {
 			FreezeMonitor.done();
 			assertWorkspaceFolderEmpty();
 		}
+	}
+
+	private String getTestName(ExtensionContext context) {
+		String className = context.getRequiredTestClass().getSimpleName();
+		String methodName = context.getRequiredTestMethod().getName();
+		String displayName = context.getDisplayName();
+		if (!displayName.contains(methodName)) {
+			methodName += displayName;
+		}
+		return className + "." + methodName;
 	}
 
 	private void restoreCleanWorkspace() {


### PR DESCRIPTION
UnifiedTree.isRecursiveLink() links check may silently ignore some links

- Main fix: the child path created from the link should use `realParentPath` to avoid silent `NoSuchFileException`'s if the constructed link does not match actual (fully resolved) file system state of the local file we are checking. Original code run into (silent) exceptions and because of that was not able to detect some of possible recursive links.
- Removed pattern checking for "../X" because backwards links can also be created with absolute paths, as seen in
`Bug_185247_recursiveLinks.test5_linkParentDirectoyTwiceWithAbsolutePath(boolean)`
- Added regression test `SymlinkResourceTest.testGithubBug2220`.
- Added `UnifiedTree` methods to set/read `disable_advanced_recursive_link_checks` flag in tests so we can test
both variants of link checking code.
- Updated existing tests to test both advanced / simple link checks (where possible): `SymlinkResourceTest`, `Bug_185247_recursiveLinks` & `Bug_185247_LinuxTests`
- Improved `WorkspaceResetExtension` to properly report test names (it only reported `false` or `true` for parametrized tests).

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2220
