### PR TITLE
Replace custom AssertionFailedErrors in test harness based on org.junit

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FussyProgressMonitor.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/harness/FussyProgressMonitor.java
@@ -15,8 +15,8 @@ package org.eclipse.core.tests.harness;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junit.framework.AssertionFailedError;
 import org.eclipse.core.runtime.jobs.Job;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * This class can be used for testing progress monitoring.

--- a/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/RemoteAssertionFailedError.java
+++ b/runtime/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/RemoteAssertionFailedError.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.session;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import junit.framework.AssertionFailedError;
+import org.opentest4j.AssertionFailedError;
 
 public class RemoteAssertionFailedError extends AssertionFailedError {
 	/**


### PR DESCRIPTION
The custom `AssertionFailedErrors` specified in `org.eclipse.core.tests.harness` are derived from JUnit 3/4's `AssertionFailedError` coming from org.junit. In order to fully migrate the test harness to JUnit 5, this change adapts those classes to subclass the AssertionFailedError from org.opentest4j as done by JUnit 5 as well.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

Requires #2350