### PR TITLE
Allow to set system property in session tests

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionConfiguration.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/CustomSessionConfiguration.java
@@ -83,4 +83,15 @@ public interface CustomSessionConfiguration extends SessionCustomization {
 	 */
 	public CustomSessionConfiguration setConfigIniValue(String key, String value);
 
+	/**
+	 * Sets the given system property for all subsequently executed sessions. If the
+	 * value is null, the property will not be set in subsequent runs anymore.
+	 *
+	 * @param key   the system property key
+	 * @param value the value to set for the key or {@code null} to remove the key
+	 *
+	 * @return this
+	 */
+	public CustomSessionConfiguration setSystemProperty(String key, String value);
+
 }

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationDummy.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationDummy.java
@@ -68,4 +68,9 @@ public class CustomSessionConfigurationDummy implements CustomSessionConfigurati
 		return this;
 	}
 
+	@Override
+	public CustomSessionConfiguration setSystemProperty(String key, String value) {
+		return this;
+	}
+
 }

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
@@ -53,6 +53,7 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 	private final Collection<BundleReference> bundleReferences = new LinkedHashSet<>();
 	private Path configurationDirectory;
 	private final Map<String, String> configIniValues = new HashMap<>();
+	private final Map<String, String> systemProperties = new HashMap<>();
 	private boolean readOnly = false;
 	private boolean cascaded = false;
 	private boolean firstExecutedSession = true;
@@ -155,6 +156,16 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 	}
 
 	@Override
+	public CustomSessionConfiguration setSystemProperty(String key, String value) {
+		if (value == null) {
+			systemProperties.remove(key);
+		} else {
+			systemProperties.put(key, value);
+		}
+		return this;
+	}
+
+	@Override
 	public CustomSessionConfiguration setConfigurationDirectory(Path configurationDirectory) {
 		Objects.requireNonNull(configurationDirectory);
 		this.configurationDirectory = configurationDirectory;
@@ -189,6 +200,7 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 		if (cascaded) {
 			createOrRefreshConfigIni();
 		}
+		setup.setSystemProperties(systemProperties);
 	}
 
 	@Override


### PR DESCRIPTION
The setup used in JUnit 3 ConfigurationSessionTestSuites allows to set/change system properties for executed sessions. This capability is currently missing in the JUnit 5 SessionTestExection and the respective CustomSessionConfiguration. This change adds it.

Required for:
- https://github.com/eclipse-equinox/equinox/pull/1226