### PR TITLE
Extract utilities from AbstractAntUITest into AntUITestUtil

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/AbstractAntDebugTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchConfiguration;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchManager;
 import static org.junit.Assert.assertNotNull;

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/BreakpointTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/BreakpointTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.debug;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Debug Tests/org/eclipse/ant/tests/ui/debug/StackTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.ant.tests.ui.debug;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 
 import org.eclipse.ant.internal.launching.debug.model.AntThread;
 import org.eclipse.core.resources.IFile;

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
@@ -20,6 +20,8 @@ package org.eclipse.ant.tests.ui.editor;
 
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getReaderContentAsString;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Files;

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AbstractAntUIBuildTest.java
@@ -15,17 +15,11 @@
 package org.eclipse.ant.tests.ui;
 
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.console.IHyperlink;
 import org.junit.Rule;
 
 public abstract class AbstractAntUIBuildTest extends AbstractAntUITest {
 
 	@Rule
 	public RunInSeparateThreadRule runInSeparateThread = new RunInSeparateThreadRule();
-
-	protected void activateLink(final IHyperlink link) {
-		Display.getDefault().asyncExec(() -> link.linkActivated());
-	}
 
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.ant.tests.ui;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
@@ -17,7 +17,9 @@ package org.eclipse.ant.tests.ui;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 
@@ -25,6 +27,7 @@ import org.eclipse.ant.internal.ui.AntUtil;
 import org.eclipse.ant.internal.ui.preferences.FileFilter;
 import org.eclipse.ant.internal.ui.views.actions.AddBuildFilesAction;
 import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IContributionItem;
@@ -108,4 +111,54 @@ public class AntViewTests extends AbstractAntUITest {
 		}
 	}
 
+	/**
+	 * This is to help in increasing the test coverage by enabling access to fields
+	 * and execution of methods irrespective of their Java language access
+	 * permissions.
+	 *
+	 * More accessor methods can be added to this on a need basis
+	 */
+	private static abstract class TypeProxy {
+
+		Object master = null;
+
+		protected TypeProxy(Object obj) {
+			master = obj;
+		}
+
+		/**
+		 * Gets the method with the given method name and argument types.
+		 *
+		 * @param methodName the method name
+		 * @param types      the argument types
+		 * @return the method
+		 */
+		protected Method get(String methodName, Class<?>[] types) {
+			Method method = null;
+			try {
+				method = master.getClass().getDeclaredMethod(methodName, types);
+			} catch (SecurityException | NoSuchMethodException e) {
+				fail();
+			}
+			Assert.isNotNull(method);
+			method.setAccessible(true);
+			return method;
+		}
+
+		/**
+		 * Invokes the given method with the given arguments.
+		 *
+		 * @param method    the given method
+		 * @param arguments the method arguments
+		 * @return the method return value
+		 */
+		protected Object invoke(Method method, Object[] arguments) {
+			try {
+				return method.invoke(master, arguments);
+			} catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
+				fail();
+			}
+			return null;
+		}
+	}
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/BuildTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/BuildTests.java
@@ -14,8 +14,13 @@
 
 package org.eclipse.ant.tests.ui;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.activateLink;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getColorAtOffset;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getHyperlink;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchConfiguration;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getProject;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.launch;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.launchAndTerminate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/separateVM/SeparateVMTests.java
@@ -14,9 +14,13 @@
 
 package org.eclipse.ant.tests.ui.separateVM;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.activateLink;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getColorAtOffset;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getHyperlink;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getJavaProject;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchConfiguration;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getProject;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.launch;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.launchAndTerminate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -36,7 +40,6 @@ import org.eclipse.ant.internal.ui.IAntUIPreferenceConstants;
 import org.eclipse.ant.launching.IAntLaunchConstants;
 import org.eclipse.ant.tests.ui.AbstractAntUIBuildTest;
 import org.eclipse.ant.tests.ui.debug.TestAgainException;
-import org.eclipse.ant.tests.ui.testplugin.AntUITestUtil;
 import org.eclipse.ant.tests.ui.testplugin.ConsoleLineTracker;
 import org.eclipse.ant.tests.ui.testplugin.ProjectHelper;
 import org.eclipse.core.resources.IFile;
