### PR TITLE
Migrate org.eclipse.core.tests.internal.preferences to JUnit 5 #903

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/EclipsePreferencesTest.java
@@ -14,12 +14,13 @@
 package org.eclipse.core.tests.internal.preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -119,7 +120,7 @@ public class EclipsePreferencesTest {
 			if (value instanceof byte[]) {
 				return "b";
 			}
-			assertTrue("0.0: " + value, false);
+			fail(value.toString());
 			return null;
 		}
 
@@ -156,14 +157,14 @@ public class EclipsePreferencesTest {
 		final String defaultValue = null;
 
 		// nothing there so expect the default
-		assertEquals("1.1", defaultValue, prefs.get(key, defaultValue));
+		assertEquals(defaultValue, prefs.get(key, defaultValue));
 		// set a value and ensure it exists
 		prefs.put(key, value);
-		assertEquals("1.2", value, prefs.get(key, defaultValue));
+		assertEquals(value, prefs.get(key, defaultValue));
 
 		// remove the node and then try to remove the key
 		prefs.removeNode();
-		assertFalse("2.5", prefs.nodeExists(""));
+		assertFalse(prefs.nodeExists(""));
 		assertThrows(IllegalStateException.class, () -> prefs.remove(key));
 	}
 
@@ -177,18 +178,18 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.get(key, defaultValue));
+			assertEquals(defaultValue, prefs.get(key, defaultValue));
 
 			// try for each value in the set
 			for (int i = 0; i < values.length; i++) {
 				String v1 = values[i];
 				String v2 = values[i] + "x";
 				prefs.put(key, v1);
-				assertEquals("1.2." + i, v1, prefs.get(key, defaultValue));
+				assertEquals(v1, prefs.get(key, defaultValue), i + "");
 				prefs.put(key, v2);
-				assertEquals("1.3." + i, v2, prefs.get(key, defaultValue));
+				assertEquals(v2, prefs.get(key, defaultValue), i + "");
 				prefs.remove(key);
-				assertEquals("1.4." + i, defaultValue, prefs.get(key, defaultValue));
+				assertEquals(defaultValue, prefs.get(key, defaultValue), i + "");
 			}
 
 			// spec'd to throw a NPE if key is null
@@ -216,24 +217,24 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.getLong(key, defaultValue));
+			assertEquals(defaultValue, prefs.getLong(key, defaultValue));
 
 			// try for each value in the set
 			for (int i = 0; i < values.length; i++) {
 				long v1 = values[i];
 				long v2 = 54L;
 				prefs.putLong(key, v1);
-				assertEquals("1.2." + i, v1, prefs.getLong(key, defaultValue));
+				assertEquals(v1, prefs.getLong(key, defaultValue), i);
 				prefs.putLong(key, v2);
-				assertEquals("1.3." + i, v2, prefs.getLong(key, defaultValue));
+				assertEquals(v2, prefs.getLong(key, defaultValue), i);
 				prefs.remove(key);
-				assertEquals("1.4." + i, defaultValue, prefs.getLong(key, defaultValue));
+				assertEquals(defaultValue, prefs.getLong(key, defaultValue), i);
 			}
 
 			String stringValue = "foo";
 			prefs.put(key, stringValue);
-			assertEquals("1.5", stringValue, prefs.get(key, null));
-			assertEquals("1.6", defaultValue, prefs.getLong(key, defaultValue));
+			assertEquals(stringValue, prefs.get(key, null));
+			assertEquals(defaultValue, prefs.getLong(key, defaultValue));
 
 			// spec'd to throw a NPE if key is null
 			assertThrows(NullPointerException.class, () -> prefs.getLong(null, defaultValue));
@@ -257,19 +258,19 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.getBoolean(key, defaultValue));
+			assertEquals(defaultValue, prefs.getBoolean(key, defaultValue));
 
 			prefs.putBoolean(key, true);
-			assertEquals("1.2", true, prefs.getBoolean(key, defaultValue));
+			assertEquals(true, prefs.getBoolean(key, defaultValue));
 			prefs.putBoolean(key, false);
-			assertEquals("1.3", false, prefs.getBoolean(key, defaultValue));
+			assertEquals(false, prefs.getBoolean(key, defaultValue));
 			prefs.remove(key);
-			assertEquals("1.4", defaultValue, prefs.getBoolean(key, defaultValue));
+			assertEquals(defaultValue, prefs.getBoolean(key, defaultValue));
 
 			String stringValue = "foo";
 			prefs.put(key, stringValue);
-			assertEquals("1.5", stringValue, prefs.get(key, null));
-			assertEquals("1.6", defaultValue, prefs.getBoolean(key, defaultValue));
+			assertEquals(stringValue, prefs.get(key, null));
+			assertEquals(defaultValue, prefs.getBoolean(key, defaultValue));
 
 			// spec'd to throw a NPE if key is null
 			assertThrows(NullPointerException.class, () -> prefs.getBoolean(null, defaultValue));
