### PR TITLE
Do not confuse background job failure with a planned stop #2323

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFileTest.java
@@ -160,6 +160,9 @@ public class IFileTest {
 					}
 				}
 			} catch (CoreException e) {
+				if (e.getStatus().matches(IStatus.CANCEL)) {
+					return Status.OK_STATUS;
+				}
 				return e.getStatus();
 			} catch (BrokenBarrierException | InterruptedException e1) {
 				return Status.error("Job has failed to start", e1);


### PR DESCRIPTION
Fixes #2323

The background payload has to be cancelled at the end of stress test. This was achieved with `Job.cancel()` method. The cancellation status from `subject.delete()` and `createInWorkspace()` was occasionally propagated to the verification stage of the test and resulted in a false positive.