### PR TITLE
Fix Breakpoint custom label not showing in breakpoint containers

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/model/elements/BreakpointLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/model/elements/BreakpointLabelProvider.java
@@ -32,9 +32,10 @@ public class BreakpointLabelProvider extends DebugElementLabelProvider {
 	@Override
 	protected String getLabel(TreePath elementPath, IPresentationContext presentationContext, String columnId, int columnIndex) throws CoreException {
 		if (columnIndex == 0) {
-			if (elementPath.getFirstSegment() instanceof Breakpoint breakpoint) {
-				if (breakpoint.getBreakpointLabel() != null) {
-					return breakpoint.getBreakpointLabel();
+			if (elementPath.getLastSegment() instanceof Breakpoint breakpoint) {
+				String breakpointLabel = breakpoint.getBreakpointLabel();
+				if (breakpointLabel != null) {
+					return breakpointLabel;
 				}
 			}
 			return super.getLabel(elementPath, presentationContext, columnId, columnIndex);


### PR DESCRIPTION
This commit fixes custom breakpoint labels not being rendered in breakpoints view when breakpoints organized based on any groupings

before

<img width="397" height="190" alt="image" src="https://github.com/user-attachments/assets/08ae51f9-9eab-460d-b018-11f2fa1a9e8d" />

after

<img width="456" height="311" alt="image" src="https://github.com/user-attachments/assets/786ef203-592d-425a-aef2-4a251058412a" />
