### PR TITLE
Include Font style pref page in console filtered preference

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
@@ -41,11 +41,14 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsoleConstants;
+import org.eclipse.ui.dialogs.PreferencesUtil;
 
 /**
  * A page to set the preferences for the console
@@ -127,7 +130,7 @@ public class ConsolePreferencePage extends FieldEditorPreferencePage implements 
 	 */
 	@Override
 	public void createFieldEditors() {
-
+		createHeaderLink();
 		fWrapEditor = new BooleanFieldEditor2(IDebugPreferenceConstants.CONSOLE_WRAP, DebugPreferencesMessages.ConsolePreferencePage_Wrap_text_1, SWT.NONE, getFieldEditorParent());
 		addField(fWrapEditor);
 
@@ -411,5 +414,25 @@ public class ConsolePreferencePage extends FieldEditorPreferencePage implements 
 		String elapsedString = String.format(dateTimeFormated, elapsedTime.toHours(), elapsedTime.toMinutesPart(),
 				elapsedTime.toSecondsPart(), elapsedTime.toMillisPart());
 		return elapsedString;
+	}
+
+	private void createHeaderLink() {
+		final Shell shell = getFieldEditorParent().getShell();
+		String text = DebugPreferencesMessages.ConsoleFontSettingsLink;
+		Link link = new Link(getFieldEditorParent(), SWT.NONE);
+		link.setText(text);
+		link.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if ("org.eclipse.ui.preferencePages.ColorsAndFonts".equals(e.text)) { //$NON-NLS-1$
+					PreferencesUtil.createPreferenceDialogOn(shell, e.text, null,
+							"selectFont:org.eclipse.debug.ui.consoleFont"); //$NON-NLS-1$
+				}
+			}
+		});
+		GridData gridData = new GridData(SWT.FILL, SWT.BEGINNING, true, false);
+		gridData.horizontalSpan = 4;
+		link.setLayoutData(gridData);
+		SWTFactory.createVerticalSpacer(getFieldEditorParent(), 2);
 	}
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
@@ -232,4 +232,5 @@ public class DebugPreferencesMessages extends NLS {
 
 	public static String ConsolePreferencePage_ConsoleIconUpdate;
 
+	public static String ConsoleFontSettingsLink;
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -37,6 +37,7 @@ ConsoleDefaultElapsedTimeFormat=H:MM:SS
 ConsoleElapsedTimeToolTip=Supports formats like: 'H:MM:SS.mmm', 'MMm SSs', 'H:MM:SS' \nYou can also use positional parameters \n%1$ = (H)hours\n%2$ = (M)minutes\n%3$ = (S)seconds\n%4$ = (mmm)milliseconds
 ConsoleDisableElapsedTime=None
 ConsolePreferencePage_ConsoleIconUpdate=Update Console icon based on currently active page
+ConsoleFontSettingsLink=To configure font style settings, see <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">'Font Styles'</a> preferences
 
 DebugPreferencePage_1=General Settings for Running and Debugging.
 DebugPreferencePage_2=Re&use editor when displaying source code

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleShowPreferencesAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleShowPreferencesAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2007 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ public class ConsoleShowPreferencesAction extends Action implements IViewActionD
 	private static final String PREF_PAGE_NAME = "org.eclipse.debug.ui.ConsolePreferencePage"; //$NON-NLS-1$
 	private static final String[] PREFS_PAGES_TO_SHOW = {
 			PREF_PAGE_NAME,
+			"org.eclipse.ui.preferencePages.ColorsAndFonts", //$NON-NLS-1$
 			"org.eclipse.debug.ui.DebugPreferencePage", //$NON-NLS-1$
 			"org.eclipse.ui.internal.console.ansi.preferences.AnsiConsolePreferencePage" //$NON-NLS-1$
 	};


### PR DESCRIPTION
Added Fonts preference page link under Console Filtered Preferences. This allows users to change console font styles directly from the console filtered preferences. similar to filtered preferences of Editor.


<img width="1518" height="1264" alt="image" src="https://github.com/user-attachments/assets/752490f4-1e61-427e-8212-5ff3a4666e28" />


<img width="943" height="311" alt="Screenshot 2025-10-30 at 8 24 42 AM" src="https://github.com/user-attachments/assets/b1b9b584-bac3-4b58-bc7d-9d25ebce5b07" />


