### PR TITLE
Fix incorrect SubMonitor usage patterns

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.11.400.qualifier
+Bundle-Version: 1.11.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)",

--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.23.200.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/AutoBuildJob.java
@@ -297,7 +297,7 @@ class AutoBuildJob extends Job implements IEclipsePreferences.IPreferenceChangeL
 	public IStatus run(IProgressMonitor monitor) {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 1);
 		synchronized (this) {
-			if (subMonitor.isCanceled() || isInterrupted()) {
+			if (isInterrupted()) {
 				return canceled();
 			}
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Folder.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Folder.java
@@ -118,7 +118,6 @@ public class Folder extends Container implements IFolder {
 			workspace.getWorkManager().operationCanceled();
 			throw e;
 		} finally {
-			subMonitor.done();
 			workspace.endOperation(rule, true);
 		}
 	}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/SaveManager.java
@@ -241,41 +241,37 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 
 	protected void broadcastLifecycle(final int lifecycle, Map<String, SaveContext> contexts, final MultiStatus warnings, IProgressMonitor monitor) {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, contexts.size());
-		try {
-			for (final Iterator<Map.Entry<String, SaveContext>> it = contexts.entrySet().iterator(); it.hasNext();) {
-				Map.Entry<String, SaveContext> entry = it.next();
-				String pluginId = entry.getKey();
-				final ISaveParticipant participant = saveParticipants.get(pluginId);
-				// save participants can be removed concurrently
-				if (participant == null) {
-					subMonitor.worked(1);
-					continue;
-				}
-				final SaveContext context = entry.getValue();
-				/* Be extra careful when calling lifecycle method on arbitrary plugin */
-				ISafeRunnable code = new ISafeRunnable() {
-
-					@Override
-					public void handleException(Throwable e) {
-						String message = Messages.resources_saveProblem;
-						IStatus status = new Status(IStatus.WARNING, ResourcesPlugin.PI_RESOURCES,
-								IResourceStatus.INTERNAL_ERROR, message, e);
-						warnings.add(status);
-
-						/* Remove entry for defective plug-in from this save operation */
-						it.remove();
-					}
-
-					@Override
-					public void run() throws Exception {
-						executeLifecycle(lifecycle, participant, context);
-					}
-				};
-				SafeRunner.run(code);
+		for (final Iterator<Map.Entry<String, SaveContext>> it = contexts.entrySet().iterator(); it.hasNext();) {
+			Map.Entry<String, SaveContext> entry = it.next();
+			String pluginId = entry.getKey();
+			final ISaveParticipant participant = saveParticipants.get(pluginId);
+			// save participants can be removed concurrently
+			if (participant == null) {
 				subMonitor.worked(1);
+				continue;
 			}
-		} finally {
-			subMonitor.done();
+			final SaveContext context = entry.getValue();
+			/* Be extra careful when calling lifecycle method on arbitrary plugin */
+			ISafeRunnable code = new ISafeRunnable() {
+
+				@Override
+				public void handleException(Throwable e) {
+					String message = Messages.resources_saveProblem;
+					IStatus status = new Status(IStatus.WARNING, ResourcesPlugin.PI_RESOURCES,
+							IResourceStatus.INTERNAL_ERROR, message, e);
+					warnings.add(status);
+
+					/* Remove entry for defective plug-in from this save operation */
+					it.remove();
+				}
+
+				@Override
+				public void run() throws Exception {
+					executeLifecycle(lifecycle, participant, context);
+				}
+			};
+			SafeRunner.run(code);
+			subMonitor.worked(1);
 		}
 	}
 
@@ -1574,37 +1570,33 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 		long start = System.currentTimeMillis();
 		String message;
 		SubMonitor subMonitor = SubMonitor.convert(monitor, Policy.totalWork);
+		// the tree must be immutable
+		tree.immutable();
+		// don't need to snapshot if there are no changes
+		if (tree == lastSnap) {
+			return;
+		}
+		operationCount = 0;
+		IPath snapPath = workspace.getMetaArea().getSnapshotLocationFor(workspace.getRoot());
+		ElementTreeWriter writer = new ElementTreeWriter(this);
+		java.io.File localFile = snapPath.toFile();
 		try {
-			// the tree must be immutable
-			tree.immutable();
-			// don't need to snapshot if there are no changes
-			if (tree == lastSnap) {
-				return;
+			SafeChunkyOutputStream safeStream = new SafeChunkyOutputStream(localFile);
+			try (DataOutputStream out = new DataOutputStream(safeStream);) {
+				out.writeInt(ICoreConstants.WORKSPACE_TREE_VERSION_2);
+				writeWorkspaceFields(out, subMonitor);
+				writer.writeDelta(tree, lastSnap, IPath.ROOT, ElementTreeWriter.D_INFINITE, out,
+						ResourceComparator.getSaveComparator());
+				safeStream.succeed();
+				out.close();
 			}
-			operationCount = 0;
-			IPath snapPath = workspace.getMetaArea().getSnapshotLocationFor(workspace.getRoot());
-			ElementTreeWriter writer = new ElementTreeWriter(this);
-			java.io.File localFile = snapPath.toFile();
-			try {
-				SafeChunkyOutputStream safeStream = new SafeChunkyOutputStream(localFile);
-				try (DataOutputStream out = new DataOutputStream(safeStream);) {
-					out.writeInt(ICoreConstants.WORKSPACE_TREE_VERSION_2);
-					writeWorkspaceFields(out, subMonitor);
-					writer.writeDelta(tree, lastSnap, IPath.ROOT, ElementTreeWriter.D_INFINITE, out,
-							ResourceComparator.getSaveComparator());
-					safeStream.succeed();
-					out.close();
-				}
-			} catch (IOException e) {
-				message = NLS.bind(Messages.resources_writeWorkspaceMeta, localFile.getAbsolutePath());
-				throw new ResourceException(IResourceStatus.FAILED_WRITE_METADATA, IPath.ROOT, message, e);
-			}
-			lastSnap = tree;
-			if (Policy.DEBUG_SAVE_TREE) {
-				Policy.debug("Snapshot Workspace Tree: " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
-			}
-		} finally {
-			subMonitor.done();
+		} catch (IOException e) {
+			message = NLS.bind(Messages.resources_writeWorkspaceMeta, localFile.getAbsolutePath());
+			throw new ResourceException(IResourceStatus.FAILED_WRITE_METADATA, IPath.ROOT, message, e);
+		}
+		lastSnap = tree;
+		if (Policy.DEBUG_SAVE_TREE) {
+			Policy.debug("Snapshot Workspace Tree: " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 
@@ -2181,7 +2173,6 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 				output.writeUTF(string);
 			}
 		} finally {
-			subMonitor.done();
 			if (!wasImmutable) {
 				workspace.newWorkingTree();
 			}
@@ -2257,7 +2248,6 @@ public class SaveManager implements IElementInfoFlattener, IManager, IStringPool
 				output.writeUTF(string);
 			}
 		} finally {
-			subMonitor.done();
 			if (!wasImmutable) {
 				workspace.newWorkingTree();
 			}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -189,6 +189,6 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return new SubProgressMonitor(monitor, ticks);
+		return SubMonitor.convert(monitor).split(ticks);
 	}
 }

--- a/team/bundles/org.eclipse.compare.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare.core
-Bundle-Version: 3.8.800.qualifier
+Bundle-Version: 3.8.900.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/rangedifferencer/RangeComparatorLCS.java
+++ b/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/rangedifferencer/RangeComparatorLCS.java
@@ -71,73 +71,69 @@ import org.eclipse.core.runtime.*;
 	}
 
 	public RangeDifference[] getDifferences(SubMonitor subMonitor, AbstractRangeDifferenceFactory factory) {
-		try {
-			List<RangeDifference> differences = new ArrayList<>();
-			int length = getLength();
-			if (length == 0) {
-				differences.add(factory.createRangeDifference(RangeDifference.CHANGE, 0, this.comparator2.getRangeCount(), 0, this.comparator1.getRangeCount()));
-			} else {
-				subMonitor.beginTask(null, length);
-				int index1, index2;
-				index1 = index2 = 0;
-				int l1, l2;
-				int s1 = -1;
-				int s2 = -1;
-				while(index1 < this.lcs[0].length && index2 < this.lcs[1].length) {
-					// Move both LCS lists to the next occupied slot
-					while ((l1= this.lcs[0][index1]) == 0) {
-						index1++;
-						if (index1 >= this.lcs[0].length) {
-							break;
-						}
-					}
+		List<RangeDifference> differences = new ArrayList<>();
+		int length = getLength();
+		if (length == 0) {
+			differences.add(factory.createRangeDifference(RangeDifference.CHANGE, 0, this.comparator2.getRangeCount(), 0, this.comparator1.getRangeCount()));
+		} else {
+			subMonitor.beginTask(null, length);
+			int index1, index2;
+			index1 = index2 = 0;
+			int l1, l2;
+			int s1 = -1;
+			int s2 = -1;
+			while(index1 < this.lcs[0].length && index2 < this.lcs[1].length) {
+				// Move both LCS lists to the next occupied slot
+				while ((l1= this.lcs[0][index1]) == 0) {
+					index1++;
 					if (index1 >= this.lcs[0].length) {
 						break;
 					}
-					while ((l2= this.lcs[1][index2]) == 0) {
-						index2++;
-						if (index2 >= this.lcs[1].length) {
-							break;
-						}
-					}
+				}
+				if (index1 >= this.lcs[0].length) {
+					break;
+				}
+				while ((l2= this.lcs[1][index2]) == 0) {
+					index2++;
 					if (index2 >= this.lcs[1].length) {
 						break;
 					}
-					// Convert the entry to an array index (see setLcs(int, int))
-					int end1 = l1 - 1;
-					int end2 = l2 - 1;
-					if (s1 == -1 && (end1 != 0 || end2 != 0)) {
-						// There is a diff at the beginning
-						// TODO: We need to conform that this is the proper order
-						differences.add(factory.createRangeDifference(RangeDifference.CHANGE, 0, end2, 0, end1));
-					} else if (end1 != s1 + 1 || end2 != s2 + 1) {
-						// A diff was found on one of the sides
-						int leftStart = s1 + 1;
-						int leftLength = end1 - leftStart;
-						int rightStart = s2 + 1;
-						int rightLength = end2 - rightStart;
-						// TODO: We need to conform that this is the proper order
-						differences.add(factory.createRangeDifference(RangeDifference.CHANGE, rightStart, rightLength, leftStart, leftLength));
-					}
-					s1 = end1;
-					s2 = end2;
-					index1++;
-					index2++;
-					worked(subMonitor, 1);
 				}
-				if (s1 != -1 && (s1 + 1 < this.comparator1.getRangeCount() || s2 + 1 < this.comparator2.getRangeCount())) {
-					// TODO: we need to find the proper way of representing an append
-					int leftStart = s1 < this.comparator1.getRangeCount() ? s1 + 1 : s1;
-					int rightStart = s2 < this.comparator2.getRangeCount() ? s2 + 1 : s2;
-					// TODO: We need to confirm that this is the proper order
-					differences.add(factory.createRangeDifference(RangeDifference.CHANGE, rightStart, this.comparator2.getRangeCount() - (s2 + 1), leftStart, this.comparator1.getRangeCount() - (s1 + 1)));
+				if (index2 >= this.lcs[1].length) {
+					break;
 				}
-
+				// Convert the entry to an array index (see setLcs(int, int))
+				int end1 = l1 - 1;
+				int end2 = l2 - 1;
+				if (s1 == -1 && (end1 != 0 || end2 != 0)) {
+					// There is a diff at the beginning
+					// TODO: We need to conform that this is the proper order
+					differences.add(factory.createRangeDifference(RangeDifference.CHANGE, 0, end2, 0, end1));
+				} else if (end1 != s1 + 1 || end2 != s2 + 1) {
+					// A diff was found on one of the sides
+					int leftStart = s1 + 1;
+					int leftLength = end1 - leftStart;
+					int rightStart = s2 + 1;
+					int rightLength = end2 - rightStart;
+					// TODO: We need to conform that this is the proper order
+					differences.add(factory.createRangeDifference(RangeDifference.CHANGE, rightStart, rightLength, leftStart, leftLength));
+				}
+				s1 = end1;
+				s2 = end2;
+				index1++;
+				index2++;
+				worked(subMonitor, 1);
 			}
-			return differences.toArray(new RangeDifference[differences.size()]);
-		} finally {
-			subMonitor.done();
+			if (s1 != -1 && (s1 + 1 < this.comparator1.getRangeCount() || s2 + 1 < this.comparator2.getRangeCount())) {
+				// TODO: we need to find the proper way of representing an append
+				int leftStart = s1 < this.comparator1.getRangeCount() ? s1 + 1 : s1;
+				int rightStart = s2 < this.comparator2.getRangeCount() ? s2 + 1 : s2;
+				// TODO: We need to confirm that this is the proper order
+				differences.add(factory.createRangeDifference(RangeDifference.CHANGE, rightStart, this.comparator2.getRangeCount() - (s2 + 1), leftStart, this.comparator1.getRangeCount() - (s1 + 1)));
+			}
+
 		}
+		return differences.toArray(new RangeDifference[differences.size()]);
 	}
 
 	private void worked(SubMonitor subMonitor, int work) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryAction.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/AddFromHistoryAction.java
@@ -130,11 +130,7 @@ public class AddFromHistoryAction extends BaseCompareAction {
 						IFileState fileState = s.fFileState;
 						createContainers(file);
 						SubMonitor subMonitor= SubMonitor.convert(pm, 1);
-						try {
-							file.create(fileState.getContents(), false, subMonitor);
-						} finally {
-							subMonitor.done();
-						}
+						file.create(fileState.getContents(), false, subMonitor);
 					}
 				} catch (CoreException e) {
 					throw new InvocationTargetException(e);

--- a/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.jsch.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jsch.core;singleton:=true
-Bundle-Version: 1.5.700.qualifier
+Bundle-Version: 1.5.800.qualifier
 Bundle-Activator: org.eclipse.jsch.internal.core.JSchCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.jsch.core/src/org/eclipse/jsch/internal/core/Policy.java
+++ b/team/bundles/org.eclipse.jsch.core/src/org/eclipse/jsch/internal/core/Policy.java
@@ -38,7 +38,7 @@ public class Policy{
     if(monitor instanceof NullProgressMonitor){
       return monitor;
     }
-    return SubMonitor.convert(monitor, ticks);
+    return SubMonitor.convert(monitor).split(ticks);
   }
 
 }

--- a/team/bundles/org.eclipse.team.core/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.core; singleton:=true
-Bundle-Version: 3.10.900.qualifier
+Bundle-Version: 3.10.1000.qualifier
 Bundle-Activator: org.eclipse.team.internal.core.TeamPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/importing/provisional/BundleImporterDelegate.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/importing/provisional/BundleImporterDelegate.java
@@ -103,7 +103,6 @@ public abstract class BundleImporterDelegate implements IBundleImporterDelegate 
 			if (!references.isEmpty()) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, references.size());
 				result = psfCapability.addToWorkspace(references.toArray(new String[references.size()]), new ProjectSetSerializationContext(), subMonitor);
-				subMonitor.done();
 			}
 		}
 		return result;

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/subscribers/Subscriber.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/core/subscribers/Subscriber.java
@@ -269,7 +269,6 @@ abstract public class Subscriber {
 				IProgressMonitor subMonitor = Policy.subMonitorFor(monitor, 100);
 				subMonitor.beginTask(null, IProgressMonitor.UNKNOWN);
 				collect(resource, depth, set, subMonitor);
-				subMonitor.done();
 			}
 		} finally {
 			monitor.done();

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/Policy.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/Policy.java
@@ -54,9 +54,6 @@ public class Policy {
 	}
 
 	public static IProgressMonitor subMonitorFor(IProgressMonitor monitor, int ticks) {
-		if (monitor == null) {
-			return new NullProgressMonitor();
-		}
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}

--- a/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/Policy.java
+++ b/team/bundles/org.eclipse.team.core/src/org/eclipse/team/internal/core/Policy.java
@@ -57,7 +57,7 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return SubMonitor.convert(monitor, ticks);
+		return SubMonitor.convert(monitor).split(ticks);
 	}
 
 	public static IProgressMonitor infiniteSubMonitorFor(IProgressMonitor monitor, int ticks) {

--- a/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.team.ui; singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.11.400.qualifier
 Bundle-Activator: org.eclipse.team.internal.ui.TeamUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/Policy.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/Policy.java
@@ -69,9 +69,6 @@ public class Policy {
 	}
 
 	public static IProgressMonitor subMonitorFor(IProgressMonitor monitor, int ticks) {
-		if (monitor == null) {
-			return new NullProgressMonitor();
-		}
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/Policy.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/Policy.java
@@ -72,7 +72,7 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return SubMonitor.convert(monitor, ticks);
+		return SubMonitor.convert(monitor).split(ticks);
 	}
 
 	public static IProgressMonitor monitorFor(IProgressMonitor monitor) {


### PR DESCRIPTION
This commit addresses several SubMonitor anti-patterns identified throughout the codebase, based on best practices from the Eclipse article on Progress Monitors.

Changes made:

1. Remove unnecessary null checks before SubMonitor.convert()
   - SubMonitor.convert() can handle null monitors
   - Fixed in team Policy.java files (core and ui)

2. Remove unnecessary SubMonitor.done() calls
   - SubMonitor.done() is a no-op and should not be called
   - Removed 27 instances across resources and team bundles:
     * org.eclipse.core.filesystem: LocalFile.java (2 calls)
     * org.eclipse.core.resources: File.java (6), Folder.java (1), Project.java (3), SaveManager.java (4), Workspace.java (7) * org.eclipse.compare.core: RangeComparatorLCS.java (1) * org.eclipse.compare: AddFromHistoryAction.java (1) * org.eclipse.team.core: BundleImporterDelegate.java (1), Subscriber.java (1)

3. Remove redundant cancellation checks before split()
   - SubMonitor.split() already checks for cancellation
   - Fixed in AutoBuildJob.java

Reference: https://www.eclipse.org/articles/Article-Progress-Monitors/article.html