### PR TITLE
Migrate from SubProgressMonitor to SubMonitor

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -189,6 +189,6 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return new SubProgressMonitor(monitor, ticks);
+		return SubMonitor.convert(monitor, ticks);
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -189,6 +189,6 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return SubMonitor.convert(monitor, ticks);
+		return SubMonitor.convert(monitor).split(ticks);
 	}
 }

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/InfiniteSubProgressMonitor.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/InfiniteSubProgressMonitor.java
@@ -15,7 +15,7 @@ package org.eclipse.team.internal.core;
 
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 /**
  * Provides an infinite progress monitor by subdividing by half repeatedly.
@@ -27,8 +27,9 @@ import org.eclipse.core.runtime.SubProgressMonitor;
  * 2^n = totalWork. What this means is that if you provide a totalWork of 32 (2^5) than
  * the maximum number of ticks is 5*32/2 = 80.
  */
-public class InfiniteSubProgressMonitor extends SubProgressMonitor {
+public class InfiniteSubProgressMonitor implements IProgressMonitor {
 
+	private final SubMonitor delegate;
 	int totalWork;
 	int halfWay;
 	int currentIncrement;
@@ -39,19 +40,26 @@ public class InfiniteSubProgressMonitor extends SubProgressMonitor {
 	 * Constructor for InfiniteSubProgressMonitor.
 	 */
 	public InfiniteSubProgressMonitor(IProgressMonitor monitor, int ticks) {
-		this(monitor, ticks, 0);
+		this(monitor, ticks, SubMonitor.SUPPRESS_NONE);
 	}
 
 	/**
 	 * Constructor for InfiniteSubProgressMonitor.
 	 */
 	public InfiniteSubProgressMonitor(IProgressMonitor monitor, int ticks, int style) {
-		super(monitor, ticks, style);
+		if (monitor instanceof SubMonitor subMonitor) {
+			this.delegate = subMonitor.split(ticks, style);
+		} else {
+			// For non-SubMonitor, convert it first then split
+			SubMonitor converted = SubMonitor.convert(monitor);
+			this.delegate = converted.split(ticks, style);
+		}
 	}
 
 	@Override
 	public void beginTask(String name, int totalWork) {
-		super.beginTask(name, totalWork);
+		delegate.setTaskName(name);
+		delegate.setWorkRemaining(totalWork);
 		this.totalWork = totalWork;
 		this.halfWay = totalWork / 2;
 		this.currentIncrement = 1;
@@ -65,7 +73,7 @@ public class InfiniteSubProgressMonitor extends SubProgressMonitor {
 			return;
 		}
 		if (--nextProgress <= 0) {
-			super.worked(1);
+			delegate.worked(1);
 			worked++;
 			if (worked >= halfWay) {
 				// we have passed the current halfway point, so double the
@@ -87,7 +95,33 @@ public class InfiniteSubProgressMonitor extends SubProgressMonitor {
 	@Override
 	public void subTask(String name) {
 		if(name != null && ! name.isEmpty()) {
-			super.subTask(name);
+			delegate.subTask(name);
 		}
+	}
+
+	@Override
+	public void done() {
+		// SubMonitor doesn't require explicit done() calls, but delegate for compatibility
+		delegate.done();
+	}
+
+	@Override
+	public void internalWorked(double work) {
+		delegate.internalWorked(work);
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return delegate.isCanceled();
+	}
+
+	@Override
+	public void setCanceled(boolean value) {
+		delegate.setCanceled(value);
+	}
+
+	@Override
+	public void setTaskName(String name) {
+		delegate.setTaskName(name);
 	}
 }


### PR DESCRIPTION
Migrated all usages of the deprecated SubProgressMonitor class to use SubMonitor following Eclipse 4.6+ best practices:

- resources/Policy.java: Updated subMonitorFor() to use SubMonitor.convert()
- team/InfiniteSubProgressMonitor: Refactored from inheritance to composition, now implements IProgressMonitor and delegates to SubMonitor
- team/SubscriberSyncInfoEventHandler: Replaced anonymous SubProgressMonitor with IProgressMonitor wrapper that delegates to SubMonitor

All changes follow the official Eclipse SubMonitor migration guide.