### PR TITLE
Migrate org.eclipse.core.tests.internal.runtime to JUnit 5

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/CollectionTrustManagerTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/CollectionTrustManagerTest.java
@@ -13,10 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.runtime;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigInteger;
 import java.security.Principal;
@@ -29,7 +27,7 @@ import java.util.List;
 import java.util.Set;
 import javax.net.ssl.X509TrustManager;
 import org.eclipse.core.internal.runtime.CollectionTrustManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public class CollectionTrustManagerTest {
@@ -44,8 +42,8 @@ public class CollectionTrustManagerTest {
 
 		X509Certificate[] allAcceptedIssuers = collectionTrustManager.getAcceptedIssuers();
 
-		assertThat(allAcceptedIssuers,
-				arrayContaining(acceptedIssuers1[0], acceptedIssuers1[1], acceptedIssuers2[0], acceptedIssuers2[1]));
+		assertThat(allAcceptedIssuers).containsExactly(acceptedIssuers1[0], acceptedIssuers1[1], acceptedIssuers2[0],
+				acceptedIssuers2[1]);
 	}
 
 	@Test
@@ -68,8 +66,8 @@ public class CollectionTrustManagerTest {
 		CertificateException exception = assertThrows(CertificateException.class, () -> {
 			collectionTrustManager.checkClientTrusted(chainTrustedByNone, authType);
 		});
-		assertThat(exception, sameInstance(manager1.exception)); // first in the list
-		assertThat(exception.getSuppressed(), arrayContaining(sameInstance(manager2.exception))); // second, suppressed
+		assertThat(exception).isSameAs(manager1.exception); // first in the list
+		assertThat(exception.getSuppressed()).containsExactly(manager2.exception); // second, suppressed
 	}
 
 	@Test
@@ -92,8 +90,8 @@ public class CollectionTrustManagerTest {
 		CertificateException exception = assertThrows(CertificateException.class, () -> {
 			collectionTrustManager.checkServerTrusted(chainTrustedByNone, authType);
 		});
-		assertThat(exception, sameInstance(manager1.exception)); // first in the list
-		assertThat(exception.getSuppressed(), arrayContaining(sameInstance(manager2.exception))); // second, suppressed
+		assertThat(exception).isSameAs(manager1.exception); // first in the list
+		assertThat(exception.getSuppressed()).containsExactly(manager2.exception); // second, suppressed
 	}
 
 	private static class StubX509TrustManager implements X509TrustManager {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/LogSerializationTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.core.tests.internal.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -41,11 +41,11 @@ public class LogSerializationTest {
 
 	private void assertStatusEqual(String msg, IStatus[] expected, IStatus[] actual) {
 		if (expected == null) {
-			assertNull(msg + " expected null but got: " + Arrays.toString(actual), actual);
+			assertNull(actual, msg + " expected null but got: " + Arrays.toString(actual));
 			return;
 		}
 		if (actual == null) {
-			assertNull(msg + " expected " + Arrays.toString(expected) + " but got null", expected);
+			assertNull(expected, msg + " expected " + Arrays.toString(expected) + " but got null");
 		}
 		assertThat(actual).as(msg + " number of statuses").hasSameSizeAs(expected);
 		for (int i = 0, imax = expected.length; i < imax; i++) {
@@ -54,24 +54,24 @@ public class LogSerializationTest {
 	}
 
 	private void assertStatusEquals(String msg, IStatus expected, IStatus actual) {
-		assertEquals(msg + " severity", expected.getSeverity(), actual.getSeverity());
-		assertEquals(msg + " plugin-id", expected.getPlugin(), actual.getPlugin());
-		assertEquals(msg + " code", expected.getCode(), actual.getCode());
-		assertEquals(msg + " message", expected.getMessage(), actual.getMessage());
+		assertEquals(expected.getSeverity(), actual.getSeverity(), msg + " severity");
+		assertEquals(expected.getPlugin(), actual.getPlugin(), msg + " plugin-id");
+		assertEquals(expected.getCode(), actual.getCode(), msg + " code");
+		assertEquals(expected.getMessage(), actual.getMessage(), msg + " message");
 		assertExceptionEquals(msg + " exception", expected.getException(), actual.getException());
 		assertStatusEqual(msg + " children", expected.getChildren(), actual.getChildren());
 	}
 
 	private void assertExceptionEquals(String msg, Throwable expected, Throwable actual) {
 		if (expected == null) {
-			assertNull(msg + " expected null but got: " + actual, actual);
+			assertNull(actual, msg + " expected null but got: " + actual);
 			return;
 		}
 		if (actual == null) {
-			assertNull(msg + " expected " + expected + " but got null", expected);
+			assertNull(expected, msg + " expected " + expected + " but got null");
 		}
-		assertEquals(msg + " stack trace", encodeStackTrace(expected), encodeStackTrace(actual));
-		assertEquals(msg + " message", expected.getMessage(), actual.getMessage());
+		assertEquals(encodeStackTrace(expected), encodeStackTrace(actual), msg + " stack trace");
+		assertEquals(expected.getMessage(), actual.getMessage(), msg + " message");
 	}
 
 	protected String encodeStackTrace(Throwable t) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLLocalTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/runtime/PlatformURLLocalTest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.runtime;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,21 +24,20 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
 import org.eclipse.core.tests.runtime.RuntimeTestsPlugin;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
 public class PlatformURLLocalTest {
 
-	public static void assertEquals(String tag, URL expected, URL actual, boolean external)
-			throws MalformedURLException {
+	public static void assertEquals(URL expected, URL actual, boolean external) throws MalformedURLException {
 		if (external) {
-			Assert.assertEquals(tag, expected, actual);
+			Assertions.assertEquals(expected, actual);
 		} else {
-			Assert.assertEquals(tag + ".1",
-				new URL(expected.getProtocol(), expected.getHost(), expected.getPort(), expected.getFile()),
-				new URL(actual.getProtocol(), actual.getHost(), actual.getPort(), actual.getFile()));
+			Assertions.assertEquals(
+					new URL(expected.getProtocol(), expected.getHost(), expected.getPort(), expected.getFile()),
+					new URL(actual.getProtocol(), actual.getHost(), actual.getPort(), actual.getFile()));
 		}
 	}
 
@@ -47,9 +46,9 @@ public class PlatformURLLocalTest {
 		// create a fake URL
 		URL platformURL = new URL("platform:/config/x");
 		URL resolvedURL = FileLocator.resolve(platformURL);
-		assertNotEquals("3.0", platformURL, resolvedURL);
+		assertNotEquals(platformURL, resolvedURL);
 		URL expected = new URL(Platform.getConfigurationLocation().getURL(), "x");
-		assertEquals("5.0", expected, resolvedURL, false);
+		assertEquals(expected, resolvedURL, false);
 	}
 
 	@Test
@@ -57,9 +56,9 @@ public class PlatformURLLocalTest {
 		// create a fake URL
 		URL platformURL = new URL("platform:/meta/" + RuntimeTestsPlugin.PI_RUNTIME_TESTS + "/x");
 		URL resolvedURL = FileLocator.resolve(platformURL);
-		assertNotEquals("3.0", platformURL, resolvedURL);
+		assertNotEquals(platformURL, resolvedURL);
 		URL expected = new URL(RuntimeTestsPlugin.getPlugin().getStateLocation().toFile().toURI().toURL(), "x");
-		assertEquals("5.0", expected, resolvedURL, false);
+		assertEquals(expected, resolvedURL, false);
 	}
 
 	@Test


### PR DESCRIPTION
- Use JUnit 5 test annotation
- Remove obsolete assertions messages
- Migrate assertions to JUnit 5
- Replace Hamcrest assertions with AssertJ

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903