@@ -345,24 +346,24 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.getFloat(key, defaultValue), tol);
+			assertEquals(defaultValue, prefs.getFloat(key, defaultValue), tol);
 
 			// try for each value in the set
 			for (int i = 0; i < values.length; i++) {
 				float v1 = values[i];
 				float v2 = 54f;
 				prefs.putFloat(key, v1);
-				assertEquals("1.2." + i, v1, prefs.getFloat(key, defaultValue), tol);
+				assertEquals(v1, prefs.getFloat(key, defaultValue), tol, i + "");
 				prefs.putFloat(key, v2);
-				assertEquals("1.3." + i, v2, prefs.getFloat(key, defaultValue), tol);
+				assertEquals(v2, prefs.getFloat(key, defaultValue), tol, i + "");
 				prefs.remove(key);
-				assertEquals("1.4." + i, defaultValue, prefs.getFloat(key, defaultValue), tol);
+				assertEquals(defaultValue, prefs.getFloat(key, defaultValue), tol, i + "");
 			}
 
 			String stringValue = "foo";
 			prefs.put(key, stringValue);
-			assertEquals("1.5", stringValue, prefs.get(key, null));
-			assertEquals("1.6", defaultValue, prefs.getFloat(key, defaultValue), tol);
+			assertEquals(stringValue, prefs.get(key, null));
+			assertEquals(defaultValue, prefs.getFloat(key, defaultValue), tol);
 
 			// spec'd to throw a NPE if key is null
 			assertThrows(NullPointerException.class, () -> prefs.getFloat(null, defaultValue));
