### PR TITLE
Fix Terminate & Remove showing every time

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRemoveAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRemoveAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -109,7 +109,7 @@ public class TerminateAndRemoveAction extends DebugCommandAction {
 		// enable the action, which whill just remove the terminated launches (bug 324959).
 		fCanTerminate = !isAllTerminated;
 		if (isAllTerminated) {
-			setEnabled(true);
+			setEnabled(!context.isEmpty());
 		} else {
 			super.debugContextChanged(event);
 		}


### PR DESCRIPTION
This PR will enable Terminate & Remove option in debug view context only when there's a valid selection

before : 

<img width="360" height="517" alt="image" src="https://github.com/user-attachments/assets/14ed1fde-c304-4b7e-bca5-6355aedfee6f" />


after : 
<img width="364" height="576" alt="image" src="https://github.com/user-attachments/assets/3816f22f-d2dd-4b50-a34d-5a6f72ec46b3" />
