### PR TITLE
Remove useless internal utilities in o.e.compare

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BinaryCompareViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BinaryCompareViewer.java
@@ -82,13 +82,9 @@ public class BinaryCompareViewer extends AbstractViewer {
 		if (fComposite != null && input instanceof ICompareInput) {
 			fInput= (ICompareInput) input;
 
-			InputStream left= null;
-			InputStream right= null;
 
 			String message= null;
-			try {
-				left= getStream(fInput.getLeft());
-				right= getStream(fInput.getRight());
+			try (InputStream left = getStream(fInput.getLeft()); InputStream right = getStream(fInput.getRight())) {
 
 				if (left != null && right != null) {
 					int pos= 0;
@@ -117,9 +113,6 @@ public class BinaryCompareViewer extends AbstractViewer {
 			} catch (CoreException | IOException ex) {
 				message = Utilities.getString(fBundle, "errorMessage"); //$NON-NLS-1$
 				CompareUIPlugin.log(ex);
-			} finally {
-				Utilities.close(left);
-				Utilities.close(right);
 			}
 			if (message != null) {
 				fMessage.setText(message);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.compare.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_16;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -60,7 +62,6 @@ import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 public class ComparePreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
 
 	private static class FakeInput implements ITypedElement, IEncodedStreamContentAccessor {
-		static final String UTF_16= "UTF-16"; //$NON-NLS-1$
 		String fContent;
 
 		FakeInput(String name) {
@@ -80,11 +81,11 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		}
 		@Override
 		public InputStream getContents() {
-			return new ByteArrayInputStream(Utilities.getBytes(fContent, UTF_16));
+			return new ByteArrayInputStream(fContent.getBytes(UTF_16));
 		}
 		@Override
 		public String getCharset() {
-			return UTF_16;
+			return UTF_16.name();
 		}
 
 		private String loadPreviewContentFromFile(String key) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/EditionAction.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/EditionAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.compare.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_16;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -57,7 +59,6 @@ public class EditionAction extends BaseCompareAction {
 	 * for a Document.
 	 */
 	static class DocumentBufferNode implements ITypedElement, IEncodedStreamContentAccessor {
-		private static final String UTF_16= "UTF-16"; //$NON-NLS-1$
 		private final IDocument fDocument;
 		private final IFile fFile;
 
@@ -83,12 +84,12 @@ public class EditionAction extends BaseCompareAction {
 
 		@Override
 		public InputStream getContents() {
-			return new ByteArrayInputStream(Utilities.getBytes(fDocument.get(), UTF_16));
+			return new ByteArrayInputStream(fDocument.get().getBytes(UTF_16));
 		}
 
 		@Override
 		public String getCharset() {
-			return UTF_16;
+			return UTF_16.name();
 		}
 	}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -358,19 +358,11 @@ public class Utilities {
 		}
 	}
 
-	public static String getFormattedString(String key, String arg) {
+	public static String getFormattedString(String key, Object... arg) {
 		try {
 			return MessageFormat.format(CompareUI.getResourceBundle().getString(key), arg);
 		} catch (MissingResourceException e) {
 			return "!" + key + "!";	//$NON-NLS-2$ //$NON-NLS-1$
-		}
-	}
-
-	public static String getFormattedString(String key, String arg0, String arg1) {
-		try {
-			return MessageFormat.format(CompareUI.getResourceBundle().getString(key), arg0, arg1);
-		} catch (MissingResourceException e) {
-			return "!" + key + "!";//$NON-NLS-2$ //$NON-NLS-1$
 		}
 	}
 
@@ -652,18 +644,6 @@ public class Utilities {
 		return ResourcesPlugin.getEncoding();
 	}
 
-	public static byte[] getBytes(String s, String encoding) {
-		byte[] bytes= null;
-		if (s != null) {
-			try {
-				bytes= s.getBytes(encoding);
-			} catch (UnsupportedEncodingException e) {
-				bytes= s.getBytes();
-			}
-		}
-		return bytes;
-	}
-
 	public static String readString(IStreamContentAccessor sa) throws CoreException {
 		String encoding= null;
 		if (sa instanceof IEncodedStreamContentAccessor) {
@@ -673,16 +653,6 @@ public class Utilities {
 			encoding= ResourcesPlugin.getEncoding();
 		}
 		return Utilities.readString(sa, encoding);
-	}
-
-	public static void close(InputStream is) {
-		if (is != null) {
-			try {
-				is.close();
-			} catch (IOException ex) {
-				// silently ignored
-			}
-		}
 	}
 
 	public static IResource getFirstResource(ISelection selection) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DocumentRangeNode.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DocumentRangeNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.compare.structuremergeviewer;
+
+import static java.nio.charset.StandardCharsets.UTF_16;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -65,7 +67,6 @@ import org.eclipse.swt.widgets.Shell;
 public class DocumentRangeNode
 		implements IDocumentRange, IStructureComparator, IEditableContent,
 		IEncodedStreamContentAccessor, IAdaptable, IEditableContentExtension {
-	private static final String UTF_16= "UTF-16"; //$NON-NLS-1$
 
 	private final IDocument fBaseDocument;
 	private Position fRange; // the range in the base document
@@ -347,7 +348,7 @@ public class DocumentRangeNode
 		} catch (BadLocationException ex) {
 			s= ""; //$NON-NLS-1$
 		}
-		return new ByteArrayInputStream(Utilities.getBytes(s, UTF_16));
+		return new ByteArrayInputStream(s.getBytes(UTF_16));
 	}
 
 
@@ -419,7 +420,7 @@ public class DocumentRangeNode
 
 	@Override
 	public String getCharset() {
-		return UTF_16;
+		return UTF_16.name();
 	}
 
 	/**


### PR DESCRIPTION
Newer Java versions have constructs and APIs that make these useless.