### PR TITLE
Auto pin behavior for opening new console

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
@@ -177,6 +177,10 @@ public class ConsolePreferencePage extends FieldEditorPreferencePage implements 
 		addField(new BooleanFieldEditor(IDebugPreferenceConstants.CONSOLE_OPEN_ON_OUT, DebugPreferencesMessages.ConsolePreferencePage_Show__Console_View_when_there_is_program_output_3, SWT.NONE, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(IDebugPreferenceConstants.CONSOLE_OPEN_ON_ERR, DebugPreferencesMessages.ConsolePreferencePage_Show__Console_View_when_there_is_program_error_3, SWT.NONE, getFieldEditorParent()));
 
+		BooleanFieldEditor autoPinEditor = new BooleanFieldEditor(IConsoleConstants.AUTO_PIN_ENABLED_PREF_NAME,
+				DebugPreferencesMessages.ConsolePreferencePage_ConsoleAutoPinEnable, SWT.NONE, getFieldEditorParent());
+		autoPinEditor.setPreferenceStore(ConsolePlugin.getDefault().getPreferenceStore());
+		addField(autoPinEditor);
 		Label comboLabel = new Label(getFieldEditorParent(), SWT.NONE);
 		comboLabel.setText(DebugPreferencesMessages.ConsoleElapsedTimeLabel);
 		fElapsedFormat = new ComboViewer(getFieldEditorParent(), SWT.DROP_DOWN | SWT.BORDER);
@@ -324,6 +328,9 @@ public class ConsolePreferencePage extends FieldEditorPreferencePage implements 
 		updateBufferSizeEditor();
 		updateInterpretCrAsControlCharacterEditor();
 		updateElapsedTimePreferences();
+
+		IPreferenceStore prefStore = ConsolePlugin.getDefault().getPreferenceStore();
+		prefStore.setValue(IConsoleConstants.REMEMBER_AUTO_PIN_DECISION_PREF_NAME, false);
 	}
 
 	protected boolean canClearErrorMessage() {

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
@@ -31,6 +31,8 @@ public class DebugPreferencesMessages extends NLS {
 	public static String ConsolePreferencePage_Console_width;
 	public static String ConsolePreferencePage_Limit_console_output_1;
 	public static String ConsolePreferencePage_Console_buffer_size__characters___2;
+
+	public static String ConsolePreferencePage_ConsoleAutoPinEnable;
 	public static String ConsolePreferencePage_The_console_buffer_size_must_be_at_least_1000_characters__1;
 	public static String ConsolePreferencePage_console_width;
 	public static String ConsolePreferencePage_12;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -23,6 +23,7 @@ ConsolePreferencePage_Wrap_text_1=Fixed &width console
 ConsolePreferencePage_Console_width=&Maximum character width:
 ConsolePreferencePage_Limit_console_output_1=&Limit console output
 ConsolePreferencePage_Console_buffer_size__characters___2=Console &buffer size (characters):
+ConsolePreferencePage_ConsoleAutoPinEnable=Pin current and the new Console views when a new Console view is opened
 ConsolePreferencePage_The_console_buffer_size_must_be_at_least_1000_characters__1=Buffer size must be between 1000 and {0} inclusive.
 ConsolePreferencePage_console_width=Character width must be between 80 and 1000 inclusive.
 ConsolePreferencePage_12=Displayed &tab width:

--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.14.400.qualifier
+Bundle-Version: 3.15.0.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
@@ -164,6 +164,22 @@ public interface IConsoleConstants {
 	String P_CONSOLE_WORD_WRAP = ConsolePlugin.getUniqueIdentifier() + ".P_CONSOLE_WORD_WRAP"; //$NON-NLS-1$
 
 	/**
+	 * The preference name for the auto pin question to avoid that opening for every
+	 * new console opening.
+	 *
+	 * @since 3.15
+	 */
+	String REMEMBER_AUTO_PIN_DECISION_PREF_NAME = ConsolePlugin.getUniqueIdentifier() + ".AUTO_PIN_ASKED"; //$NON-NLS-1$
+
+	/**
+	 * The preference name for automatically pinning current Console view when
+	 * opening a new Console view.
+	 *
+	 * @since 3.15
+	 */
+	String AUTO_PIN_ENABLED_PREF_NAME = ConsolePlugin.getUniqueIdentifier() + ".AUTO_PIN_ENABLED"; //$NON-NLS-1$
+
+	/**
 	 * The default tab size for text consoles.
 	 *
 	 * @since 3.1

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.java
@@ -33,6 +33,10 @@ public class ConsoleMessages extends NLS {
 	public static String PinConsoleAction_0;
 	public static String PinConsoleAction_1;
 
+	public static String TurnOnAutoPinDialogMessage;
+	public static String TurnOnAutoPinDialogTitle;
+	public static String TurnOnAutoPinRememberDecision;
+
 	public static String ClearOutputAction_title;
 	public static String ClearOutputAction_toolTipText;
 
@@ -62,6 +66,7 @@ public class ConsoleMessages extends NLS {
 	public static String TextConsolePage_CopyDescrip;
 	public static String TextConsolePage_PasteText;
 	public static String TextConsolePage_PasteDescrip;
+
 
 	static {
 		// load message values from bundle file

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.properties
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.properties
@@ -59,3 +59,6 @@ PatternMatchListenerExtension_3=Console Pattern Match Listener
 PatternMatchListenerExtension_4=contributed by
 PatternMatchListenerExtension_5=is missing required enablement expression and will be removed
 UpdatingConsoleState=Updating console state
+TurnOnAutoPinDialogMessage=To see updates of different console pages in parallel, both current and new Console view will be pinned now.
+TurnOnAutoPinDialogTitle=Pin Console views?
+TurnOnAutoPinRememberDecision=Remember my decision

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleUIPreferenceInitializer.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleUIPreferenceInitializer.java
@@ -29,6 +29,8 @@ public class ConsoleUIPreferenceInitializer extends AbstractPreferenceInitialize
 		IPreferenceStore prefs = ConsolePlugin.getDefault().getPreferenceStore();
 		prefs.setDefault(IConsoleConstants.P_CONSOLE_AUTO_SCROLL_LOCK, true);
 		prefs.setDefault(IConsoleConstants.P_CONSOLE_WORD_WRAP, false);
+		prefs.setDefault(IConsoleConstants.AUTO_PIN_ENABLED_PREF_NAME, true);
+		prefs.setDefault(IConsoleConstants.REMEMBER_AUTO_PIN_DECISION_PREF_NAME, false);
 	}
 
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
@@ -461,7 +461,7 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 		fDisplayConsoleAction = new ConsoleDropDownAction(this);
 		ConsoleFactoryExtension[] extensions = ((ConsoleManager)ConsolePlugin.getDefault().getConsoleManager()).getConsoleFactoryExtensions();
 		if (extensions.length > 0) {
-			fOpenConsoleAction = new OpenConsoleAction();
+			fOpenConsoleAction = new OpenConsoleAction(this);
 		}
 	}
 

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleViewConsoleFactory.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleViewConsoleFactory.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.console;
 
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
@@ -24,22 +30,70 @@ import org.eclipse.ui.console.IConsoleFactory;
 public class ConsoleViewConsoleFactory implements IConsoleFactory {
 
 	int counter = 1;
+	private ConsoleView currentConsoleView;
 
 	@Override
 	public void openConsole() {
 		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if (window != null) {
-			IWorkbenchPage page = window.getActivePage();
-			if (page != null) {
-				try {
-					String secondaryId = "Console View #" + counter; //$NON-NLS-1$
-					page.showView(IConsoleConstants.ID_CONSOLE_VIEW, secondaryId, 1);
-					counter++;
-				} catch (PartInitException e) {
-					ConsolePlugin.log(e);
-				}
-			}
+		if (window == null) {
+			return;
 		}
+		IWorkbenchPage page = window.getActivePage();
+		if (page == null) {
+			return;
+		}
+		boolean shouldPin = handleAutoPin();
+		try {
+			String secondaryId = "Console View #" + counter; //$NON-NLS-1$
+			IViewPart view = page.showView(IConsoleConstants.ID_CONSOLE_VIEW, secondaryId, 1);
+			if (view instanceof ConsoleView newConsoleView) {
+				newConsoleView.setPinned(shouldPin);
+			}
+			counter++;
+		} catch (PartInitException e) {
+			ConsolePlugin.log(e);
+		}
+	}
+
+	/**
+	 * This handler checks if the remember auto-pin decision state <b>not true</b>
+	 * and asks the user if auto pin of the view content should be enabled.
+	 * Afterwards it checks if remember auto-pin decision was checked and sets the
+	 * preference according to that
+	 *
+	 * If the remember auto-pin decision state is <b>true</b> it gathers the auto
+	 * pin preference value and sets this to the current view.
+	 */
+	private boolean handleAutoPin() {
+		if (currentConsoleView == null) {
+			return false;
+		}
+		IPreferenceStore store = ConsolePlugin.getDefault().getPreferenceStore();
+		if (!store.getBoolean(IConsoleConstants.REMEMBER_AUTO_PIN_DECISION_PREF_NAME)) {
+			Shell shell = Display.getDefault().getActiveShell();
+			MessageDialogWithToggle toggleDialog = MessageDialogWithToggle.openOkCancelConfirm(shell,
+					ConsoleMessages.TurnOnAutoPinDialogTitle, ConsoleMessages.TurnOnAutoPinDialogMessage,
+					ConsoleMessages.TurnOnAutoPinRememberDecision, false, null, null);
+
+			store.setValue(IConsoleConstants.AUTO_PIN_ENABLED_PREF_NAME,
+					toggleDialog.getReturnCode() == IDialogConstants.OK_ID);
+
+			store.setValue(IConsoleConstants.REMEMBER_AUTO_PIN_DECISION_PREF_NAME, toggleDialog.getToggleState());
+		}
+
+		if (store.getBoolean(IConsoleConstants.AUTO_PIN_ENABLED_PREF_NAME)) {
+			// To avoid if pinned manually and unpin due to preference..
+			currentConsoleView.setPinned(true);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Sets the console view, on which the open new console action was called.
+	 */
+	void setConsoleView(ConsoleView consoleView) {
+		this.currentConsoleView = consoleView;
 	}
 
 }


### PR DESCRIPTION
The console view has a "pin console" action, which pins the current console. If the user wants a new console, the original one should be pinned, otherwise a console switch will switch all unpinned console views.

- Added auto pin behavior for the console view. If user opens a new
console, it will raise the question if auto pin should be done.
- Added a new preference to the ConsolePreferencePage