@@ -425,24 +426,24 @@ public class EclipsePreferencesTest {
 		try {
 
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.getDouble(key, defaultValue), tol);
+			assertEquals(defaultValue, prefs.getDouble(key, defaultValue), tol);
 
 			// try for each value in the set
 			for (int i = 0; i < values.length; i++) {
 				double v1 = values[i];
 				double v2 = 54.0;
 				prefs.putDouble(key, v1);
-				assertEquals("1.2." + i, v1, prefs.getDouble(key, defaultValue), tol);
+				assertEquals(v1, prefs.getDouble(key, defaultValue), tol, i + "");
 				prefs.putDouble(key, v2);
-				assertEquals("1.3." + i, v2, prefs.getDouble(key, defaultValue), tol);
+				assertEquals(v2, prefs.getDouble(key, defaultValue), tol, i + "");
 				prefs.remove(key);
-				assertEquals("1.4." + i, defaultValue, prefs.getDouble(key, defaultValue), tol);
+				assertEquals(defaultValue, prefs.getDouble(key, defaultValue), tol, i + "");
 			}
 
 			String stringValue = "foo";
 			prefs.put(key, stringValue);
-			assertEquals("1.5", stringValue, prefs.get(key, null));
-			assertEquals("1.6", defaultValue, prefs.getDouble(key, defaultValue), tol);
+			assertEquals(stringValue, prefs.get(key, null));
+			assertEquals(defaultValue, prefs.getDouble(key, defaultValue), tol);
 
 			// spec'd to throw a NPE if key is null
 			assertThrows(NullPointerException.class, () -> prefs.getDouble(null, defaultValue));
@@ -467,24 +468,24 @@ public class EclipsePreferencesTest {
 
 		try {
 			// nothing there so expect the default
-			assertEquals("1.1", defaultValue, prefs.getInt(key, defaultValue));
+			assertEquals(defaultValue, prefs.getInt(key, defaultValue));
 
 			// try for each value in the set
 			for (int i = 0; i < values.length; i++) {
 				int v1 = values[i];
 				int v2 = 54;
 				prefs.putInt(key, v1);
-				assertEquals("1.2." + i, v1, prefs.getInt(key, defaultValue));
+				assertEquals(v1, prefs.getInt(key, defaultValue), i);
 				prefs.putInt(key, v2);
-				assertEquals("1.3." + i, v2, prefs.getInt(key, defaultValue));
+				assertEquals(v2, prefs.getInt(key, defaultValue), i);
 				prefs.remove(key);
-				assertEquals("1.4." + i, defaultValue, prefs.getInt(key, defaultValue));
+				assertEquals(defaultValue, prefs.getInt(key, defaultValue), i);
 			}
 
 			String stringValue = "foo";
 			prefs.put(key, stringValue);
-			assertEquals("1.5", stringValue, prefs.get(key, null));
-			assertEquals("1.6", defaultValue, prefs.getInt(key, defaultValue));
+			assertEquals(stringValue, prefs.get(key, null));
+			assertEquals(defaultValue, prefs.getInt(key, defaultValue));
 
 			// spec'd to throw a NPE if key is null
 			assertThrows(NullPointerException.class, () -> prefs.getInt(null, defaultValue));
@@ -510,14 +511,14 @@ public class EclipsePreferencesTest {
 		// all exist
 		for (Iterator<Preferences> i = list.iterator(); i.hasNext();) {
 			Preferences node = i.next();
-			assertTrue("1." + i, node.nodeExists(""));
+			assertTrue(node.nodeExists(""), i + "");
 		}
 
 		// remove each
 		for (Iterator<Preferences> i = list.iterator(); i.hasNext();) {
 			Preferences node = i.next();
 			node.removeNode();
-			assertTrue("2." + i, !node.nodeExists(""));
+			assertFalse(node.nodeExists(""), i + "");
 		}
 	}
 
@@ -534,22 +535,22 @@ public class EclipsePreferencesTest {
 		node.flush();
 		File file = TestHelper.getInstanceBaseLocation().append(".settings").append("foo.prefs").toFile();
 
-		assertTrue("1.0", file.exists());
+		assertTrue(file.exists());
 		node.removeNode();
 		parent.flush();
 		// ensure file was deleted
-		assertFalse("3.0", file.exists());
+		assertFalse(file.exists());
 	}
 
 	@Test
 	public void testName() {
 		Preferences node = Platform.getPreferencesService().getRootNode();
 
-		assertEquals("1.0", "", node.name());
+		assertEquals("", node.name());
 		node = node.node(TestScope.SCOPE);
-		assertEquals("2.0", TestScope.SCOPE, node.name());
+		assertEquals(TestScope.SCOPE, node.name());
 		node = node.node("foo");
-		assertEquals("3.0", "foo", node.name());
+		assertEquals("foo", node.name());
 	}
 
 	@Test
@@ -557,40 +558,40 @@ public class EclipsePreferencesTest {
 		Preferences node = Platform.getPreferencesService().getRootNode();
 
 		// root node
-		assertNotNull("1.0", node);
-		assertEquals("1.1", "", node.name());
-		assertEquals("1.2", "/", node.absolutePath());
+		assertNotNull(node);
+		assertEquals("", node.name());
+		assertEquals("/", node.absolutePath());
 		// Bug 57150 [runtime] prefs: root.node("/") should return root
-		assertEquals("1.3", node, node.node("/"));
+		assertEquals(node, node.node("/"));
 
 		// scope root
 		node = node.node(TestScope.SCOPE);
-		assertNotNull("2.0", node);
-		assertEquals("2.1", TestScope.SCOPE, node.name());
-		assertEquals("2.2", "/" + TestScope.SCOPE, node.absolutePath());
+		assertNotNull(node);
+		assertEquals(TestScope.SCOPE, node.name());
+		assertEquals("/" + TestScope.SCOPE, node.absolutePath());
 
 		// child
 		String name = getUniqueString();
 		node = node.node(name);
-		assertNotNull("3.0", node);
-		assertEquals("3.1", name, node.name());
-		assertEquals("3.2", "/" + TestScope.SCOPE + "/" + name, node.absolutePath());
+		assertNotNull(node);
+		assertEquals(name, node.name());
+		assertEquals("/" + TestScope.SCOPE + "/" + name, node.absolutePath());
 	}
 
 	@Test
 	public void testParent() {
 		// parent of the root is null
-		assertNull("1.0", Platform.getPreferencesService().getRootNode().parent());
+		assertNull(Platform.getPreferencesService().getRootNode().parent());
 
 		// parent of the scope root is the root
 		Preferences node = Platform.getPreferencesService().getRootNode().node(TestScope.SCOPE);
 		Preferences parent = node.parent();
-		assertEquals("2.0", "/", parent.absolutePath());
+		assertEquals("/", parent.absolutePath());
 
 		// parent of a child is the scope root
 		node = getScopeRoot().node(getUniqueString());
 		parent = node.parent();
-		assertEquals("2.0", "/" + TestScope.SCOPE, parent.absolutePath());
+		assertEquals("/" + TestScope.SCOPE, parent.absolutePath());
 	}
 
 	@Test
@@ -601,7 +602,7 @@ public class EclipsePreferencesTest {
 		// ensure nothing exists to begin with
 		for (int i = 0; i < keys.length; i++) {
 			String key = keys[i];
-			assertNull("1.0." + i, node.get(key, null));
+			assertNull(node.get(key, null), i + "");
 		}
 
 		// set all keys
@@ -640,24 +641,24 @@ public class EclipsePreferencesTest {
 		String fake = "fake";
 
 		// check the root node
-		assertTrue("1.0", node.nodeExists(""));
-		assertTrue("1.1", !node.nodeExists(fake));
+		assertTrue(node.nodeExists(""));
+		assertFalse(node.nodeExists(fake));
 
 		// check the scope root
 		parent = node;
 		node = getScopeRoot();
-		assertTrue("2.0", parent.nodeExists(node.name()));
-		assertTrue("2.1", node.nodeExists(""));
-		assertTrue("2.2", !parent.nodeExists(fake));
-		assertTrue("2.3", !node.nodeExists(fake));
+		assertTrue(parent.nodeExists(node.name()));
+		assertTrue(node.nodeExists(""));
+		assertFalse(parent.nodeExists(fake));
+		assertFalse(node.nodeExists(fake));
 
 		// check a child
 		parent = node;
 		node = parent.node(getUniqueString());
-		assertTrue("3.0", parent.nodeExists(node.name()));
-		assertTrue("3.1", node.nodeExists(""));
-		assertTrue("3.2", !parent.nodeExists(fake));
-		assertTrue("3.3", !node.nodeExists(fake));
+		assertTrue(parent.nodeExists(node.name()));
+		assertTrue(node.nodeExists(""));
+		assertFalse(parent.nodeExists(fake));
+		assertFalse(node.nodeExists(fake));
 
 		// create some more children and check
 		parent = node;
@@ -666,18 +667,18 @@ public class EclipsePreferencesTest {
 			nodes[i] = parent.node(childrenNames[i]);
 		}
 		for (String childrenName : childrenNames) {
-			assertTrue("4.0", parent.nodeExists(childrenName));
-			assertTrue("4.1", !parent.nodeExists(fake));
+			assertTrue(parent.nodeExists(childrenName));
+			assertFalse(parent.nodeExists(fake));
 		}
 		for (Preferences preferenceNode : nodes) {
-			assertTrue("4.2", preferenceNode.nodeExists(""));
+			assertTrue(preferenceNode.nodeExists(""));
 		}
 
 		// remove children and check
 		for (Preferences n : nodes) {
 			n.removeNode();
-			assertTrue("5.1", !parent.nodeExists(n.name()));
-			assertTrue("5.2", !n.nodeExists(""));
+			assertFalse(parent.nodeExists(n.name()));
+			assertFalse(n.nodeExists(""));
 		}
 	}
 
@@ -700,7 +701,7 @@ public class EclipsePreferencesTest {
 		node.clear();
 		assertThat(node.keys()).isEmpty();
 		for (int i = 0; i < keys.length; i++) {
-			assertNull("3.1." + i, node.get(keys[i], null));
+			assertNull(node.get(keys[i], null), i + "");
 		}
 	}
 
@@ -710,18 +711,18 @@ public class EclipsePreferencesTest {
 		Preferences node = Platform.getPreferencesService().getRootNode();
 
 		// root node
-		assertEquals("1.0", expected.toString(), node.absolutePath());
+		assertEquals(expected.toString(), node.absolutePath());
 
 		// scope root
 		expected = expected.append(TestScope.SCOPE);
 		node = node.node(TestScope.SCOPE);
-		assertEquals("2.0", expected.toString(), node.absolutePath());
+		assertEquals(expected.toString(), node.absolutePath());
 
 		// another child
 		String name = getUniqueString();
 		expected = expected.append(name);
 		node = node.node(name);
-		assertEquals("3.0", expected.toString(), node.absolutePath());
+		assertEquals(expected.toString(), node.absolutePath());
 	}
 
 	@Test
@@ -766,37 +767,35 @@ public class EclipsePreferencesTest {
 		String key = "foo";
 
 		// initial state
-		assertEquals("0.0", "", tracer.log.toString());
+		assertEquals("", tracer.log.toString());
 
 		// add preference (string value)
 		node.put(key, "bar");
 		String string = node.get(key, null);
-		assertNotNull("1.0", string);
-		assertEquals("1.1", "bar", string);
-		assertEquals("1.2", "[foo:null->Sbar]", tracer.log.toString());
+		assertNotNull(string);
+		assertEquals("bar", string);
+		assertEquals("[foo:null->Sbar]", tracer.log.toString());
 
 		// change its value
 		tracer.log.setLength(0);
 		node.put(key, "quux");
 		string = node.get(key, null);
-		assertNotNull("2.0", string);
-		assertEquals("2.1", "quux", string);
-		assertEquals("2.2", "[foo:Sbar->Squux]", tracer.log.toString());
+		assertNotNull(string);
+		assertEquals("quux", string);
+		assertEquals("[foo:Sbar->Squux]", tracer.log.toString());
 
 		// change its type - should have no effect (events are strings)
 		tracer.log.setLength(0);
 		node.putInt(key, 123);
 		int i = node.getInt(key, 0);
-		assertEquals("3.0", 123, i);
-		assertEquals("3.1", "[foo:Squux->S123]", tracer.log.toString());
+		assertEquals(123, i);
+		assertEquals("[foo:Squux->S123]", tracer.log.toString());
 
 		node.put(key, "aaa");
 		tracer.log.setLength(0);
 		node.remove(key);
-		assertNull("4.0", node.get(key, null));
-		assertEquals("4.1", "[foo:Saaa->null]", tracer.log.toString());
-
-		// TODO finish these
+		assertNull(node.get(key, null));
+		assertEquals("[foo:Saaa->null]", tracer.log.toString());
 	}
 
 	@Test
@@ -806,25 +805,25 @@ public class EclipsePreferencesTest {
 		root.addNodeChangeListener(tracer);
 
 		// initial state
-		assertEquals("0.0", "", tracer.log.toString());
+		assertEquals("", tracer.log.toString());
 
 		// add a child
 		String name = getUniqueString();
 		IPath parent = IPath.fromOSString(root.absolutePath());
 		IPath child = parent.append(name);
 		Preferences node = root.node(name);
-		assertEquals("1.0", "[A:" + parent + ',' + child + ']', tracer.log.toString());
+		assertEquals("[A:" + parent + ',' + child + ']', tracer.log.toString());
 
 		// remove the child
 		tracer.log.setLength(0);
 		node.removeNode();
-		assertEquals("2.0", "[R:" + parent + ',' + child + ']', tracer.log.toString());
+		assertEquals("[R:" + parent + ',' + child + ']', tracer.log.toString());
 
 		// remove the listener and make sure we don't get any changes
 		root.removeNodeChangeListener(tracer);
 		tracer.log.setLength(0);
 		root.node(name);
-		assertEquals("3.0", "", tracer.log.toString());
+		assertEquals("", tracer.log.toString());
 	}
 
 	/*
@@ -857,11 +856,11 @@ public class EclipsePreferencesTest {
 		Preferences current = node;
 		int count = 0;
 		while (current != null && current instanceof EclipsePreferences && current.parent() != null && IPath.fromOSString(current.absolutePath()).segment(0).equals(TestScope.SCOPE)) {
-			assertTrue("1.0." + current.absolutePath(), ((EclipsePreferences) current).isDirty());
+			assertTrue(((EclipsePreferences) current).isDirty(), current.absolutePath());
 			count++;
 			current = current.parent();
 		}
-		assertEquals("2.0." + count, 4, count);
+		assertEquals(4, count);
 	}
 
 	/*
@@ -882,7 +881,7 @@ public class EclipsePreferencesTest {
 		// save the prefs to disk
 		node.flush();
 
-		assertTrue("2.0", node instanceof TestScope2);
+		assertTrue(node instanceof TestScope2);
 
 		// read the file outside of the pref mechanism
 		IPath location = ((TestScope2) node).getLocation();
@@ -891,7 +890,7 @@ public class EclipsePreferencesTest {
 
 		// ensure there is no comment or timestamp in the file
 		for (String line : lines) {
-			assertFalse("3." + line, line.startsWith("#"));
+			assertFalse(line.startsWith("#"), line);
 		}
 	}
 
@@ -921,7 +920,7 @@ public class EclipsePreferencesTest {
 		for (String key : keys) {
 			String value = getUniqueString();
 			node.put(key, value);
-			assertEquals("1.0." + key, value, node.get(key, null));
+			assertEquals(value, node.get(key, null), key);
 		}
 
 		// test paths
@@ -929,7 +928,7 @@ public class EclipsePreferencesTest {
 		for (String path : paths) {
 			String expected = root + IPath.SEPARATOR + path;
 			String actual = node.node(path).absolutePath();
-			assertEquals("2.0." + path, expected, actual);
+			assertEquals(expected, actual, path);
 		}
 	}
 
@@ -963,7 +962,7 @@ public class EclipsePreferencesTest {
 			node.node(info.path).put(info.key, Integer.toString(i));
 		}
 
-		assertTrue("0.8", node instanceof EclipsePreferences);
+		assertTrue(node instanceof EclipsePreferences);
 
 		Properties properties = null;
 		properties = TestHelper.convertToProperties((EclipsePreferences) node, "");
@@ -972,8 +971,8 @@ public class EclipsePreferencesTest {
 			String key = (String) object;
 			String value = properties.getProperty(key);
 			Info info = list.get(Integer.parseInt(value));
-			assertNotNull("2.0", info);
-			assertEquals("2.1." + key, info.encoded, key);
+			assertNotNull(info);
+			assertEquals(info.encoded, key);
 		}
 	}
 
@@ -1012,10 +1011,10 @@ public class EclipsePreferencesTest {
 
 		for (Iterator<Item> i = list.iterator(); i.hasNext();) {
 			Item item = i.next();
-			assertEquals("a" + i + item.expected, item.expected, EclipsePreferences.encodePath(item.path, item.key));
+			assertEquals(item.expected, EclipsePreferences.encodePath(item.path, item.key), "a" + i + item.expected);
 			String[] result = EclipsePreferences.decodePath(item.expected);
-			assertEquals("b" + i + item.path, item.path, result[0]);
-			assertEquals("c" + i + item.key, item.key, result[1]);
+			assertEquals(item.path, result[0], "b" + i + item.path);
+			assertEquals(item.key, result[1], "c" + i + item.key);
 		}
 	}
 
@@ -1036,7 +1035,8 @@ public class EclipsePreferencesTest {
 		};
 		for (int i = 0; i < data.length; i++) {
 			String[] line = data[i];
-			assertEquals("1.0." + i + ':' + line[1] + " (" + line[2] + ')', line[0], EclipsePreferences.getSegment(line[1], Integer.parseInt(line[2])));
+			assertEquals(line[0], EclipsePreferences.getSegment(line[1], Integer.parseInt(line[2])),
+					i + ':' + line[1] + " (" + line[2] + ')');
 		}
 	}
 
@@ -1051,7 +1051,7 @@ public class EclipsePreferencesTest {
 				new String[] {"instance/", "1"}, //
 		};
 		for (String[] line : data) {
-			assertEquals("1.0:" + line[0], Integer.parseInt(line[1]), EclipsePreferences.getSegmentCount(line[0]));
+			assertEquals(Integer.parseInt(line[1]), EclipsePreferences.getSegmentCount(line[0]), line[0]);
 		}
 	}
 
@@ -1103,29 +1103,29 @@ public class EclipsePreferencesTest {
 		Collection<String> expectedChildren = Arrays.asList(file.list());
 		String[] children = node.childrenNames();
 		for (String child : children) {
-			assertTrue("1.1." + child, expectedChildren.contains(child));
+			assertTrue(expectedChildren.contains(child), child);
 		}
 
 		// check the child has the expected values
 		Preferences child = node.node("foo");
 		assertThat(child.keys()).hasSize(2);
-		assertEquals("2.1", "value1", child.get("key1", null));
-		assertEquals("2.2", "value2", child.get("key2", null));
+		assertEquals("value1", child.get("key1", null));
+		assertEquals("value2", child.get("key2", null));
 
 		// set a new value, flush (which saves the file) and check the file contents
 		child.put("key8", "value8");
 		child.flush();
 		String prop = System.getProperty("equinox.preference.test.TestNodeStorage3,root");
-		assertNotNull("3.1", prop);
+		assertNotNull(prop);
 		File rootFile = new File(prop);
 		File childFile = new File(rootFile, "foo");
-		assertTrue("3.2", childFile.exists());
+		assertTrue(childFile.exists());
 		Properties contents = loadProperties(IPath.fromOSString(childFile.getAbsolutePath()));
-		assertEquals("3.3", "value8", contents.getProperty("key8", null));
+		assertEquals("value8", contents.getProperty("key8", null));
 
 		// delete the node (which should remove the file)
 		child.removeNode();
-		assertFalse("4.1", childFile.exists());
+		assertFalse(childFile.exists());
 	}
 
 	private static String getUniqueString() {

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/IScopeContextTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/IScopeContextTest.java
@@ -14,10 +14,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.preferences;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
@@ -42,18 +42,18 @@ public class IScopeContextTest {
 		// valid single segment
 		String qualifier = Long.toString(System.currentTimeMillis());
 		Preferences node = context.getNode(qualifier);
-		assertNotNull("2.0", node);
+		assertNotNull(node);
 		String expected = "/instance/" + qualifier;
 		String actual = node.absolutePath();
-		assertEquals("2.1", expected, actual);
+		assertEquals(expected, actual);
 
 		// path
 		qualifier = IPath.fromOSString(Long.toString(System.currentTimeMillis())).append("a").toString();
 		node = context.getNode(qualifier);
-		assertNotNull("3.0", node);
+		assertNotNull(node);
 		expected = "/instance/" + qualifier;
 		actual = node.absolutePath();
-		assertEquals("3.1", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	@Test
@@ -61,7 +61,7 @@ public class IScopeContextTest {
 		IScopeContext context = new BadTestScope();
 		IPreferencesService service = Platform.getPreferencesService();
 		assertThrows(RuntimeException.class, () -> context.getNode("qualifier"));
-		assertNull("1.0", service.getString("qualifier", "foo", null, new IScopeContext[] {context}));
+		assertNull(service.getString("qualifier", "foo", null, new IScopeContext[] { context }));
 	}
 
 }

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/internal/preferences/PreferencesServiceTest.java
@@ -15,11 +15,12 @@
 package org.eclipse.core.tests.internal.preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -123,12 +124,12 @@ public class PreferencesServiceTest {
 				}
 			}
 			if (properties.isEmpty()) {
-				assertTrue("2.0", expected.isEmpty());
+				assertTrue(expected.isEmpty());
 				return;
 			}
-			assertEquals("3.0", expected.size(), properties.size());
+			assertEquals(expected.size(), properties.size());
 			for (String key : expected) {
-				assertNotNull("4.0." + key, properties.get(key));
+				assertNotNull(properties.get(key), key);
 			}
 		}
 	}
@@ -151,13 +152,13 @@ public class PreferencesServiceTest {
 		String key1 = "http://eclipse.org:24";
 		String value1 = getUniqueString() + "v1";
 		String actual = test.get(key, null);
-		assertNull("1.0", actual);
+		assertNull(actual);
 		test.put(key, value);
 		test.put(key1, value1);
 		actual = test.get(key, null);
-		assertEquals("1.1", value, actual);
+		assertEquals(value, actual);
 		actual = test.get(key1, null);
-		assertEquals("1.2", value1, actual);
+		assertEquals(value1, actual);
 
 		// export it
 		byte[] bytes;
@@ -170,14 +171,14 @@ public class PreferencesServiceTest {
 		String newKey = getUniqueString() + '3';
 		String newValue = getUniqueString() + '4';
 		actual = test.get(newKey, null);
-		assertNull("3.0", actual);
+		assertNull(actual);
 		test.put(newKey, newValue);
 		actual = test.get(newKey, null);
-		assertEquals("3.1", newValue, actual);
+		assertEquals(newValue, actual);
 		String newOldValue = getUniqueString() + '5';
 		test.put(key, newOldValue);
 		actual = test.get(key, null);
-		assertEquals("3.2", newOldValue, actual);
+		assertEquals(newOldValue, actual);
 
 		// import
 		try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
@@ -187,23 +188,23 @@ public class PreferencesServiceTest {
 		// verify
 		test = new TestScope().getNode(qualifier);
 		actual = test.get(key, null);
-		assertEquals("5.0", value, actual);
+		assertEquals(value, actual);
 		actual = test.get(key1, null);
-		assertEquals("5.1", value1, actual);
+		assertEquals(value1, actual);
 		actual = test.get(newKey, null);
-		assertNull("5.2", actual);
+		assertNull(actual);
 		// ensure that the node isn't dirty (has been saved after the import)
-		assertTrue("5.3", test instanceof EclipsePreferences);
-		assertTrue("5.4", !((EclipsePreferences) test).isDirty());
+		assertTrue(test instanceof EclipsePreferences);
+		assertFalse(((EclipsePreferences) test).isDirty());
 
 		// clear all
 		test.clear();
 		actual = test.get(key, null);
-		assertNull("6.1", actual);
+		assertNull(actual);
 		actual = test.get(key1, null);
-		assertNull("6.2", actual);
+		assertNull(actual);
 		actual = test.get(newKey, null);
-		assertNull("6.3", actual);
+		assertNull(actual);
 
 		// import
 		try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
@@ -213,11 +214,11 @@ public class PreferencesServiceTest {
 		// verify
 		test = new TestScope().getNode(qualifier);
 		actual = test.get(key, null);
-		assertEquals("8.0", value, actual);
+		assertEquals(value, actual);
 		actual = test.get(key1, null);
-		assertEquals("8.1", value1, actual);
+		assertEquals(value1, actual);
 		actual = test.get(newKey, null);
-		assertNull("8.2", actual);
+		assertNull(actual);
 	}
 
 	@Test
@@ -298,58 +299,58 @@ public class PreferencesServiceTest {
 		// nothing set - navigation
 		Preferences node = service.getRootNode().node(TestScope.SCOPE).node(qualifier);
 		String actual = node.get(key, null);
-		assertNull("10", actual);
+		assertNull(actual);
 
 		// nothing set - service searching
 		actual = service.get(key, null, new Preferences[] {node});
-		assertNull("2.0", actual);
+		assertNull(actual);
 
 		// set value
 		node.put(key, expected);
 
 		// value is set - navigation
 		actual = node.get(key, null);
-		assertNotNull("3.0", actual);
-		assertEquals("3.1", expected, actual);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 
 		// value is set - service searching
 		actual = service.get(key, null, new Preferences[] {node});
-		assertNotNull("4.0", actual);
-		assertEquals("4.1", expected, actual);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 
 		// return default value if node list is null
 		actual = service.get(key, null, null);
-		assertNull("5.0", actual);
+		assertNull(actual);
 
 		// skip over null nodes
 		actual = service.get(key, null, new Preferences[] {null, node});
-		assertNotNull("6.0", actual);
-		assertEquals("6.1", expected, actual);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 
 		// set the value in the default scope as well
 		Preferences defaultNode = service.getRootNode().node(DefaultScope.SCOPE).node(qualifier);
 		String defaultValue = getUniqueString();
 		defaultNode.put(key, defaultValue);
 		actual = defaultNode.get(key, null);
-		assertNotNull("7.0", actual);
-		assertEquals("7.1", defaultValue, actual);
+		assertNotNull(actual);
+		assertEquals(defaultValue, actual);
 
 		// pass in both nodes
 		actual = service.get(key, null, new Preferences[] {node, defaultNode});
-		assertNotNull("8.0", actual);
-		assertEquals("8.1", expected, actual);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 		// skip nulls
 		actual = service.get(key, null, new Preferences[] {null, node, null, defaultNode, null});
-		assertNotNull("8.2", actual);
-		assertEquals("8.3", expected, actual);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 		// reverse the order
 		actual = service.get(key, null, new Preferences[] {defaultNode, node});
-		assertNotNull("8.4", actual);
-		assertEquals("8.5", defaultValue, actual);
+		assertNotNull(actual);
+		assertEquals(defaultValue, actual);
 		// skip nulls
 		actual = service.get(key, null, new Preferences[] {null, null, defaultNode, null, node, null});
-		assertNotNull("8.6", actual);
-		assertEquals("8.7", defaultValue, actual);
+		assertNotNull(actual);
+		assertEquals(defaultValue, actual);
 	}
 
 	@Test
@@ -376,33 +377,33 @@ public class PreferencesServiceTest {
 		// nothing is set
 		for (int i = 0; i < contexts.length; i++) {
 			actual = service.getString(qualifier, key, null, contexts[i]);
-			assertNull("1.0." + i, actual);
+			assertNull(actual, i + "");
 		}
 
 		// set a default value
 		defaultNode.put(key, defaultValue);
 		actual = defaultNode.get(key, null);
-		assertNotNull("2.0", actual);
-		assertEquals("2.1", defaultValue, actual);
+		assertNotNull(actual);
+		assertEquals(defaultValue, actual);
 
 		// should find it because "default" is in the default-default lookup order
 		for (int i = 0; i < contexts.length; i++) {
 			actual = service.getString(qualifier, key, null, contexts[i]);
-			assertNotNull("3.0." + i, actual);
-			assertEquals("3.1." + i, defaultValue, actual);
+			assertNotNull(actual, i + "");
+			assertEquals(defaultValue, actual, i + "");
 		}
 
 		// set a real value
 		node.put(key, value);
 		actual = node.get(key, null);
-		assertNotNull("4.0", actual);
-		assertEquals("4.1", value, actual);
+		assertNotNull(actual);
+		assertEquals(value, actual);
 
 		// should find the default value since the "test" scope isn't in the lookup order
 		for (int i = 0; i < contexts.length; i++) {
 			actual = service.getString(qualifier, key, null, contexts[i]);
-			assertNotNull("5.0." + i, actual);
-			assertEquals("5.1." + i, defaultValue, actual);
+			assertNotNull(actual, i + "");
+			assertEquals(defaultValue, actual, i + "");
 		}
 
 		// set the lookup order for qualifier/null
@@ -414,8 +415,8 @@ public class PreferencesServiceTest {
 		// get the value, should be the real one
 		for (int i = 0; i < contexts.length; i++) {
 			actual = service.getString(qualifier, key, null, contexts[i]);
-			assertNotNull("7.0." + i, actual);
-			assertEquals("7.1." + i, value, actual);
+			assertNotNull(actual, i + "");
+			assertEquals(value, actual, i + "");
 		}
 
 		// set the order to be the reverse for the qualifier/key
@@ -427,8 +428,8 @@ public class PreferencesServiceTest {
 		// get the value, should be the default one
 		for (int i = 0; i < contexts.length; i++) {
 			actual = service.getString(qualifier, key, null, contexts[i]);
-			assertNotNull("9.0." + i, actual);
-			assertEquals("9.1." + i, defaultValue, actual);
+			assertNotNull(actual, i + "");
+			assertEquals(defaultValue, actual, i + "");
 		}
 	}
 
@@ -443,35 +444,35 @@ public class PreferencesServiceTest {
 
 		String searchPath = "a";
 		node.put("a", searchPath);
-		assertEquals("3.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "a/b";
 		node.node("a").put("b", searchPath);
-		assertEquals("4.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "a//b";
 		node.node("a").put("b", searchPath);
-		assertEquals("5.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "a/b//c";
 		node.node("a").node("b").put("c", searchPath);
-		assertEquals("6.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "a/b//c/d";
 		node.node("a").node("b").put("c/d", searchPath);
-		assertEquals("7.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "/a";
 		node.put("a", searchPath);
-		assertEquals("8.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "/a/b";
 		node.node("a").put("b", searchPath);
-		assertEquals("9.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 
 		searchPath = "///a";
 		node.put("/a", searchPath);
-		assertEquals("10.0", searchPath, service.getString(qualifier, searchPath, null, null));
+		assertEquals(searchPath, service.getString(qualifier, searchPath, null, null));
 	}
 
 	@Test
@@ -493,7 +494,7 @@ public class PreferencesServiceTest {
 
 		// nodes shouldn't exist
 		for (String qualifier : qualifiers) {
-			assertTrue("1.0", !node.nodeExists(qualifier));
+			assertFalse(node.nodeExists(qualifier));
 		}
 
 		// store some values
@@ -502,11 +503,11 @@ public class PreferencesServiceTest {
 			for (String oldKey : oldKeys) {
 				current.put(oldKey, getUniqueString());
 				actual = current.get(oldKey, null);
-				assertNotNull("2.0." + current.absolutePath() + IPath.SEPARATOR + oldKey, actual);
+				assertNotNull(actual, current.absolutePath() + IPath.SEPARATOR + oldKey);
 			}
 			for (String newKey : newKeys) {
 				actual = current.get(newKey, null);
-				assertNull("2.1." + current.absolutePath() + IPath.SEPARATOR + newKey, actual);
+				assertNull(actual, current.absolutePath() + IPath.SEPARATOR + newKey);
 			}
 		}
 
@@ -519,11 +520,11 @@ public class PreferencesServiceTest {
 		for (String qualifier : qualifiers) {
 			Preferences current = node.node(qualifier);
 			for (String oldKey : oldKeys) {
-				assertNull("4.0." + current.absolutePath() + IPath.SEPARATOR + oldKey, current.get(oldKey, null));
+				assertNull(current.get(oldKey, null), current.absolutePath() + IPath.SEPARATOR + oldKey);
 			}
 			for (String newKey : newKeys) {
 				actual = current.get(newKey, null);
-				assertNotNull("4.1." + current.absolutePath() + IPath.SEPARATOR + newKey, actual);
+				assertNotNull(actual, current.absolutePath() + IPath.SEPARATOR + newKey);
 			}
 		}
 	}
@@ -654,7 +655,7 @@ public class PreferencesServiceTest {
 	@Test
 	public void testDefaultFromInitializer() {
 		String value = Platform.getPreferencesService().getString(RuntimeTestsPlugin.PI_RUNTIME_TESTS, TestInitializer.DEFAULT_PREF_KEY, null, null);
-		assertEquals("1.0", TestInitializer.DEFAULT_PREF_VALUE, value);
+		assertEquals(TestInitializer.DEFAULT_PREF_VALUE, value);
 	}
 
 	/*
@@ -717,7 +718,7 @@ public class PreferencesServiceTest {
 		// no errors if the file doesn't exist
 		IPath path = FileSystemHelper.getRandomLocation();
 		IStatus result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
-		assertTrue("1.0", result.isOK());
+		assertTrue(result.isOK());
 
 		// an empty file wasn't written by #export so its an invalid file format
 		// NOTE: this changed from "do nothing" to being an error in Eclipse 3.1
@@ -726,12 +727,12 @@ public class PreferencesServiceTest {
 			properties.store(output, null);
 		}
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
-		assertTrue("2.0", !result.isOK());
+		assertFalse(result.isOK());
 
 		// no errors for a file which we write out right now
 		org.eclipse.core.runtime.Preferences.exportPreferences(path);
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
-		assertTrue("3.1", result.isOK());
+		assertTrue(result.isOK());
 
 		// warning for old versions
 		properties = new Properties();
@@ -749,7 +750,7 @@ public class PreferencesServiceTest {
 			properties.store(output, null);
 		}
 		result = org.eclipse.core.runtime.Preferences.validatePreferenceVersions(path);
-		assertTrue("4.2", !result.isOK());
+		assertFalse(result.isOK());
 
 	}
 
@@ -1087,7 +1088,7 @@ public class PreferencesServiceTest {
 		children = node.childrenNames();
 		assertThat(children).as(debugString).isEmpty();
 
-		assertEquals(debugString, "someValue", node.get("someKey", null));
+		assertEquals("someValue", node.get("someKey", null), debugString);
 	}
 
 	@Test


### PR DESCRIPTION
- Remove obsolete assertions messages
- Migrate assertions to JUnit 5

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903