@@ -311,7 +314,7 @@ public class SeparateVMTests extends AbstractAntUIBuildTest {
 		assertNotNull("Could not locate launch configuration for " + "echoingSepVM", config); //$NON-NLS-1$ //$NON-NLS-2$
 		ILaunchConfigurationWorkingCopy copy = config.getWorkingCopy();
 		copy.setAttribute(IAntUIConstants.SET_INPUTHANDLER, false);
-		AntUITestUtil.launch(copy);
+		launch(copy);
 		String message = ConsoleLineTracker.getMessage(1);
 		assertNotNull("There must be a message", message); //$NON-NLS-1$
 		assertTrue("Incorrect message. Should start with Message:. Message: " + message, message.startsWith("echo1")); //$NON-NLS-1$ //$NON-NLS-2$

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.externaltools;
 
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchManager;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getProject;
 import static org.junit.Assert.assertFalse;
@@ -384,7 +385,8 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	 */
 	@Test
 	public void testIsUnmigratedConfig1() throws Exception {
-		ILaunchConfigurationType type = getLaunchManager().getLaunchConfigurationType(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE);
+		ILaunchConfigurationType type = getLaunchManager()
+				.getLaunchConfigurationType(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE);
 		if (type != null) {
 			ILaunchConfigurationWorkingCopy config = type.newInstance(BuilderCoreUtils.getBuilderFolder(getProject(), true), "testIsUnmigratedConfig1"); //$NON-NLS-1$
 			assertTrue("should be considered 'unmigrated'", BuilderCoreUtils.isUnmigratedConfig(config)); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AbstractAntUITest.java
@@ -14,47 +14,23 @@
 package org.eclipse.ant.tests.ui.testplugin;
 
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.assertProject;
-import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchConfiguration;
-import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.launchAndTerminate;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 
-import org.eclipse.ant.internal.ui.AntUIPlugin;
 import org.eclipse.ant.internal.ui.model.AntModel;
 import org.eclipse.ant.tests.ui.editor.support.TestLocationProvider;
 import org.eclipse.ant.tests.ui.editor.support.TestProblemRequestor;
-import org.eclipse.core.externaltools.internal.IExternalToolConstants;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.IDocumentPartitioner;
-import org.eclipse.jface.text.ITypedRegion;
-import org.eclipse.jface.text.Position;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.ui.console.IHyperlink;
-import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
-import org.eclipse.ui.internal.console.IOConsolePartition;
 import org.junit.Before;
 import org.junit.Rule;
 
 /**
  * Abstract Ant UI test class
  */
-@SuppressWarnings("restriction")
 public abstract class AbstractAntUITest {
 
 	public static final String ANT_EDITOR_ID = "org.eclipse.ant.ui.internal.editor.AntEditor"; //$NON-NLS-1$
@@ -63,26 +39,6 @@ public abstract class AbstractAntUITest {
 
 	@Rule
 	public TestAgainExceptionRule testAgainRule = new TestAgainExceptionRule(5);
-
-	/**
-	 * Returns the {@link IFile} for the given build file name
-	 *
-	 * @return the associated {@link IFile} for the given build file name
-	 */
-	protected IFile getIFile(String buildFileName) {
-		return AntUITestUtil.getProject().getFolder("buildfiles").getFile(buildFileName); //$NON-NLS-1$
-	}
-
-	/**
-	 * Returns the {@link File} for the given build file name
-	 *
-	 * @return the {@link File} for the given build file name
-	 */
-	protected File getBuildFile(String buildFileName) {
-		IFile file = getIFile(buildFileName);
-		assertTrue("Could not find build file named: " + buildFileName, file.exists()); //$NON-NLS-1$
-		return file.getLocation().toFile();
-	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -106,39 +62,14 @@ public abstract class AbstractAntUITest {
 	}
 
 	/**
-	 * Returns the contents of the given {@link BufferedReader} as a {@link String}
-	 *
-	 * @return the contents of the given {@link BufferedReader} as a {@link String}
-	 */
-	protected String getReaderContentAsString(BufferedReader bufferedReader) {
-		StringBuilder result = new StringBuilder();
-		try {
-			String line = bufferedReader.readLine();
-
-			while (line != null) {
-				if (result.length() != 0) {
-					result.append(System.lineSeparator());
-				}
-				result.append(line);
-				line = bufferedReader.readLine();
-			}
-		}
-		catch (IOException e) {
-			AntUIPlugin.log(e);
-			return null;
-		}
-
-		return result.toString();
-	}
-
-	/**
 	 * Returns the {@link AntModel} for the given file name
 	 *
 	 * @return the {@link AntModel} for the given file name
 	 */
 	protected AntModel getAntModel(String fileName) {
 		currentDocument = getDocument(fileName);
-		AntModel model = new AntModel(currentDocument, new TestProblemRequestor(), new TestLocationProvider(getBuildFile(fileName)));
+		AntModel model = new AntModel(currentDocument, new TestProblemRequestor(),
+				new TestLocationProvider(getBuildFile(fileName)));
 		model.reconcile();
 		return model;
 	}
@@ -157,132 +88,5 @@ public abstract class AbstractAntUITest {
 		this.currentDocument = currentDocument;
 	}
 
-	/**
-	 * Launches the Ant build with the build file name (no extension).
-	 *
-	 * @param buildFileName
-	 *            the ant build file name
-	 */
-	protected void launch(String buildFileName) throws CoreException {
-		ILaunchConfiguration config = getLaunchConfiguration(buildFileName);
-		assertNotNull("Could not locate launch configuration for " + buildFileName, config); //$NON-NLS-1$
-		launchAndTerminate(config, 20000);
-	}
 
-	/**
-	 * Launches the Ant build with the build file name (no extension).
-	 *
-	 * @param buildFileName
-	 *            the build file
-	 * @param arguments
-	 *            the ant arguments
-	 */
-	protected void launch(String buildFileName, String arguments) throws CoreException {
-		ILaunchConfiguration config = getLaunchConfiguration(buildFileName);
-		assertNotNull("Could not locate launch configuration for " + buildFileName, config); //$NON-NLS-1$
-		ILaunchConfigurationWorkingCopy copy = config.getWorkingCopy();
-		copy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, arguments);
-		launchAndTerminate(copy, 20000);
-	}
-
-	/**
-	 * Returns the {@link IHyperlink} at the given offset on the given document, or <code>null</code> if there is no {@link IHyperlink} at that offset
-	 * on the document.
-	 *
-	 * @return the {@link IHyperlink} at the given offset on the given document or <code>null</code>
-	 */
-	protected IHyperlink getHyperlink(int offset, IDocument doc) {
-		if (offset >= 0 && doc != null) {
-			Position[] positions = null;
-			try {
-				positions = doc.getPositions(ConsoleHyperlinkPosition.HYPER_LINK_CATEGORY);
-			}
-			catch (BadPositionCategoryException ex) {
-				// no links have been added
-				return null;
-			}
-			for (Position position : positions) {
-				if (offset >= position.getOffset() && offset <= (position.getOffset() + position.getLength())) {
-					return ((ConsoleHyperlinkPosition) position).getHyperLink();
-				}
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Returns the {@link Color} at the given offset on the given document, or <code>null</code> if there is no {@link Color} at that offset on the
-	 * document.
-	 *
-	 * @return the {@link Color} at the given offset on the given document or <code>null</code>
-	 */
-	protected Color getColorAtOffset(int offset, IDocument document) throws BadLocationException {
-		if (document != null) {
-			IDocumentPartitioner partitioner = document.getDocumentPartitioner();
-			if (partitioner != null) {
-				ITypedRegion[] regions = partitioner.computePartitioning(offset, document.getLineInformationOfOffset(offset).getLength());
-				if (regions.length > 0) {
-					IOConsolePartition partition = (IOConsolePartition) regions[0];
-					return partition.getColor();
-				}
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * This is to help in increasing the test coverage by enabling access to fields and execution of methods irrespective of their Java language
-	 * access permissions.
-	 *
-	 * More accessor methods can be added to this on a need basis
-	 */
-	protected static abstract class TypeProxy {
-
-		Object master = null;
-
-		protected TypeProxy(Object obj) {
-			master = obj;
-		}
-
-		/**
-		 * Gets the method with the given method name and argument types.
-		 *
-		 * @param methodName
-		 *            the method name
-		 * @param types
-		 *            the argument types
-		 * @return the method
-		 */
-		protected Method get(String methodName, Class<?>[] types) {
-			Method method = null;
-			try {
-				method = master.getClass().getDeclaredMethod(methodName, types);
-			}
-			catch (SecurityException | NoSuchMethodException e) {
-				fail();
-			}
-			Assert.isNotNull(method);
-			method.setAccessible(true);
-			return method;
-		}
-
-		/**
-		 * Invokes the given method with the given arguments.
-		 *
-		 * @param method
-		 *            the given method
-		 * @param arguments
-		 *            the method arguments
-		 * @return the method return value
-		 */
-		protected Object invoke(Method method, Object[] arguments) {
-			try {
-				return method.invoke(master, arguments);
-			}
-			catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-				fail();
-			}
-			return null;
-		}
-	}
 }

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUITestUtil.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUITestUtil.java
@@ -10,8 +10,10 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.testplugin;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -19,6 +21,7 @@ import java.net.URL;
 import org.eclipse.ant.internal.ui.AntUIPlugin;
 import org.eclipse.ant.internal.ui.IAntUIPreferenceConstants;
 import org.eclipse.ant.tests.ui.debug.TestAgainException;
+import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -30,10 +33,22 @@ import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPositionCategoryException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.Position;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
+import org.eclipse.ui.internal.console.IOConsolePartition;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -192,5 +207,132 @@ public final class AntUITestUtil {
 	 */
 	public static IProject getProject() {
 		return ResourcesPlugin.getWorkspace().getRoot().getProject(ProjectHelper.PROJECT_NAME);
+	}
+
+	/**
+	 * Launches the Ant build with the build file name (no extension).
+	 *
+	 * @param buildFileName
+	 *            the build file
+	 * @param arguments
+	 *            the ant arguments
+	 */
+	public static void launch(String buildFileName, String arguments) throws CoreException {
+		ILaunchConfiguration config = getLaunchConfiguration(buildFileName);
+		assertNotNull("Could not locate launch configuration for " + buildFileName, config); //$NON-NLS-1$
+		ILaunchConfigurationWorkingCopy copy = config.getWorkingCopy();
+		copy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, arguments);
+		launchAndTerminate(copy, 20000);
+	}
+
+	/**
+	 * Launches the Ant build with the build file name (no extension).
+	 *
+	 * @param buildFileName
+	 *            the ant build file name
+	 */
+	public static void launch(String buildFileName) throws CoreException {
+		ILaunchConfiguration config = getLaunchConfiguration(buildFileName);
+		assertNotNull("Could not locate launch configuration for " + buildFileName, config); //$NON-NLS-1$
+		launchAndTerminate(config, 20000);
+	}
+
+	/**
+	 * Returns the {@link IFile} for the given build file name
+	 *
+	 * @return the associated {@link IFile} for the given build file name
+	 */
+	public static IFile getIFile(String buildFileName) {
+		return getProject().getFolder("buildfiles").getFile(buildFileName); //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns the {@link File} for the given build file name
+	 *
+	 * @return the {@link File} for the given build file name
+	 */
+	public static File getBuildFile(String buildFileName) {
+		IFile file = getIFile(buildFileName);
+		assertTrue("Could not find build file named: " + buildFileName, file.exists()); //$NON-NLS-1$
+		return file.getLocation().toFile();
+	}
+
+	/**
+	 * Returns the contents of the given {@link BufferedReader} as a {@link String}
+	 *
+	 * @return the contents of the given {@link BufferedReader} as a {@link String}
+	 */
+	public static String getReaderContentAsString(BufferedReader bufferedReader) {
+		StringBuilder result = new StringBuilder();
+		try {
+			String line = bufferedReader.readLine();
+
+			while (line != null) {
+				if (result.length() != 0) {
+					result.append(System.lineSeparator());
+				}
+				result.append(line);
+				line = bufferedReader.readLine();
+			}
+		}
+		catch (IOException e) {
+			AntUIPlugin.log(e);
+			return null;
+		}
+
+		return result.toString();
+	}
+
+	/**
+	 * Returns the {@link Color} at the given offset on the given document, or
+	 * <code>null</code> if there is no {@link Color} at that offset on the
+	 * document.
+	 *
+	 * @return the {@link Color} at the given offset on the given document or
+	 *         <code>null</code>
+	 */
+	public static Color getColorAtOffset(int offset, IDocument document) throws BadLocationException {
+		if (document != null) {
+			IDocumentPartitioner partitioner = document.getDocumentPartitioner();
+			if (partitioner != null) {
+				ITypedRegion[] regions = partitioner.computePartitioning(offset,
+						document.getLineInformationOfOffset(offset).getLength());
+				if (regions.length > 0) {
+					IOConsolePartition partition = (IOConsolePartition) regions[0];
+					return partition.getColor();
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the {@link IHyperlink} at the given offset on the given document, or
+	 * <code>null</code> if there is no {@link IHyperlink} at that offset on the
+	 * document.
+	 *
+	 * @return the {@link IHyperlink} at the given offset on the given document or
+	 *         <code>null</code>
+	 */
+	public static IHyperlink getHyperlink(int offset, IDocument doc) {
+		if (offset >= 0 && doc != null) {
+			Position[] positions = null;
+			try {
+				positions = doc.getPositions(ConsoleHyperlinkPosition.HYPER_LINK_CATEGORY);
+			} catch (BadPositionCategoryException ex) {
+				// no links have been added
+				return null;
+			}
+			for (Position position : positions) {
+				if (offset >= position.getOffset() && offset <= (position.getOffset() + position.getLength())) {
+					return ((ConsoleHyperlinkPosition) position).getHyperLink();
+				}
+			}
+		}
+		return null;
+	}
+
+	public static void activateLink(final IHyperlink link) {
+		Display.getDefault().asyncExec(() -> link.linkActivated());
 	}
 }


### PR DESCRIPTION
In order to remove the inheritance hierarchy of Ant UI tests for JUnit 5 migration, this moves the utility methods embedded into the inheritance hierarchy via the AbstractAntUITest root class to the dedicated AntUITestUtil.