### PR TITLE
Improve quality of breakpoint enablement icon

### DIFF
--- a/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_grp4.svg
+++ b/debug/org.eclipse.debug.ui/icons/full/obj16/brkp_grp4.svg
@@ -1,15 +1,134 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-	<title>brkp_grp</title>
-	<defs>
-		<image  width="17" height="16" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAQCAMAAADH72RtAAAAAXNSR0IB2cksfwAAAGBQTFRFAAAAPjsuU1BDVlNGUk9DPzwwW1lNyce/4+LbyMa+WlhMUk9DtLGnysi+sa+lUE1BUU9Csa6isK2hUE5BTUs+m5iMrquemZaKTUs+VlNGrKqewsC1q6mdPjsvVVJGUk9Dw+LY9wAAACB0Uk5TACG/274e4////+PD////v+D//9zA////vuP///8c272PXtXDAAAAQ0lEQVR4nGNkQAeMg0WEEQR+I4kwsoJFfiNEuBkZQeo+IkQEGME63yJERCBqXiBEWIFCjH9ZHiPZxfpfivHfYyzuAQDQgQsRSsLW3gAAAABJRU5ErkJggg=="/>
-		<image  width="17" height="16" id="img2" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAQCAMAAADH72RtAAAAAXNSR0IB2cksfwAAAGBQTFRFAAAAPjsuU1BDVlNGUk9DPzwwW1lNyce/4+LbyMa+WlhMUk9DtLGnysi+sa+lUE1BUU9Csa6isK2hUE5BTUs+m5iMrquemZaKTUs+VlNGrKqewsC1q6mdPjsvVVJGUk9Dw+LY9wAAACB0Uk5TACG/274e4////+PD////v+D//9zA////vuP///8c272PXtXDAAAAQ0lEQVR4nGNkQAeMg0WEEQR+I4kwsoJFfiNEuBkZQeo+IkQEGME63yJERCBqXiBEWIFCjH9ZHiPZxfpfivHfYyzuAQDQgQsRSsLW3gAAAABJRU5ErkJggg=="/>
-		<image  width="7" height="7" id="img3" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAMAAADzjKfhAAAAAXNSR0IB2cksfwAAAGBQTFRFAAAAHzZrM0h6N0t9M0l5IjVlPFCAnK/QtMfknK7QOk+AMEh6fJfDjanUepXBMEd4Lkd6ZozEZYvDLUZ5K0R3VHmzXofBU3ixK0J2MUl8aIi6dpjKGzdsMEZ4Mkh6MUZ4tWWvnQAAACB0Uk5TACG/274e4////+PD////v+D//9zA////vuP//xy+272RaLIbAAAALUlEQVR4nGNkYASB34yMrBCam5GRASQmAKRAtAiUzwpk/P/PzMjAKsHI+PcJAHywBmNVmJQJAAAAAElFTkSuQmCC"/>
-	</defs>
-	<style>
-	</style>
-	<g id="layer1">
-		<use id="Hue/Saturation 3 copy" href="#img1" x="-4" y="-7"/>
-		<use id="Hue/Saturation 3" href="#img2" x="0" y="0"/>
-		<use id="Hue/Saturation 1" href="#img3" x="1" y="8"/>
-	</g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   sodipodi:docname="brkp_grp2.svg"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs4"><linearGradient
+       id="linearGradient4894"><stop
+         id="stop4896"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" /><stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898" /><stop
+         id="stop4900"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" /></linearGradient><linearGradient
+       id="linearGradient4806"><stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="0"
+         id="stop4808" /><stop
+         id="stop4816"
+         offset="0.5"
+         style="stop-color:#a9a9a9;stop-opacity:1;" /><stop
+         style="stop-color:#bababa;stop-opacity:1;"
+         offset="1"
+         id="stop4810" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4806"
+       id="linearGradient4812"
+       x1="8.7378912"
+       y1="2.1550355"
+       x2="8.7378912"
+       y2="6.8716693"
+       gradientUnits="userSpaceOnUse" /><linearGradient
+       id="linearGradient4806-7"><stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="0"
+         id="stop4808-4" /><stop
+         id="stop4816-0"
+         offset="0.5"
+         style="stop-color:#a9a9a9;stop-opacity:1;" /><stop
+         style="stop-color:#bababa;stop-opacity:1;"
+         offset="1"
+         id="stop4810-9" /></linearGradient><linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4834"
+       xlink:href="#linearGradient4806-7"
+       inkscape:collect="always" /><linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4871"
+       xlink:href="#linearGradient4894"
+       inkscape:collect="always" /></defs><sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999995"
+     inkscape:cx="-10.500001"
+     inkscape:cy="4.3125003"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1350"
+     inkscape:window-height="1230"
+     inkscape:window-x="145"
+     inkscape:window-y="277"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"><inkscape:grid
+       type="xygrid"
+       id="grid3999" /></sodipodi:namedview><metadata
+     id="metadata7"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)"><path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4812);fill-opacity:1;stroke:#696969;stroke-width:0.93798538;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4035"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,-0.59529061,1036.0648)" /><path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4834);fill-opacity:1;stroke:#696969;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,3.4047096,1043.0648)" /><path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:#244a6e;stroke-width:0.93798535999999999;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,-4.59529,1043.0648)" /></g></svg>


### PR DESCRIPTION
The icon for breakpoint enablement is currently composed of three PNG images, which leads to blurry results when scaling it. There exist similar images (with the contained circles just colored differently) as properly vectorized SVGs. As a side note: the blue tone does also not perfectly fit to the blue tone used in the other similar icons.

This change proposes a replacement of the breakpoint enablement icon which adapts the existing, fully vectorized icon for breakpoint groups.

@SougandhS the SVG was introduced with:
- https://github.com/eclipse-platform/eclipse.platform/pull/1962

I guess it was just created like that by accident and not on purpose, was it? Could you please check whether the proposed replacement fits to how you wanted it to look like?

### Screenshots
Appearance at 100% and 175%

#### Before
<img width="235" height="91" alt="image" src="https://github.com/user-attachments/assets/93bd57e9-e77c-455a-90e6-21eaa57798bc" />
<img width="360" height="162" alt="image" src="https://github.com/user-attachments/assets/abc6c0b1-f61b-43d8-9594-3e0ea3a295d3" />

#### After
<img width="232" height="91" alt="image" src="https://github.com/user-attachments/assets/2bc07cbb-a172-428c-aa8d-ceee513a96f6" />
<img width="384" height="157" alt="image" src="https://github.com/user-attachments/assets/5b2a8263-1cd2-440c-a6bc-16bff57780fb" />
