### PR TITLE
Migrate properties, mappings and events tests to JUnit 5

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/events/BuildProjectFromMultipleJobsTest.java
@@ -19,8 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,12 +39,12 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.internal.builders.ConfigurationBuilder;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.core.tests.resources.regression.SimpleBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that triggering a project build from multiple jobs does not cause assertion failures,
@@ -52,16 +52,14 @@ import org.junit.Test;
  *
  * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=517411">Eclipse bug 517411</a>
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class BuildProjectFromMultipleJobsTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String TEST_PROJECT_NAME = "ProjectForBuildCommandTest";
 
 	private final ErrorLogListener logListener = new ErrorLogListener();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// auto-build makes reproducing the problem harder,
 		// since it may build before we trigger parallel builds from the test
@@ -69,7 +67,7 @@ public class BuildProjectFromMultipleJobsTest {
 		Platform.addLogListener(logListener);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Job.getJobManager().cancel(BuildTestProject.class);
 
@@ -148,10 +146,10 @@ public class BuildProjectFromMultipleJobsTest {
 
 	private IProject createTestProject(String builderId, IProgressMonitor monitor) throws CoreException {
 		IProject project = getTestProject();
-		assertFalse("Expected test project to not exist at beginning of test", project.exists());
+		assertFalse(project.exists(), "Expected test project to not exist at beginning of test");
 
 		createInWorkspace(project);
-		assertTrue("Expected test project to be open after creation", project.isOpen());
+		assertTrue(project.isOpen(), "Expected test project to be open after creation");
 
 		// add some builder to the project, so that we can run into the concurrency problem
 		updateProjectDescription(project).addingCommand(builderId).apply();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/ChangeValidationTest.java
@@ -19,8 +19,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWo
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,19 +33,17 @@ import org.eclipse.core.resources.mapping.ModelStatus;
 import org.eclipse.core.resources.mapping.ResourceChangeValidator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests for change validation
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ChangeValidationTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IResourceChangeDescriptionFactory factory;
 	private IProject project;
@@ -106,7 +104,7 @@ public class ChangeValidationTest {
 		return null;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		TestModelProvider.enabled = true;
 		project = getWorkspace().getRoot().getProject("Project");
@@ -116,7 +114,7 @@ public class ChangeValidationTest {
 		factory = createEmptyChangeDescription();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		TestModelProvider.enabled = false;
 	}
@@ -284,7 +282,7 @@ public class ChangeValidationTest {
 		try {
 			TestModelProvider.checkContentsDeletion = true;
 			IStatus status = validateChange(factory);
-			assertEquals(assertMessage, expectedStatus, status.getSeverity());
+			assertEquals(expectedStatus, status.getSeverity(), assertMessage);
 		} finally {
 			TestModelProvider.checkContentsDeletion = false;
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/mapping/TestProjectDeletion.java
@@ -17,25 +17,23 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.assertExistsInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.mapping.IResourceChangeDescriptionFactory;
 import org.eclipse.core.resources.mapping.ResourceChangeValidator;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test to validate project kind and flags on deletion.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class TestProjectDeletion {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IResourceChangeDescriptionFactory factory;
 	private IProject project;
@@ -43,7 +41,7 @@ public class TestProjectDeletion {
 	private static int KIND_MASK = 0xFF;
 	private static int FLAGS_MASK = MASK ^= KIND_MASK;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project = getWorkspace().getRoot().getProject("Project");
 		IResource[] resources = buildResources(project, new String[] { "a/", "a/b/", "a/c/", "a/d", "a/b/e", "a/b/f" });
@@ -52,8 +50,8 @@ public class TestProjectDeletion {
 		factory = ResourceChangeValidator.getValidator().createDeltaFactory();
 		int kind = factory.getDelta().getKind();
 		int flags = factory.getDelta().getFlags();
-		assertEquals("Projects delta kind should not contain any bits before refactoring.", 0, kind &= ~KIND_MASK);
-		assertEquals("Projects delta flags should not be set before refactoring.", 0, flags &= ~FLAGS_MASK);
+		assertEquals(0, kind &= ~KIND_MASK, "Projects delta kind should not contain any bits before refactoring.");
+		assertEquals(0, flags &= ~FLAGS_MASK, "Projects delta flags should not be set before refactoring.");
 	}
 
 	@Test
@@ -73,15 +71,16 @@ public class TestProjectDeletion {
 
 	private void checkAffectedChildrenStatus(IResourceDelta[] affectedChildren, boolean deleteContents) {
 		for (IResourceDelta iResourceDelta : affectedChildren) {
-			assertEquals("IResourceDelta.REMOVED kind is expected on project deletion.", IResourceDelta.REMOVED,
-					iResourceDelta.getKind());
+			assertEquals(IResourceDelta.REMOVED, iResourceDelta.getKind(),
+					"IResourceDelta.REMOVED kind is expected on project deletion.");
 			if (deleteContents) {
-				assertEquals("IResourceDelta.DELETE_CONTENT_PROPOSED flag should be set on project contents deletion.",
+				assertEquals(
 						IResourceDelta.DELETE_CONTENT_PROPOSED,
-						iResourceDelta.getFlags());
+						iResourceDelta.getFlags(),
+						"IResourceDelta.DELETE_CONTENT_PROPOSED flag should be set on project contents deletion.");
 			} else {
-				assertEquals("No flags should be set on project deletion from workspace.", 0,
-						iResourceDelta.getFlags());
+				assertEquals(0, iResourceDelta.getFlags(),
+						"No flags should be set on project deletion from workspace.");
 			}
 			checkAffectedChildrenStatus(iResourceDelta.getAffectedChildren(), deleteContents);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/properties/PropertyManagerTest.java
@@ -19,14 +19,14 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RE
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -45,22 +45,20 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class PropertyManagerTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 
-	@Before
+	@BeforeEach
 	public void createTestProject() throws CoreException {
 		project = getWorkspace().getRoot().getProject("test");
 		createInWorkspace(project);
@@ -214,14 +212,14 @@ public class PropertyManagerTest {
 		manager.setProperty(source, propName, propValue);
 		manager.setProperty(sourceFolder, propName, propValue);
 		manager.setProperty(sourceFile, propName, propValue);
-		assertNotNull("1.1", manager.getProperty(source, propName));
+		assertNotNull(manager.getProperty(source, propName));
 
 		String hint = "Property cache returned another instance. Same instance is not required but expected. Eiter the Garbage Collector deleted the cache or the cache is not working.";
-		assertSame(hint + "1.2", propValue, manager.getProperty(source, propName));
-		assertNotNull("1.3", manager.getProperty(sourceFolder, propName));
-		assertSame(hint + "1.4", propValue, manager.getProperty(sourceFolder, propName));
-		assertNotNull("1.5", manager.getProperty(sourceFile, propName));
-		assertSame(hint + "1.6", propValue, manager.getProperty(sourceFile, propName));
+		assertSame(propValue, manager.getProperty(source, propName), hint);
+		assertNotNull(manager.getProperty(sourceFolder, propName));
+		assertSame(propValue, manager.getProperty(sourceFolder, propName), hint);
+		assertNotNull(manager.getProperty(sourceFile, propName));
+		assertSame(propValue, manager.getProperty(sourceFile, propName), hint);
 	}
 
 	@Test
@@ -241,11 +239,11 @@ public class PropertyManagerTest {
 		manager.setProperty(sourceFile, propName, propValue);
 
 		String hint = "Property cache returned another instance. Same instance is not required but expected. Eiter the Garbage Collector deleted the cache or the cache is not working.";
-		assertSame(hint + "1.2", propValue, manager.getProperty(source, propName));
+		assertSame(propValue, manager.getProperty(source, propName), hint);
 		assertNotNull(manager.getProperty(sourceFolder, propName));
-		assertSame(hint + "1.4", propValue, manager.getProperty(sourceFolder, propName));
+		assertSame(propValue, manager.getProperty(sourceFolder, propName), hint);
 		assertNotNull(manager.getProperty(sourceFile, propName));
-		assertSame(hint + "1.6", propValue, manager.getProperty(sourceFile, propName));
+		assertSame(propValue, manager.getProperty(sourceFile, propName), hint);
 
 		List<byte[]> wastedMemory = new LinkedList<>();
 		try {
@@ -503,14 +501,14 @@ public class PropertyManagerTest {
 		// set the properties individually and retrieve them
 		for (StoredProperty prop : props) {
 			manager.setProperty(target, prop.getName(), prop.getStringValue());
-			assertEquals("1.0." + prop.getName(), prop.getStringValue(), manager.getProperty(target, prop.getName()));
+			assertEquals(prop.getStringValue(), manager.getProperty(target, prop.getName()), prop.getName().toString());
 		}
 		// check properties are be appropriately deleted (when set to null)
 		for (StoredProperty prop : props) {
 			manager.setProperty(target, prop.getName(), null);
-			assertEquals("2.0." + prop.getName(), null, manager.getProperty(target, prop.getName()));
+			assertNull(manager.getProperty(target, prop.getName()), prop.getName().toString());
 		}
-		assertEquals("3.0", 0, manager.getProperties(target).size());
+		assertEquals(0, manager.getProperties(target).size());
 		manager.deleteProperties(target, IResource.DEPTH_INFINITE);
 	}
 


### PR DESCRIPTION
- Use JUnit 5 test annotations
- Remove obsolete assertion messages
- Migrate assertions to JUnit 5