### PR TITLE
Remove obsolete org.junit dependency from org.eclipse.core.tests.runtime

### DIFF
--- a/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -10,8 +10,7 @@ Export-Package: org.eclipse.core.tests.internal.preferences,
  org.eclipse.core.tests.runtime,
  org.eclipse.core.tests.runtime.jobs,
  org.eclipse.core.tests.runtime.perf
-Require-Bundle: org.junit,
- org.eclipse.test.performance;resolution:=optional,
+Require-Bundle: org.eclipse.test.performance;resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.core.tests.harness;bundle-version="3.11.0"
 Import-Package: org.assertj.core.api,


### PR DESCRIPTION
With all migrations to JUnit 5 being completed, `org.eclipse.core.tests.runtime` does not consume anything from org.junit anymore, such that the dependency can be removed.