### PR TITLE
Fix not disposed Clipboard instances

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
@@ -188,7 +188,11 @@ public class ClipboardCompare extends BaseCompareAction implements IObjectAction
 	 */
 	private Object getClipboard() {
 		Clipboard clip = new Clipboard(Display.getDefault());
-		return clip.getContents(TextTransfer.getInstance());
+		try {
+			return clip.getContents(TextTransfer.getInstance());
+		} finally {
+			clip.dispose();
+		}
 	}
 
 	@Override

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardReplace.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardReplace.java
@@ -92,7 +92,11 @@ public class ClipboardReplace extends BaseCompareAction {
 	 */
 	private Object getClipboard() {
 		Clipboard clip = new Clipboard(Display.getDefault());
-		return clip.getContents(TextTransfer.getInstance());
+		try {
+			return clip.getContents(TextTransfer.getInstance());
+		} finally {
+			clip.dispose();
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes not disposed Clipboard instances `org.eclipse.compare`.