### PR TITLE
Add constant and example for UI session tests

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/SessionTestExtension.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
  */
 public interface SessionTestExtension extends InvocationInterceptor {
 	public static final String CORE_TEST_APPLICATION = "org.eclipse.pde.junit.runtime.coretestapplication"; //$NON-NLS-1$
+	public static final String UI_TEST_APPLICATION = "org.eclipse.pde.junit.runtime.uitestapplication"; //$NON-NLS-1$
 
 	/**
 	 * Creates a builder for the session test extension. Make sure to finally call

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/samples/SampleUISessionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/samples/SampleUISessionTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.harness.session.samples;
+
+import static org.eclipse.core.tests.harness.TestHarnessPlugin.PI_HARNESS;
+
+import java.util.Date;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Example demonstrating the a session test executed as UI application using the
+ * JUnit 5 platform.
+ */
+public class SampleUISessionTest {
+	@RegisterExtension
+	final SessionTestExtension sessionTestExtension = SessionTestExtension.forPlugin(PI_HARNESS)
+			.withApplicationId(SessionTestExtension.UI_TEST_APPLICATION).create();
+
+	@Test
+	public void testApplicationStartup() {
+		message("Running startup test");
+	}
+
+	/**
+	 * Print a debug message to the console. Pre-pend the message with the current
+	 * date and the name of the current thread.
+	 */
+	public static void message(String message) {
+		StringBuilder buffer = new StringBuilder();
+		buffer.append(new Date(System.currentTimeMillis()));
+		buffer.append(" - ["); //$NON-NLS-1$
+		buffer.append(Thread.currentThread().getName());
+		buffer.append("] "); //$NON-NLS-1$
+		buffer.append(message);
+		System.out.println(buffer.toString());
+	}
+
+}


### PR DESCRIPTION
The JUnit 5 session tests based on the SessionTestExtension support the specification of an application ID to start the sessions with. Currently only a single constant for non-UI tests is provided by the SessionTestExtension whereas the JUnit 3 SessionTestSuite also provides the constant for UI tests.

This change adds the according constant to the SessionTestExtension and adds an example test, conforming to the existing UISampleSessionTest for the JUnit 3 framework.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903