### PR TITLE
Migrate org.eclipse.core.tests.runtime.jobs to JUnit 5

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AbstractJobTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import org.eclipse.core.internal.jobs.JobListeners;
@@ -100,6 +100,6 @@ public class AbstractJobTest  {
 		int jobListenerTimeout = JobListeners.getJobListenerTimeout();
 		JobListeners.resetJobListenerTimeout();
 		int defaultTimeout = JobListeners.getJobListenerTimeout();
-		assertEquals("See logfile for TimeoutException to get details.", defaultTimeout, jobListenerTimeout);
+		assertEquals(defaultTimeout, jobListenerTimeout, "See logfile for TimeoutException to get details.");
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/BeginEndRuleTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/BeginEndRuleTest.java
@@ -14,10 +14,11 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -94,7 +95,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			passedMonitor.set(monitor);
 			manager.beginRule(rule, monitor);
 			try {
-				assertTrue("Monitor not created for " + monitor, createdMonitor.get());
+				assertTrue(createdMonitor.get(), "Monitor not created for " + monitor);
 			} finally {
 				manager.endRule(rule);
 			}
@@ -129,8 +130,8 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		//all jobs should be running
 		//the status flag should be set to START
 		for (int i = 0; i < status.length(); i++) {
-			assertEquals("1." + i, Job.RUNNING, jobs[i].getState());
-			assertEquals("2." + i, TestBarrier2.STATUS_START, status.get(i));
+			assertEquals(Job.RUNNING, jobs[i].getState(), i);
+			assertEquals(TestBarrier2.STATUS_START, status.get(i), i);
 		}
 
 		//the order that the jobs will be executed
@@ -150,9 +151,9 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			}
 
 			//the first job should be running, the remaining jobs should be waiting
-			assertEquals("3.0", TestBarrier2.STATUS_RUNNING, status.get(order[0]));
-			assertEquals("3.0", TestBarrier2.STATUS_BLOCKED, status.get(order[1]));
-			assertEquals("3.0", TestBarrier2.STATUS_BLOCKED, status.get(order[2]));
+			assertEquals(TestBarrier2.STATUS_RUNNING, status.get(order[0]));
+			assertEquals(TestBarrier2.STATUS_BLOCKED, status.get(order[1]));
+			assertEquals(TestBarrier2.STATUS_BLOCKED, status.get(order[2]));
 
 			//let the first job finish
 			status.set(order[0], TestBarrier2.STATUS_WAIT_FOR_DONE);
@@ -187,9 +188,9 @@ public class BeginEndRuleTest extends AbstractJobTest {
 
 		for (int i = 0; i < jobs.length; i++) {
 			//check that the final status of all jobs is correct
-			assertEquals("9." + i, TestBarrier2.STATUS_DONE, status.get(i));
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("11." + i, IStatus.OK, jobs[i].getResult().getSeverity());
+			assertEquals(TestBarrier2.STATUS_DONE, status.get(i), i);
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(IStatus.OK, jobs[i].getResult().getSeverity(), i);
 		}
 	}
 
@@ -215,10 +216,10 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
 		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 
-		assertEquals("2.0", Job.RUNNING, jobs[0].getState());
-		assertEquals("2.1", Job.RUNNING, jobs[1].getState());
-		assertEquals("2.2", TestBarrier2.STATUS_START, status.get(0));
-		assertEquals("2.3", TestBarrier2.STATUS_START, status.get(1));
+		assertEquals(Job.RUNNING, jobs[0].getState());
+		assertEquals(Job.RUNNING, jobs[1].getState());
+		assertEquals(TestBarrier2.STATUS_START, status.get(0));
+		assertEquals(TestBarrier2.STATUS_START, status.get(1));
 
 		//the order of execution of the jobs (by their index in the status array)
 		int first = 0;
@@ -237,8 +238,8 @@ public class BeginEndRuleTest extends AbstractJobTest {
 
 			//only the first job should be running
 			//the other job should be blocked by the beginRule method
-			assertEquals("3.1", TestBarrier2.STATUS_RUNNING, status.get(first));
-			assertEquals("3.2", TestBarrier2.STATUS_WAIT_FOR_RUN, status.get(second));
+			assertEquals(TestBarrier2.STATUS_RUNNING, status.get(first));
+			assertEquals(TestBarrier2.STATUS_WAIT_FOR_RUN, status.get(second));
 
 			//let the first job finish execution and call endRule
 			//the second thread will then become unblocked
@@ -251,8 +252,8 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			TestBarrier2.waitForStatus(status, second, TestBarrier2.STATUS_RUNNING);
 
 			//the first job is done, the second job is executing
-			assertEquals("4.1", TestBarrier2.STATUS_DONE, status.get(first));
-			assertEquals("4.2", TestBarrier2.STATUS_RUNNING, status.get(second));
+			assertEquals(TestBarrier2.STATUS_DONE, status.get(first));
+			assertEquals(TestBarrier2.STATUS_RUNNING, status.get(second));
 
 			//let the second job finish execution
 			status.set(second,  TestBarrier2.STATUS_WAIT_FOR_DONE);
@@ -261,8 +262,8 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			TestBarrier2.waitForStatus(status, second, TestBarrier2.STATUS_DONE);
 
 			//both jobs are done now
-			assertEquals("5.1", TestBarrier2.STATUS_DONE, status.get(first));
-			assertEquals("5.2", TestBarrier2.STATUS_DONE, status.get(second));
+			assertEquals(TestBarrier2.STATUS_DONE, status.get(first));
+			assertEquals(TestBarrier2.STATUS_DONE, status.get(second));
 
 			//flip the order of execution of the jobs
 			int temp = first;
@@ -275,12 +276,12 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		waitForEnd(jobs[first]);
 
 		//check that the final status of both jobs is correct
-		assertEquals("6.1", TestBarrier2.STATUS_DONE, status.get(0));
-		assertEquals("6.2", TestBarrier2.STATUS_DONE, status.get(1));
-		assertEquals("6.3", Job.NONE, jobs[0].getState());
-		assertEquals("6.4", Job.NONE, jobs[1].getState());
-		assertEquals("6.5", IStatus.OK, jobs[0].getResult().getSeverity());
-		assertEquals("6.6", IStatus.OK, jobs[1].getResult().getSeverity());
+		assertEquals(TestBarrier2.STATUS_DONE, status.get(0));
+		assertEquals(TestBarrier2.STATUS_DONE, status.get(1));
+		assertEquals(Job.NONE, jobs[0].getState());
+		assertEquals(Job.NONE, jobs[1].getState());
+		assertEquals(IStatus.OK, jobs[0].getResult().getSeverity());
+		assertEquals(IStatus.OK, jobs[1].getResult().getSeverity());
 	}
 
 	@Test
@@ -374,8 +375,8 @@ public class BeginEndRuleTest extends AbstractJobTest {
 		job.setRule(rule1);
 		job.schedule();
 		waitForEnd(job);
-		assertNotNull("1.0", exception[0]);
-		assertTrue("1.1", exception[0].getMessage().indexOf("does not match outer scope rule") > 0);
+		assertNotNull(exception[0]);
+		assertTrue(exception[0].getMessage().indexOf("does not match outer scope rule") > 0);
 	}
 
 	@Test
@@ -501,7 +502,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			//ignore
 		}
 		//the thread should be dead now
-		assertTrue("1.0", !endingThread.isAlive());
+		assertFalse(endingThread.isAlive());
 
 		//should be able to end the rule from this thread
 		manager.endRule(rule1);
@@ -526,7 +527,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 				//ignore
 			}
 			//the thread should be dead now
-			assertTrue("2." + i, !t.isAlive());
+			assertFalse(t.isAlive(), i + "");
 		}
 
 		//try to end the rules when they are all started
@@ -541,7 +542,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 				//ignore
 			}
 			//the thread should be dead now
-			assertTrue("3." + i, !t.isAlive());
+			assertFalse(t.isAlive(), i + "");
 		}
 
 		//try to end the rules after manager.endRule() has been called
@@ -557,7 +558,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 				//ignore
 			}
 			//the thread should be dead now
-			assertTrue("4." + i, !t.isAlive());
+			assertFalse(t.isAlive(), i + "");
 		}
 	}
 
@@ -575,7 +576,7 @@ public class BeginEndRuleTest extends AbstractJobTest {
 			}
 			Thread.yield();
 			//sanity test to avoid hanging tests
