### PR TITLE
Migrate direct subclasses of AbstractAntUITest to JUnit 5

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorContentOutlineTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorContentOutlineTests.java
@@ -17,26 +17,28 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.ant.internal.ui.model.AntElementNode;
 import org.eclipse.ant.internal.ui.model.AntModel;
 import org.eclipse.ant.internal.ui.model.IAntElement;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 import org.eclipse.ant.tests.ui.testplugin.AntModelForDocument;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the correct creation of the outline for an xml file.
  */
-public class AntEditorContentOutlineTests extends AbstractAntUITest {
+@AntUITest
+public class AntEditorContentOutlineTests {
 
 	/**
 	 * Tests the creation of the AntElementNode, that includes parsing a file and determining the correct location of the tags.
@@ -167,7 +169,7 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	public void testWithEmptyBuildFile() {
 		AntModel model = new AntModelForDocument("empty.xml").getAntModel(); //$NON-NLS-1$
 		AntElementNode rootProject = model.getProjectNode();
-		assertTrue(rootProject == null);
+		assertNull(rootProject);
 	}
 
 	/**
@@ -207,9 +209,11 @@ public class AntEditorContentOutlineTests extends AbstractAntUITest {
 	@Test
 	public void testInternalTargets() {
 		AntModel model = new AntModelForDocument("internalTargets.xml").getAntModel(); //$NON-NLS-1$
-		assertTrue("Target without description should be internal", model.getTargetNode("internal1").isInternal()); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Target with name starting with '-' should be internal", model.getTargetNode("-internal2").isInternal()); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("Target with description attribute should not be internal", model.getTargetNode("non-internal").isInternal()); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("Default target should not be internal", model.getTargetNode("-default").isInternal()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(model.getTargetNode("internal1").isInternal(), "Target without description should be internal"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(model.getTargetNode("-internal2").isInternal(), //$NON-NLS-1$
+				"Target with name starting with '-' should be internal\""); //$NON-NLS-1$
+		assertFalse(model.getTargetNode("non-internal").isInternal(), //$NON-NLS-1$
+				"Target with description attribute should not be internal"); //$NON-NLS-1$
+		assertFalse(model.getTargetNode("-default").isInternal(), "Default target should not be internal"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/AntEditorTests.java
@@ -24,7 +24,7 @@ import java.io.File;
 import org.eclipse.ant.internal.ui.editor.AntEditor;
 import org.eclipse.ant.internal.ui.editor.text.XMLTextHover;
 import org.eclipse.ant.tests.ui.editor.performance.EditorTestHelper;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -36,7 +36,8 @@ import org.junit.After;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-public class AntEditorTests extends AbstractAntUITest {
+@AntUITest
+public class AntEditorTests {
 
 	@Test
 	public void testHoverForPath() throws PartInitException, BadLocationException {

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/CodeCompletionTest.java
@@ -22,12 +22,12 @@ import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,8 +45,8 @@ import org.eclipse.ant.internal.ui.IAntUIConstants;
 import org.eclipse.ant.internal.ui.editor.AntEditor;
 import org.eclipse.ant.tests.ui.editor.performance.EditorTestHelper;
 import org.eclipse.ant.tests.ui.editor.support.TestTextCompletionProcessor;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 import org.eclipse.ant.tests.ui.testplugin.AntModelForDocument;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.internal.runtime.XmlProcessorFactory;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.BadLocationException;
@@ -54,7 +54,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.PartInitException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -64,7 +64,8 @@ import org.w3c.dom.Element;
  * Tests everything about code completion and code assistance.
  */
 @SuppressWarnings("restriction")
-public class CodeCompletionTest extends AbstractAntUITest {
+@AntUITest
+public class CodeCompletionTest {
 
 	private static final String ANT_EDITOR_ID = "org.eclipse.ant.ui.internal.editor.AntEditor"; //$NON-NLS-1$
 
@@ -474,7 +475,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 				break;
 			}
 		}
-		assertTrue("Did not find displayString: " + displayString, found); //$NON-NLS-1$
+		assertTrue(found, "Did not find displayString: " + displayString); //$NON-NLS-1$
 	}
 
 	/**
@@ -489,7 +490,7 @@ public class CodeCompletionTest extends AbstractAntUITest {
 				break;
 			}
 		}
-		assertFalse("Found displayString: " + displayString, found); //$NON-NLS-1$
+		assertFalse(found, "Found displayString: " + displayString); //$NON-NLS-1$
 	}
 
 	/**
@@ -620,7 +621,8 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		assertThat(proposals).hasSize(2);
 		assertContains("v", proposals); //$NON-NLS-1$
 		assertContains("eclipse", proposals); //$NON-NLS-1$
-		assertTrue("Additional proposal information not correct", proposals[1].getAdditionalProposalInfo().startsWith("Testing Eclipse")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(proposals[1].getAdditionalProposalInfo().startsWith("Testing Eclipse"), //$NON-NLS-1$
+				"Additional proposal information not correct"); //$NON-NLS-1$
 		processor.dispose();
 	}
 
@@ -662,8 +664,9 @@ public class CodeCompletionTest extends AbstractAntUITest {
 		processor.setCursorPosition(lineOffset + columnNumber);
 		ICompletionProposal[] proposals = processor.getProposalsFromDocument(document, ""); //$NON-NLS-1$
 		assertThat(proposals).hasSize(1);
-		assertTrue("Proposal not correct", proposals[0].getDisplayString().equals("some-tasks")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("Additional proposal information not correct", proposals[0].getAdditionalProposalInfo().endsWith("Not required")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(proposals[0].getDisplayString().equals("some-tasks"), "Proposal not correct"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(proposals[0].getAdditionalProposalInfo().endsWith("Not required"), //$NON-NLS-1$
+				"Additional proposal information not correct"); //$NON-NLS-1$
 		processor.dispose();
 	}
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/OccurrencesFinderTests.java
@@ -14,24 +14,27 @@
 package org.eclipse.ant.tests.ui.editor;
 
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getIFile;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.ant.internal.ui.editor.AntEditor;
 import org.eclipse.ant.internal.ui.editor.OccurrencesFinder;
 import org.eclipse.ant.tests.ui.editor.performance.EditorTestHelper;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 import org.eclipse.ui.PartInitException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class OccurrencesFinderTests extends AbstractAntUITest {
+@AntUITest
+public class OccurrencesFinderTests {
 
 	@Test
 	public void testFromPropertyName() throws PartInitException, BadLocationException {
@@ -51,8 +54,8 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	private void propertyOccurences(AntEditor editor, int offset) throws BadLocationException {
 		OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 		List<Position> positions = finder.perform();
-		assertNotNull("Expecting a position listing", positions); //$NON-NLS-1$
-		assertTrue("7 positions should have been found; found: " + positions.size(), positions.size() == 7); //$NON-NLS-1$
+		assertNotNull(positions, "Expecting a position listing"); //$NON-NLS-1$
+		assertEquals(7, positions.size());
 		assertContainsPosition(positions, offset, 8);
 		int newoffset = getOffsetWithinLine(editor, 34, 21);
 		assertContainsPosition(positions, newoffset, 8);
@@ -98,8 +101,8 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 			editor.selectAndReveal(offset, 50);
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertNotNull("Expecting a position listing", positions); //$NON-NLS-1$
-			assertTrue("3 positions should have been found; found: " + positions.size(), positions.size() == 3); //$NON-NLS-1$
+			assertNotNull(positions, "Expecting a position listing"); //$NON-NLS-1$
+			assertEquals(3, positions.size());
 			assertContainsPosition(positions, offset, 15);
 			offset = getOffsetWithinLine(editor, 40, 20);
 			assertContainsPosition(positions, offset, 15);
@@ -109,8 +112,8 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 			editor.selectAndReveal(offset, 10);
 			finder = getOccurrencesFinder(editor, offset);
 			positions = finder.perform();
-			assertNotNull("Expecting a position listing", positions); //$NON-NLS-1$
-			assertTrue("3 positions should have been found; found: " + positions.size(), positions.size() == 3); //$NON-NLS-1$
+			assertNotNull(positions, "Expecting a position listing"); //$NON-NLS-1$
+			assertEquals(3, positions.size());
 			assertContainsPosition(positions, offset, 15);
 			offset = getOffsetWithinLine(editor, 39, 20);
 			assertContainsPosition(positions, offset, 15);
@@ -139,7 +142,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 	private void macrodefAttributeOccurences(AntEditor editor, int offset) throws BadLocationException {
 		OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 		List<Position> positions = finder.perform();
-		assertTrue("6 positions should have been found; found: " + positions.size(), positions.size() == 6); //$NON-NLS-1$
+		assertEquals(6, positions.size());
 		assertContainsPosition(positions, offset, 7);
 		int newoffset = getOffsetWithinLine(editor, 19, 32);
 		assertContainsPosition(positions, newoffset, 7);
@@ -170,7 +173,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertTrue("4 positions should have been found; found: " + positions.size(), positions.size() == 4); //$NON-NLS-1$
+			assertEquals(4, positions.size());
 			assertContainsPosition(positions, offset, 7);
 			offset = getOffsetWithinLine(editor, 10, 16);
 			assertContainsPosition(positions, offset, 7);
@@ -192,7 +195,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertTrue("4 positions should have been found; found: " + positions.size(), positions.size() == 4); //$NON-NLS-1$
+			assertEquals(4, positions.size());
 			assertContainsPosition(positions, offset, 7);
 			offset = getOffsetWithinLine(editor, 10, 16);
 			assertContainsPosition(positions, offset, 7);
@@ -217,7 +220,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertTrue("2 positions should have been found; found: " + positions.size(), positions.size() == 2); //$NON-NLS-1$
+			assertEquals(2, positions.size());
 			assertContainsPosition(positions, offset, 7);
 			offset = getOffsetWithinLine(editor, 1, 45);
 			assertContainsPosition(positions, offset, 7);
@@ -241,7 +244,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			// from the declaration
 			List<Position> positions = finder.perform();
-			assertTrue("2 positions should have been found; found: " + positions.size(), positions.size() == 2); //$NON-NLS-1$
+			assertEquals(2, positions.size());
 			assertContainsPosition(positions, offset, 7);
 			offset = getOffsetWithinLine(editor, 5, 20);
 			assertContainsPosition(positions, offset, 7);
@@ -250,14 +253,14 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 			offset = getOffsetWithinLine(editor, 5, 20);
 			finder = getOccurrencesFinder(editor, offset);
 			positions = finder.perform();
-			assertTrue("2 positions should have been found; found: " + positions.size(), positions.size() == 2); //$NON-NLS-1$
+			assertEquals(2, positions.size());
 
 			// from the description
 			offset = getOffsetWithinLine(editor, 1, 30);
 			editor.selectAndReveal(offset, 0);
 			finder = getOccurrencesFinder(editor, offset);
 			positions = finder.perform();
-			assertTrue("No positions should have been found", positions == null); //$NON-NLS-1$
+			assertNull(positions);
 		}
 		finally {
 			EditorTestHelper.closeAllEditors();
@@ -292,7 +295,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertTrue("No positions should have been found", positions == null); //$NON-NLS-1$
+			assertNull(positions);
 		}
 		finally {
 			EditorTestHelper.closeAllEditors();
@@ -336,7 +339,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 
 			OccurrencesFinder finder = getOccurrencesFinder(editor, offset);
 			List<Position> positions = finder.perform();
-			assertTrue("2 positions should have been found; found: " + positions.size(), positions.size() == 2); //$NON-NLS-1$
+			assertEquals(2, positions.size());
 			assertContainsPosition(positions, offset, 4);
 			offset = getOffsetWithinLine(editor, 6, 17);
 			assertContainsPosition(positions, offset, 4);
@@ -346,7 +349,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 			editor.selectAndReveal(offset, 0);
 			finder = getOccurrencesFinder(editor, offset);
 			positions = finder.perform();
-			assertTrue("2 positions should have been found; found: " + positions.size(), positions.size() == 2); //$NON-NLS-1$
+			assertEquals(2, positions.size());
 			assertContainsPosition(positions, offset, 4);
 			offset = getOffsetWithinLine(editor, 7, 12);
 			assertContainsPosition(positions, offset, 4);
@@ -364,7 +367,7 @@ public class OccurrencesFinderTests extends AbstractAntUITest {
 				break;
 			}
 		}
-		assertTrue("Did not find position at offset: " + offset + " length: " + length, found); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(found, "Did not find position at offset: " + offset + " length: " + length); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private OccurrencesFinder getOccurrencesFinder(AntEditor editor, int offset) {

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/TaskDescriptionProviderTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/TaskDescriptionProviderTest.java
@@ -16,19 +16,20 @@
 
 package org.eclipse.ant.tests.ui.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ant.internal.ui.editor.TaskDescriptionProvider;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.junit.Test;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the tasks description provider.
  */
 @SuppressWarnings("restriction")
-public class TaskDescriptionProviderTest extends AbstractAntUITest {
+@AntUITest
+public class TaskDescriptionProviderTest {
 
 	/**
 	 * Tests getting the description of a task.

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/FormattingPreferencesTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/FormattingPreferencesTest.java
@@ -13,14 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.junit.Test;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class FormattingPreferencesTest extends AbstractAntUITest {
+@AntUITest
+public class FormattingPreferencesTest {
 
 	@Test
 	public final void testGetCanonicalIndent() {

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlDocumentFormatterTest.java
@@ -15,17 +15,18 @@ package org.eclipse.ant.tests.ui.editor.formatter;
 
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getReaderContentAsString;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Files;
 
 import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlDocumentFormatter;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.junit.Test;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class XmlDocumentFormatterTest extends AbstractAntUITest {
+@AntUITest
+public class XmlDocumentFormatterTest {
 
 	/**
 	 * General Test

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/formatter/XmlTagFormatterTest.java
@@ -14,22 +14,23 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.editor.formatter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.ant.internal.ui.editor.formatter.FormattingPreferences;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlTagFormatter;
 import org.eclipse.ant.internal.ui.editor.formatter.XmlTagFormatter.AttributePair;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
-import org.junit.Test;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class XmlTagFormatterTest extends AbstractAntUITest {
+@AntUITest
+public class XmlTagFormatterTest {
 
 	// TODO This test is too low level and too tightly coupled to internals.
 

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntUtilTests.java
@@ -16,10 +16,10 @@ package org.eclipse.ant.tests.ui;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
@@ -33,17 +33,17 @@ import org.eclipse.ant.internal.ui.model.AntTargetNode;
 import org.eclipse.ant.internal.ui.model.IAntElement;
 import org.eclipse.ant.internal.ui.model.IAntModel;
 import org.eclipse.ant.launching.IAntLaunchConstants;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.ant.tests.ui.testplugin.AntUITestUtil;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class AntUtilTests extends AbstractAntUITest {
+@AntUITest
+public class AntUtilTests {
 
 	private static final long EXECUTION_THRESHOLD_INCLUDE_TASK = 10000;
 	private static final long WINDOWS_EXECUTION_THRESHOLD_INCLUDE_TASK = 15000;
@@ -180,24 +180,25 @@ public class AntUtilTests extends AbstractAntUITest {
 		boolean atLeastOneExternal = false;
 		List<IAntElement> childNodes = project.getChildNodes();
 
-		Assert.assertNotNull(childNodes);
+		assertNotNull(childNodes);
 
 		int actualSize = childNodes.size();
-		Assert.assertEquals("Expecting " + childNodesExpected + " childnodes, but have: " + actualSize, childNodesExpected, actualSize); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(childNodesExpected, actualSize,
+				"Expecting " + childNodesExpected + " childnodes, but have: " + actualSize); //$NON-NLS-1$ //$NON-NLS-2$
 
 		for (IAntElement element : childNodes) {
 			// "External" seems to be true if the element was defined within an "importNode" => check the import nodes
 			IAntElement importNode = element.getImportNode();
 
 			if (importNode != null) {
-				Assert.assertTrue(element.isExternal());
+				assertTrue(element.isExternal());
 				atLeastOneExternal = true;
 			} else {
-				Assert.assertFalse(element.isExternal());
+				assertFalse(element.isExternal());
 			}
 		}
 		// At least on external include-file was found
-		Assert.assertTrue(atLeastOneExternal);
+		assertTrue(atLeastOneExternal);
 		// Then just execute the rest of the previous test
 		AntTargetNode[] targets = getAntTargetNodesOfBuildFile(buildFileName);
 		String[] expectedTargets = { "deploy", "commonLv1.deploy", "commonLv1.commonLv2.deploySuper", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -219,7 +220,7 @@ public class AntUtilTests extends AbstractAntUITest {
 		AntProjectNode project = model.getProjectNode();
 		long endTimeInNanoseconds = ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
 
-		Assert.assertNotNull(project);
+		assertNotNull(project);
 		/*
 		 * Parsing the file-hierarchy should not take longer than:
 		 *
@@ -232,8 +233,9 @@ public class AntUtilTests extends AbstractAntUITest {
 		// Change this value if it does not fit the performance needs
 		long maxDuration = this.getExecutionTresholdIncludeTask();
 
-		Assert.assertTrue("Expecting a duration < " + maxDuration + ", but we have " + durationInMilliseconds + "ms", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				durationInMilliseconds < maxDuration);
+		assertTrue(durationInMilliseconds < maxDuration,
+				"Expecting a duration < " + maxDuration + ", but we have " + durationInMilliseconds + "ms");//$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
 		// Test the rest
 		AntTargetNode[] targets = getAntTargetNodesOfBuildFile(buildFileName);
 
@@ -268,8 +270,9 @@ public class AntUtilTests extends AbstractAntUITest {
 	private void assertTargets(AntTargetNode[] targets, String[] expectedTargetNames) {
 		// Before the bugfix, the dependend target (defined in the included file) was not found and the dependencies-check failed
 		int expectedSize = expectedTargetNames.length;
-		assertTrue("Incorrect number of targets retrieved; should be " + expectedSize + " was: " //$NON-NLS-1$ //$NON-NLS-2$
-				+ targets.length, targets.length == expectedSize);
+		assertTrue(targets.length == expectedSize,
+				"Incorrect number of targets retrieved; should be " + expectedSize + " was: " //$NON-NLS-1$ //$NON-NLS-2$
+						+ targets.length);
 
 		for (String expectedTarget : expectedTargetNames) {
 			assertContains(expectedTarget, targets);
@@ -278,7 +281,7 @@ public class AntUtilTests extends AbstractAntUITest {
 
 	protected ILaunchConfiguration getLaunchConfiguration(String buildFileName, String arguments, Map<String, String> properties, String propertyFiles) throws CoreException {
 		ILaunchConfiguration config = AntUITestUtil.getLaunchConfiguration(buildFileName);
-		assertNotNull("Could not locate launch configuration for " + buildFileName, config); //$NON-NLS-1$
+		assertNotNull(config, "Could not locate launch configuration for " + buildFileName); //$NON-NLS-1$
 		ILaunchConfigurationWorkingCopy copy = config.getWorkingCopy();
 		if (arguments != null) {
 			copy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, arguments);
@@ -304,16 +307,16 @@ public class AntUtilTests extends AbstractAntUITest {
 				break;
 			}
 		}
-		assertEquals("Did not find target: " + targetName, true, found); //$NON-NLS-1$
+		assertEquals(true, found, "Did not find target: " + targetName); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testIsKnownAntFileName() throws Exception {
-		assertTrue("The file name 'foo.xml' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.xml")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("The file name 'foo.ant' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.ant")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("The file name 'foo.ent' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.ent")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue("The file name 'foo.macrodef' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.macrodef")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("The file name 'foo.xsi' is not a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.xsi")); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("The file name 'foo.txt' is a valid name", AntUtil.isKnownAntFileName("a/b/c/d/foo.txt")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(AntUtil.isKnownAntFileName("a/b/c/d/foo.xml"), "The file name 'foo.xml' is a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(AntUtil.isKnownAntFileName("a/b/c/d/foo.ant"), "The file name 'foo.ant' is a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(AntUtil.isKnownAntFileName("a/b/c/d/foo.ent"), "The file name 'foo.ent' is a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(AntUtil.isKnownAntFileName("a/b/c/d/foo.macrodef"), "The file name 'foo.macrodef' is a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertFalse(AntUtil.isKnownAntFileName("a/b/c/d/foo.xsi"), "The file name 'foo.xsi' is not a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertFalse(AntUtil.isKnownAntFileName("a/b/c/d/foo.txt"), "The file name 'foo.txt' is a valid name"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.ant.tests.ui;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -26,7 +26,7 @@ import java.util.Collections;
 import org.eclipse.ant.internal.ui.AntUtil;
 import org.eclipse.ant.internal.ui.preferences.FileFilter;
 import org.eclipse.ant.internal.ui.views.actions.AddBuildFilesAction;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -35,23 +35,24 @@ import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class AntViewTests extends AbstractAntUITest {
+@AntUITest
+public class AntViewTests {
 
 	@Test
 	public void testAddBuildFilesAction() throws CoreException {
 		// Ensure that AddBuildFilesAction is present!
 		String viewId = "org.eclipse.ant.ui.views.AntView"; //$NON-NLS-1$
 		IViewPart view = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(viewId);
-		assertNotNull("Failed to obtain the AntView", view); //$NON-NLS-1$
+		assertNotNull(view, "Failed to obtain the AntView"); //$NON-NLS-1$
 		IViewSite viewSite = view.getViewSite();
-		assertNotNull("Failed to obtain view site", viewSite); //$NON-NLS-1$
+		assertNotNull(viewSite, "Failed to obtain view site"); //$NON-NLS-1$
 		IToolBarManager toolBarMgr = viewSite.getActionBars().getToolBarManager();
-		assertNotNull("Failed to obtain the AntView ToolBar", toolBarMgr); //$NON-NLS-1$
+		assertNotNull(toolBarMgr, "Failed to obtain the AntView ToolBar"); //$NON-NLS-1$
 		AddBuildFilesAction action = getAddBuildFilesAction(toolBarMgr);
-		assertNotNull("Failed to obtain the AddBuildFilesAction", action); //$NON-NLS-1$
+		assertNotNull(action, "Failed to obtain the AddBuildFilesAction"); //$NON-NLS-1$
 	}
 
 	private AddBuildFilesAction getAddBuildFilesAction(IToolBarManager toolBarMgr) {
@@ -76,20 +77,20 @@ public class AntViewTests extends AbstractAntUITest {
 		{// Accept only a single extension
 			String extnFilter1 = "xml"; //$NON-NLS-1$
 			FileFilterProxy ff1 = new FileFilterProxy(extnFilter1);
-			assertTrue("xml is not accepted as a build file extension", ff1.canAccept("xml")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertFalse("ent is accepted as a build file extension", ff1.canAccept("ent")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff1.canAccept("xml"), "xml is not accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertFalse(ff1.canAccept("ent"), "ent is accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
 		{// Accept multiple extensions
 			String extnFilter2 = AntUtil.getKnownBuildFileExtensionsAsPattern();
 			FileFilterProxy ff2 = new FileFilterProxy(extnFilter2);
-			assertTrue("xml is not accepted as a build file extension", ff2.canAccept("xml")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertTrue("ant is not accepted as a build file extension", ff2.canAccept("ant")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertTrue("ent is not accepted as a build file extension", ff2.canAccept("ent")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertFalse("def is accepted as a build file extension", ff2.canAccept("def")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertTrue("macrodef is not accepted as a build file extension", ff2.canAccept("macrodef")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertTrue("XML is not accepted as a build file extension", ff2.canAccept("XML")); //$NON-NLS-1$ //$NON-NLS-2$
-			assertFalse("macro is accepted as a build file extension", ff2.canAccept("macro")); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff2.canAccept("xml"), "xml is not accepted as a build file extension\""); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff2.canAccept("ant"), "ant is not accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff2.canAccept("ent"), "ent is not accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertFalse(ff2.canAccept("def"), "def is accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff2.canAccept("macrodef"), "macrodef is not accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertTrue(ff2.canAccept("XML"), "XML is not accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
+			assertFalse(ff2.canAccept("macro"), "macro is accepted as a build file extension"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 
@@ -106,7 +107,7 @@ public class AntViewTests extends AbstractAntUITest {
 				canAcceptMethod = get("canAccept", new Class[] { String.class }); //$NON-NLS-1$
 			}
 			Object result = invoke(canAcceptMethod, new String[] { extn });
-			assertNotNull("Failed to invoke 'canAccept()'", result); //$NON-NLS-1$
+			assertNotNull(result, "Failed to invoke 'canAccept()'"); //$NON-NLS-1$
 			return ((Boolean) result).booleanValue();
 		}
 	}

--- a/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.tests.ui/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Import-Package: org.assertj.core.api,
  org.assertj.core.api.iterable,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
- org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)"
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUITest.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/AntUITest.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ant.tests.ui.testplugin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith({ TestAgainExtension.class, InitializeAntTestProjectExtension.class, CloseWelcomeScreenExtension.class })
+public @interface AntUITest {
+	//
+}

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/InitializeAntTestProjectExtension.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/InitializeAntTestProjectExtension.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ant.tests.ui.testplugin;
+
+import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.assertProject;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Initializes a common test project before each test case
+ */
+class InitializeAntTestProjectExtension implements BeforeEachCallback {
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		assertProject();
+	}
+
+}

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/TestAgainExtension.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/TestAgainExtension.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ant.tests.ui.testplugin;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.ant.tests.ui.debug.TestAgainException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+/**
+ * Executes the test again multiple times in case a {@link TestAgainException}
+ * is thrown.
+ */
+class TestAgainExtension implements TestExecutionExceptionHandler {
+
+	private static final int RETRY_COUNT = 5;
+
+	private final AtomicInteger counter = new AtomicInteger(1);
+
+	public TestAgainExtension() {
+	}
+
+	@Override
+	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+		printError(context, throwable);
+		context.getTestMethod().ifPresent(method -> {
+			while (counter.incrementAndGet() <= RETRY_COUNT) {
+				try {
+					context.getExecutableInvoker().invoke(method, context.getRequiredTestInstance());
+				} catch (TestAgainException t) {
+					printError(context, throwable);
+					if (counter.get() >= RETRY_COUNT) {
+						throw t;
+					}
+				}
+			}
+		});
+	}
+
+	private void printError(ExtensionContext context, Throwable e) {
+		String errorMessage = String.format("%s failed attempt %s. Re-testing.", //$NON-NLS-1$
+				context.getDisplayName(), counter.get());
+		System.out.println(errorMessage);
+		e.printStackTrace();
+	}
+
+}


### PR DESCRIPTION
- Introduce test extensions for shared functionality from AbstractAntUITest and combine all relevant extensions for Ant UI tests in an AntUiTest annotation
- Use JUnit 5 test annotations
- Migrate assertions to JUnit 5
- Simplify several assertions