### PR TITLE
Enhance 'Find' context in Expression View

### DIFF
--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.19.200.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/icons/full/elcl16/find.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/elcl16/find.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="find.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4177">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4179" />
+      <stop
+         style="stop-color:#e2edf7;stop-opacity:1"
+         offset="1"
+         id="stop4181" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4167"
+       id="linearGradient4173"
+       x1="24.279608"
+       y1="1038.3673"
+       x2="22.69014"
+       y2="1045.7269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7071067,0,0,0.7071067,-0.61192312,304.5052)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4167">
+      <stop
+         style="stop-color:#6f877d;stop-opacity:1"
+         offset="0"
+         id="stop4169" />
+      <stop
+         style="stop-color:#2b66b2;stop-opacity:1"
+         offset="1"
+         id="stop4171" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="radialGradient4245"
+       cx="14.311938"
+       cy="1039.2069"
+       fx="14.311938"
+       fy="1039.2069"
+       r="5.4497476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56661844,0,0,0.7071067,6.4781913,304.5052)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="40.932365"
+     inkscape:cx="7.9971098"
+     inkscape:cy="7.9902516"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4196"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4242">
+      <g
+         transform="translate(-9.5563496,1.6205583)"
+         id="g3353">
+        <g
+           id="g4196">
+          <image
+             y="1034.7417"
+             x="25.556349"
+             id="image4545"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0
+U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEOSURBVHjaYvz//z8DJYCRagaA6CsPb/xf
+s/cOw8fXp8Fi/KKmDCHOKgw68hqMKJoYkbggjSB86f61//nttf8fvnr///XH72AMYoPEQHL//v1j
+gGGYHrDlMEbpjINgDe++/ULg77/AYnVzNuE0gAnmkm3nPjJwsXMw/P39j+H3Xwj+++sfWGztKdxh
+wIIu8P0PaqBysuAPRLh0sBkDw7efPxh+MbEyMPxjYGAGiv0FhdHf32A5XADuBVBoe9UcZvj+7S9Y
+M9g1P/4ylMU0M9w78Zi0aIT5GWQzSPPvR3cZWOWUGRbNymREj0YUA3CBuLTp/5ENIdkAdEMWz85i
+xAgDQgBkM0gz7fLCgBkAEGAAEK3gCltmSwUAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16"
+             width="16" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4185"
+             d="m 22.198388,1047.091 0,-0.9107 -4.082341,-3.9411 -1.05718,1.0207 4.163663,4.0196 z"
+             style="fill:#574672;fill-opacity:1;fill-rule:evenodd;stroke:#5c6495;stroke-width:0.71592331;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             r="3.4999998"
+             cy="1040.7417"
+             cx="15.55635"
+             id="path4157"
+             style="opacity:1;fill:url(#radialGradient4245);fill-opacity:1;stroke:url(#linearGradient4173);stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
@@ -66,6 +66,7 @@ public class DebugPluginImages {
 		declareRegistryImage(IDebugUIConstants.IMG_ACT_RUN, CTOOL + "run_exc.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_ACT_SYNCED, ELCL + "synced.svg"); //$NON-NLS-1$
 		declareRegistryImage(IDebugUIConstants.IMG_SKIP_BREAKPOINTS, ELCL + "skip_brkp.svg"); //$NON-NLS-1$
+		declareRegistryImage(IDebugUIConstants.IMG_FIND_ACTION, ELCL + "find.svg"); //$NON-NLS-1$
 
 		//menus
 		declareRegistryImage(IDebugUIConstants.IMG_LCL_CHANGE_VARIABLE_VALUE,

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/expression/ExpressionView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/expression/ExpressionView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ import org.eclipse.debug.core.IExpressionManager;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IDebugElement;
 import org.eclipse.debug.core.model.IWatchExpression;
+import org.eclipse.debug.internal.ui.DebugPluginImages;
 import org.eclipse.debug.internal.ui.IDebugHelpContextIds;
 import org.eclipse.debug.internal.ui.actions.expressions.EditWatchExpressinInPlaceAction;
 import org.eclipse.debug.internal.ui.actions.expressions.PasteWatchExpressionsAction;
@@ -80,13 +81,18 @@ public class ExpressionView extends VariablesView {
 	protected void fillContextMenu(IMenuManager menu) {
 		menu.add(new Separator(IDebugUIConstants.EMPTY_EXPRESSION_GROUP));
 		menu.add(new Separator(IDebugUIConstants.EXPRESSION_GROUP));
-		menu.add(getAction(FIND_ACTION));
+		IAction action;
+		if (DebugPlugin.getDefault().getExpressionManager().getExpressions().length > 0) {
+			action = getAction(FIND_ACTION);
+			action.setImageDescriptor(DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_FIND_ACTION));
+			menu.add(action);
+		}
 		ChangeVariableValueAction changeValueAction = (ChangeVariableValueAction)getAction("ChangeVariableValue"); //$NON-NLS-1$
 		if (changeValueAction.isApplicable()) {
 			menu.add(changeValueAction);
 		}
 		menu.add(new Separator());
-		IAction action = new AvailableLogicalStructuresAction(this);
+		action = new AvailableLogicalStructuresAction(this);
 		if (action.isEnabled()) {
 			menu.add(action);
 		}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/IDebugUIConstants.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/IDebugUIConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2019 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -1356,5 +1356,12 @@ public interface IDebugUIConstants {
 	 * @since 3.8
 	 */
 	String COLUMN_ID_VARIABLE_VALUE_TYPE = COLUMN_PRESENTATION_ID_VARIABLE + ".COL_VALUE_TYPE"; //$NON-NLS-1$
+
+	/**
+	 * "Find" action image identifier
+	 *
+	 * @since 3.20
+	 */
+	String IMG_FIND_ACTION = "FIND_ACTION_ICON"; //$NON-NLS-1$
 
 }


### PR DESCRIPTION
Make 'Find' context in Expressions view appears only when valid expressions exist.

Before :
<img width="335" height="359" alt="image" src="https://github.com/user-attachments/assets/b3e465b3-0d7f-4070-be59-c5829e6fcf68" />

After :
<img width="401" height="389" alt="image" src="https://github.com/user-attachments/assets/3ae904e9-5bff-4d2a-a3ab-07dda071ad48" />

<img width="468" height="405" alt="image" src="https://github.com/user-attachments/assets/2963dcdb-925c-4ce3-9735-f72468641cae" />
