### PR TITLE
Breakpoint "inline editor" bugfixes and refactoring

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/launch/DebugElementHelper.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/launch/DebugElementHelper.java
@@ -30,7 +30,6 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * Translates images, colors, and fonts into image descriptors, RGBs, and font
@@ -146,14 +145,7 @@ public class DebugElementHelper {
 
 		if (element instanceof Breakpoint breakpoint) {
 			if (breakpoint.getBreakpointLabel() != null) {
-				final RGB[] rgb = new RGB[1];
-				Display.getDefault().syncExec(() -> {
-					Color redColor = Display.getDefault().getSystemColor(SWT.COLOR_RED);
-					rgb[0] = redColor.getRGB();
-				});
-				if (rgb[0] != null) {
-					return rgb[0];
-				}
+				return new RGB(255, 0, 0);
 			}
 			return null;
 		}


### PR DESCRIPTION
Bug fixes:
- Set label background to avoid overlapping text if theming is disabled
- Trim inline editor text to avoid "invisible" breakpoints
- Add more space for inline editor if original labels is very short

Refactoring:
- perform preconditions checking at the beginning
- extracted repeated dispose() code to InlineEditor.dispose()
- extract Mac workaround code to dedicated method
- extract editor extent calculation to dedicated method
- removed useless tree.setText(current) and tree.setText("") calls
- don't use syncExec to get RGB of red color

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2262