### PR TITLE
Move org.eclipse.help feature to eclipse.platform git repository

### DIFF
--- a/ua/org.eclipse.help-feature/.project
+++ b/ua/org.eclipse.help-feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.help-feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/ua/org.eclipse.help-feature/.settings/org.eclipse.core.resources.prefs
+++ b/ua/org.eclipse.help-feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ua/org.eclipse.help-feature/.settings/org.eclipse.core.runtime.prefs
+++ b/ua/org.eclipse.help-feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/ua/org.eclipse.help-feature/build.properties
+++ b/ua/org.eclipse.help-feature/build.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2008, 2012 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bin.includes = feature.xml,\
+               feature.properties

--- a/ua/org.eclipse.help-feature/feature.properties
+++ b/ua/org.eclipse.help-feature/feature.properties
@@ -1,0 +1,42 @@
+###############################################################################
+# Copyright (c) 2008, 2013 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=Eclipse Help System
+
+# "providerName" property - name of the company that provides the feature
+providerName=Eclipse.org
+
+# "description" property - description of the feature
+description=Eclipse help system.
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=\
+Copyright (c) 2008, 2013 IBM Corporation and others.\n\
+
+This program and the accompanying materials\n\
+are made available under the terms of the Eclipse Public License 2.0\n\
+which accompanies this distribution, and is available at\n\
+https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0\n\
+\n\
+Contributors:\n\
+    IBM Corporation - initial API and implementation\n
+################ end of copyright property ####################################

--- a/ua/org.eclipse.help-feature/feature.xml
+++ b/ua/org.eclipse.help-feature/feature.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- NOTE: Usually we keep branding and feature bundle version in sync, but we can't increase the major version -->
+<feature
+      id="org.eclipse.help"
+      label="%featureName"
+      version="2.3.2500.qualifier"
+      provider-name="%providerName"
+      plugin="org.eclipse.help.base"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <plugin
+         id="org.eclipse.equinox.http.jetty"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.http.registry"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.http.servlet"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.jsp.jasper"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.jsp.jasper.registry"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.help.base"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.help.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.help.webapp"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.core.net"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.security"
+         version="0.0.0"/>
+
+</feature>

--- a/ua/org.eclipse.help-feature/forceQualifierUpdate.txt
+++ b/ua/org.eclipse.help-feature/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+# To force a version qualifier update add the bug here

--- a/ua/pom.xml
+++ b/ua/pom.xml
@@ -26,6 +26,7 @@
     <module>org.eclipse.help.base</module>
     <module>org.eclipse.help.ui</module>
     <module>org.eclipse.help.webapp</module>
+    <module>org.eclipse.help-feature</module>
     <module>org.eclipse.ua.tests</module>
     <module>org.eclipse.ua.tests.doc</module>
     <module>org.eclipse.ui.cheatsheets</module>


### PR DESCRIPTION
This is the addition part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3526

The feature is copied into this repository from
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/dc928ef206f23fc909c4a8839ed995f3848571f0/eclipse.platform.releng/features/org.eclipse.help-feature