### PR TITLE
Migrate assertions in org.eclipse.core.tests.harness to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/alias/BasicAliasTest.java
@@ -427,6 +427,7 @@ public class BasicAliasTest {
 			link2TempFolder.createLink(tempStore.toURI(), IResource.NONE, createTestMonitor());
 			// change the location of p2 project to the temp folder
 			replaceProject(p2, tempStore.toURI());
+			return null;
 		});
 
 		// now p2 and link2TempFolder should be aliases

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemComparator.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemComparator.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -24,7 +27,6 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
 
 /**
  * A utility class that compares file system states. It is able to take snapshot of the file system and save it into a
@@ -90,9 +92,11 @@ public class FileSystemComparator {
 		for (Object element : newSnapshot.values()) {
 			FileSummary newElement = (FileSummary) element;
 			FileSummary oldElement = (FileSummary) oldSnapshot.get(newElement.getPath());
-			Assert.assertNotNull(tag + " - " + newElement.getPath() + " was added", oldElement);
-			Assert.assertEquals(tag + " - " + newElement.getPath() + " changed timestamp ", oldElement.getTimestamp(), newElement.getTimestamp());
-			Assert.assertEquals(tag + " - " + newElement.getPath() + " changed size ", oldElement.getSize(), newElement.getSize());
+			assertNotNull(oldElement, tag + " - " + newElement.getPath() + " was added");
+			assertEquals(oldElement.getTimestamp(), newElement.getTimestamp(),
+					tag + " - " + newElement.getPath() + " changed timestamp ");
+			assertEquals(oldElement.getSize(), newElement.getSize(),
+					tag + " - " + newElement.getPath() + " changed size ");
 		}
 		// one or more entries were removed
 		// need to do the reverse (take the old snapshot as basis) to figure out what are the missing entries
@@ -100,7 +104,7 @@ public class FileSystemComparator {
 			for (Object element : oldSnapshot.values()) {
 				FileSummary oldElement = (FileSummary) element;
 				FileSummary newElement = (FileSummary) newSnapshot.get(oldElement.getPath());
-				Assert.assertNotNull(tag + " - " + oldElement.getPath() + " was removed", newElement);
+				assertNotNull(newElement, tag + " - " + oldElement.getPath() + " was removed");
 			}
 		}
 	}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemHelper.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FileSystemHelper.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.Callable;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.junit.function.ThrowingRunnable;
 
 /**
  * Home for file system-related utility methods.
@@ -243,9 +243,9 @@ public class FileSystemHelper {
 	 * @param operationToExecute the operation to execute
 	 * @throws Throwable if a throwable is thrown in the operation to execute
 	 */
-	public static void deleteAfterExecution(Path pathToDelete, ThrowingRunnable operationToExecute) throws Throwable {
+	public static <T> T deleteAfterExecution(Path pathToDelete, Callable<T> operationToExecute) throws Throwable {
 		try {
-			operationToExecute.run();
+			return operationToExecute.call();
 		} finally {
 			FileSystemHelper.deleteRecursively(pathToDelete);
 		}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestBarrier2.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/TestBarrier2.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.harness;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
@@ -20,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 
 /**
  * This class acts as an implementation of a barrier that is appropriate for
@@ -92,10 +93,10 @@ public class TestBarrier2 {
 			if (!condition) {
 				String dump = getThreadDump();
 				if (statuses.get(index) > status) {
-					Assert.fail("Timeout after " + elapsed + "ms - Status already in state "
+					fail("Timeout after " + elapsed + "ms - Status already in state "
 							+ getStatus(statuses.get(index)) + " - waiting for " + getStatus(status) + "\n" + dump);
 				} else {
-					Assert.fail("Timeout after " + elapsed + "ms waiting for status to change from "
+					fail("Timeout after " + elapsed + "ms waiting for status to change from "
 						+ getStatus(statuses.get(index)) + " to " + getStatus(status) + "\n" + dump);
 				}
 			}

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/session/customization/CustomSessionConfigurationImpl.java
@@ -12,7 +12,8 @@ package org.eclipse.core.tests.harness.session.customization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.deleteOnShutdownRecursively;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +33,6 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.harness.session.CustomSessionConfiguration;
 import org.eclipse.core.tests.session.Setup;
-import org.junit.Assert;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
@@ -255,7 +255,7 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 
 	private void addBundle(Class<?> classFromBundle, String suffix) {
 		Bundle bundle = FrameworkUtil.getBundle(classFromBundle);
-		Assert.assertNotNull("Class is not from a bundle: " + classFromBundle, bundle);
+		assertNotNull(bundle, "Class is not from a bundle: " + classFromBundle);
 		addBundle(bundle, suffix);
 	}
 
@@ -294,7 +294,7 @@ public class CustomSessionConfigurationImpl implements CustomSessionConfiguratio
 
 		String toURL() {
 			Optional<File> location = FileLocator.getBundleFileLocation(bundle);
-			assertTrue("Unable to locate bundle with id: " + bundle.getSymbolicName(), location.isPresent());
+			assertTrue(location.isPresent(), "Unable to locate bundle with id: " + bundle.getSymbolicName());
 			String externalForm;
 			try {
 				externalForm = location.get().toURI().toURL().toExternalForm();


### PR DESCRIPTION
All consumers of functionality in org.eclipse.core.tests.harness use JUnit 5. Thus the used assertions within that functionality can be migrated to JUnit 5 as well. This change replaces all assertions accordingly.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903