-			assertTrue("Timeout waiting for job to end", i++ < 100);
+			assertTrue(i++ < 100, "Timeout waiting for job to end");
 		}
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
@@ -75,7 +76,7 @@ public class Bug_307282 extends AbstractJobTest {
 
 				// Now attempt acquire lock1 with an integer delay
 				try {
-					assertTrue(!lock1.acquire(60 * 1000));
+					assertFalse(lock1.acquire(60 * 1000));
 				} catch (InterruptedException e) {
 					tb2.setStatus(INTERRUPTED);
 				}
@@ -110,7 +111,7 @@ public class Bug_307282 extends AbstractJobTest {
 		// We should now be able to acquire lock1 without difficulty
 		assertTrue(lock1.acquire(1000));
 		// T2 should still hold the lock2
-		assertTrue(!lock2.acquire(0));
+		assertFalse(lock2.acquire(0));
 
 		tb2.setStatus(RELEASE_LOCK);
 		assertTrue(lock2.acquire(1000));

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -83,8 +83,8 @@ public class Bug_311756 extends AbstractJobTest {
 		if (exceptionInJob.get() != null) {
 			throw exceptionInJob.get();
 		}
-		assertEquals(blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called", CLEARED,
-				blocked[0]);
+		assertEquals(CLEARED, blocked[0],
+				blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called");
 	}
 
 	/**
@@ -147,8 +147,8 @@ public class Bug_311756 extends AbstractJobTest {
 		if (exceptionInJob.get() != null) {
 			throw exceptionInJob.get();
 		}
-		assertEquals(blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called", CLEARED,
-				blocked[0]);
+		assertEquals(CLEARED, blocked[0],
+				blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called");
 	}
 
 	/**
@@ -207,7 +207,8 @@ public class Bug_311756 extends AbstractJobTest {
 		if (exceptionInJob.get() != null) {
 			throw exceptionInJob.get();
 		}
-		assertEquals(blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called", CLEARED, blocked[0]);
+		assertEquals(CLEARED, blocked[0],
+				blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called");
 	}
 
 	/**
@@ -263,7 +264,8 @@ public class Bug_311756 extends AbstractJobTest {
 		if (exceptionInJob.get() != null) {
 			throw exceptionInJob.get();
 		}
-		assertEquals(blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called", CLEARED, blocked[0]);
+		assertEquals(CLEARED, blocked[0],
+				blocked[0] == UNSET ? "setBlocked never called" : "clearBlocked never called");
 	}
 
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_366170.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_366170.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -43,7 +43,7 @@ public class Bug_366170 extends AbstractJobTest {
 		Thread.sleep(2000L);
 
 		//lock should now be free if C is finished
-		assertTrue("Failed: Job C was not run", m_jobBStopHint.tryAcquire());
+		assertTrue(m_jobBStopHint.tryAcquire(), "Failed: Job C was not run");
 	}
 
 	private void scheduleJobA(long delay) throws Exception {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_412138.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_412138.java
@@ -14,7 +14,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.eclipse.core.tests.runtime.RuntimeTestsPlugin.PI_RUNTIME_TESTS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -23,7 +23,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicIntegerArray;
-import junit.framework.AssertionFailedError;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -93,7 +92,7 @@ public class Bug_412138 {
 			fakeBuild.join();
 			assertTrue(job.getResult() != null && job.getResult().isOK());
 			assertTrue(fakeBuild.getResult() != null && fakeBuild.getResult().isOK());
-		} catch (AssertionFailedError e) {
+		} catch (AssertionError e) {
 			// the test failed so there is a deadlock, but this deadlock would prevent us
 			// from reporting test results; serialize the error to a helper file and
 			// exit JVM to "resolve" deadlock
@@ -119,9 +118,9 @@ public class Bug_412138 {
 		// if the file does not exist, there was no deadlock so the whole test pass
 		if (file.exists()) {
 			try {
-				AssertionFailedError e;
+				AssertionError e;
 				try (ObjectInputStream stream = new ObjectInputStream(Files.newInputStream(file.toPath()))) {
-					e = (AssertionFailedError) stream.readObject();
+					e = (AssertionError) stream.readObject();
 				}
 				throw e;
 			} finally {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_478634.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -39,7 +39,7 @@ public class Bug_478634 extends AbstractJobTest {
 		j.setRule(rootRule);
 		j.schedule();
 		waitForCompletion(j);
-		assertFalse("Job was blocked", j.wasBlocked());
+		assertFalse(j.wasBlocked(), "Job was blocked");
 	}
 
 	class ShouldNotBeBlockedJob extends Job {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_550738.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_550738.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +88,7 @@ public class Bug_550738 extends AbstractJobTest {
 				job.cancel();
 				job.schedule();
 
-				assertTrue("Job should start after schedule. Iteration " + i, startedLatch.await(5, TimeUnit.SECONDS));
+				assertTrue(startedLatch.await(5, TimeUnit.SECONDS), "Job should start after schedule. Iteration " + i);
 
 				// A sequence of cancellations and rescheduling that is not expected to affect
 				// further operations.
@@ -97,7 +97,7 @@ public class Bug_550738 extends AbstractJobTest {
 				job.schedule();
 
 				job.cancel();
-				assertTrue("Job should stop after cancellation. Iteration " + i, job.join(5000, null));
+				assertTrue(job.join(5000, null), "Job should stop after cancellation. Iteration " + i);
 
 			}
 		} finally {
@@ -126,8 +126,8 @@ public class Bug_550738 extends AbstractJobTest {
 			// Job post-processing may happen after it is switched to NONE state
 			// join() alone is not enough
 			Thread.sleep(200);
-			assertEquals("Job should be completed once per schedule.", eventCount.scheduledCount.get(),
-					eventCount.doneCount.get());
+			assertEquals(eventCount.scheduledCount.get(), eventCount.doneCount.get(),
+					"Job should be completed once per schedule.");
 
 		} finally {
 			job.cancelWithoutRelyingOnFramework = true;

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_574883.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -109,8 +109,8 @@ public class Bug_574883 extends AbstractJobTest {
 							+ executions.get() + ", cpu: " + processors);
 				}
 			}
-			assertEquals("Job still running after first join, executed: " + firstState + ", cpu: " + processors, 0,
-					length);
+			assertEquals(0, length,
+					"Job still running after first join, executed: " + firstState + ", cpu: " + processors);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
 			Job.getJobManager().cancel(this);
@@ -143,10 +143,9 @@ public class Bug_574883 extends AbstractJobTest {
 				if (executions.get() != INNER_RUNS) {
 					System.out.println("error");
 				}
-				assertEquals("after " + l + " tries: Job still running after join, executed: " + firstState
-						+ ", cpu: " + processors, 0,
-						length);
-				assertEquals("after " + l + " tries", INNER_RUNS, executions.get());
+				assertEquals(0, length, "after " + l + " tries: Job still running after join, executed: " + firstState
+						+ ", cpu: " + processors);
+				assertEquals(INNER_RUNS, executions.get(), "after " + l + " tries");
 			} catch (Throwable t) {
 				Job.getJobManager().cancel(this);
 				Thread.sleep(1000);
@@ -178,8 +177,8 @@ public class Bug_574883 extends AbstractJobTest {
 							+ executions.get() + ", cpu: " + processors);
 				}
 			}
-			assertEquals("Job still running after first join, executed: " + firstState + ", cpu: " + processors, 0,
-					length);
+			assertEquals(0, length,
+					"Job still running after first join, executed: " + firstState + ", cpu: " + processors);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
 			Job.getJobManager().cancel(this);
@@ -220,8 +219,8 @@ public class Bug_574883 extends AbstractJobTest {
 							+ executions.get() + ", cpu: " + processors);
 				}
 			}
-			assertEquals("Job still running after first join, executed: " + firstState + ", cpu: " + processors, 0,
-					length);
+			assertEquals(0, length,
+					"Job still running after first join, executed: " + firstState + ", cpu: " + processors);
 			assertEquals(RUNS, executions.get());
 		} catch (Throwable t) {
 			Job.getJobManager().cancel(this);
@@ -239,7 +238,7 @@ public class Bug_574883 extends AbstractJobTest {
 			((Runnable) () -> executions.incrementAndGet()).run();
 			long t2 = now();
 			long diff = t2 - t1;
-			assertTrue("Time should not go back: " + diff + " at: " + i, diff >= 0);
+			assertTrue(diff >= 0, "Time should not go back: " + diff + " at: " + i);
 		}
 		assertEquals(RUNS, executions.get());
 	}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -118,10 +119,10 @@ public class DeadlockDetectionTest {
 			} catch (InterruptedException e1) {
 				//ignore
 			}
-			assertTrue("1." + i, !allRunnables.get(i).isAlive());
+			assertFalse(allRunnables.get(i).isAlive(), i + "");
 		}
 		//the underlying array has to be empty
-		assertTrue("Locks not removed from graph.", lockManager.isEmpty());
+		assertTrue(lockManager.isEmpty(), "Locks not removed from graph.");
 	}
 
 	/**
@@ -177,10 +178,10 @@ public class DeadlockDetectionTest {
 			public void run() {
 				lock.acquire();
 				status.set(0, TestBarrier2.STATUS_START);
-				assertTrue("1.0", getLockManager().isLockOwner());
+				assertTrue(getLockManager().isLockOwner());
 				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 				manager.beginRule(rule, null);
-				assertTrue("2.0", getLockManager().isLockOwner());
+				assertTrue(getLockManager().isLockOwner());
 				manager.endRule(rule);
 				lock.release();
 				status.set(0, TestBarrier2.STATUS_DONE);
@@ -192,10 +193,10 @@ public class DeadlockDetectionTest {
 			public void run() {
 				manager.beginRule(rule, null);
 				status.set(1, TestBarrier2.STATUS_START);
-				assertTrue("1.0", getLockManager().isLockOwner());
+				assertTrue(getLockManager().isLockOwner());
 				TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 				lock.acquire();
-				assertTrue("2.0", getLockManager().isLockOwner());
+				assertTrue(getLockManager().isLockOwner());
 				lock.release();
 				manager.endRule(rule);
 				status.set(1, TestBarrier2.STATUS_DONE);
@@ -215,11 +216,11 @@ public class DeadlockDetectionTest {
 		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
 		waitForThreadDeath(first);
 		waitForThreadDeath(second);
-		assertTrue("3.0", !first.isAlive());
-		assertTrue("4.0", !second.isAlive());
+		assertFalse(first.isAlive());
+		assertFalse(second.isAlive());
 		//the underlying array has to be empty
 		if (!getLockManager().isEmpty()) {
-			assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+			assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 		}
 	}
 
@@ -238,12 +239,12 @@ public class DeadlockDetectionTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					assertTrue("1.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					monitor.beginTask("Testing", 1);
 					status.set(0, TestBarrier2.STATUS_START);
 					lock.acquire();
 					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
-					assertTrue("2.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					lock.release();
 					monitor.worked(1);
 					status.set(0, TestBarrier2.STATUS_DONE);
@@ -258,12 +259,12 @@ public class DeadlockDetectionTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					assertTrue("1.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					monitor.beginTask("Testing", 1);
 					status.set(1, TestBarrier2.STATUS_START);
 					lock.acquire();
 					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
-					assertTrue("2.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					lock.release();
 					monitor.worked(1);
 					status.set(1, TestBarrier2.STATUS_DONE);
@@ -290,12 +291,12 @@ public class DeadlockDetectionTest {
 		waitForCompletion(first);
 		waitForCompletion(second);
 
-		assertEquals("3.0", Job.NONE, first.getState());
-		assertEquals("3.1", Status.OK_STATUS, first.getResult());
-		assertEquals("4.0", Job.NONE, second.getState());
-		assertEquals("4.1", Status.OK_STATUS, second.getResult());
+		assertEquals(Job.NONE, first.getState());
+		assertEquals(Status.OK_STATUS, first.getResult());
+		assertEquals(Job.NONE, second.getState());
+		assertEquals(Status.OK_STATUS, second.getResult());
 		//the underlying array has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	public static void fill(AtomicIntegerArray a, int val) {
@@ -408,11 +409,11 @@ public class DeadlockDetectionTest {
 		}
 
 		for (int i = 0; i < jobs.length; i++) {
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("10." + i, Status.OK_STATUS, jobs[i].getResult());
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(Status.OK_STATUS, jobs[i].getResult(), i + "");
 		}
 		//the underlying graph has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	/**
@@ -515,11 +516,11 @@ public class DeadlockDetectionTest {
 		}
 
 		for (int i = 0; i < jobs.length; i++) {
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("10." + i, Status.OK_STATUS, jobs[i].getResult());
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(Status.OK_STATUS, jobs[i].getResult(), i + "");
 		}
-		//the underlying graph has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		// the underlying graph has to be empty
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 		});
 	}
 
@@ -615,7 +616,7 @@ public class DeadlockDetectionTest {
 		}
 
 		//the underlying graph has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	/**
@@ -683,7 +684,7 @@ public class DeadlockDetectionTest {
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 		waitForCompletion(ruleOwner);
 		//the underlying graph should now be empty
-		assertTrue("Canceled rule not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Canceled rule not removed from graph.");
 	}
 
 	/**
@@ -803,7 +804,7 @@ public class DeadlockDetectionTest {
 			}
 			//timeout if the two jobs don't start within a reasonable time
 			long elapsed = AbstractJobTest.now() - waitStart;
-			assertTrue("Timeout waiting for job to end: " + elapsed, elapsed < 30000);
+			assertTrue(elapsed < 30000, "Timeout waiting for job to end: " + elapsed);
 		}
 		//wait until all jobs are done
 		for (Job job : jobs) {
@@ -811,11 +812,11 @@ public class DeadlockDetectionTest {
 		}
 
 		for (int i = 0; i < jobs.length; i++) {
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("10." + i, Status.OK_STATUS, jobs[i].getResult());
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(Status.OK_STATUS, jobs[i].getResult(), i + "");
 		}
 		//the underlying graph has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	/**
@@ -965,11 +966,11 @@ public class DeadlockDetectionTest {
 		}
 
 		for (int i = 0; i < jobs.length; i++) {
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("10." + i, Status.OK_STATUS, jobs[i].getResult());
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(Status.OK_STATUS, jobs[i].getResult(), i + "");
 		}
 		//the underlying graph has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	/**
@@ -1008,7 +1009,7 @@ public class DeadlockDetectionTest {
 			} catch (InterruptedException e) {
 				//ignore
 			}
-			assertTrue("Timeout waiting for job to end:" + job, ++i < 100);
+			assertTrue(++i < 100, "Timeout waiting for job to end:" + job);
 		}
 	}
 
@@ -1023,7 +1024,7 @@ public class DeadlockDetectionTest {
 			} catch (InterruptedException e) {
 				//ignore
 			}
-			assertTrue("Timeout waiting for job to end.", ++i < 100);
+			assertTrue(++i < 100, "Timeout waiting for job to end.");
 		}
 	}
 
@@ -1054,7 +1055,7 @@ public class DeadlockDetectionTest {
 								manager.beginRule(rules[indexRule], null);
 								locks[indexLock].acquire();
 								locks[secondIndex].acquire();
-								assertTrue(indexRule + ".0", getLockManager().isLockOwner());
+								assertTrue(getLockManager().isLockOwner(), indexRule + "");
 								locks[secondIndex].release();
 								locks[indexLock].release();
 								manager.endRule(rules[indexRule]);
@@ -1062,7 +1063,7 @@ public class DeadlockDetectionTest {
 								locks[indexLock].acquire();
 								manager.beginRule(rules[indexRule], null);
 								locks[secondIndex].acquire();
-								assertTrue(indexLock + ".0", getLockManager().isLockOwner());
+								assertTrue(getLockManager().isLockOwner(), indexLock + "");
 								locks[secondIndex].release();
 								manager.endRule(rules[indexRule]);
 								locks[indexLock].release();
@@ -1097,16 +1098,16 @@ public class DeadlockDetectionTest {
 					//ignore
 				}
 				//sanity check to avoid hanging tests
-				assertTrue("Timeout waiting for jobs to finish.", ++j < 1000);
+				assertTrue(++j < 1000, "Timeout waiting for jobs to finish.");
 			}
 		}
 
 		for (int i = 0; i < jobs.length; i++) {
-			assertEquals("10." + i, Job.NONE, jobs[i].getState());
-			assertEquals("10." + i, Status.OK_STATUS, jobs[i].getResult());
+			assertEquals(Job.NONE, jobs[i].getState(), i);
+			assertEquals(Status.OK_STATUS, jobs[i].getResult(), i + "");
 		}
 		//the underlying array has to be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	/**
@@ -1120,7 +1121,7 @@ public class DeadlockDetectionTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					assertTrue("1.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					status.set(0, TestBarrier2.STATUS_START);
 					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					monitor.worked(1);
@@ -1136,7 +1137,7 @@ public class DeadlockDetectionTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					assertTrue("2.0", getLockManager().isLockOwner());
+					assertTrue(getLockManager().isLockOwner());
 					monitor.worked(1);
 				} finally {
 					monitor.done();
@@ -1163,7 +1164,7 @@ public class DeadlockDetectionTest {
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 		waitForCompletion(first);
 		//the underlying graph should now be empty
-		assertTrue("Canceled job not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Canceled job not removed from graph.");
 	}
 
 	/**
@@ -1234,14 +1235,14 @@ public class DeadlockDetectionTest {
 		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//the underlying graph should not be empty yet
-		assertTrue("Held lock removed from graph.", !getLockManager().isEmpty());
+		assertFalse(getLockManager().isEmpty(), "Held lock removed from graph.");
 
 		//wait until the jobs are done
 		status.set(1, TestBarrier2.STATUS_RUNNING);
 		waitForCompletion(first);
 		waitForCompletion(second);
 		//the underlying graph should now be empty
-		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
+		assertTrue(getLockManager().isEmpty(), "Jobs not removed from graph.");
 	}
 
 	private void start(ArrayList<RandomTestRunnable> allRunnables) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/GithubBug_193.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/GithubBug_193.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,13 +52,13 @@ public class GithubBug_193 {
 		JobWatcher watcher = JobWatcher.startWatchingFor(JOB_FAMILY1, JOB_FAMILY2, JOB_FAMILY3);
 		List<Job> fewJobs = startFewJobs(jobCount);
 
-		assertEquals("Unexpected number of started jobs.", jobCount, fewJobs.size());
+		assertEquals(jobCount, fewJobs.size(), "Unexpected number of started jobs.");
 
 		watcher.waitUntilJobsAreDone();
 
-		assertEquals("There are still uncompleted jobs.", Collections.emptyList(), watcher.getJobsToWaitFor());
-		assertEquals("Unexpected number of scheduled jobs.", jobCount, watcher.getScheduled());
-		assertEquals("Unexpected number of done jobs.", jobCount, watcher.getDone());
+		assertEquals(Collections.emptyList(), watcher.getJobsToWaitFor(), "There are still uncompleted jobs.");
+		assertEquals(jobCount, watcher.getScheduled(), "Unexpected number of scheduled jobs.");
+		assertEquals(jobCount, watcher.getDone(), "Unexpected number of done jobs.");
 	}
 
 	private List<Job> startFewJobs(int jobCount) {
@@ -259,7 +259,7 @@ class JobWatcher {
 			errors.forEach(e -> {
 				throw new AssertionError(e);
 			});
-			assertEquals("Jobs delivered in wrong order for " + getJobsToWaitFor(), 0, latchToWaitFor.getCount());
+			assertEquals(0, latchToWaitFor.getCount(), "Jobs delivered in wrong order for " + getJobsToWaitFor());
 		}
 	}
 

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobEventTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.core.internal.jobs.JobListeners;

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobGroupTest.java
@@ -15,14 +15,14 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLong;
-import junit.framework.AssertionFailedError;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -96,15 +95,15 @@ public class JobGroupTest extends AbstractJobTest {
 			barrier.setStatus(TestBarrier2.STATUS_DONE);
 		});
 
-		assertEquals("1.0", JobGroup.ACTIVE, jobGroup.getState());
+		assertEquals(JobGroup.ACTIVE, jobGroup.getState());
 		// Start the thread and wait for it to complete.
 		t.start();
 		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 
-		assertEquals("2.0", JobGroup.NONE, jobGroup.getState());
-		assertTrue("3.0", maxThreadsUsed[0] > 0);
-		assertTrue("4.0", maxThreadsUsed[0] <= MAX_THREADS);
+		assertEquals(JobGroup.NONE, jobGroup.getState());
+		assertTrue(maxThreadsUsed[0] > 0);
+		assertTrue(maxThreadsUsed[0] <= MAX_THREADS);
 	}
 
 	@Test
@@ -119,20 +118,20 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 			waitForStart(job);
 			// Job group should be in the ACTIVE state with one active job.
-			assertEquals("1." + i, 1, jobGroup.getActiveJobs().size());
-			assertEquals("2." + i, JobGroup.ACTIVE, jobGroup.getState());
+			assertEquals(1, jobGroup.getActiveJobs().size(), i);
+			assertEquals(JobGroup.ACTIVE, jobGroup.getState(), i);
 			// Cancel the test job and wait for it to finish.
 			job.cancel();
 			waitForCompletion(job);
 			// Verify that the group does not contain any active jobs.
-			assertEquals("3." + i, 0, jobGroup.getActiveJobs().size());
+			assertEquals(0, jobGroup.getActiveJobs().size(), i);
 			// Verify that the group will be in the ACTIVE state even when there are no active jobs
 			// and transitions to NONE state only after all the seed jobs are completed.
 			if (i < NUM_SEED_JOBS) {
-				assertEquals("4." + i, JobGroup.ACTIVE, jobGroup.getState());
+				assertEquals(JobGroup.ACTIVE, jobGroup.getState(), i);
 			} else {
 				waitForCompletion(jobGroup);
-				assertEquals("4." + i, JobGroup.NONE, jobGroup.getState());
+				assertEquals(JobGroup.NONE, jobGroup.getState(), i);
 			}
 		}
 	}
@@ -163,22 +162,22 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 			waitForCompletion(job);
 			// Job group should be in the ACTIVE state with the active child jobs.
-			assertEquals("1." + i, NUM_CHILD_JOBS, jobGroup.getActiveJobs().size());
-			assertEquals("2." + i, JobGroup.ACTIVE, jobGroup.getState());
+			assertEquals(NUM_CHILD_JOBS, jobGroup.getActiveJobs().size(), i);
+			assertEquals(JobGroup.ACTIVE, jobGroup.getState(), i);
 			// Cancel all the active child jobs and wait for them to finish.
 			for (Job activeJob : jobGroup.getActiveJobs()) {
 				activeJob.cancel();
 				waitForCompletion(activeJob);
 			}
 			// Verify that the group does not contain any active jobs.
-			assertEquals("3." + i, 0, jobGroup.getActiveJobs().size());
+			assertEquals(0, jobGroup.getActiveJobs().size(), i);
 			// Verify that the group will be in the ACTIVE state even when there are no active jobs
 			// and transitions to NONE state only after all the seed jobs are completed.
 			if (i < NUM_SEED_JOBS) {
-				assertEquals("4." + i, JobGroup.ACTIVE, jobGroup.getState());
+				assertEquals(JobGroup.ACTIVE, jobGroup.getState(), i);
 			} else {
 				waitForCompletion(jobGroup);
-				assertEquals("4." + i, JobGroup.NONE, jobGroup.getState());
+				assertEquals(JobGroup.NONE, jobGroup.getState(), i);
 			}
 		}
 	}
@@ -201,7 +200,7 @@ public class JobGroupTest extends AbstractJobTest {
 			// Verify that all the repeating jobs have run the expected number of times,
 			// which only happen when the job group treats the multiple executions of
 			// a repeating job as a single seed job.
-			assertEquals("1." + i, REPEATING_COUNT, jobs[i].getRunCount());
+			assertEquals(REPEATING_COUNT, jobs[i].getRunCount(), i);
 		}
 	}
 
@@ -228,14 +227,14 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 
 		waitForStart(jobs[0]);
-		assertState("1.0", jobs[0], Job.RUNNING);
+		assertState(jobs[0], Job.RUNNING);
 
 		waitForStart(jobs[1]);
-		assertState("2.0", jobs[1], Job.RUNNING);
+		assertState(jobs[1], Job.RUNNING);
 
 		// Verify that the first two jobs are running and the rest are waiting.
 		for (int i = 2; i < NUM_JOBS; i++) {
-			assertState("1." + i, jobs[i], Job.WAITING);
+			assertState(jobs[i], Job.WAITING, i);
 		}
 
 		// Cancel the first group of jobs.
@@ -243,18 +242,18 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForCompletion(firstJobGroup);
 
 		// Verify that the the previously running job is canceled and moved to NONE state.
-		assertState("2.0", jobs[0], Job.NONE);
+		assertState(jobs[0], Job.NONE);
 
 		for (int i = 2; i < NUM_JOBS; i++) {
 			// Verify that all other jobs in the first group are also canceled and moved to NONE state.
 			if (jobs[i].getJobGroup() == firstJobGroup) {
-				assertState("2." + i, jobs[i], Job.NONE);
+				assertState(jobs[i], Job.NONE, i);
 				jobs[i].wakeUp();
-				assertState("2." + i, jobs[i], Job.NONE);
+				assertState(jobs[i], Job.NONE, i);
 				jobs[i].sleep();
-				assertState("2." + i, jobs[i], Job.NONE);
+				assertState(jobs[i], Job.NONE, i);
 			} else { // Verify that all other jobs in the second groups are in the waiting state.
-				assertState("3." + i, jobs[i], Job.WAITING);
+				assertState(jobs[i], Job.WAITING, i);
 			}
 		}
 
@@ -263,11 +262,11 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForCompletion(secondJobGroup);
 
 		// Verify that the running job from the second group is canceled to moved to NONE state.
-		assertState("7.0", jobs[1], Job.NONE);
+		assertState(jobs[1], Job.NONE);
 
 		for (int i = 0; i < NUM_JOBS; i++) {
 			// Verify that all the jobs are canceled and moved to NONE state.
-			assertState("8." + i, jobs[i], Job.NONE);
+			assertState(jobs[i], Job.NONE, i);
 		}
 	}
 
@@ -345,7 +344,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// The first job should still be running.
 		for (int i = 0; i < 5; i++) {
-			assertState("7.0", jobs[i], Job.RUNNING);
+			assertState(jobs[i], Job.RUNNING);
 		}
 
 		// Cancel the first job group.
@@ -386,7 +385,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// Verify that all jobs are canceled and moved to NONE state
 		for (int i = 0; i < NUM_JOBS; i++) {
-			assertState("12." + i, jobs[i], Job.NONE);
+			assertState(jobs[i], Job.NONE, i);
 		}
 
 		// Finding all jobs should return no jobs from our job groups.
@@ -452,12 +451,12 @@ public class JobGroupTest extends AbstractJobTest {
 
 			// Verify that when the thread is complete then all jobs must be done.
 			if (currentStatus == TestBarrier2.STATUS_DONE) {
-				assertTrue("1." + i, result.isEmpty());
+				assertTrue(result.isEmpty(), i + "");
 				break;
 			}
 			sleep(1);
 		}
-		assertTrue("2.0", i < 10000);
+		assertTrue(i < 10000);
 
 		// Cancel the second job group.
 		secondJobGroup.cancel();
@@ -465,7 +464,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// Verify that all the jobs are now in the NONE state.
 		for (int j = 0; j < NUM_JOBS; j++) {
-			assertState("3." + j, jobs[j], Job.NONE);
+			assertState(jobs[j], Job.NONE, j);
 		}
 	}
 
@@ -513,12 +512,12 @@ public class JobGroupTest extends AbstractJobTest {
 
 		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 		// Verify that thread is done
-		assertNotEquals("Waiting for join to time out failed", -1, duration[0]);
-		assertEquals("Group with long running jobs should still be active after join timed out", JobGroup.ACTIVE,
-				firstJobGroup.getState());
+		assertNotEquals(-1, duration[0], "Waiting for join to time out failed");
+		assertEquals(JobGroup.ACTIVE, firstJobGroup.getState(),
+				"Group with long running jobs should still be active after join timed out");
 		// Verify that join call is blocked for at least the duration of given timeout
 		String durationAndTimoutMessage = "duration: " + duration[0] + " timeout: " + timeout;
-		assertTrue("Join did not run into timeout; " + durationAndTimoutMessage, duration[0] >= timeout);
+		assertTrue(duration[0] >= timeout, "Join did not run into timeout; " + durationAndTimoutMessage);
 
 		// Cancel both job groups.
 		firstJobGroup.cancel();
@@ -528,7 +527,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// Verify that all the jobs are now in the NONE state.
 		for (int j = 0; j < NUM_JOBS; j++) {
-			assertState("Job " + j, jobs[j], Job.NONE);
+			assertState(jobs[j], Job.NONE, j);
 		}
 	}
 
@@ -578,8 +577,8 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForStart(jobs[0]);
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 
-		assertState("2.0", jobs[0], Job.RUNNING);
-		assertEquals("2.1", TestBarrier2.STATUS_RUNNING, status.get(0));
+		assertState(jobs[0], Job.RUNNING);
+		assertEquals(TestBarrier2.STATUS_RUNNING, status.get(0));
 
 		// Cancel the first job group. The join call should be unblocked when
 		// all the jobs are canceled.
@@ -587,7 +586,7 @@ public class JobGroupTest extends AbstractJobTest {
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 
 		// Verify that there are no active jobs in the the first group.
-		assertTrue("2.2", firstJobGroup.getActiveJobs().isEmpty());
+		assertTrue(firstJobGroup.getActiveJobs().isEmpty());
 
 		// Cancel the second job group.
 		secondJobGroup.cancel();
@@ -595,7 +594,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// Verify that all the jobs are now in the NONE state.
 		for (int j = 0; j < NUM_JOBS; j++) {
-			assertState("3." + j, jobs[j], Job.NONE);
+			assertState(jobs[j], Job.NONE, j);
 		}
 	}
 
@@ -647,17 +646,17 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForStart(jobs[0]);
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 
-		assertState("2.0", jobs[0], Job.RUNNING);
-		assertEquals("2.1", TestBarrier2.STATUS_RUNNING, status.get(0));
+		assertState(jobs[0], Job.RUNNING);
+		assertEquals(TestBarrier2.STATUS_RUNNING, status.get(0));
 
 		// Cancel the monitor that is attached to the join call.
 		canceler.setCanceled(true);
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 
 		// The first job in the first group should still be running.
-		assertState("2.2", jobs[0], Job.RUNNING);
-		assertEquals("2.3", TestBarrier2.STATUS_DONE, status.get(0));
-		assertFalse("2.4", firstJobGroup.getActiveJobs().isEmpty());
+		assertState(jobs[0], Job.RUNNING);
+		assertEquals(TestBarrier2.STATUS_DONE, status.get(0));
+		assertFalse(firstJobGroup.getActiveJobs().isEmpty());
 
 		// Cancel both job groups.
 		secondJobGroup.cancel();
@@ -667,7 +666,7 @@ public class JobGroupTest extends AbstractJobTest {
 
 		// Verify that all the jobs are now in the NONE state.
 		for (int j = 0; j < NUM_JOBS; j++) {
-			assertState("3." + j, jobs[j], Job.NONE);
+			assertState(jobs[j], Job.NONE, j);
 		}
 	}
 
@@ -683,7 +682,7 @@ public class JobGroupTest extends AbstractJobTest {
 		job.schedule();
 		jobGroup.join(0, null);
 		// Verify that the job has run the expected number of times.
-		assertEquals("1.2", count, job.getRunCount());
+		assertEquals(count, job.getRunCount());
 	}
 
 	/**
@@ -716,7 +715,7 @@ public class JobGroupTest extends AbstractJobTest {
 		secondJob.setJobGroup(jobGroup);
 		secondJob.schedule();
 		waitForCompletion(secondJob);
-		assertTrue("1.0", joinFailed[0]);
+		assertTrue(joinFailed[0]);
 
 		firstJob.cancel();
 		waitForCompletion(jobGroup);
@@ -793,7 +792,7 @@ public class JobGroupTest extends AbstractJobTest {
 		assertThat(children).hasSize(SEED_JOBS);
 		Integer[] results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
-			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
+			assertEquals(i + 1, results[i].intValue(), "Job result in unexpected order");
 		}
 
 		TestJob testJob = new TestJob("TestJob", 1, 10) {
@@ -815,7 +814,7 @@ public class JobGroupTest extends AbstractJobTest {
 		assertThat(children).hasSize(SEED_JOBS + 1);
 		results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
-			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
+			assertEquals(i + 1, results[i].intValue(), "Job result in unexpected order");
 		}
 
 		// Check the progress reporting on monitor.
@@ -833,7 +832,7 @@ public class JobGroupTest extends AbstractJobTest {
 		assertThat(children).hasSize(SEED_JOBS + 2);
 		results = Arrays.stream(children).map(s -> Integer.valueOf(s.getMessage())).toArray(Integer[]::new);
 		for (int i = 0; i < results.length; i++) {
-			assertEquals("Job result in unexpected order", i + 1, results[i].intValue());
+			assertEquals(i + 1, results[i].intValue(), "Job result in unexpected order");
 		}
 		// Check the progress reporting on monitor.
 		monitor.sanityCheck();
@@ -892,7 +891,7 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			assertEquals(1, groupJobsCount[0]);
-		} catch (AssertionFailedError e) {
+		} catch (AssertionError e) {
 			// interrupt to avoid deadlock and perform cleanup
 			Thread thread = job.getThread();
 			if (thread != null) {
@@ -968,7 +967,7 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			assertEquals(1, groupJobsCount[0]);
-		} catch (AssertionFailedError e) {
+		} catch (AssertionError e) {
 			// interrupt to avoid deadlock and perform cleanup
 			Thread thread = job.getThread();
 			if (thread != null) {
@@ -1040,7 +1039,7 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			assertEquals(0, groupJobsCount[0]);
-		} catch (AssertionFailedError e) {
+		} catch (AssertionError e) {
 			// interrupt to avoid deadlock and perform cleanup
 			Thread thread = job.getThread();
 			if (thread != null) {
@@ -1076,10 +1075,10 @@ public class JobGroupTest extends AbstractJobTest {
 			waitForStart(job);
 		}
 		// Verify that all the test jobs are running.
-		assertEquals("1.0", JobGroup.ACTIVE, jobGroup.getState());
-		assertEquals("1.1", NUM_SEED_JOBS - 1, jobGroup.getActiveJobs().size());
+		assertEquals(JobGroup.ACTIVE, jobGroup.getState());
+		assertEquals(NUM_SEED_JOBS - 1, jobGroup.getActiveJobs().size());
 		for (int i = 0; i < NUM_SEED_JOBS - 1; i++) {
-			assertState("2." + i, jobs[i], Job.RUNNING);
+			assertState(jobs[i], Job.RUNNING, i);
 		}
 
 		final TestBarrier2 barrier = new TestBarrier2();
@@ -1097,8 +1096,8 @@ public class JobGroupTest extends AbstractJobTest {
 		barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		// Verify that the failing job also started running.
-		assertEquals("3.0", NUM_SEED_JOBS, jobGroup.getActiveJobs().size());
-		assertState("3.1", failedJob, Job.RUNNING);
+		assertEquals(NUM_SEED_JOBS, jobGroup.getActiveJobs().size());
+		assertState(failedJob, Job.RUNNING);
 
 		for (int i = NUM_SEED_JOBS; i < NUM_SEED_JOBS + NUM_ADDITIONAL_JOBs; i++) {
 			Job job = new TestJob("AdditionalJob", 1000000, 1);
@@ -1108,9 +1107,9 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 
 		// Verify that all the jobs are active.
-		assertEquals("4.0", NUM_SEED_JOBS + NUM_ADDITIONAL_JOBs, jobGroup.getActiveJobs().size());
+		assertEquals(NUM_SEED_JOBS + NUM_ADDITIONAL_JOBs, jobGroup.getActiveJobs().size());
 		for (int i = NUM_SEED_JOBS; i < NUM_SEED_JOBS + NUM_ADDITIONAL_JOBs; i++) {
-			assertState("5." + i, jobs[i], Job.WAITING);
+			assertState(jobs[i], Job.WAITING, i);
 		}
 		// Allow the failing job to complete.
 		barrier.setStatus(TestBarrier2.STATUS_RUNNING);
@@ -1119,19 +1118,19 @@ public class JobGroupTest extends AbstractJobTest {
 		// Verify that all the jobs are moved to NONE state. Also verify that the failing job failed,
 		// other running jobs got canceled and the waiting jobs are never allowed to run.
 		for (int i = 0; i < NUM_SEED_JOBS + NUM_ADDITIONAL_JOBs; i++) {
-			assertState("6." + i, jobs[i], Job.NONE);
+			assertState(jobs[i], Job.NONE, i);
 			if (i < NUM_SEED_JOBS - 1) {
-				assertEquals("6." + i, IStatus.CANCEL, jobs[i].getResult().getSeverity());
+				assertEquals(IStatus.CANCEL, jobs[i].getResult().getSeverity(), i);
 			} else if (i == NUM_SEED_JOBS - 1) {
-				assertEquals("6." + i, IStatus.ERROR, jobs[i].getResult().getSeverity());
+				assertEquals(IStatus.ERROR, jobs[i].getResult().getSeverity(), i);
 			} else if (i == NUM_SEED_JOBS) {
 				// This job might have been started running before the group gets canceled.
 				IStatus result = jobs[i].getResult();
 				if (result != null) {
-					assertEquals("6." + i, IStatus.CANCEL, result.getSeverity());
+					assertEquals(IStatus.CANCEL, result.getSeverity(), i);
 				}
 			} else {
-				assertNull("6." + i, jobs[i].getResult());
+				assertNull(jobs[i].getResult(), i + "");
 			}
 		}
 	}
@@ -1162,7 +1161,7 @@ public class JobGroupTest extends AbstractJobTest {
 			job.schedule();
 		}
 		waitForCompletion(jobGroup);
-		assertEquals("1.0", NUM_JOBS - 1, numShouldCancelCalled[0]);
+		assertEquals(NUM_JOBS - 1, numShouldCancelCalled[0]);
 	}
 
 	/**
@@ -1219,17 +1218,17 @@ public class JobGroupTest extends AbstractJobTest {
 
 			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			// Verify that the shouldCancel method is called with appropriate values.
-			assertEquals("1." + i, i + 1, numShouldCancelCalled[0]);
-			assertEquals("2." + i, returnedStatus[0], completedJobResult[0]);
+			assertEquals(i + 1, numShouldCancelCalled[0], i);
+			assertEquals(returnedStatus[0], completedJobResult[0], i + "");
 			if (i < 3) {
-				assertEquals("3." + i, 0, failedJobsCount[0]);
+				assertEquals(0, failedJobsCount[0], i);
 			} else {
-				assertEquals("3." + i, 1, failedJobsCount[0]);
+				assertEquals(1, failedJobsCount[0], i);
 			}
 			if (i < 4) {
-				assertEquals("4." + i, 0, canceledJobsCount[0]);
+				assertEquals(0, canceledJobsCount[0], i);
 			} else {
-				assertEquals("4." + i, 1, canceledJobsCount[0]);
+				assertEquals(1, canceledJobsCount[0], i);
 			}
 		}
 		waitForCompletion(jobGroup);
@@ -1275,10 +1274,10 @@ public class JobGroupTest extends AbstractJobTest {
 		// Allow the jobs to proceed to run.
 		barrier.setStatus(TestBarrier2.STATUS_START);
 		waitForCompletion(jobGroup);
-		assertTrue("1.0", numShouldCancelCalled[0] >= NUM_JOBS_LIMIT);
+		assertTrue(numShouldCancelCalled[0] >= NUM_JOBS_LIMIT);
 		// Verify that the group is canceled in a reasonable time,
 		// i.e only 10 jobs are allowed to run after the shouldCancel method returned true.
-		assertTrue("2.0", numShouldCancelCalled[0] < NUM_JOBS_LIMIT + 10);
+		assertTrue(numShouldCancelCalled[0] < NUM_JOBS_LIMIT + 10);
 	}
 
 	/**
@@ -1377,7 +1376,7 @@ public class JobGroupTest extends AbstractJobTest {
 		// Verify that the group result contains all the job results except the OK statuses.
 		assertThat(jobResults).hasSize(status.length - 1);
 		for (int i = 1; i < status.length; i++) {
-			assertEquals("2." + i, status[i], jobResults[i - 1].getSeverity());
+			assertEquals(status[i], jobResults[i - 1].getSeverity(), i);
 		}
 	}
 
@@ -1417,10 +1416,10 @@ public class JobGroupTest extends AbstractJobTest {
 		// Verify that the compute group result is called with all the completed job results.
 		assertThat(originalJobResults[0]).hasSameSizeAs(status);
 		for (int i = 0; i < status.length; i++) {
-			assertEquals("3." + i, status[i], originalJobResults[0][i].getSeverity());
+			assertEquals(status[i], originalJobResults[0][i].getSeverity(), i);
 		}
 		// Verify that JobGroup.getResult returns the status returned by JobGroup.computeGroupResult method.
-		assertEquals("4.0", returnedGroupResult[0], jobGroup.getResult());
+		assertEquals(returnedGroupResult[0], jobGroup.getResult());
 	}
 
 	// https://bugs.eclipse.org/461621
@@ -1445,9 +1444,9 @@ public class JobGroupTest extends AbstractJobTest {
 		waitForCompletion(job, Duration.ofMillis(100));
 
 		boolean completed = jobGroup.join(1000, null);
-		assertTrue("2.0", completed);
+		assertTrue(completed);
 		MultiStatus result = jobGroup.getResult();
-		assertNotNull("3.0", result);
+		assertNotNull(result);
 	}
 
 	/**
@@ -1463,8 +1462,8 @@ public class JobGroupTest extends AbstractJobTest {
 			testJob.setJobGroup(jobGroup);
 			testJob.schedule();
 		}
-		assertEquals("1.0", JobGroup.ACTIVE, jobGroup.getState());
-		assertEquals("2.0", NUM_GROUP_JOBS, jobGroup.getActiveJobs().size());
+		assertEquals(JobGroup.ACTIVE, jobGroup.getState());
+		assertEquals(NUM_GROUP_JOBS, jobGroup.getActiveJobs().size());
 
 		TestJob normalJobs[] = new TestJob[NUM_NORMAL_JOBS];
 		for (int i = 0; i < NUM_NORMAL_JOBS; i++) {
@@ -1477,8 +1476,8 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 
 		// Tests that the normal jobs are completed fine while the group jobs are still running.
-		assertEquals("3.0", JobGroup.ACTIVE, jobGroup.getState());
-		assertEquals("4.0", NUM_GROUP_JOBS, jobGroup.getActiveJobs().size());
+		assertEquals(JobGroup.ACTIVE, jobGroup.getState());
+		assertEquals(NUM_GROUP_JOBS, jobGroup.getActiveJobs().size());
 		jobGroup.cancel();
 		waitForCompletion(jobGroup);
 	}
@@ -1522,14 +1521,17 @@ public class JobGroupTest extends AbstractJobTest {
 			List<IJobChangeEvent> events = new ArrayList<>();
 			eventQueue.forEach(events::add);
 
-			assertEquals("Should have seen as many job completion events as the count of jobs in the job group.", NUM_GROUP_JOBS, events.size());
+			assertEquals(NUM_GROUP_JOBS, events.size(),
+					"Should have seen as many job completion events as the count of jobs in the job group.");
 			for (int i = 0; i < NUM_GROUP_JOBS; i++) {
 				IJobChangeEvent event = events.get(i);
-				assertNotNull("All job completion events should have a job status.", event.getResult());
+				assertNotNull(event.getResult(), "All job completion events should have a job status.");
 				if (i < NUM_GROUP_JOBS - 1) {
-					assertNull("Only the last job competion event shoud have a job group status.", event.getJobGroupResult());
+					assertNull(event.getJobGroupResult(),
+							"Only the last job competion event shoud have a job group status.");
 				} else {
-					assertNotNull("The last job competion event shoud have a job group status.", event.getJobGroupResult());
+					assertNotNull(event.getJobGroupResult(),
+							"The last job competion event shoud have a job group status.");
 				}
 			}
 		} finally {
@@ -1537,11 +1539,17 @@ public class JobGroupTest extends AbstractJobTest {
 		}
 	}
 
-	private void assertState(String msg, Job job, int expectedState) {
+	private void assertState(Job job, int expectedState) {
 		int actualState = job.getState();
-		assertSame(
-				msg + ": expected state: " + printState(expectedState) + " actual state: " + printState(actualState),
-				actualState, expectedState);
+		assertSame(actualState, expectedState,
+				"expected state: " + printState(expectedState) + " actual state: "
+						+ printState(actualState));
+	}
+
+	private void assertState(Job job, int expectedState, int jobNumber) {
+		int actualState = job.getState();
+		assertSame(actualState, expectedState, "Job " + jobNumber + ", expected state: " + printState(expectedState)
+				+ " actual state: " + printState(actualState));
 	}
 
 	private String printState(int state) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobQueueTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobQueueTest.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.jobs.InternalJob;
 import org.eclipse.core.internal.jobs.JobQueue;
@@ -56,32 +56,32 @@ public class JobQueueTest {
 		for (int i = 0; i < entries.length; i++) {
 			entries[i] = new Entry(Job.LONG);
 			queue.enqueue(entries[i]);
-			assertEquals("1.0." + i, entries[0], queue.peek());
+			assertEquals(entries[0], queue.peek(), i + "");
 		}
 		for (int i = 0; i < entries.length; i++) {
-			assertEquals("2.0." + i, entries[i], queue.dequeue());
+			assertEquals(entries[i], queue.dequeue(), i + "");
 		}
 	}
 
 	@Test
 	public void testBasic() {
 		Entry[] entries = createEntries();
-		assertTrue("1.0", queue.isEmpty());
-		assertNull("1.1", queue.dequeue());
-		assertNull("1.2", queue.peek());
+		assertTrue(queue.isEmpty());
+		assertNull(queue.dequeue());
+		assertNull(queue.peek());
 		for (Entry entry : entries) {
 			queue.enqueue(entry);
-			assertNotNull("1.3", queue.peek());
+			assertNotNull(queue.peek());
 		}
 		for (int i = 0; i < entries.length; i++) {
 			queue.remove(entries[i]);
 			if (i + 1 < entries.length) {
-				assertNotNull("1.4." + i, queue.peek());
+				assertNotNull(queue.peek(), i + "");
 			}
 		}
-		assertTrue("2.0", queue.isEmpty());
-		assertNull("2.1", queue.dequeue());
-		assertNull("2.2", queue.peek());
+		assertTrue(queue.isEmpty());
+		assertNull(queue.dequeue());
+		assertNull(queue.peek());
 		for (Entry entry : entries) {
 			queue.enqueue(entry);
 		}
@@ -89,10 +89,10 @@ public class JobQueueTest {
 		while (!queue.isEmpty()) {
 			InternalJob peek = queue.peek();
 			InternalJob removed = queue.dequeue();
-			assertEquals("3.0." + count, peek, removed);
+			assertEquals(peek, removed, count + "");
 			count--;
 		}
-		assertEquals("3.1", 0, count);
+		assertEquals(0, count);
 	}
 
 	private Entry[] createEntries() {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/JobTest.java
@@ -21,13 +21,13 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -73,10 +73,10 @@ public class JobTest extends AbstractJobTest {
 		//calling the done method on a job that is not executing asynchronously should have no effect
 
 		shortJob.done(Status.OK_STATUS);
-		assertTrue("1.0", shortJob.getResult() == null);
+		assertNull(shortJob.getResult());
 
 		shortJob.done(Status.CANCEL_STATUS);
-		assertTrue("2.0", shortJob.getResult() == null);
+		assertNull(shortJob.getResult());
 
 		//calling the done method after the job is scheduled
 		shortJob.schedule();
@@ -84,10 +84,10 @@ public class JobTest extends AbstractJobTest {
 		waitForState(shortJob, Job.NONE);
 
 		//the done call should be ignored, and the job should finish execution normally
-		assertTrue("3.0", shortJob.getResult().getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, shortJob.getResult().getSeverity());
 
 		shortJob.done(Status.CANCEL_STATUS);
-		assertTrue("4.0", shortJob.getResult().getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, shortJob.getResult().getSeverity());
 
 		//calling the done method before a job is canceled
 		longJob.schedule();
@@ -97,10 +97,10 @@ public class JobTest extends AbstractJobTest {
 		waitForState(longJob, Job.NONE);
 
 		//the done call should be ignored, and the job status should still be canceled
-		assertEquals("5.0", IStatus.CANCEL, longJob.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, longJob.getResult().getSeverity());
 
 		longJob.done(Status.OK_STATUS);
-		assertEquals("6.0", IStatus.CANCEL, longJob.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, longJob.getResult().getSeverity());
 
 	}
 
@@ -159,7 +159,7 @@ public class JobTest extends AbstractJobTest {
 		waitForState(main, Job.NONE);
 
 		//after the job is finished, the thread should be reset
-		assertEquals("job finished with unexpected result", IStatus.OK, main.getResult().getSeverity());
+		assertEquals(IStatus.OK, main.getResult().getSeverity(), "job finished with unexpected result");
 		assertNull(main.getThread());
 
 		//reset status
@@ -194,7 +194,7 @@ public class JobTest extends AbstractJobTest {
 		waitForState(main, Job.NONE);
 
 		//thread should be reset to null after cancellation
-		assertEquals("job finished with unexpected result", IStatus.CANCEL, main.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, main.getResult().getSeverity(), "job finished with unexpected result");
 		assertNull(main.getThread());
 	}
 
@@ -205,8 +205,8 @@ public class JobTest extends AbstractJobTest {
 
 		for (int i = 0; i < jobs.length; i++) {
 			jobs[i] = new AsynchTestJob("TestJob" + (i + 1));
-			assertNull("job unexpectedly has thread assigned: " + jobs[i], jobs[i].getThread());
-			assertNull("job unexpectedly has a result: " + jobs[i], jobs[i].getResult());
+			assertNull(jobs[i].getThread(), "job unexpectedly has thread assigned: " + jobs[i]);
+			assertNull(jobs[i].getResult(), "job unexpectedly has a result: " + jobs[i]);
 			jobs[i].schedule();
 		}
 		//all the jobs should be running at the same time
@@ -253,8 +253,8 @@ public class JobTest extends AbstractJobTest {
 		//the threads should have been reset to null
 		for (AsynchTestJob job : jobs) {
 			waitForState(job, Job.NONE);
-			assertEquals("job finished with unexpected state: " + job, IStatus.OK, job.getResult().getSeverity());
-			assertNull("job still has a thread assigned: " + job, job.getThread());
+			assertEquals(IStatus.OK, job.getResult().getSeverity(), "job finished with unexpected state: " + job);
+			assertNull(job.getThread(), "job still has a thread assigned: " + job);
 		}
 	}
 
@@ -267,8 +267,8 @@ public class JobTest extends AbstractJobTest {
 
 		for (int i = 0; i < jobs.length; i++) {
 			jobs[i] = new AsynchTestJob("TestJob" + (i + 1));
-			assertNull("job unexpectedly has thread assigned: " + jobs[i], jobs[i].getThread());
-			assertNull("job unexpectedly has a result: " + jobs[i], jobs[i].getResult());
+			assertNull(jobs[i].getThread(), "job unexpectedly has thread assigned: " + jobs[i]);
+			assertNull(jobs[i].getResult(), "job unexpectedly has a result: " + jobs[i]);
 			if (i < 2) {
 				jobs[i].schedule();
 			} else if (i > 2) {
@@ -312,9 +312,9 @@ public class JobTest extends AbstractJobTest {
 		//the 2 newly scheduled jobs should be waiting since they conflict with the third job
 		//no threads were assigned to them yet
 		waitForState(jobs[3], Job.WAITING);
-		assertNull("job unexpectedly has a thread assigned: " + jobs[3], jobs[3].getThread());
+		assertNull(jobs[3].getThread(), "job unexpectedly has a thread assigned: " + jobs[3]);
 		waitForState(jobs[4], Job.WAITING);
-		assertNull("job unexpectedly has a thread assigned: " + jobs[4], jobs[4].getThread());
+		assertNull(jobs[4].getThread(), "job unexpectedly has a thread assigned: " + jobs[4]);
 
 		//let the two non-conflicting jobs execute together
 		for (int i = 0; i < 2; i++) {
@@ -364,15 +364,15 @@ public class JobTest extends AbstractJobTest {
 		for (int i = 0; i < 4; i++) {
 			AsynchTestJob job = jobs[i];
 			waitForState(job, Job.NONE);
-			assertEquals("job finished with unexpected state: " + job, IStatus.OK, job.getResult().getSeverity());
-			assertNull("job still has a thread assigned: " + job, job.getThread());
+			assertEquals(IStatus.OK, job.getResult().getSeverity(), "job finished with unexpected state: " + job);
+			assertNull(job.getThread(), "job still has a thread assigned: " + job);
 		}
 
 		//the fifth job should have null as its status (it never finished running)
 		//the thread for it should have also been reset
 		waitForState(jobs[3], Job.NONE);
-		assertNull("job should not have a result: " + jobs[4], jobs[4].getResult());
-		assertNull("job still has a thread assigned: " + jobs[4], jobs[4].getThread());
+		assertNull(jobs[4].getResult(), "job should not have a result: " + jobs[4]);
+		assertNull(jobs[4].getThread(), "job still has a thread assigned: " + jobs[4]);
 	}
 
 	private static void assertThreadType(Job job, Class<?> threadType) {
@@ -406,9 +406,9 @@ public class JobTest extends AbstractJobTest {
 		});
 		job.schedule();
 		job.join();
-		assertEquals("1.0", 0, job.getRunCount());
-		assertEquals("1.1", 1, doneCount[0]);
-		assertEquals("1.2", 0, runningCount[0]);
+		assertEquals(0, job.getRunCount());
+		assertEquals(1, doneCount[0]);
+		assertEquals(0, runningCount[0]);
 	}
 
 	/**
@@ -557,11 +557,11 @@ public class JobTest extends AbstractJobTest {
 		//schedule the job and wait on the barrier until it is running
 		job.schedule();
 		barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
-		assertEquals("1.0", 0, canceling[0]);
+		assertEquals(0, canceling[0]);
 		job.cancel();
-		assertEquals("1.1", 1, canceling[0]);
+		assertEquals(1, canceling[0]);
 		job.cancel();
-		assertEquals("1.2", 1, canceling[0]);
+		assertEquals(1, canceling[0]);
 		//let the job finish
 		barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 		waitForState(job, Job.NONE);
@@ -596,11 +596,11 @@ public class JobTest extends AbstractJobTest {
 			//schedule the job and wait on the barrier until it is running
 			job.schedule();
 			barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
-			assertEquals(i + ".1.0", 0, canceling[0]);
+			assertEquals(0, canceling[0], i);
 			jobmonitor[0].setCanceled(true);
-			assertEquals(i + ".1.1", 1, canceling[0]);
+			assertEquals(1, canceling[0], i);
 			jobmonitor[0].setCanceled(true);
-			assertEquals(i + ".1.2", 1, canceling[0]);
+			assertEquals(1, canceling[0], i);
 			//let the job finish
 			barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 			waitForState(job, Job.NONE);
@@ -664,7 +664,7 @@ public class JobTest extends AbstractJobTest {
 			j.schedule();
 			Thread.sleep(1000);
 			Job.getJobManager().join(this, null);
-			assertFalse("1.0", failure[0]);
+			assertFalse(failure[0]);
 		} finally {
 			Job.getJobManager().removeJobChangeListener(listener);
 		}
@@ -672,8 +672,8 @@ public class JobTest extends AbstractJobTest {
 
 	@Test
 	public void testGetName() {
-		assertEquals("1.0", "Short Test Job", shortJob.getName());
-		assertEquals("1.1", "Long Test Job", longJob.getName());
+		assertEquals("Short Test Job", shortJob.getName());
+		assertEquals("Long Test Job", longJob.getName());
 
 		//try creating a job with a null name
 		assertThrows(RuntimeException.class, () -> new TestJob(null));
@@ -688,7 +688,7 @@ public class JobTest extends AbstractJobTest {
 
 		for (int i = 0; i < priority.length; i++) {
 			shortJob.setPriority(priority[i]);
-			assertEquals("1." + i, priority[i], shortJob.getPriority());
+			assertEquals(priority[i], shortJob.getPriority(), i);
 		}
 	}
 
@@ -696,26 +696,26 @@ public class JobTest extends AbstractJobTest {
 	public void testGetProperty() {
 		QualifiedName n1 = new QualifiedName("org.eclipse.core.tests.runtime", "p1");
 		QualifiedName n2 = new QualifiedName("org.eclipse.core.tests.runtime", "p2");
-		assertNull("1.0", shortJob.getProperty(n1));
+		assertNull(shortJob.getProperty(n1));
 		shortJob.setProperty(n1, null);
-		assertNull("1.1", shortJob.getProperty(n1));
+		assertNull(shortJob.getProperty(n1));
 		shortJob.setProperty(n1, shortJob);
-		assertEquals("1.2", shortJob.getProperty(n1), shortJob);
-		assertNull("1.3", shortJob.getProperty(n2));
+		assertEquals(shortJob.getProperty(n1), shortJob);
+		assertNull(shortJob.getProperty(n2));
 		shortJob.setProperty(n1, "hello");
-		assertEquals("1.4", "hello", shortJob.getProperty(n1));
+		assertEquals("hello", shortJob.getProperty(n1));
 		shortJob.setProperty(n1, null);
-		assertNull("1.5", shortJob.getProperty(n1));
-		assertNull("1.6", shortJob.getProperty(n2));
+		assertNull(shortJob.getProperty(n1));
+		assertNull(shortJob.getProperty(n2));
 	}
 
 	@Test
 	public void testGetResult() {
 		//execute a short job
-		assertNull("1.0", shortJob.getResult());
+		assertNull(shortJob.getResult());
 		shortJob.schedule();
 		waitForState(shortJob, Job.NONE);
-		assertEquals("1.1", IStatus.OK, shortJob.getResult().getSeverity());
+		assertEquals(IStatus.OK, shortJob.getResult().getSeverity());
 
 		//cancel a long job
 		waitForState(longJob, Job.NONE);
@@ -723,24 +723,24 @@ public class JobTest extends AbstractJobTest {
 		waitForState(longJob, Job.RUNNING);
 		longJob.cancel();
 		waitForState(longJob, Job.NONE);
-		assertEquals("2.0", IStatus.CANCEL, longJob.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, longJob.getResult().getSeverity());
 	}
 
 	@Test
 	public void testGetRule() {
 		//set several rules for the job, check if getRule returns the rule that was set
 		//no rule was set yet
-		assertNull("1.0", shortJob.getRule());
+		assertNull(shortJob.getRule());
 
 		shortJob.setRule(new IdentityRule());
-		assertTrue("1.1", (shortJob.getRule() instanceof IdentityRule));
+		assertTrue((shortJob.getRule() instanceof IdentityRule));
 
 		ISchedulingRule rule = new PathRule("/testGetRule");
 		shortJob.setRule(rule);
-		assertEquals("1.2", shortJob.getRule(), rule);
+		assertEquals(shortJob.getRule(), rule);
 
 		shortJob.setRule(null);
-		assertNull("1.3", shortJob.getRule());
+		assertNull(shortJob.getRule());
 	}
 
 	@Test
@@ -749,17 +749,17 @@ public class JobTest extends AbstractJobTest {
 		//if the job is scheduled, only jobs that return the asynch_exec status will run in the indicated thread
 
 		//main is not running now
-		assertNull("1.0", shortJob.getThread());
+		assertNull(shortJob.getThread());
 
 		Thread t = new Thread();
 		shortJob.setThread(t);
-		assertEquals("1.1", shortJob.getThread(), t);
+		assertEquals(shortJob.getThread(), t);
 
 		shortJob.setThread(new Thread());
-		assertNotEquals("1.2", shortJob.getThread(), t);
+		assertNotEquals(shortJob.getThread(), t);
 
 		shortJob.setThread(null);
-		assertNull("1.3", shortJob.getThread());
+		assertNull(shortJob.getThread());
 	}
 
 	@Test
@@ -778,10 +778,10 @@ public class JobTest extends AbstractJobTest {
 		//start the build job, and make sure it is not blocking
 		medium.schedule();
 		waitForState(medium, Job.RUNNING);
-		assertTrue("1.0", !medium.isBlocking());
+		assertFalse(medium.isBlocking());
 		//schedule a lower priority job, and it should still not be blocking
 		low.schedule();
-		assertTrue("1.1", !medium.isBlocking());
+		assertFalse(medium.isBlocking());
 		//schedule a higher priority job - now it should be blocking
 		high.schedule();
 		//wait for the high priority job to become blocked
@@ -790,7 +790,7 @@ public class JobTest extends AbstractJobTest {
 		} catch (InterruptedException e) {
 			//ignore
 		}
-		assertTrue("1.2", medium.isBlocking());
+		assertTrue(medium.isBlocking());
 
 		//cancel everything
 		Job[] jobs = new Job[] {high, medium, low};
@@ -802,7 +802,7 @@ public class JobTest extends AbstractJobTest {
 		medium.schedule();
 		waitForState(medium, Job.RUNNING);
 		high.schedule();
-		assertTrue("2.0", !medium.isBlocking());
+		assertFalse(medium.isBlocking());
 
 		//clean up
 		cancel(jobs);
@@ -841,14 +841,14 @@ public class JobTest extends AbstractJobTest {
 		//reset the system parameter several times
 		shortJob.setUser(false);
 		shortJob.setSystem(false);
-		assertTrue("1.0", !shortJob.isUser());
-		assertTrue("1.1", !shortJob.isSystem());
+		assertFalse(shortJob.isUser());
+		assertFalse(shortJob.isSystem());
 		shortJob.setSystem(true);
-		assertTrue("1.2", !shortJob.isUser());
-		assertTrue("1.3", shortJob.isSystem());
+		assertFalse(shortJob.isUser());
+		assertTrue(shortJob.isSystem());
 		shortJob.setSystem(false);
-		assertTrue("1.4", !shortJob.isUser());
-		assertTrue("1.5", !shortJob.isSystem());
+		assertFalse(shortJob.isUser());
+		assertFalse(shortJob.isSystem());
 	}
 
 	@Test
@@ -856,14 +856,14 @@ public class JobTest extends AbstractJobTest {
 		//reset the user parameter several times
 		shortJob.setUser(false);
 		shortJob.setSystem(false);
-		assertTrue("1.0", !shortJob.isUser());
-		assertTrue("1.1", !shortJob.isSystem());
+		assertFalse(shortJob.isUser());
+		assertFalse(shortJob.isSystem());
 		shortJob.setUser(true);
-		assertTrue("1.2", shortJob.isUser());
-		assertTrue("1.3", !shortJob.isSystem());
+		assertTrue(shortJob.isUser());
+		assertFalse(shortJob.isSystem());
 		shortJob.setUser(false);
-		assertTrue("1.4", !shortJob.isUser());
-		assertTrue("1.5", !shortJob.isSystem());
+		assertFalse(shortJob.isUser());
+		assertFalse(shortJob.isSystem());
 	}
 
 	@Test
@@ -884,16 +884,16 @@ public class JobTest extends AbstractJobTest {
 		});
 		t.start();
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_START);
-		assertEquals("1.0", TestBarrier2.STATUS_START, status.get(0));
+		assertEquals(TestBarrier2.STATUS_START, status.get(0));
 		//putting the job to sleep should not affect the join call
 		longJob.sleep();
 		//give a chance for the sleep to take effect
 		sleep(100);
-		assertEquals("1.0", TestBarrier2.STATUS_START, status.get(0));
+		assertEquals(TestBarrier2.STATUS_START, status.get(0));
 		//similarly waking the job up should not affect the join
 		longJob.wakeUp(100000);
 		sleep(100);
-		assertEquals("1.0", TestBarrier2.STATUS_START, status.get(0));
+		assertEquals(TestBarrier2.STATUS_START, status.get(0));
 
 		//finally canceling the job will cause the join to return
 		longJob.cancel();
@@ -926,11 +926,11 @@ public class JobTest extends AbstractJobTest {
 
 		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 		// Verify that thread is done
-		assertNotEquals("Waiting for join to time out failed", -1, duration[0]);
-		assertEquals("Long running job should still be running after join timed out", Job.RUNNING, longJob.getState());
+		assertNotEquals(-1, duration[0], "Waiting for join to time out failed");
+		assertEquals(Job.RUNNING, longJob.getState(), "Long running job should still be running after join timed out");
 		// Verify that join call is blocked for at least the duration of given timeout
 		String durationAndTimoutMessage = "duration: " + duration[0] + " timeout: " + timeout;
-		assertTrue("Join did not run into timeout; " + durationAndTimoutMessage, duration[0] >= timeout);
+		assertTrue(duration[0] >= timeout, "Join did not run into timeout; " + durationAndTimoutMessage);
 
 		// Finally cancel the job
 		longJob.cancel();
@@ -960,7 +960,7 @@ public class JobTest extends AbstractJobTest {
 		});
 		t.start();
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_START);
-		assertEquals("1.0", TestBarrier2.STATUS_START, status.get(0));
+		assertEquals(TestBarrier2.STATUS_START, status.get(0));
 		// Wakeup the job to get the join call to complete
 		shortJob.wakeUp();
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
@@ -999,7 +999,7 @@ public class JobTest extends AbstractJobTest {
 		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 		monitor.sanityCheck();
 		// Verify that the join call is still running
-		assertEquals("job unexpectedly stopped running after join call", Job.RUNNING, longJob.getState());
+		assertEquals(Job.RUNNING, longJob.getState(), "job unexpectedly stopped running after join call");
 		// Finally cancel the job
 		longJob.cancel();
 		waitForCompletion(longJob);
@@ -1032,7 +1032,7 @@ public class JobTest extends AbstractJobTest {
 		barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
 		t.interrupt();
 		job.join();
-		assertEquals("Thread not interrupted", Status.OK_STATUS, job.getResult());
+		assertEquals(Status.OK_STATUS, job.getResult(), "Thread not interrupted");
 	}
 
 	@Test
@@ -1058,7 +1058,7 @@ public class JobTest extends AbstractJobTest {
 		waitForState(job, Job.RUNNING);
 		t.interrupt();
 		job.join();
-		assertEquals("Thread interrupted", Status.OK_STATUS, job.getResult());
+		assertEquals(Status.OK_STATUS, job.getResult(), "Thread interrupted");
 	}
 
 	/**
@@ -1135,7 +1135,7 @@ public class JobTest extends AbstractJobTest {
 		};
 		selfJoiner.schedule();
 		selfJoiner.join();
-		assertNotNull("1.0", failure[0]);
+		assertNotNull(failure[0]);
 	}
 
 	/**
@@ -1244,11 +1244,11 @@ public class JobTest extends AbstractJobTest {
 		status.set(0, TestBarrier2.STATUS_RUNNING);
 		//wait until the job runs again
 		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_WAIT_FOR_RUN);
-		assertEquals("1.0", 1, runCount[0]);
+		assertEquals(1, runCount[0]);
 		//let the job finish
 		status.set(0, TestBarrier2.STATUS_RUNNING);
 		waitForState(job, Job.NONE);
-		assertEquals("1.0", 2, runCount[0]);
+		assertEquals(2, runCount[0]);
 	}
 
 	/*
@@ -1280,7 +1280,7 @@ public class JobTest extends AbstractJobTest {
 		status.set(0, TestBarrier2.STATUS_RUNNING);
 		//now wait until the job is scheduled again and put to sleep
 		waitForState(job, Job.SLEEPING);
-		assertEquals("1.0", 1, runCount[0]);
+		assertEquals(1, runCount[0]);
 
 		//reschedule the job while it is sleeping
 		job.schedule();
@@ -1290,8 +1290,8 @@ public class JobTest extends AbstractJobTest {
 		status.set(0, TestBarrier2.STATUS_RUNNING);
 		//make sure the job was not rescheduled while the executing job was sleeping
 		waitForState(job, Job.NONE);
-		assertEquals("1.0", Job.NONE, job.getState());
-		assertEquals("1.0", 2, runCount[0]);
+		assertEquals(Job.NONE, job.getState());
+		assertEquals(2, runCount[0]);
 	}
 
 	/*
@@ -1323,8 +1323,8 @@ public class JobTest extends AbstractJobTest {
 				//ignore
 			}
 		}
-		assertTrue("1.0", timeout < 100);
-		assertEquals("1.1", REPEATS, count[0]);
+		assertTrue(timeout < 100);
+		assertEquals(REPEATS, count[0]);
 	}
 
 	/*
@@ -1419,8 +1419,8 @@ public class JobTest extends AbstractJobTest {
 				//ignore
 			}
 		}
-		assertTrue("1.0", timeout < 100);
-		assertEquals("1.1", REPEATS, count[0]);
+		assertTrue(timeout < 100);
+		assertEquals(REPEATS, count[0]);
 	}
 
 	/*
@@ -1524,8 +1524,8 @@ public class JobTest extends AbstractJobTest {
 
 		//make sure the second job was not rescheduled
 		waitForState(second, Job.NONE);
-		assertEquals("2.0", Job.NONE, second.getState());
-		assertEquals("2.1", 1, runCount[0]);
+		assertEquals(Job.NONE, second.getState());
+		assertEquals(1, runCount[0]);
 	}
 
 	/**
@@ -1567,7 +1567,7 @@ public class JobTest extends AbstractJobTest {
 			long n0 = System.nanoTime();
 			while (runningCount.get() < 3) {
 				Thread.yield();
-				assertTrue("timeout runningCount=" + runningCount.get(), (System.nanoTime() - n0) < ONE_SECOND);
+				assertTrue((System.nanoTime() - n0) < ONE_SECOND, "timeout runningCount=" + runningCount.get());
 			}
 			j.join();
 			assertEquals(3, runningCount.get());
@@ -1676,7 +1676,7 @@ public class JobTest extends AbstractJobTest {
 		waitForState(job, Job.NONE);
 		assertThat(group).withFailMessage("job progress has not been reported to group monitor")
 				.matches(IProgressMonitor::isCanceled);
-		assertEquals("job was unexpectedly not canceled", IStatus.CANCEL, job.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, job.getResult().getSeverity(), "job was unexpectedly not canceled");
 	}
 
 	@Test
@@ -1693,7 +1693,7 @@ public class JobTest extends AbstractJobTest {
 		checkMonitorJob.schedule();
 		checkMonitorJob.join();
 
-		assertEquals("The job should have been canceled", IStatus.CANCEL, checkMonitorJob.getResult().getSeverity());
+		assertEquals(IStatus.CANCEL, checkMonitorJob.getResult().getSeverity(), "The job should have been canceled");
 	}
 
 	private Job createJobReactingToCancelRequest() {
@@ -1736,55 +1736,55 @@ public class JobTest extends AbstractJobTest {
 		longJob.setRule(new PathRule("/testSetRule/B/C/D"));
 		assertThat(longJob.getRule()).isInstanceOf(PathRule.class);
 		longJob.setRule(null);
-		assertNull("job still has a rule assigned: " + longJob, longJob.getRule());
+		assertNull(longJob.getRule(), "job still has a rule assigned: " + longJob);
 	}
 
 	@Test
 	public void testSetThread() {
 		//setting the thread of a job that is not an asynchronous job should not affect the actual thread the job will run in
-		assertNull("0.0", longJob.getThread());
+		assertNull(longJob.getThread());
 
 		longJob.setThread(Thread.currentThread());
-		assertEquals("1.0", longJob.getThread(), Thread.currentThread());
+		assertEquals(longJob.getThread(), Thread.currentThread());
 		longJob.schedule();
 		waitForState(longJob, Job.RUNNING);
 
 		//the setThread method should have no effect on jobs that execute normally
-		assertNotEquals("2.0", longJob.getThread(), Thread.currentThread());
+		assertNotEquals(longJob.getThread(), Thread.currentThread());
 
 		longJob.cancel();
 		waitForState(longJob, Job.NONE);
 
 		//the thread should reset to null when the job finishes execution
-		assertNull("3.0", longJob.getThread());
+		assertNull(longJob.getThread());
 
 		longJob.setThread(null);
-		assertNull("4.0", longJob.getThread());
+		assertNull(longJob.getThread());
 
 		longJob.schedule();
 		waitForState(longJob, Job.RUNNING);
 
 		//the thread that the job is executing in is not the one that was set
-		assertNotNull("5.0 (state=" + JobManager.printState(longJob.getState()) + ')', longJob.getThread());
+		assertNotNull(longJob.getThread(), "(state=" + JobManager.printState(longJob.getState()) + ')');
 		longJob.cancel();
 		waitForState(longJob, Job.NONE);
 
 		//thread should reset to null after execution of job
-		assertNull("6.0", longJob.getThread());
+		assertNull(longJob.getThread());
 
 		Thread t = new Thread();
 		longJob.setThread(t);
-		assertEquals("7.0", longJob.getThread(), t);
+		assertEquals(longJob.getThread(), t);
 		longJob.schedule();
 		waitForState(longJob, Job.RUNNING);
 
 		//the thread that the job is executing in is not the one that it was set to
-		assertNotEquals("8.0", longJob.getThread(), t);
+		assertNotEquals(longJob.getThread(), t);
 		longJob.cancel();
 		waitForState(longJob, Job.NONE);
 
 		//execution thread should reset to null after job is finished
-		assertNull("9.0", longJob.getThread());
+		assertNull(longJob.getThread());
 
 		//when the state is changed to RUNNING, the thread should not be null
 		final Thread[] thread = new Thread[1];
@@ -1800,7 +1800,7 @@ public class JobTest extends AbstractJobTest {
 		longJob.cancel();
 		longJob.removeJobChangeListener(listener);
 		waitForState(longJob, Job.NONE);
-		assertNotNull("10.0", thread[0]);
+		assertNotNull(thread[0]);
 	}
 
 	/**

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/MultiRuleTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/MultiRuleTest.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.MultiRule;
@@ -34,19 +35,19 @@ public class MultiRuleTest extends AbstractJobTest {
 		MultiRule multi1 = new MultiRule(new ISchedulingRule[] {child1, child2});
 
 		//add multi to its own children
-		assertEquals("1.0", multi1, MultiRule.combine(new ISchedulingRule[] {multi1}));
-		assertEquals("1.1", multi1, MultiRule.combine(new ISchedulingRule[] {multi1, child1, child2, childOfChild1}));
-		assertEquals("1.2", multi1, MultiRule.combine(multi1, child2));
-		assertEquals("1.3", multi1, MultiRule.combine(childOfChild1, multi1));
+		assertEquals(multi1, MultiRule.combine(new ISchedulingRule[] { multi1 }));
+		assertEquals(multi1, MultiRule.combine(new ISchedulingRule[] { multi1, child1, child2, childOfChild1 }));
+		assertEquals(multi1, MultiRule.combine(multi1, child2));
+		assertEquals(multi1, MultiRule.combine(childOfChild1, multi1));
 
 		//null
-		assertEquals("1.4", null, MultiRule.combine(null, null));
-		assertEquals("1.5", multi1, MultiRule.combine(null, multi1));
-		assertEquals("1.6", child1, MultiRule.combine(child1, null));
+		assertEquals(null, MultiRule.combine(null, null));
+		assertEquals(multi1, MultiRule.combine(null, multi1));
+		assertEquals(child1, MultiRule.combine(child1, null));
 
 		MultiRule result = (MultiRule) MultiRule.combine(multi1, nonChild);
-		assertTrue("2.0" + result, result.contains(multi1));
-		assertTrue("2.1", result.contains(nonChild));
+		assertTrue(result.contains(multi1));
+		assertTrue(result.contains(nonChild));
 
 	}
 
@@ -59,13 +60,13 @@ public class MultiRuleTest extends AbstractJobTest {
 		MultiRule multi1 = new MultiRule(new ISchedulingRule[] {child1, child2});
 		MultiRule multi2 = new MultiRule(new ISchedulingRule[] {childOfChild1});
 
-		assertTrue("1.0", multi1.contains(child1));
-		assertTrue("1.1", multi1.contains(child2));
-		assertTrue("1.2", !multi1.contains(nonChild));
-		assertTrue("1.3", multi1.contains(childOfChild1));
-		assertTrue("1.4", multi1.contains(multi2));
-		assertTrue("1.5", !multi2.contains(multi1));
-		assertTrue("1.6", multi1.contains(multi1));
+		assertTrue(multi1.contains(child1));
+		assertTrue(multi1.contains(child2));
+		assertFalse(multi1.contains(nonChild));
+		assertTrue(multi1.contains(childOfChild1));
+		assertTrue(multi1.contains(multi2));
+		assertFalse(multi2.contains(multi1));
+		assertTrue(multi1.contains(multi1));
 	}
 
 	@Test
@@ -77,12 +78,12 @@ public class MultiRuleTest extends AbstractJobTest {
 		MultiRule multi1 = new MultiRule(new ISchedulingRule[] {child1, child2});
 		MultiRule multi2 = new MultiRule(new ISchedulingRule[] {childOfChild1, nonChild});
 
-		assertTrue("1.0", multi1.isConflicting(child1));
-		assertTrue("1.1", multi1.isConflicting(child2));
-		assertTrue("1.2", !multi1.isConflicting(nonChild));
-		assertTrue("1.3", multi1.isConflicting(childOfChild1));
-		assertTrue("1.4", multi1.isConflicting(multi2));
-		assertTrue("1.5", multi2.isConflicting(multi1));
-		assertTrue("1.6", multi1.isConflicting(multi1));
+		assertTrue(multi1.isConflicting(child1));
+		assertTrue(multi1.isConflicting(child2));
+		assertFalse(multi1.isConflicting(nonChild));
+		assertTrue(multi1.isConflicting(childOfChild1));
+		assertTrue(multi1.isConflicting(multi2));
+		assertTrue(multi2.isConflicting(multi1));
+		assertTrue(multi1.isConflicting(multi1));
 	}
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderAsserter.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderAsserter.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collection;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class OrderAsserter {
 		}
 		try {
 			int currentProgress = progress.incrementAndGet();
-			assertNotNull("Should not happen but was event number " + getEventString(currentProgress), event);
+			assertNotNull(event, "Should not happen but was event number " + getEventString(currentProgress));
 
 			// two locks at the same time => race condition happend
 			if (!lock.tryLock()) {
@@ -89,10 +89,10 @@ public class OrderAsserter {
 				lock.unlock();
 			}
 
-			assertFalse("Too late. Expected to happen as " + event + " but was " + getEventString(currentProgress),
-					currentProgress > event.eventNumber);
-			assertFalse("Too early. Expected to happen as " + event + " but was " + getEventString(currentProgress),
-					currentProgress < event.eventNumber);
+			assertFalse(currentProgress > event.eventNumber,
+					"Too late. Expected to happen as " + event + " but was " + getEventString(currentProgress));
+			assertFalse(currentProgress < event.eventNumber,
+					"Too early. Expected to happen as " + event + " but was " + getEventString(currentProgress));
 		} catch (Throwable e) {
 			addError(e);
 		}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/OrderedLockTest.java
@@ -15,7 +15,8 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -64,7 +65,7 @@ public class OrderedLockTest {
 			createRunnables(new ILock[] { lock2, lock3, lock1 }, 5, allRunnables);
 			execute(allRunnables);
 			// the underlying array has to be empty
-			assertTrue("Locks not removed from graph.", manager.isEmpty());
+			assertTrue(manager.isEmpty(), "Locks not removed from graph.");
 		});
 	}
 
@@ -94,7 +95,7 @@ public class OrderedLockTest {
 			}
 			execute(allRunnables);
 			// the underlying array has to be empty
-			assertTrue("Locks not removed from graph.", manager.isEmpty());
+			assertTrue(manager.isEmpty(), "Locks not removed from graph.");
 		});
 	}
 
@@ -110,7 +111,7 @@ public class OrderedLockTest {
 			createRunnables(new ILock[] { lock3, lock2, lock1 }, 1, allRunnables);
 			execute(allRunnables);
 			// the underlying array has to be empty
-			assertTrue("Locks not removed from graph.", manager.isEmpty());
+			assertTrue(manager.isEmpty(), "Locks not removed from graph.");
 		});
 	}
 
@@ -143,7 +144,7 @@ public class OrderedLockTest {
 		t.interrupt();
 		lock.release();
 		t.join();
-		assertTrue("1.0", wasInterupted[0]);
+		assertTrue(wasInterupted[0]);
 	}
 
 	/**
@@ -178,8 +179,8 @@ public class OrderedLockTest {
 				success = lock.acquire(0);
 			} catch (InterruptedException e) {
 			}
-			assertTrue("1.0", !success);
-			assertTrue("1.1", !manager.isLockOwner());
+			assertFalse(success);
+			assertFalse(manager.isLockOwner());
 			status.upgradeTo(TestBarrier2.STATUS_WAIT_FOR_DONE);
 		};
 
@@ -196,7 +197,7 @@ public class OrderedLockTest {
 		alive[0] = false;
 		status.waitForStatus(TestBarrier2.STATUS_DONE);
 		//the underlying array has to be empty
-		assertTrue("Locks not removed from graph.", manager.isEmpty());
+		assertTrue(manager.isEmpty(), "Locks not removed from graph.");
 	}
 
 	/**
@@ -240,7 +241,7 @@ public class OrderedLockTest {
 					status2waitForLock.upgradeTo(TestBarrier2.STATUS_START);
 					lock.acquire(); // has to be in waiting state before manager.setLockListener(listener) should
 									// happen
-					assertTrue("1.0", manager.isLockOwner());
+					assertTrue(manager.isLockOwner());
 					// status2waitForLock.upgrade(TestBarrier2.STATUS_WAIT_FOR_DONE);// done in
 					// waitListener
 					lock.release();
@@ -310,10 +311,10 @@ public class OrderedLockTest {
 		status2waitForLock.waitForStatus(TestBarrier2.STATUS_DONE);
 
 		// the underlying array has to be empty
-		assertTrue("Locks not removed from graph.", manager.isEmpty());
+		assertTrue(manager.isEmpty(), "Locks not removed from graph.");
 		errors.forEach(Throwable::printStackTrace);
-		assertTrue("Error happend: " + errors.stream().map(e -> "" + e).collect(Collectors.joining(", ")),
-				errors.isEmpty());
+		assertTrue(errors.isEmpty(),
+				"Error happend: " + errors.stream().map(e -> "" + e).collect(Collectors.joining(", ")));
 	}
 
 	private void execute(ArrayList<LockAcquiringRunnable> allRunnables) {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/TestLockListener.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/TestLockListener.java
@@ -14,9 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.function.Function;
 import org.eclipse.core.runtime.jobs.LockListener;
-import org.junit.Assert;
 
 /**
  * A lock listener used for testing that ensures wait/release calls are correctly paired.
@@ -58,7 +59,7 @@ public class TestLockListener extends LockListener {
 	 * @param message The assertion message
 	 */
 	public synchronized void assertNotWaiting(String message) {
-		Assert.assertTrue(message, !waiting);
+		assertTrue(!waiting, message);
 	}
 
 	/**
@@ -68,7 +69,7 @@ public class TestLockListener extends LockListener {
 	 * @param message The assertion message
 	 */
 	public synchronized void assertHasBeenWaiting(String message) {
-		Assert.assertTrue(message, hasBeenWaiting);
+		assertTrue(hasBeenWaiting, message);
 	}
 
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/WorkerPoolTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/WorkerPoolTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -25,7 +26,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
@@ -89,7 +89,7 @@ public class WorkerPoolTest {
 		int workerThreadCount = getWorkerThreadCount();
 		while (workerThreadCount > MAX_ALLOWED_IDLE_WORKER_THREADS) {
 			if (System.currentTimeMillis() - startTimeInMSec > WORKER_TIMEOUT_IN_MSEC) {
-				Assert.fail("Timeout reached! Too many worker threads active: " + workerThreadCount
+				fail("Timeout reached! Too many worker threads active: " + workerThreadCount
 						+ ", expected <= "
 						+ MAX_ALLOWED_IDLE_WORKER_THREADS);
 			}

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/YieldTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/YieldTest.java
@@ -13,11 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -173,16 +174,16 @@ public class YieldTest extends AbstractJobTest {
 		Job yieldJob = new Job(testName + " Yielding") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				assertNull("Conflicting job result is not null: " + jobs[1].getResult(), jobs[1].getResult());
+				assertNull(jobs[1].getResult(), "Conflicting job result is not null: " + jobs[1].getResult());
 				Thread before = getThread();
 				while (yieldRule(null) == null) {
 					//loop until yield succeeds
 				}
 				waitForCompletion(jobs[1]);
 				Thread after = getThread();
-				assertEquals("Thread not restored", before, after);
-				assertTrue("Conflicting job not done", jobs[1].getResult().isOK());
-				assertEquals("Conflicting job still running", Job.NONE, jobs[1].getState());
+				assertEquals(before, after, "Thread not restored");
+				assertTrue(jobs[1].getResult().isOK(), "Conflicting job not done");
+				assertEquals(Job.NONE, jobs[1].getState(), "Conflicting job still running");
 				return Status.OK_STATUS;
 			}
 		};
@@ -203,7 +204,7 @@ public class YieldTest extends AbstractJobTest {
 		yieldJob.schedule();
 		conflictingJob.schedule();
 		waitForCompletion(yieldJob);
-		assertTrue("Result is not ok: " + yieldJob.getResult(), yieldJob.getResult().isOK());
+		assertTrue(yieldJob.getResult().isOK(), "Result is not ok: " + yieldJob.getResult());
 		waitForCompletion(conflictingJob);
 		assertTrue(conflictingJob.getResult().isOK());
 	}
@@ -521,7 +522,7 @@ public class YieldTest extends AbstractJobTest {
 
 	private synchronized void waitForCompletion() {
 		int i = 0;
-		assertTrue("Jobs completed that weren't scheduled", completedJobs <= scheduledJobs);
+		assertTrue(completedJobs <= scheduledJobs, "Jobs completed that weren't scheduled");
 		while (completedJobs < scheduledJobs) {
 			try {
 				wait(500);
@@ -531,7 +532,7 @@ public class YieldTest extends AbstractJobTest {
 			//sanity test to avoid hanging tests
 			if (i++ > 1000) {
 				dumpState();
-				assertTrue("Timeout waiting for job to complete", false);
+				fail("Timeout waiting for job to complete");
 			}
 		}
 	}
@@ -680,7 +681,7 @@ public class YieldTest extends AbstractJobTest {
 			throw new CoreException(yieldResult);
 		}
 		waitForCompletion(conflictingJob);
-		assertTrue(conflictingJob.toString(), conflictingJob.getResult().isOK());
+		assertTrue(conflictingJob.getResult().isOK(), conflictingJob.toString());
 	}
 
 	@Test
@@ -736,7 +737,7 @@ public class YieldTest extends AbstractJobTest {
 		waitForJobsCompletion(jobs.toArray(new Job[jobs.size()]), 5000);
 
 		for (Job conflict : jobs) {
-			assertNotNull("Null result for " + conflict, conflict.getResult());
+			assertNotNull(conflict.getResult(), "Null result for " + conflict);
 			assertTrue(conflict.getResult().isOK());
 		}
 
@@ -858,12 +859,12 @@ public class YieldTest extends AbstractJobTest {
 		waitForJobsCompletion(jobs_B.toArray(new Job[jobs_B.size()]), 5000);
 
 		for (Job conflict : jobs_A) {
-			assertNotNull("Null result for " + conflict, conflict.getResult());
+			assertNotNull(conflict.getResult(), "Null result for " + conflict);
 			assertTrue(conflict.getResult().isOK());
 		}
 
 		for (Job conflict : jobs_B) {
-			assertNotNull("Null result for " + conflict, conflict.getResult());
+			assertNotNull(conflict.getResult(), "Null result for " + conflict);
 			assertTrue(conflict.getResult().isOK());
 		}
 	}
@@ -946,7 +947,7 @@ public class YieldTest extends AbstractJobTest {
 			assertNull(failureMessage[0], failureMessage[0]);
 		}
 
-		assertTrue("yieldRule should have thrown OperationCanceledException", operationWasCanceled[0]);
+		assertTrue(operationWasCanceled[0], "yieldRule should have thrown OperationCanceledException");
 	}
 
 	@Test
@@ -1096,7 +1097,7 @@ public class YieldTest extends AbstractJobTest {
 		try {
 			waitForCompletion(yieldA);
 			waitForCompletion(conflicting);
-			assertEquals("While resuming from yieldRule, implicit Job should only run once", 1, count[0]);
+			assertEquals(1, count[0], "While resuming from yieldRule, implicit Job should only run once");
 		} finally {
 			//clean up even if the test fails
 			yieldA.cancel();
@@ -1155,7 +1156,7 @@ public class YieldTest extends AbstractJobTest {
 			conflicting.schedule();
 			waitForCompletion(yieldA);
 			waitForCompletion(conflicting);
-			assertEquals("While resuming from yieldRule, conflicting job should only run once", 1, count[0]);
+			assertEquals(1, count[0], "While resuming from yieldRule, conflicting job should only run once");
 		} finally {
 			Job.getJobManager().removeJobChangeListener(a);
 		}
@@ -1182,7 +1183,7 @@ public class YieldTest extends AbstractJobTest {
 			// sanity test to avoid hanging tests
 			if (i++ > ticks) {
 				dumpState();
-				assertTrue("Timeout waiting for job to complete", false);
+				fail("Timeout waiting for job to complete");
 			}
 			for (Iterator<Job> iterator = jobList.iterator(); iterator.hasNext();) {
 				if (iterator.next().getState() == Job.NONE) {


### PR DESCRIPTION
- Use JUnit 5 test annotation
- Remove obsolete assertions messages
- Migrate assertions to JUnit 5

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903