### PR TITLE
Migrate several resource tests to JUnit 5

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -29,11 +29,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.touchInFilesystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -80,21 +80,24 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.service.prefs.BackingStoreException;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class CharsetTest {
 
-	@Rule
-	public TestName testName = new TestName();
+	private TestInfo testInfo;
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		this.testInfo = info;
+	}
 
 	private static final class JobChangeAdapterExtension extends JobChangeAdapter {
 		private IStatus result;
@@ -191,7 +194,7 @@ public class CharsetTest {
 	private String savedWorkspaceCharset;
 
 	@Test
-	@Ignore("disabled due to bug 67606")
+	@Disabled("disabled due to bug 67606")
 	public void testBug67606() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		final IProject project = workspace.getRoot().getProject("MyProject");
@@ -200,13 +203,13 @@ public class CharsetTest {
 			createInWorkspace(file);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			workspace.run((IWorkspaceRunnable) monitor -> {
-				assertEquals("0.9", "FOO", file.getCharset());
+				assertEquals("FOO", file.getCharset());
 				file.setCharset("BAR", createTestMonitor());
-				assertEquals("1.0", "BAR", file.getCharset());
+				assertEquals("BAR", file.getCharset());
 				file.move(project.getFullPath().append("file2.txt"), IResource.NONE, monitor);
 				IFile file2 = project.getFile("file2.txt");
 				assertExistsInWorkspace(file2);
-				assertEquals("2.0", "BAR", file.getCharset());
+				assertEquals("BAR", file.getCharset());
 			}, null);
 		} finally {
 			removeFromWorkspace(project);
@@ -221,20 +224,20 @@ public class CharsetTest {
 			final IFile file = project.getFile("file.txt");
 			createInWorkspace(file);
 			project.setDefaultCharset("FOO", createTestMonitor());
-			assertEquals("Setting up Projects default charset was successful", "FOO", file.getCharset());
+			assertEquals("FOO", file.getCharset(), "Setting up Projects default charset was successful");
 			file.setCharset("BAR", createTestMonitor());
-			assertEquals("Setting up file's explicit charset was successful", "BAR", file.getCharset());
+			assertEquals("BAR", file.getCharset(), "Setting up file's explicit charset was successful");
 			file.move(project.getFullPath().append("file2.txt"), IResource.NONE, createTestMonitor());
 			IFile file2 = project.getFile("file2.txt");
 			assertExistsInWorkspace(file2);
-			assertEquals("The file's charset was correctly copied while coying the file", "BAR", file2.getCharset());
+			assertEquals("BAR", file2.getCharset(), "The file's charset was correctly copied while coying the file");
 		} finally {
 			removeFromWorkspace(project);
 		}
 	}
 
 	@Test
-	@Ignore("https://github.com/eclipse-platform/eclipse.platform/issues/634")
+	@Disabled("https://github.com/eclipse-platform/eclipse.platform/issues/634")
 	public void testCopyFileCopiesCharset() throws CoreException {
 		IWorkspace workspace = getWorkspace();
 		final IProject project = workspace.getRoot().getProject("MyProject");
@@ -244,10 +247,10 @@ public class CharsetTest {
 			final IFile file = project.getFile("file.txt");
 			createInWorkspace(file);
 			file.setCharset("FOO", createTestMonitor());
-			assertEquals("File charset correctly set", file.getCharset(true), "FOO");
+			assertEquals(file.getCharset(true), "FOO", "File charset correctly set");
 			file.copy(project.getFullPath().append("file2.txt"), IResource.NONE, createTestMonitor());
 			final IFile copiedFile = project.getFile("file2.txt");
-			assertEquals("File with explicitly set charset keeps charset", copiedFile.getCharset(true), "FOO");
+			assertEquals(copiedFile.getCharset(true), "FOO", "File with explicitly set charset keeps charset");
 		} finally {
 			removeFromWorkspace(project);
 		}
@@ -256,11 +259,11 @@ public class CharsetTest {
 	/**
 	 * Asserts that the given resources have the given [default] charset.
 	 */
-	private void assertCharsetIs(String tag, String encoding, IResource[] resources, boolean checkImplicit) throws CoreException {
+	private void assertCharsetIs(String encoding, IResource[] resources, boolean checkImplicit) throws CoreException {
 		for (IResource resource : resources) {
 			String resourceCharset = resource instanceof IFile f ? f.getCharset(checkImplicit)
 					: ((IContainer) resource).getDefaultCharset(checkImplicit);
-			assertEquals(tag + " " + resource.getFullPath(), encoding, resourceCharset);
+			assertEquals(encoding, resourceCharset, resource.getFullPath().toString());
 		}
 	}
 
@@ -285,7 +288,7 @@ public class CharsetTest {
 			return true;
 		};
 		root.accept(visitor);
-		waitForEncodingRelatedJobs(testName.getMethodName());
+		waitForEncodingRelatedJobs(testInfo.getDisplayName());
 	}
 
 	private IFile getResourcesPreferenceFile(IProject project, boolean forDerivedResources) {
@@ -335,19 +338,19 @@ public class CharsetTest {
 		return InstanceScope.INSTANCE.getNode(PI_RESOURCES);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// save the workspace charset so it can be restored after the test
 		savedWorkspaceCharset = getResourcesPreferences().get(ResourcesPlugin.PREF_ENCODING, "");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// restore the workspace charset
 		getResourcesPreferences().put(ResourcesPlugin.PREF_ENCODING, savedWorkspaceCharset);
 		// Reset the PREF_LIGHTWEIGHT_AUTO_REFRESH preference to its default value.
 		getResourcesPreferences().remove(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH);
-		waitForEncodingRelatedJobs(testName.getMethodName());
+		waitForEncodingRelatedJobs(testInfo.getDisplayName());
 	}
 
 	@Test
@@ -373,16 +376,16 @@ public class CharsetTest {
 		IProject project = workspace.getRoot().getProject("MyProject");
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType anotherXML = contentTypeManager.getContentType("org.eclipse.core.tests.resources.anotherXML");
-		assertNotNull("0.5", anotherXML);
+		assertNotNull(anotherXML);
 		createInWorkspace(project);
 		IFile file = project.getFile("file.xml");
 		createInWorkspace(file, SAMPLE_SPECIFIC_XML);
 		IContentDescription description = file.getContentDescription();
-		assertNotNull("1.0", description);
-		assertEquals("1.1", anotherXML, description.getContentType());
+		assertNotNull(description);
+		assertEquals(anotherXML, description.getContentType());
 		description = file.getContentDescription();
-		assertNotNull("2.0", description);
-		assertEquals("2.1", anotherXML, description.getContentType());
+		assertNotNull(description);
+		assertEquals(anotherXML, description.getContentType());
 	}
 
 	@Test
@@ -394,12 +397,12 @@ public class CharsetTest {
 		IFile file = project.getFile("file.txt");
 		createInWorkspace(file);
 		IContentDescription description = file.getContentDescription();
-		assertNotNull("1.0", description);
-		assertEquals("1.1", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 		removeFromWorkspace(file);
 		CoreException e = assertThrows(CoreException.class, file::getContentDescription);
 		// Ok, the resource does not exist.
-		assertEquals("1.3", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
+		assertEquals(IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
 	}
 
 	@Test
@@ -408,10 +411,10 @@ public class CharsetTest {
 		String originalUserCharset = root.getDefaultCharset(false);
 		try {
 			root.setDefaultCharset(null, null);
-			assertNull("1.0", root.getDefaultCharset(false));
+			assertNull(root.getDefaultCharset(false));
 
 			root.setDefaultCharset(null, new NullProgressMonitor());
-			assertNull("1.0", root.getDefaultCharset(false));
+			assertNull(root.getDefaultCharset(false));
 		} finally {
 			if (originalUserCharset != null) {
 				root.setDefaultCharset(originalUserCharset, null);
@@ -430,16 +433,16 @@ public class CharsetTest {
 
 			IFolder folder = project.getFolder(createUniqueString());
 			IFile file = folder.getFile(createUniqueString());
-			assertEquals("1.0", "BAR", file.getCharset(true));
+			assertEquals("BAR", file.getCharset(true));
 
 			createInWorkspace(folder);
-			assertEquals("2.0", "BAR", file.getCharset(true));
+			assertEquals("BAR", file.getCharset(true));
 
 			folder.setDerived(true, createTestMonitor());
-			assertEquals("3.0", "BAR", file.getCharset(true));
+			assertEquals("BAR", file.getCharset(true));
 
 			setDerivedEncodingStoredSeparately(project, true);
-			assertEquals("5.0", "BAR", file.getCharset(true));
+			assertEquals("BAR", file.getCharset(true));
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -479,26 +482,26 @@ public class CharsetTest {
 
 		// 1) first set the content type to ascii
 		file.setContents(ascii.getBytes("ascii"), IResource.FORCE, createTestMonitor());
-		assertTrue("4.0", file.getCharset().equals("ascii"));
-		assertTrue("4.1", file.getContentDescription().getCharset().equals("ascii"));
+		assertTrue(file.getCharset().equals("ascii"));
+		assertTrue(file.getContentDescription().getCharset().equals("ascii"));
 
 		// 2) Make out of sync - Methods should still work, giving the previous value
 		touchInFilesystem(file);
-		assertTrue("4.2", file.getCharset().equals("ascii"));
+		assertTrue(file.getCharset().equals("ascii"));
 		CoreException e = assertThrows(CoreException.class,
 				() -> file.getContentDescription().getCharset().equals("ascii"));
-		assertEquals("the file should be out of sync", IResourceStatus.OUT_OF_SYNC_LOCAL, e.getStatus().getCode());
+		assertEquals(IResourceStatus.OUT_OF_SYNC_LOCAL, e.getStatus().getCode(), "the file should be out of sync");
 
 		// As we now know that #getContentDescription correctly checks sync state, just enable LIGHTWEIGHT refresh
 		// for the rest of the test.
 		getResourcesPreferences().putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, true);
-		assertTrue("4.5", file.getContentDescription().getCharset().equals("ascii"));
+		assertTrue(file.getContentDescription().getCharset().equals("ascii"));
 
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 		// Prime the cache...
-		assertTrue("4.6", file.getCharset().equals("ascii"));
+		assertTrue(file.getCharset().equals("ascii"));
 
 		// 3) Change the content type of the file under eclipse's feet
 		try (FileWriter writer = new FileWriter(file.getLocation().toFile())) {
@@ -506,14 +509,14 @@ public class CharsetTest {
 		}
 		touchInFilesystem(file);
 		// #getCharset uses the cached value (bug 209167) - doesn't check sync state
-		assertTrue("5.4", file.getCharset().equals("ascii"));
+		assertTrue(file.getCharset().equals("ascii"));
 		// #getContentDescription checks sync and discovers the real content type
-		assertTrue("5.5", file.getContentDescription().getCharset().equals("UTF-8"));
+		assertTrue(file.getContentDescription().getCharset().equals("UTF-8"));
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
 		// #getCharset will now have noticed that the file has changed.
-		assertTrue("5.6", file.getCharset().equals("UTF-8"));
+		assertTrue(file.getCharset().equals("UTF-8"));
 
 		// 4) Change the content type of the file under eclipse's feet once more (to non-default).
 		try (FileWriter writer = new FileWriter(file.getLocation().toFile())) {
@@ -521,13 +524,13 @@ public class CharsetTest {
 		}
 		touchInFilesystem(file);
 		// #getCharset uses the cached value (bug 209167) - doesn't check sync state
-		assertTrue("6.7", file.getCharset().equals("UTF-8"));
+		assertTrue(file.getCharset().equals("UTF-8"));
 		// #getContentDescription checks sync and discovers the real content type
-		assertTrue("6.8", file.getContentDescription().getCharset().equals("ascii"));
+		assertTrue(file.getContentDescription().getCharset().equals("ascii"));
 		// getContentDescription will have noticed out-of-sync
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_REFRESH);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, createTestMonitor());
-		assertTrue("6.9", file.getCharset().equals("ascii"));
+		assertTrue(file.getCharset().equals("ascii"));
 	}
 
 	@Test
@@ -558,19 +561,19 @@ public class CharsetTest {
 			verifier.addExpectedChange(regularPrefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			setDerivedEncodingStoredSeparately(project1, true);
-			assertTrue("1.1", verifier.waitForEvent(10000));
-			assertTrue("1.2 " + verifier.getMessage(), verifier.isDeltaValid());
+			assertTrue(verifier.waitForEvent(10000));
+			assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 			assertExistsInWorkspace(regularPrefs);
 			assertDoesNotExistInWorkspace(derivedPrefs);
-			assertTrue("1.5", isDerivedEncodingStoredSeparately(project1));
+			assertTrue(isDerivedEncodingStoredSeparately(project1));
 
 			//2 - changing charset for file
 			verifier.reset();
 			verifier.addExpectedChange(a, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			a.setCharset("UTF-8", createTestMonitor());
-			assertTrue("2.1", verifier.waitForEvent(10000));
-			assertTrue("2.2 " + verifier.getMessage(), verifier.isDeltaValid());
+			assertTrue(verifier.waitForEvent(10000));
+			assertTrue(verifier.isDeltaValid(), verifier.getMessage());
 			assertExistsInWorkspace(regularPrefs);
 			assertDoesNotExistInWorkspace(derivedPrefs);
 
@@ -582,7 +585,7 @@ public class CharsetTest {
 			waitForCharsetManagerJob();
 			assertExistsInWorkspace(regularPrefs);
 			assertExistsInWorkspace(derivedPrefs);
-			assertTrue("3.3", derivedPrefs.isDerived());
+			assertTrue(derivedPrefs.isDerived());
 
 			//4 - setting derived == 'false' for file
 			// TODO update the test when bug 345271 is fixed
@@ -602,14 +605,14 @@ public class CharsetTest {
 			a.move(destination.getFullPath(), true, createTestMonitor());
 			a = destination;
 			waitForCharsetManagerJob();
-			assertTrue("5.1", backgroundVerifier.waitForAllDeltas(10000, 15000));
-			backgroundVerifier.assertExpectedDeltasWereReceived("5.2");
+			assertTrue(backgroundVerifier.waitForAllDeltas(10000, 15000));
+			backgroundVerifier.assertExpectedDeltasWereReceived();
 			assertExistsInWorkspace(regularPrefs);
 			assertExistsInWorkspace(derivedPrefs);
 			assertDoesNotExistInWorkspace(source);
 			assertExistsInWorkspace(destination);
-			assertTrue("5.7", derivedPrefs.isDerived());
-			assertCharsetIs("5.8", "UTF-8", new IResource[] { a }, true);
+			assertTrue(derivedPrefs.isDerived());
+			assertCharsetIs("UTF-8", new IResource[] { a }, true);
 
 			//6 - removing preference on project
 			verifier.reset();
@@ -617,10 +620,10 @@ public class CharsetTest {
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.REMOVED, 0);
 			setDerivedEncodingStoredSeparately(project1, false);
-			assertTrue("6.1.1", verifier.waitForEvent(10000));
-			assertTrue("6.1.2", backgroundVerifier.waitForFirstDelta(10000));
-			assertTrue("6.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			backgroundVerifier.assertExpectedDeltasWereReceived("6.2.2");
+			assertTrue(verifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.waitForFirstDelta(10000));
+			assertTrue(verifier.isDeltaValid(), verifier.getMessage());
+			backgroundVerifier.assertExpectedDeltasWereReceived();
 			assertExistsInWorkspace(regularPrefs);
 			assertDoesNotExistInWorkspace(derivedPrefs);
 
@@ -630,14 +633,14 @@ public class CharsetTest {
 			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.ADDED, 0);
 			setDerivedEncodingStoredSeparately(project1, true);
-			assertTrue("7.1.1", verifier.waitForEvent(10000));
-			assertTrue("7.1.2", backgroundVerifier.waitForFirstDelta(10000));
-			assertTrue("7.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			backgroundVerifier.assertExpectedDeltasWereReceived("7.2.2");
+			assertTrue(verifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.waitForFirstDelta(10000));
+			assertTrue(verifier.isDeltaValid(), verifier.getMessage());
+			backgroundVerifier.assertExpectedDeltasWereReceived();
 			assertExistsInWorkspace(regularPrefs);
 			assertExistsInWorkspace(derivedPrefs);
-			assertTrue("7.5", isDerivedEncodingStoredSeparately(project1));
-			assertTrue("7.6", derivedPrefs.isDerived());
+			assertTrue(isDerivedEncodingStoredSeparately(project1));
+			assertTrue(derivedPrefs.isDerived());
 
 			//			//8 - manually changing preference 'true'->'false'
 			//			verifier.reset();
@@ -786,12 +789,12 @@ public class CharsetTest {
 		IFile file = project1.getFile("file1.xml");
 		createInWorkspace(file, SAMPLE_XML_ISO_8859_1_ENCODING);
 		ContentDescriptionManagerTest.waitForCacheFlush();
-		assertEquals("1.0", "ISO-8859-1", file.getCharset());
+		assertEquals("ISO-8859-1", file.getCharset());
 
 		//delete and recreate the file with different contents
 		removeFromWorkspace(file);
 		createInWorkspace(file, SAMPLE_XML_DEFAULT_ENCODING);
-		assertEquals("2.0", "UTF-8", file.getCharset());
+		assertEquals("UTF-8", file.getCharset());
 	}
 
 	@Test
@@ -811,14 +814,14 @@ public class CharsetTest {
 			// preserved
 			folder.move(project2.getFullPath().append("folder"), false, false, null);
 			folder = project2.getFolder("folder");
-			assertEquals("1.0", "BAR", folder.getDefaultCharset());
-			assertEquals("1.1", "BAR", folder.getFile("file2.txt").getCharset());
+			assertEquals("BAR", folder.getDefaultCharset());
+			assertEquals("BAR", folder.getFile("file2.txt").getCharset());
 			// move a file with no charset set and check if it inherits
 			// properly from the new parent
-			assertEquals("2.0", project1.getDefaultCharset(), file1.getCharset());
+			assertEquals(project1.getDefaultCharset(), file1.getCharset());
 			file1.move(project2.getFullPath().append("file1.txt"), false, false, null);
 			file1 = project2.getFile("file1.txt");
-			assertEquals("2.1", project2.getDefaultCharset(), file1.getCharset());
+			assertEquals(project2.getDefaultCharset(), file1.getCharset());
 		} finally {
 			clearAllEncodings(project1);
 			clearAllEncodings(project2);
@@ -841,19 +844,19 @@ public class CharsetTest {
 			// preserved
 			folder.move(project.getFullPath().append("folder2"), false, false, null);
 			folder = project.getFolder("folder2");
-			assertEquals("1.0", "BAR", folder.getDefaultCharset());
-			assertEquals("1.1", "BAR", folder.getFile("file2.txt").getCharset());
+			assertEquals("BAR", folder.getDefaultCharset());
+			assertEquals("BAR", folder.getFile("file2.txt").getCharset());
 			// move a file inside the project and ensure its encoding is
 			// update accordingly
 			file2 = folder.getFile("file2.txt");
 			file2.move(project.getFullPath().append("file2.txt"), false, false, null);
 			file2 = project.getFile("file2.txt");
-			assertEquals("2.0", project.getDefaultCharset(), file2.getCharset());
+			assertEquals(project.getDefaultCharset(), file2.getCharset());
 			// delete a file and recreate it and ensure the encoding is not
 			// remembered
 			file1.delete(false, false, null);
 			createInWorkspace(new IResource[] {file1});
-			assertEquals("3.0", project.getDefaultCharset(), file1.getCharset());
+			assertEquals(project.getDefaultCharset(), file1.getCharset());
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -877,10 +880,10 @@ public class CharsetTest {
 			IProject projectB = workspace.getRoot().getProject(project.getName());
 			projectB.open(null);
 			assertExistsInWorkspace(getResourcesPreferenceFile(projectB, false));
-			assertEquals("1.0", "FOO", projectB.getDefaultCharset());
-			assertEquals("3.0", "FRED", projectB.getFile("file1.txt").getCharset());
-			assertEquals("2.0", "BAR", projectB.getFolder("folder").getDefaultCharset());
-			assertEquals("2.1", "BAR", projectB.getFolder("folder").getFile("file2.txt").getCharset());
+			assertEquals("FOO", projectB.getDefaultCharset());
+			assertEquals("FRED", projectB.getFile("file1.txt").getCharset());
+			assertEquals("BAR", projectB.getFolder("folder").getDefaultCharset());
+			assertEquals("BAR", projectB.getFolder("folder").getFile("file2.txt").getCharset());
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -897,32 +900,32 @@ public class CharsetTest {
 			createInWorkspace(project);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
-			assertEquals("0.9", "FOO", project.getDefaultCharset());
+			assertEquals("FOO", project.getDefaultCharset());
 			// content-based encoding is BAR
 			createInWorkspace(file, SAMPLE_XML_US_ASCII_ENCODING);
-			assertEquals("1.0", "US-ASCII", file.getCharset());
+			assertEquals("US-ASCII", file.getCharset());
 			// content-based encoding is FRED
 			file.setContents(SAMPLE_XML_ISO_8859_1_ENCODING.getBytes(StandardCharsets.ISO_8859_1), false, false, null);
-			assertEquals("2.0", "ISO-8859-1", file.getCharset());
+			assertEquals("ISO-8859-1", file.getCharset());
 			// content-based encoding is UTF-8 (default for XML)
 			file.setContents(SAMPLE_XML_DEFAULT_ENCODING.getBytes(StandardCharsets.UTF_8), false, false, null);
-			assertEquals("3.0", "UTF-8", file.getCharset());
+			assertEquals("UTF-8", file.getCharset());
 			// tests with BOM -BOMs are strings for convenience, encoded itno bytes using ISO-8859-1 (which handles 128-255 bytes better)
 			// tests with UTF-8 BOM
 			String UTF8_BOM = new String(IContentDescription.BOM_UTF_8, StandardCharsets.ISO_8859_1);
 			file.setContents((UTF8_BOM + SAMPLE_XML_DEFAULT_ENCODING).getBytes(StandardCharsets.ISO_8859_1), false,
 					false, null);
-			assertEquals("4.0", "UTF-8", file.getCharset());
+			assertEquals("UTF-8", file.getCharset());
 			// tests with UTF-16 Little Endian BOM
 			String UTF16_LE_BOM = new String(IContentDescription.BOM_UTF_16LE, StandardCharsets.ISO_8859_1);
 			file.setContents((UTF16_LE_BOM + SAMPLE_XML_DEFAULT_ENCODING).getBytes(StandardCharsets.ISO_8859_1), false,
 					false, null);
-			assertEquals("5.0", "UTF-16", file.getCharset());
+			assertEquals("UTF-16", file.getCharset());
 			// tests with UTF-16 Big Endian BOM
 			String UTF16_BE_BOM = new String(IContentDescription.BOM_UTF_16BE, StandardCharsets.ISO_8859_1);
 			file.setContents((UTF16_BE_BOM + SAMPLE_XML_DEFAULT_ENCODING).getBytes(StandardCharsets.ISO_8859_1), false,
 					false, null);
-			assertEquals("6.0", "UTF-16", file.getCharset());
+			assertEquals("UTF-16", file.getCharset());
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -949,64 +952,69 @@ public class CharsetTest {
 			project.setDefaultCharset(null, createTestMonitor());
 			assertEquals(null, project.getDefaultCharset(false));
 
-			waitForEncodingRelatedJobs(testName.getMethodName());
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertThat(markers).as("check missing encoding markers").hasSize(1);
 
 			createInWorkspace(new IResource[] {file1, file2, file3});
 			// project and children should be using the workspace's default now
-			assertCharsetIs("1.0", ResourcesPlugin.getEncoding(), new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
-			assertCharsetIs("1.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
+			assertCharsetIs(ResourcesPlugin.getEncoding(),
+					new IResource[] { workspace.getRoot(), project, file1, folder1, file2, folder2, file3 }, true);
+			assertCharsetIs(null, new IResource[] { project, file1, folder1, file2, folder2, file3 }, false);
 
 			// sets workspace default charset
 			workspace.getRoot().setDefaultCharset("FOO", createTestMonitor());
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertThat(markers).as("check missing encoding markers").hasSize(1);
 
-			assertCharsetIs("2.0", "FOO", new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
-			assertCharsetIs("2.1", null, new IResource[] {project, file1, folder1, file2, folder2, file3}, false);
+			assertCharsetIs("FOO",
+					new IResource[] { workspace.getRoot(), project, file1, folder1, file2, folder2, file3 }, true);
+			assertCharsetIs(null, new IResource[] { project, file1, folder1, file2, folder2, file3 }, false);
 
 			// sets project default charset
 			project.setDefaultCharset("BAR", createTestMonitor());
-			waitForEncodingRelatedJobs(testName.getMethodName());
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertThat(markers).as("check no missing encoding markers").isEmpty();
 
-			assertCharsetIs("3.0", "BAR", new IResource[] {project, file1, folder1, file2, folder2, file3}, true);
-			assertCharsetIs("3.1", null, new IResource[] {file1, folder1, file2, folder2, file3}, false);
-			assertCharsetIs("3.2", "FOO", new IResource[] {workspace.getRoot()}, true);
+			assertCharsetIs("BAR", new IResource[] { project, file1, folder1, file2, folder2, file3 }, true);
+			assertCharsetIs(null, new IResource[] { file1, folder1, file2, folder2, file3 }, false);
+			assertCharsetIs("FOO", new IResource[] { workspace.getRoot() }, true);
 			// sets folder1 default charset
 			folder1.setDefaultCharset("FRED", createTestMonitor());
-			assertCharsetIs("4.0", "FRED", new IResource[] {folder1, file2, folder2, file3}, true);
-			assertCharsetIs("4.1", null, new IResource[] {file2, folder2, file3}, false);
-			assertCharsetIs("4.2", "BAR", new IResource[] {project, file1}, true);
+			assertCharsetIs("FRED", new IResource[] { folder1, file2, folder2, file3 }, true);
+			assertCharsetIs(null, new IResource[] { file2, folder2, file3 }, false);
+			assertCharsetIs("BAR", new IResource[] { project, file1 }, true);
 			// sets folder2 default charset
 			folder2.setDefaultCharset("ZOO", createTestMonitor());
-			assertCharsetIs("5.0", "ZOO", new IResource[] {folder2, file3}, true);
-			assertCharsetIs("5.1", null, new IResource[] {file3}, false);
-			assertCharsetIs("5.2", "FRED", new IResource[] {folder1, file2}, true);
+			assertCharsetIs("ZOO", new IResource[] { folder2, file3 }, true);
+			assertCharsetIs(null, new IResource[] { file3 }, false);
+			assertCharsetIs("FRED", new IResource[] { folder1, file2 }, true);
 			// sets file3 charset
 			file3.setCharset("ZIT", createTestMonitor());
-			assertCharsetIs("6.0", "ZIT", new IResource[] {file3}, false);
+			assertCharsetIs("ZIT", new IResource[] { file3 }, false);
 			folder2.setDefaultCharset(null, createTestMonitor());
-			assertCharsetIs("7.0", folder2.getParent().getDefaultCharset(), new IResource[] {folder2}, true);
-			assertCharsetIs("7.1", null, new IResource[] {folder2}, false);
-			assertCharsetIs("7.2", "ZIT", new IResource[] {file3}, false);
+			assertCharsetIs(folder2.getParent().getDefaultCharset(), new IResource[] { folder2 }, true);
+			assertCharsetIs(null, new IResource[] { folder2 }, false);
+			assertCharsetIs("ZIT", new IResource[] { file3 }, false);
 			folder1.setDefaultCharset(null, createTestMonitor());
-			assertCharsetIs("8.0", folder1.getParent().getDefaultCharset(), new IResource[] {folder1, file2, folder2}, true);
-			assertCharsetIs("8.1", null, new IResource[] {folder1, file2, folder2}, false);
-			assertCharsetIs("8.2", "ZIT", new IResource[] {file3}, false);
+			assertCharsetIs(folder1.getParent().getDefaultCharset(), new IResource[] { folder1, file2, folder2 }, true);
+			assertCharsetIs(null, new IResource[] { folder1, file2, folder2 }, false);
+			assertCharsetIs("ZIT", new IResource[] { file3 }, false);
 			project.setDefaultCharset(null, createTestMonitor());
-			assertCharsetIs("9.0", project.getParent().getDefaultCharset(), new IResource[] {project, file1, folder1, file2, folder2}, true);
-			assertCharsetIs("9.1", null, new IResource[] {project, file1, folder1, file2, folder2}, false);
-			assertCharsetIs("9.2", "ZIT", new IResource[] {file3}, false);
+			assertCharsetIs(project.getParent().getDefaultCharset(),
+					new IResource[] { project, file1, folder1, file2, folder2 }, true);
+			assertCharsetIs(null, new IResource[] { project, file1, folder1, file2, folder2 }, false);
+			assertCharsetIs("ZIT", new IResource[] { file3 }, false);
 			workspace.getRoot().setDefaultCharset(null, createTestMonitor());
-			assertCharsetIs("10.0", project.getParent().getDefaultCharset(), new IResource[] {project, file1, folder1, file2, folder2}, true);
-			assertCharsetIs("10.1", "ZIT", new IResource[] {file3}, false);
+			assertCharsetIs(project.getParent().getDefaultCharset(),
+					new IResource[] { project, file1, folder1, file2, folder2 }, true);
+			assertCharsetIs("ZIT", new IResource[] { file3 }, false);
 			file3.setCharset(null, createTestMonitor());
-			assertCharsetIs("11.0", ResourcesPlugin.getEncoding(), new IResource[] {workspace.getRoot(), project, file1, folder1, file2, folder2, file3}, true);
+			assertCharsetIs(ResourcesPlugin.getEncoding(),
+					new IResource[] { workspace.getRoot(), project, file1, folder1, file2, folder2, file3 }, true);
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -1023,8 +1031,8 @@ public class CharsetTest {
 		getWorkspace().addResourceChangeListener(backgroundVerifier, IResourceChangeEvent.POST_CHANGE);
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType myType = contentTypeManager.getContentType("org.eclipse.core.tests.resources.myContent2");
-		assertNotNull("0.1", myType);
-		assertEquals("0.2", PROVIDER_SETTING, myType.getDefaultCharset());
+		assertNotNull(myType);
+		assertEquals(PROVIDER_SETTING, myType.getDefaultCharset());
 		IProject project = getWorkspace().getRoot().getProject("project1");
 		try {
 			IFolder folder1 = project.getFolder("folder1");
@@ -1042,11 +1050,11 @@ public class CharsetTest {
 			// change content type's default charset
 			myType.setDefaultCharset(USER_SETTING);
 			// ensure the property events were generated
-			assertTrue("2.1", backgroundVerifier.waitForEvent(10000));
-			assertTrue("2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			assertEquals("3.0", USER_SETTING, file2.getCharset());
-			assertEquals("3.1", USER_SETTING, file3.getCharset());
-			assertEquals("3.2", "BAR", file4.getCharset());
+			assertTrue(backgroundVerifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.isDeltaValid(), backgroundVerifier.getMessage());
+			assertEquals(USER_SETTING, file2.getCharset());
+			assertEquals(USER_SETTING, file3.getCharset());
+			assertEquals("BAR", file4.getCharset());
 
 			// change back to the provider-provided default
 			// configure verifier
@@ -1055,11 +1063,11 @@ public class CharsetTest {
 			// reset charset to default
 			myType.setDefaultCharset(null);
 			// ensure the property events were generated
-			assertTrue("4.1", backgroundVerifier.waitForEvent(10000));
-			assertTrue("4.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			assertEquals("5.0", PROVIDER_SETTING, file2.getCharset());
-			assertEquals("5.1", PROVIDER_SETTING, file3.getCharset());
-			assertEquals("5.2", "BAR", file4.getCharset());
+			assertTrue(backgroundVerifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.isDeltaValid(), backgroundVerifier.getMessage());
+			assertEquals(PROVIDER_SETTING, file2.getCharset());
+			assertEquals(PROVIDER_SETTING, file3.getCharset());
+			assertEquals("BAR", file4.getCharset());
 		} finally {
 			getWorkspace().removeResourceChangeListener(backgroundVerifier);
 			myType.setDefaultCharset(null);
@@ -1081,11 +1089,11 @@ public class CharsetTest {
 			createInWorkspace(new IResource[] {file1, file2});
 
 			IFile resourcesPrefs = getResourcesPreferenceFile(project, false);
-			assertTrue("0.9", resourcesPrefs.exists());
+			assertTrue(resourcesPrefs.exists());
 			String prefsContent = Files.readString(resourcesPrefs.getLocation().toFile().toPath());
 			assertTrue(prefsContent.contains(ResourcesPlugin.getEncoding()));
 			file1.setCharset("CHARSET1", createTestMonitor());
-			assertTrue("1.1", resourcesPrefs.exists());
+			assertTrue(resourcesPrefs.exists());
 			waitForCharsetManagerJob();
 
 			prefsContent = Files.readString(resourcesPrefs.getLocation().toFile().toPath());
@@ -1095,8 +1103,8 @@ public class CharsetTest {
 			backgroundVerifier.addExpectedChange(new IResource[] {project, folder1, file1, file2, resourcesPrefs, resourcesPrefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			// cause a resource change event without actually changing contents
 			resourcesPrefs.setContents(prefsContent.getBytes(), 0, createTestMonitor());
-			assertTrue("2.1", backgroundVerifier.waitForEvent(10000));
-			assertTrue("2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
+			assertTrue(backgroundVerifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.isDeltaValid(), backgroundVerifier.getMessage());
 
 			IMarker[] markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertThat(markers).as("check no missing enconding markers").isEmpty();
@@ -1110,10 +1118,10 @@ public class CharsetTest {
 			// delete the preferences file
 			resourcesPrefs.delete(true, createTestMonitor());
 			waitForCharsetManagerJob();
-			waitForEncodingRelatedJobs(testName.getMethodName());
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
 
-			assertTrue("3.1", backgroundVerifier.waitForEvent(10000));
-			assertTrue("3.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
+			assertTrue(backgroundVerifier.waitForEvent(10000));
+			assertTrue(backgroundVerifier.isDeltaValid(), backgroundVerifier.getMessage());
 
 			markers = project.findMarkers(ValidateProjectEncoding.MARKER_TYPE, false, IResource.DEPTH_ONE);
 			assertThat(markers).as("check missing encoding markers").hasSize(1);
@@ -1142,7 +1150,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(new IResource[] { prefs.getParent() }, IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(new IResource[] { prefs }, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset("new_charset", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("1.1.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// folder with children
 			IFolder folder2 = folder1.getFolder("folder2");
@@ -1154,7 +1162,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset("a_charset", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("2.1.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// folder w. children, some with non-inherited values
 			// set the child to have a non-inherited value
@@ -1164,7 +1172,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset("newOne", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("3.2.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change from non-default to another non-default
 			verifier.reset();
@@ -1172,7 +1180,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset("newTwo", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("4.2.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change to default (clear it)
 			verifier.reset();
@@ -1180,7 +1188,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset(null, createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("5.1.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change to default (equal to it but it doesn't inherit)
 			verifier.reset();
@@ -1188,7 +1196,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs.getParent(), IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			folder1.setDefaultCharset(project.getDefaultCharset(), createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("6.1.");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// clear all the encoding info before we start working with the project
 			clearAllEncodings(project);
@@ -1196,16 +1204,16 @@ public class CharsetTest {
 			verifier.addExpectedChange(new IResource[] {project, folder1, folder2, file1, file2, prefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			verifier.addExpectedChange(prefs, IResourceDelta.ADDED, 0);
 			project.setDefaultCharset("foo", createTestMonitor());
-			waitForEncodingRelatedJobs(testName.getMethodName());
-			verifier.assertExpectedDeltasWereReceived("7.2.");
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
+			verifier.assertExpectedDeltasWereReceived();
 
 			// clear all the encoding info before we start working with the root
 			clearAllEncodings(project);
 			verifier.reset();
 			verifier.addExpectedChange(new IResource[] {project, folder1, folder2, file1, file2, prefs.getParent()}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			getWorkspace().getRoot().setDefaultCharset("foo", createTestMonitor());
-			waitForEncodingRelatedJobs(testName.getMethodName());
-			verifier.assertExpectedDeltasWereReceived("8.2.");
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
+			verifier.assertExpectedDeltasWereReceived();
 		} finally {
 			verifier.removeResourceChangeListeners();
 			clearAllEncodings(project);
@@ -1235,14 +1243,14 @@ public class CharsetTest {
 			verifier.addExpectedChange(new IResource[] { prefs.getParent() }, IResourceDelta.CHANGED, 0);
 			verifier.addExpectedChange(new IResource[] { prefs }, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			file1.setCharset("FOO", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("1.0.1");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change to default (clear it)
 			verifier.reset();
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			file1.setCharset(null, createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("1.1.1");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change to default (equal to it but it doesn't inherit)
 			verifier.reset();
@@ -1250,7 +1258,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(file1, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
 			file1.setCharset(project.getDefaultCharset(), createTestMonitor());
 
-			verifier.assertExpectedDeltasWereReceived("1.2.1");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// change from non-default to another non-default
 			// sets to a non-default value first
@@ -1262,7 +1270,7 @@ public class CharsetTest {
 			verifier.addExpectedChange(prefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
 			// sets to another non-defauilt value
 			file1.setCharset("BAR", createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("1.3.2");
+			verifier.assertExpectedDeltasWereReceived();
 
 			// multiple files (same operation)
 			verifier.reset();
@@ -1275,7 +1283,7 @@ public class CharsetTest {
 				file1.setCharset("FOO", createTestMonitor());
 				file2.setCharset("FOO", createTestMonitor());
 			}, createTestMonitor());
-			verifier.assertExpectedDeltasWereReceived("1.4.1");
+			verifier.assertExpectedDeltasWereReceived();
 		} finally {
 			verifier.removeResourceChangeListeners();
 			clearAllEncodings(project);
@@ -1331,26 +1339,27 @@ public class CharsetTest {
 			project.setDefaultCharset("BAR", createTestMonitor());
 			oldFile.setCharset("FOO", createTestMonitor());
 			// project and non-existing file share the same encoding
-			assertCharsetIs("0.1", "BAR", new IResource[] {project, newXMLFile, newTXTFile, newRandomFile}, true);
+			assertCharsetIs("BAR", new IResource[] { project, newXMLFile, newTXTFile, newRandomFile }, true);
 			// existing file has encoding determined by user
-			assertCharsetIs("0.2", "FOO", new IResource[] {oldFile}, true);
+			assertCharsetIs("FOO", new IResource[] { oldFile }, true);
 
 			// for an existing file, user set charset will prevail (if any)
-			assertEquals("1.0", "FOO", oldFile.getCharsetFor(getTextContents("")));
-			assertEquals("1.1", "FOO", oldFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
+			assertEquals("FOO", oldFile.getCharsetFor(getTextContents("")));
+			assertEquals("FOO", oldFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
 
 			// for a non-existing file, or for a file that exists but does not have a user set charset,  the content type (if any) rules
-			assertEquals("2.0", xml.getDefaultCharset(), newXMLFile.getCharsetFor(getTextContents("")));
-			assertEquals("2.1", xml.getDefaultCharset(), newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
-			assertEquals("2.2", "US-ASCII", newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
+			assertEquals(xml.getDefaultCharset(), newXMLFile.getCharsetFor(getTextContents("")));
+			assertEquals(xml.getDefaultCharset(),
+					newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
+			assertEquals("US-ASCII", newXMLFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
 			oldFile.setCharset(null, createTestMonitor());
-			assertEquals("2.3", xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents("")));
-			assertEquals("2.4", xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
-			assertEquals("2.5", "US-ASCII", oldFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
+			assertEquals(xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents("")));
+			assertEquals(xml.getDefaultCharset(), oldFile.getCharsetFor(getTextContents(SAMPLE_XML_DEFAULT_ENCODING)));
+			assertEquals("US-ASCII", oldFile.getCharsetFor(getTextContents(SAMPLE_XML_US_ASCII_ENCODING)));
 
 			// if the content type has no default charset, or the file has no known content type, fallback to parent default charset
-			assertEquals("3.0", project.getDefaultCharset(), newTXTFile.getCharsetFor(getTextContents("")));
-			assertEquals("3.1", project.getDefaultCharset(), newRandomFile.getCharsetFor(getTextContents("")));
+			assertEquals(project.getDefaultCharset(), newTXTFile.getCharsetFor(getTextContents("")));
+			assertEquals(project.getDefaultCharset(), newRandomFile.getCharsetFor(getTextContents("")));
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -1373,10 +1382,10 @@ public class CharsetTest {
 			project1.setDefaultCharset("FOO", createTestMonitor());
 			folder.setDefaultCharset("BAR", createTestMonitor());
 
-			assertEquals("1.0", "BAR", folder.getDefaultCharset());
-			assertEquals("1.1", "BAR", file2.getCharset());
-			assertEquals("1.2", "FOO", file1.getCharset());
-			assertEquals("1.3", "FOO", project1.getDefaultCharset());
+			assertEquals("BAR", folder.getDefaultCharset());
+			assertEquals("BAR", file2.getCharset());
+			assertEquals("FOO", file1.getCharset());
+			assertEquals("FOO", project1.getDefaultCharset());
 
 			// move project and ensures charsets settings are preserved
 			project1.move(IPath.fromOSString("Project2"), false, null);
@@ -1384,10 +1393,10 @@ public class CharsetTest {
 			folder = project2.getFolder("folder1");
 			file1 = project2.getFile("file1.txt");
 			file2 = folder.getFile("file2.txt");
-			assertEquals("2.0", "BAR", folder.getDefaultCharset());
-			assertEquals("2.1", "BAR", file2.getCharset());
-			assertEquals("2.2", "FOO", project2.getDefaultCharset());
-			assertEquals("2.3", "FOO", file1.getCharset());
+			assertEquals("BAR", folder.getDefaultCharset());
+			assertEquals("BAR", file2.getCharset());
+			assertEquals("FOO", project2.getDefaultCharset());
+			assertEquals("FOO", file1.getCharset());
 		} finally {
 			clearAllEncodings(project1);
 			clearAllEncodings(project2);
@@ -1405,20 +1414,20 @@ public class CharsetTest {
 		IProject project = workspace.getRoot().getProject("MyProject");
 		try {
 			CoreException e = assertThrows(CoreException.class, () -> project.setDefaultCharset("FOO", createTestMonitor()));
-			assertEquals("project should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
+			assertEquals(IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode(), "project should not exist yet");
 			createInWorkspace(project);
 			project.setDefaultCharset("FOO", createTestMonitor());
 			IFile file = project.getFile("file.xml");
 			assertDoesNotExistInWorkspace(file);
-			assertEquals("2.2", "FOO", file.getCharset());
+			assertEquals("FOO", file.getCharset());
 			e = assertThrows(CoreException.class, () -> file.setCharset("BAR", createTestMonitor()));
-			assertEquals("file should not exist yet", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
+			assertEquals(IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode(), "file should not exist yet");
 			createInWorkspace(file);
 			file.setCharset("BAR", createTestMonitor());
-			assertEquals("2.8", "BAR", file.getCharset());
+			assertEquals("BAR", file.getCharset());
 			file.delete(IResource.NONE, null);
 			assertDoesNotExistInWorkspace(file);
-			assertEquals("2.11", "FOO", file.getCharset());
+			assertEquals("FOO", file.getCharset());
 		} finally {
 			clearAllEncodings(project);
 		}
@@ -1433,7 +1442,7 @@ public class CharsetTest {
 		createInWorkspace(file);
 		file.getLocation().toFile().delete();
 		CoreException e = assertThrows(CoreException.class, file::getContentDescription);
-		assertEquals("the resource should not exist", IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode());
+		assertEquals(IResourceStatus.RESOURCE_NOT_FOUND, e.getStatus().getCode(), "the resource should not exist");
 	}
 
 	@Test
@@ -1575,25 +1584,24 @@ public class CharsetTest {
 			deltaVerifiers.clear();
 		}
 
-		void assertExpectedDeltasWereReceived(String message) {
+		void assertExpectedDeltasWereReceived() {
 			waitForNotificationManagerJob();
 			if (expectedDeltasCount > 0 && verifiedDeltasCount == 0) {
-				fail(message + ", expected " + expectedDeltasCount + " deltas but received no deltas");
+				fail("expected " + expectedDeltasCount + " deltas but received no deltas");
 			}
 			if (verifiedDeltasCount > 0 && expectedDeltasCount == 0) {
-				fail(message + ", expected no deltas but received " + verifiedDeltasCount + " deltas");
+				fail("expected no deltas but received " + verifiedDeltasCount + " deltas");
 			}
 			if (!singleDeltaVerifier.isDeltaValid()) {
 				if (verifiedDeltasCount == 1) {
-					fail(message + ", " + singleDeltaVerifier.getMessage());
+					fail(singleDeltaVerifier.getMessage());
 				} else {
 					boolean validDeltas = true;
-					StringBuilder failMessage = new StringBuilder(message);
+					StringBuilder failMessage = new StringBuilder();
 					for (int i = 0; i < expectedDeltasCount; i++) {
 						CharsetVerifier deltaVerifier = deltaVerifiers.get(i);
 						boolean isValidDelta = deltaVerifier.isDeltaValid();
 						validDeltas &= isValidDelta;
-						failMessage.append(System.lineSeparator());
 						failMessage.append("listing verification result for expected change with index " + i);
 						failMessage.append(System.lineSeparator());
 						failMessage.append("verifier.isValidDelta(): " + isValidDelta);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ContentDescriptionManagerTest.java
@@ -16,12 +16,12 @@ package org.eclipse.core.tests.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -44,14 +44,13 @@ import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.runtime.content.IContentTypeSettings;
 import org.eclipse.core.runtime.jobs.Job;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.service.prefs.Preferences;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ContentDescriptionManagerTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String CONTENT_TYPE_RELATED_NATURE1 = "org.eclipse.core.tests.resources.contentTypeRelated1";
 	private static final String CONTENT_TYPE_RELATED_NATURE2 = "org.eclipse.core.tests.resources.contentTypeRelated2";
@@ -96,31 +95,32 @@ public class ContentDescriptionManagerTest {
 		// wait for cache flush to finish
 		waitForCacheFlush();
 		// cache is new at this point
-		assertEquals("0.9", ContentDescriptionManager.EMPTY_CACHE, ((Workspace) workspace).getContentDescriptionManager().getCacheState());
+		assertEquals(ContentDescriptionManager.EMPTY_CACHE,
+				((Workspace) workspace).getContentDescriptionManager().getCacheState());
 
 		IContentDescription description1a = null, description1b = null, description1c = null, description1d = null;
 		IContentDescription description2 = null;
 		description1a = file1.getContentDescription();
 		description2 = file2.getContentDescription();
-		assertNotNull("1.1", description1a);
-		assertEquals("1.2", xml, description1a.getContentType());
-		assertNull("1.3", description2);
+		assertNotNull(description1a);
+		assertEquals(xml, description1a.getContentType());
+		assertNull(description2);
 
 		description1b = file1.getContentDescription();
 		// ensure it comes from the cache (should be the very same object)
-		assertNotNull(" 2.1", description1b);
-		assertSame("2.2", description1a, description1b);
+		assertNotNull(description1b);
+		assertSame(description1a, description1b);
 		try {
 			// change the content type
 			xml.addFileSpec(newExtension, IContentType.FILE_EXTENSION_SPEC);
 			description1c = file1.getContentDescription();
 			description2 = file2.getContentDescription();
 			// ensure it does *not* come from the cache (should be a different object)
-			assertNotNull("4.1", description1c);
-			assertNotSame("4.2", description1a, description1c);
-			assertEquals("4.3", xml, description1c.getContentType());
-			assertNotNull("4.4", description2);
-			assertEquals("4.5", xml, description2.getContentType());
+			assertNotNull(description1c);
+			assertNotSame(description1a, description1c);
+			assertEquals(xml, description1c.getContentType());
+			assertNotNull(description2);
+			assertEquals(xml, description2.getContentType());
 		} finally {
 			// dissociate the xml2 extension from the XML content type
 			xml.removeFileSpec(newExtension, IContentType.FILE_EXTENSION_SPEC);
@@ -128,31 +128,31 @@ public class ContentDescriptionManagerTest {
 		description1d = file1.getContentDescription();
 		description2 = file2.getContentDescription();
 		// ensure it does *not* come from the cache (should be a different object)
-		assertNotNull("5.1", description1d);
-		assertNotSame("5.2", description1c, description1d);
-		assertEquals("5.3", xml, description1d.getContentType());
-		assertNull("5.4", description2);
+		assertNotNull(description1d);
+		assertNotSame(description1c, description1d);
+		assertEquals(xml, description1d.getContentType());
+		assertNull(description2);
 	}
 
 	@Test
 	public void testBug94516() throws Exception {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
-		assertNotNull("0.1", text);
+		assertNotNull(text);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFile unrelatedFile = project.getFile("file.unrelated");
 		createInWorkspace(unrelatedFile, "");
 
 		IContentDescription description = null;
 		description = unrelatedFile.getContentDescription();
-		assertNull("0.8", description);
+		assertNull(description);
 
 		try {
 			text.addFileSpec(unrelatedFile.getName(), IContentType.FILE_NAME_SPEC);
 
 			description = unrelatedFile.getContentDescription();
-			assertNotNull("1.1", description);
-			assertEquals("1.2", text, description.getContentType());
+			assertNotNull(description);
+			assertEquals(text, description.getContentType());
 
 			final ProjectScope projectScope = new ProjectScope(project);
 			Preferences contentTypePrefs = projectScope.getNode(ContentTypeManager.CONTENT_TYPE_PREF_NODE);
@@ -161,19 +161,19 @@ public class ContentDescriptionManagerTest {
 			contentTypePrefs.flush();
 			// global settings should not matter anymore
 			description = unrelatedFile.getContentDescription();
-			assertNull("2.1", description);
+			assertNull(description);
 
 			IContentTypeSettings settings = null;
 			settings = text.getSettings(projectScope);
-			assertNotNull("3.1", settings);
-			assertNotSame("3.2", text, settings);
-			assertTrue("3.3", settings instanceof ContentTypeSettings);
+			assertNotNull(settings);
+			assertNotSame(text, settings);
+			assertTrue(settings instanceof ContentTypeSettings);
 
 			settings.addFileSpec(unrelatedFile.getFullPath().getFileExtension(), IContentType.FILE_EXTENSION_SPEC);
 			contentTypePrefs.flush();
 			description = unrelatedFile.getContentDescription();
-			assertNotNull("5.1", description);
-			assertEquals("5.2", text, description.getContentType());
+			assertNotNull(description);
+			assertEquals(text, description.getContentType());
 		} finally {
 			text.removeFileSpec(unrelatedFile.getName(), IContentType.FILE_NAME_SPEC);
 		}
@@ -187,8 +187,8 @@ public class ContentDescriptionManagerTest {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType baseType = contentTypeManager.getContentType("org.eclipse.core.tests.resources.nature_associated_1");
 		IContentType derivedType = contentTypeManager.getContentType("org.eclipse.core.tests.resources.nature_associated_2");
-		assertNotNull("0.1", baseType);
-		assertNotNull("0.2", derivedType);
+		assertNotNull(baseType);
+		assertNotNull(derivedType);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		IFile file = project.getFile("file.nature-associated");
 		IFile descFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -201,8 +201,9 @@ public class ContentDescriptionManagerTest {
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
-		assertNotNull("1.2", description);
-		assertSame("1.3", ((ContentTypeHandler) baseType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
+		assertNotNull(description);
+		assertSame(((ContentTypeHandler) baseType).getTarget(),
+				((ContentTypeHandler) description.getContentType()).getTarget());
 
 		// change project description to include one of the natures
 		try (InputStream input = projectDescriptionWithNatures(project.getName(), new String[] { CONTENT_TYPE_RELATED_NATURE1 })) {
@@ -210,8 +211,9 @@ public class ContentDescriptionManagerTest {
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
-		assertNotNull("2.2", description);
-		assertSame("2.3", ((ContentTypeHandler) baseType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
+		assertNotNull(description);
+		assertSame(((ContentTypeHandler) baseType).getTarget(),
+				((ContentTypeHandler) description.getContentType()).getTarget());
 
 		// change project description to include the other nature
 		try (InputStream input = projectDescriptionWithNatures(project.getName(),
@@ -220,8 +222,9 @@ public class ContentDescriptionManagerTest {
 		}
 		waitForCacheFlush();
 		description = file.getContentDescription();
-		assertNotNull("3.2", description);
-		assertSame("3.3", ((ContentTypeHandler) derivedType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
+		assertNotNull(description);
+		assertSame(((ContentTypeHandler) derivedType).getTarget(),
+				((ContentTypeHandler) description.getContentType()).getTarget());
 
 		// change project description to include both of the natures
 		try (InputStream input = projectDescriptionWithNatures(project.getName(),
@@ -231,16 +234,18 @@ public class ContentDescriptionManagerTest {
 		waitForCacheFlush();
 
 		description = file.getContentDescription();
-		assertNotNull("4.2", description);
-		assertSame("4.3", ((ContentTypeHandler) baseType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
+		assertNotNull(description);
+		assertSame(((ContentTypeHandler) baseType).getTarget(),
+				((ContentTypeHandler) description.getContentType()).getTarget());
 
 		// back to no natures
 		descFile.setContents(projectDescriptionWithNatures(project.getName(), new String[0]), IResource.FORCE,
 				createTestMonitor());
 		waitForCacheFlush();
 		description = file.getContentDescription();
-		assertNotNull("5.2", description);
-		assertSame("5.3", ((ContentTypeHandler) baseType).getTarget(), ((ContentTypeHandler) description.getContentType()).getTarget());
+		assertNotNull(description);
+		assertSame(((ContentTypeHandler) baseType).getTarget(),
+				((ContentTypeHandler) description.getContentType()).getTarget());
 	}
 
 	@Test
@@ -248,8 +253,8 @@ public class ContentDescriptionManagerTest {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
 		IContentType xml = contentTypeManager.getContentType("org.eclipse.core.runtime.xml");
-		assertNotNull("0.1", text);
-		assertNotNull("0.2", xml);
+		assertNotNull(text);
+		assertNotNull(xml);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 
 		IFile txtFile = project.getFile("example.txt");
@@ -259,8 +264,8 @@ public class ContentDescriptionManagerTest {
 		createInWorkspace(xmlFile, "");
 
 		project.setDefaultCharset("FOO", createTestMonitor());
-		assertEquals("1.0", "FOO", txtFile.getCharset());
-		assertEquals("1.1", "UTF-8", xmlFile.getCharset());
+		assertEquals("FOO", txtFile.getCharset());
+		assertEquals("UTF-8", xmlFile.getCharset());
 
 		final ProjectScope projectScope = new ProjectScope(project);
 		Preferences contentTypePrefs = projectScope.getNode(ContentTypeManager.CONTENT_TYPE_PREF_NODE);
@@ -271,14 +276,14 @@ public class ContentDescriptionManagerTest {
 		settings = text.getSettings(projectScope);
 		settings.setDefaultCharset("BAR");
 		contentTypePrefs.flush();
-		assertEquals("3.0", "BAR", txtFile.getCharset());
-		assertEquals("3.1", "UTF-8", xmlFile.getCharset());
+		assertEquals("BAR", txtFile.getCharset());
+		assertEquals("UTF-8", xmlFile.getCharset());
 
 		settings = xml.getSettings(projectScope);
 		settings.setDefaultCharset("");
 		contentTypePrefs.flush();
-		assertEquals("4.1", "BAR", txtFile.getCharset());
-		assertEquals("4.2", "FOO", xmlFile.getCharset());
+		assertEquals("BAR", txtFile.getCharset());
+		assertEquals("FOO", xmlFile.getCharset());
 	}
 
 	@Test
@@ -286,8 +291,8 @@ public class ContentDescriptionManagerTest {
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		IContentType text = contentTypeManager.getContentType("org.eclipse.core.runtime.text");
 		IContentType xml = contentTypeManager.getContentType("org.eclipse.core.runtime.xml");
-		assertNotNull("0.1", text);
-		assertNotNull("0.2", xml);
+		assertNotNull(text);
+		assertNotNull(xml);
 		IProject project = getWorkspace().getRoot().getProject("proj1");
 		String unrelatedFileExtension = "unrelated";
 
@@ -301,14 +306,14 @@ public class ContentDescriptionManagerTest {
 		IContentDescription description = null;
 
 		description = txtFile.getContentDescription();
-		assertNotNull("0.7b", description);
-		assertEquals("0.7c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = xmlFile.getContentDescription();
-		assertNotNull("0.8b", description);
-		assertEquals("0.8c", xml, description.getContentType());
+		assertNotNull(description);
+		assertEquals(xml, description.getContentType());
 
-		assertNull("0.9b", unrelatedFile.getContentDescription());
+		assertNull(unrelatedFile.getContentDescription());
 
 		final ProjectScope projectScope = new ProjectScope(project);
 		Preferences contentTypePrefs = projectScope.getNode(ContentTypeManager.CONTENT_TYPE_PREF_NODE);
@@ -317,35 +322,35 @@ public class ContentDescriptionManagerTest {
 		contentTypePrefs.flush();
 		// there are no local settings yet, everything should be the same
 		description = txtFile.getContentDescription();
-		assertNotNull("1.0b", description);
-		assertEquals("1.0c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = xmlFile.getContentDescription();
-		assertNotNull("1.1b", description);
-		assertEquals("1.1c", xml, description.getContentType());
+		assertNotNull(description);
+		assertEquals(xml, description.getContentType());
 
-		assertNull("1.2b", unrelatedFile.getContentDescription());
+		assertNull(unrelatedFile.getContentDescription());
 
 		IContentTypeSettings settings = null;
 		settings = text.getSettings(projectScope);
-		assertNotNull("2.1", settings);
-		assertNotSame("2.2", text, settings);
-		assertTrue("2.3", settings instanceof ContentTypeSettings);
+		assertNotNull(settings);
+		assertNotSame(text, settings);
+		assertTrue(settings instanceof ContentTypeSettings);
 
 		settings.addFileSpec(unrelatedFileExtension, IContentTypeSettings.FILE_EXTENSION_SPEC);
 		contentTypePrefs.flush();
 		description = unrelatedFile.getContentDescription();
-		assertNotNull("3.2b", description);
-		assertEquals("3.2c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		// other content types should still be recognized
 		description = txtFile.getContentDescription();
-		assertNotNull("3.3b", description);
-		assertEquals("3.3c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = xmlFile.getContentDescription();
-		assertNotNull("3.4b", description);
-		assertEquals("3.4c", xml, description.getContentType());
+		assertNotNull(description);
+		assertEquals(xml, description.getContentType());
 
 		// disable project-specific settings for this project
 		contentTypePrefs.putBoolean("enabled", false);
@@ -353,14 +358,14 @@ public class ContentDescriptionManagerTest {
 
 		// no project settings should be in effect
 		description = txtFile.getContentDescription();
-		assertNotNull("4.0b", description);
-		assertEquals("4.0c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = xmlFile.getContentDescription();
-		assertNotNull("4.1b", description);
-		assertEquals("4.1c", xml, description.getContentType());
+		assertNotNull(description);
+		assertEquals(xml, description.getContentType());
 
-		assertNull("4.2b", unrelatedFile.getContentDescription());
+		assertNull(unrelatedFile.getContentDescription());
 
 		// enable project-specific settings again
 		contentTypePrefs.putBoolean("enabled", true);
@@ -371,16 +376,16 @@ public class ContentDescriptionManagerTest {
 		contentTypePrefs.flush();
 
 		description = unrelatedFile.getContentDescription();
-		assertNotNull("5.2b", description);
-		assertEquals("5.2c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = txtFile.getContentDescription();
-		assertNotNull("5.3b", description);
-		assertEquals("5.3c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 
 		description = xmlFile.getContentDescription();
-		assertNotNull("5.4b", description);
-		assertEquals("5.4c", text, description.getContentType());
+		assertNotNull(description);
+		assertEquals(text, description.getContentType());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/HiddenResourceTest.java
@@ -25,10 +25,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForEncodingRelatedJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -41,20 +41,16 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class HiddenResourceTest {
 
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	@Test
-	public void testRefreshLocal() throws Exception {
+	public void testRefreshLocal(TestInfo testInfo) throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject(createUniqueString());
 		IFolder folder = project.getFolder("folder");
@@ -62,7 +58,7 @@ public class HiddenResourceTest {
 		IFile subFile = folder.getFile("subfile.txt");
 		IResource[] resources = new IResource[] {project, folder, file, subFile};
 		createInWorkspace(resources);
-		waitForEncodingRelatedJobs(testName.getMethodName());
+		waitForEncodingRelatedJobs(testInfo.getDisplayName());
 
 		ResourceDeltaVerifier listener = new ResourceDeltaVerifier();
 		listener.addExpectedChange(subFile, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
@@ -71,7 +67,7 @@ public class HiddenResourceTest {
 			setHidden(folder, true, IResource.DEPTH_ZERO);
 			ensureOutOfSync(subFile);
 			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 		} finally {
 			removeResourceChangeListener(listener);
 		}
@@ -91,24 +87,24 @@ public class HiddenResourceTest {
 		createInWorkspace(resources);
 
 		// no hidden resources
-		assertEquals("1.0", project, root.findMember(project.getFullPath()));
-		assertEquals("1.1", folder, root.findMember(folder.getFullPath()));
-		assertEquals("1.2", file, root.findMember(file.getFullPath()));
-		assertEquals("1.3", subFile, root.findMember(subFile.getFullPath()));
+		assertEquals(project, root.findMember(project.getFullPath()));
+		assertEquals(folder, root.findMember(folder.getFullPath()));
+		assertEquals(file, root.findMember(file.getFullPath()));
+		assertEquals(subFile, root.findMember(subFile.getFullPath()));
 
 		// the folder is hidden
 		setHidden(folder, true, IResource.DEPTH_ZERO);
-		assertEquals("2.1", project, root.findMember(project.getFullPath()));
-		assertEquals("2.2", folder, root.findMember(folder.getFullPath()));
-		assertEquals("2.3", file, root.findMember(file.getFullPath()));
-		assertEquals("2.4", subFile, root.findMember(subFile.getFullPath()));
+		assertEquals(project, root.findMember(project.getFullPath()));
+		assertEquals(folder, root.findMember(folder.getFullPath()));
+		assertEquals(file, root.findMember(file.getFullPath()));
+		assertEquals(subFile, root.findMember(subFile.getFullPath()));
 
 		// all are hidden
 		setHidden(project, true, IResource.DEPTH_INFINITE);
-		assertEquals("3.1", project, root.findMember(project.getFullPath()));
-		assertEquals("3.2", folder, root.findMember(folder.getFullPath()));
-		assertEquals("3.3", file, root.findMember(file.getFullPath()));
-		assertEquals("3.4", subFile, root.findMember(subFile.getFullPath()));
+		assertEquals(project, root.findMember(project.getFullPath()));
+		assertEquals(folder, root.findMember(folder.getFullPath()));
+		assertEquals(file, root.findMember(file.getFullPath()));
+		assertEquals(subFile, root.findMember(subFile.getFullPath()));
 	}
 
 	/**
@@ -219,20 +215,20 @@ public class HiddenResourceTest {
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
 
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		// set the folder to be hidden. It and its children should
 		// be ignored by the visitor
@@ -244,7 +240,7 @@ public class HiddenResourceTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(project);
@@ -253,27 +249,27 @@ public class HiddenResourceTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 		// should see all resources if we include the flag
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 		// should NOT visit the folder and its members if we call accept on it directly
 		visitor.reset();
 		folder.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(folder);
 		visitor.addExpected(subFile);
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_HIDDEN);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 	}
 
 	@Test
@@ -444,7 +440,7 @@ public class HiddenResourceTest {
 	}
 
 	@Test
-	public void testDeltas() throws CoreException {
+	public void testDeltas(TestInfo testInfo) throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		final IProject project = root.getProject(createUniqueString());
 		final IFolder folder = project.getFolder("folder");
@@ -463,10 +459,10 @@ public class HiddenResourceTest {
 			addResourceChangeListener(listener);
 			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
-			waitForEncodingRelatedJobs(testName.getMethodName());
+			waitForEncodingRelatedJobs(testInfo.getDisplayName());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
@@ -485,7 +481,7 @@ public class HiddenResourceTest {
 			getWorkspace().run(body, createTestMonitor());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
@@ -504,7 +500,7 @@ public class HiddenResourceTest {
 			getWorkspace().run(body, createTestMonitor());
 			// FIXME sometimes fails with "Verifier has not yet been given a resource
 			// delta":
-			assertTrue("3.1." + listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			removeResourceChangeListener(listener);
@@ -579,7 +575,7 @@ public class HiddenResourceTest {
 		// initial values should be false
 		for (IResource resource2 : resources) {
 			IResource resource = resource2;
-			assertTrue("1.0: " + resource.getFullPath(), !resource.isHidden());
+			assertFalse(resource.isHidden(), resource.getFullPath().toString());
 		}
 
 		// now set the values
@@ -594,10 +590,10 @@ public class HiddenResourceTest {
 				case IResource.PROJECT :
 				case IResource.FOLDER :
 				case IResource.FILE :
-					assertTrue("3.0: " + resource.getFullPath(), resource.isHidden());
+					assertTrue(resource.isHidden(), resource.getFullPath().toString());
 					break;
 				case IResource.ROOT :
-					assertFalse("3.1: " + resource.getFullPath(), resource.isHidden());
+					assertFalse(resource.isHidden(), resource.getFullPath().toString());
 					break;
 			}
 		}
@@ -610,7 +606,7 @@ public class HiddenResourceTest {
 		// values should be false again
 		for (IResource resource2 : resources) {
 			IResource resource = resource2;
-			assertFalse("5.0: " + resource.getFullPath(), resource.isHidden());
+			assertFalse(resource.isHidden(), resource.getFullPath().toString());
 		}
 	}
 
@@ -649,7 +645,7 @@ public class HiddenResourceTest {
 			if (resource.getType() == IResource.PROJECT || resource.getType() == IResource.FILE || resource.getType() == IResource.FOLDER) {
 				expected = value;
 			}
-			assertEquals(resource.getFullPath() + "", expected, resource.isHidden());
+			assertEquals(expected, resource.isHidden(), resource.getFullPath().toString());
 			return true;
 		};
 		root.accept(visitor, depth, IContainer.INCLUDE_HIDDEN);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -30,12 +30,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -73,14 +73,13 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IFileTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	//name of files according to sync category
 	public static final String DOES_NOT_EXIST = "DoesNotExistFile";
@@ -311,7 +310,7 @@ public class IFileTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		generateInterestingFiles();
 	}
@@ -561,7 +560,7 @@ public class IFileTest {
 			AtomicInteger changeCount = new AtomicInteger();
 			ResourcesPlugin.getWorkspace().addResourceChangeListener(event -> changeCount.incrementAndGet());
 			derived.write(("updateOrCreate" + i).getBytes(), false, setDerived, keepHistory, monitor);
-			assertEquals("not atomic", 1, changeCount.get());
+			assertEquals(1, changeCount.get(), "not atomic");
 			monitor.assertUsedUp();
 			if (deleteBefore) {
 				assertEquals(setDerived, derived.isDerived());
@@ -576,7 +575,7 @@ public class IFileTest {
 			derived.write(("update" + i).getBytes(), false, false, keepHistory, null);
 			boolean oldDerived2 = derived.isDerived();
 			assertEquals(oldDerived2, derived.isDerived());
-			assertEquals("not atomic", 1, changeCount.get());
+			assertEquals(1, changeCount.get(), "not atomic");
 			IFileState[] history2 = derived.getHistory(null);
 			assertEquals((keepHistory && !oldDerived2) ? 1 : 0, history2.length - history1.length);
 		}
@@ -682,14 +681,14 @@ public class IFileTest {
 			resource.write(("create").getBytes(), false, false, false, null);
 		}, workspace.getRuleFactory().createRule(resource), IWorkspace.AVOID_UPDATE, null);
 		assertTrue(resource.exists());
-		assertEquals("not atomic", 1, changeCount.get());
+		assertEquals(1, changeCount.get(), "not atomic");
 		// test that modifyRule can be used for IFile.write() if the file already exits:
 		changeCount.set(0);
 		workspace.run(pm -> {
 			resource.write(("replace").getBytes(), false, false, false, null);
 		}, workspace.getRuleFactory().modifyRule(resource), IWorkspace.AVOID_UPDATE, null);
 		assertTrue(resource.exists());
-		assertEquals("not atomic", 1, changeCount.get());
+		assertEquals(1, changeCount.get(), "not atomic");
 	}
 
 	@Test
@@ -1084,10 +1083,10 @@ public class IFileTest {
 		for (String name : names) {
 			monitor.prepare();
 			IFile file = project.getFile(IPath.fromPortableString(name));
-			assertTrue("1.0 " + name, !file.exists());
+			assertFalse(file.exists(), name);
 			assertThrows(CoreException.class, () -> file.create(createRandomContentsStream(), true, monitor));
 			monitor.sanityCheck();
-			assertTrue("1.2 " + name, !file.exists());
+			assertFalse(file.exists(), name);
 		}
 
 		//do some tests with valid names that are *almost* invalid
@@ -1100,11 +1099,11 @@ public class IFileTest {
 		}
 		for (String name : names) {
 			IFile file = project.getFile(name);
-			assertFalse(name + " shouldn't exist", file.exists());
+			assertFalse(file.exists(), name + " shouldn't exist");
 			monitor.prepare();
 			file.create(createRandomContentsStream(), true, monitor);
 			monitor.assertUsedUp();
-			assertTrue(name + " should exist", file.exists());
+			assertTrue(file.exists(), name + " should exist");
 		}
 	}
 
@@ -1243,7 +1242,7 @@ public class IFileTest {
 					target.setContents(content, true, false, monitor);
 					monitor.assertUsedUp();
 					byte[] allBytes = target.readAllBytes();
-					assertArrayEquals(target.getName(), content, allBytes);
+					assertArrayEquals(content, allBytes, target.getName());
 					char[] allChars = target.readAllChars();
 					String readString = target.readString();
 					String expected;
@@ -1254,8 +1253,8 @@ public class IFileTest {
 						// ".txt" files autodetect charset by BOM if present
 						expected = testString;
 					}
-					assertArrayEquals(target.getName(), expected.toCharArray(), allChars);
-					assertEquals(target.getName(), expected, readString);
+					assertArrayEquals(expected.toCharArray(), allChars, target.getName());
+					assertEquals(expected, readString, target.getName());
 				}
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -26,9 +26,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
@@ -41,13 +42,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IFolderTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testChangeCase() throws CoreException {
@@ -88,8 +88,8 @@ public class IFolderTest {
 		assertThrows(CoreException.class, () -> before.copy(after.getFullPath(), IResource.FORCE, createTestMonitor()));
 
 		//the destination should not exist, because the source does not exist
-		assertTrue("1.1", !before.exists());
-		assertTrue("1.2", !after.exists());
+		assertFalse(before.exists());
+		assertFalse(after.exists());
 	}
 
 	@Test
@@ -100,12 +100,12 @@ public class IFolderTest {
 		removeFromWorkspace(derived);
 
 		derived.create(IResource.DERIVED, true, createTestMonitor());
-		assertTrue("1.0", derived.isDerived());
-		assertTrue("1.1", !derived.isTeamPrivateMember());
+		assertTrue(derived.isDerived());
+		assertFalse(derived.isTeamPrivateMember());
 		derived.delete(false, createTestMonitor());
 		derived.create(IResource.NONE, true, createTestMonitor());
-		assertTrue("2.0", !derived.isDerived());
-		assertTrue("2.1", !derived.isTeamPrivateMember());
+		assertFalse(derived.isDerived());
+		assertFalse(derived.isTeamPrivateMember());
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class IFolderTest {
 
 		derived.create(IResource.FORCE | IResource.DERIVED, true, createTestMonitor());
 
-		assertTrue("2.0", verifier.isDeltaValid());
+		assertTrue(verifier.isDeltaValid());
 	}
 
 	@Test
@@ -132,13 +132,13 @@ public class IFolderTest {
 		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE | IResource.DERIVED, true, createTestMonitor());
-		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
-		assertTrue("1.1", teamPrivate.isDerived());
+		assertTrue(teamPrivate.isTeamPrivateMember());
+		assertTrue(teamPrivate.isDerived());
 
 		teamPrivate.delete(false, createTestMonitor());
 		teamPrivate.create(IResource.NONE, true, createTestMonitor());
-		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
-		assertTrue("2.1", !teamPrivate.isDerived());
+		assertFalse(teamPrivate.isTeamPrivateMember());
+		assertFalse(teamPrivate.isDerived());
 	}
 
 	@Test
@@ -149,13 +149,13 @@ public class IFolderTest {
 		removeFromWorkspace(teamPrivate);
 
 		teamPrivate.create(IResource.TEAM_PRIVATE, true, createTestMonitor());
-		assertTrue("1.0", teamPrivate.isTeamPrivateMember());
-		assertTrue("1.1", !teamPrivate.isDerived());
+		assertTrue(teamPrivate.isTeamPrivateMember());
+		assertFalse(teamPrivate.isDerived());
 
 		teamPrivate.delete(false, createTestMonitor());
 		teamPrivate.create(IResource.NONE, true, createTestMonitor());
-		assertTrue("2.0", !teamPrivate.isTeamPrivateMember());
-		assertTrue("2.1", !teamPrivate.isDerived());
+		assertFalse(teamPrivate.isTeamPrivateMember());
+		assertFalse(teamPrivate.isDerived());
 	}
 
 	@Test
@@ -165,32 +165,32 @@ public class IFolderTest {
 		createInWorkspace(project);
 
 		IFolder target = project.getFolder("Folder1");
-		assertTrue("1.0", !target.exists());
+		assertFalse(target.exists());
 		target.create(true, true, createTestMonitor());
-		assertTrue("1.1", target.exists());
+		assertTrue(target.exists());
 
 		// nested folder creation
 		IFolder nestedTarget = target.getFolder("Folder2");
-		assertTrue("2.0", !nestedTarget.exists());
+		assertFalse(nestedTarget.exists());
 		nestedTarget.create(true, true, createTestMonitor());
-		assertTrue("2.1", nestedTarget.exists());
+		assertTrue(nestedTarget.exists());
 
 		// try to create a folder that already exists
-		assertTrue("3.0", target.exists());
+		assertTrue(target.exists());
 		IFolder folderTarget = target;
 		assertThrows(CoreException.class, () -> folderTarget.create(true, true, createTestMonitor()));
-		assertTrue("3.2", target.exists());
+		assertTrue(target.exists());
 
 		// try to create a folder over a file that exists
 		IFile file = target.getFile("File1");
 		target = target.getFolder("File1");
 		file.create(createRandomContentsStream(), true, createTestMonitor());
-		assertTrue("4.0", file.exists());
+		assertTrue(file.exists());
 
 		IFolder subfolderTarget = target;
 		assertThrows(CoreException.class, () -> subfolderTarget.create(true, true, createTestMonitor()));
-		assertTrue("5.1", file.exists());
-		assertTrue("5.2", !target.exists());
+		assertTrue(file.exists());
+		assertFalse(target.exists());
 
 		// try to create a folder on a project (one segment) path
 		assertThrows(IllegalArgumentException.class,
@@ -201,20 +201,20 @@ public class IFolderTest {
 		file.create(null, true, createTestMonitor());
 
 		target = project.getFolder("File2/Folder4");
-		assertTrue("7.1", !target.exists());
+		assertFalse(target.exists());
 		IFolder nonexistentSubfolderTarget = target;
 		assertThrows(CoreException.class, () -> nonexistentSubfolderTarget.create(true, true, createTestMonitor()));
-		assertTrue("7.3", file.exists());
-		assertTrue("7.4", !target.exists());
+		assertTrue(file.exists());
+		assertFalse(target.exists());
 
 		// try to create a folder under a non-existant parent
 		IFolder folder = project.getFolder("Folder5");
 		target = folder.getFolder("Folder6");
-		assertTrue("8.0", !folder.exists());
+		assertFalse(folder.exists());
 		IFolder nonexistentFolderTarget = target;
 		assertThrows(CoreException.class, () -> nonexistentFolderTarget.create(true, true, createTestMonitor()));
-		assertTrue("8.2", !folder.exists());
-		assertTrue("8.3", !target.exists());
+		assertFalse(folder.exists());
+		assertFalse(target.exists());
 	}
 
 	@Test
@@ -259,9 +259,9 @@ public class IFolderTest {
 		IFile existing = getWorkspace().getRoot().getFile(path);
 		createInWorkspace(existing);
 		IFolder target = getWorkspace().getRoot().getFolder(path);
-		assertThrows("Should not be able to create folder over a file", CoreException.class,
-				() -> target.create(true, true, createTestMonitor()));
-		assertTrue("2.0", existing.exists());
+		assertThrows(CoreException.class, () -> target.create(true, true, createTestMonitor()),
+				"Should not be able to create folder over a file");
+		assertTrue(existing.exists());
 	}
 
 	/**
@@ -284,9 +284,9 @@ public class IFolderTest {
 
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
-			assertTrue("1.0 " + name, !folder.exists());
+			assertFalse(folder.exists(), name);
 			assertThrows(CoreException.class, () -> folder.create(true, true, createTestMonitor()));
-			assertTrue("1.2 " + name, !folder.exists());
+			assertFalse(folder.exists(), name);
 		}
 
 		//do some tests with valid names that are *almost* invalid
@@ -299,9 +299,9 @@ public class IFolderTest {
 		}
 		for (String name : names) {
 			IFolder folder = project.getFolder(name);
-			assertTrue("2.0 " + name, !folder.exists());
+			assertFalse(folder.exists(), name);
 			folder.create(true, true, createTestMonitor());
-			assertTrue("2.2 " + name, folder.exists());
+			assertTrue(folder.exists(), name);
 		}
 	}
 
@@ -331,7 +331,7 @@ public class IFolderTest {
 		source.copy(dest.getFullPath(), true, createTestMonitor());
 		assertExistsInWorkspace(dest);
 		assertExistsInWorkspace(source);
-		assertTrue("1.2", dest.isReadOnly());
+		assertTrue(dest.isReadOnly());
 
 		// cleanup - ensure that the files can be deleted.
 		source.setReadOnly(false);
@@ -351,10 +351,10 @@ public class IFolderTest {
 		createInWorkspace(target);
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
-		assertTrue("2.0", target.getPersistentProperty(name).equals(value));
+		assertTrue(target.getPersistentProperty(name).equals(value));
 		// see what happens if we get a non-existant property
 		QualifiedName nonExistentPropertyName = new QualifiedName("itp-test", "testNonProperty");
-		assertNull("2.1", target.getPersistentProperty(nonExistentPropertyName));
+		assertNull(target.getPersistentProperty(nonExistentPropertyName));
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -18,11 +18,12 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -44,35 +45,34 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests path variables.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class IPathVariableTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	IPathVariableManager manager = null;
 	IProject project = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project = getWorkspace().getRoot().getProject("MyProject");
 		project.create(createTestMonitor());
 		project.open(createTestMonitor());
-		assertTrue("1.4", project.exists());
+		assertTrue(project.exists());
 		manager = project.getPathVariableManager();
 	}
 
 	/**
 	 * Ensure there are no path variables in the workspace.
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		String[] names = manager.getPathVariableNames();
 		for (String name : names) {
@@ -200,28 +200,28 @@ public class IPathVariableTest {
 		manager.setValue("one", getRandomLocation());
 		names = manager.getPathVariableNames();
 		List<String> list = Arrays.asList(names);
-		assertTrue("1.2", list.contains("one"));
+		assertTrue(list.contains("one"));
 
 		// add another
 		manager.setValue("two", IPath.ROOT);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
-		assertTrue("2.2", list.contains("one"));
-		assertTrue("2.3", list.contains("two"));
+		assertTrue(list.contains("one"));
+		assertTrue(list.contains("two"));
 
 		// remove one
 		manager.setValue("one", (IPath) null);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
-		assertTrue("3.2", list.contains("two"));
-		assertTrue("3.3", !list.contains("one"));
+		assertTrue(list.contains("two"));
+		assertFalse(list.contains("one"));
 
 		// remove the last one
 		manager.setValue("two", (IPath) null);
 		names = manager.getPathVariableNames();
 		list = Arrays.asList(names);
-		assertTrue("4.2", !list.contains("two"));
-		assertTrue("4.3", !list.contains("one"));
+		assertFalse(list.contains("two"));
+		assertFalse(list.contains("one"));
 	}
 
 	/**
@@ -237,33 +237,33 @@ public class IPathVariableTest {
 		IPath pathOneEdit = WINDOWS ? IPath.fromOSString("D:/foobar") : IPath.fromOSString("/foobar");
 
 		// nothing to begin with
-		assertNull("0.0", manager.getValue("one"));
+		assertNull(manager.getValue("one"));
 
 		// add a value to the table
 		manager.setValue("one", pathOne);
 		IPath value = manager.getValue("one");
-		assertNotNull("1.1", value);
-		assertEquals("1.2", pathOne, value);
+		assertNotNull(value);
+		assertEquals(pathOne, value);
 
 		// add another value
 		manager.setValue("two", pathTwo);
 		value = manager.getValue("two");
-		assertNotNull("2.1", value);
-		assertEquals("2.2", pathTwo, value);
+		assertNotNull(value);
+		assertEquals(pathTwo, value);
 
 		// edit the first value
 		manager.setValue("one", pathOneEdit);
 		value = manager.getValue("one");
-		assertNotNull("3.1", value);
-		assertTrue("3.2", pathOneEdit.equals(value));
+		assertNotNull(value);
+		assertTrue(pathOneEdit.equals(value));
 
 		// setting with value == null will remove
 		manager.setValue("one", (IPath) null);
-		assertNull("4.1", manager.getValue("one"));
+		assertNull(manager.getValue("one"));
 
 		// set values with bogus names
-		assertThrows("Accepted invalid variable name in setValue()", CoreException.class,
-				() -> manager.setValue("ECLIPSE$HOME", IPath.ROOT));
+		assertThrows(CoreException.class, () -> manager.setValue("ECLIPSE$HOME", IPath.ROOT),
+				"Accepted invalid variable name in setValue()");
 
 		// set value with relative path
 		manager.setValue("one", IPath.fromOSString("foo/bar"));
@@ -272,9 +272,9 @@ public class IPathVariableTest {
 		if (WINDOWS) {
 			String invalidPathString = "C:/a/\\::/b";
 			IPath invalidPath = IPath.fromPortableString(invalidPathString);
-			assertTrue("6.0", invalidPath.isAbsolute());
-			assertTrue("6.1", !IPath.EMPTY.isValidPath(invalidPathString));
-			assertTrue("6.2", manager.validateValue(invalidPath).isOK());
+			assertTrue(invalidPath.isAbsolute());
+			assertFalse(IPath.EMPTY.isValidPath(invalidPathString));
+			assertTrue(manager.validateValue(invalidPath).isOK());
 			manager.setValue("one", invalidPath);
 		}
 
@@ -285,11 +285,11 @@ public class IPathVariableTest {
 	 */
 	@Test
 	public void testIsDefined() throws CoreException {
-		assertTrue("0.0", !manager.isDefined("one"));
+		assertFalse(manager.isDefined("one"));
 		manager.setValue("one", IPath.ROOT);
-		assertTrue("1.1", manager.isDefined("one"));
+		assertTrue(manager.isDefined("one"));
 		manager.setValue("one", (IPath) null);
-		assertTrue("2.1", !manager.isDefined("one"));
+		assertFalse(manager.isDefined("one"));
 	}
 
 	/**
@@ -310,7 +310,7 @@ public class IPathVariableTest {
 		IPath path = IPath.fromOSString("three/bar");
 		IPath expected = IPath.fromOSString("/tmp/backup/extra/bar").setDevice(WINDOWS ? "c:" : null);
 		IPath actual = manager.resolvePath(path);
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	@Test
@@ -320,7 +320,7 @@ public class IPathVariableTest {
 
 		IPath expected = projectLocation.append("bar");
 		IPath actual = manager.resolvePath(path);
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	@Test
@@ -328,7 +328,7 @@ public class IPathVariableTest {
 		IPath path = IPath.fromOSString("${ECLIPSE_HOME}/bar");
 		IPath expected = IPath.fromOSString(Platform.getInstallLocation().getURL().getPath()).append("bar");
 		IPath actual = manager.resolvePath(path);
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	@Test
@@ -336,7 +336,7 @@ public class IPathVariableTest {
 		IPath path = IPath.fromOSString("${WORKSPACE_LOC}/bar");
 		IPath expected = project.getWorkspace().getRoot().getLocation().append("bar");
 		IPath actual = manager.resolvePath(path);
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	/**
@@ -355,15 +355,15 @@ public class IPathVariableTest {
 		path = IPath.fromOSString(Platform.getInstallLocation().getURL().getPath()).append("bar");
 		expected = IPath.fromOSString("ECLIPSE_HOME/bar");
 		actual = getVariableRelativePathLocation(project, path);
-		assertEquals("2.0", expected, actual);
+		assertEquals(expected, actual);
 
 		path = project.getLocation().append("bar");
 		expected = IPath.fromOSString("PROJECT_LOC/bar");
 		actual = getVariableRelativePathLocation(project, path);
-		assertEquals("3.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = getVariableRelativePathLocation(project, IPath.fromOSString("/nonExistentPath/foo"));
-		assertEquals("4.0", null, actual);
+		assertEquals(null, actual);
 	}
 
 	private static IPath getVariableRelativePathLocation(IProject project, IPath location) {
@@ -394,40 +394,40 @@ public class IPathVariableTest {
 		IPath path = IPath.fromOSString("one/bar");
 		IPath expected = IPath.fromOSString("/testGetSetValue/foo/bar").setDevice(WINDOWS ? "C:" : null);
 		IPath actual = manager.resolvePath(path);
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// another substitution
 		path = IPath.fromOSString("two/myworld");
 		expected = IPath.fromOSString("/blort/backup/myworld");
 		expected = IPath.fromOSString(expected.toFile().getAbsolutePath());
 		actual = manager.resolvePath(path);
-		assertEquals("2.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// variable not defined
 		path = IPath.fromOSString("three/nothere");
 		expected = path;
 		actual = manager.resolvePath(path);
-		assertEquals("3.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// device
 		path = IPath.fromOSString("/one").setDevice(WINDOWS ? "C:" : null);
 		expected = path;
 		actual = manager.resolvePath(path);
-		assertEquals("4.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// device2
 		if (WINDOWS) {
 			path = IPath.fromOSString("C:two");
 			expected = path;
 			actual = manager.resolvePath(path);
-			assertEquals("5.0", expected, actual);
+			assertEquals(expected, actual);
 		}
 
 		// absolute
 		path = IPath.fromOSString("/one");
 		expected = path;
 		actual = manager.resolvePath(path);
-		assertEquals("6.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// just resolving, check if the variable stored in the manager is canonicalized
 		if (WINDOWS) {
@@ -435,12 +435,12 @@ public class IPathVariableTest {
 			expected = FileUtil.canonicalPath(pathOne);
 			actual = manager.resolvePath(path);
 			// the path stored in the manager is canonicalized, so the device id of actual will be upper case
-			assertEquals("7.0", expected, actual);
+			assertEquals(expected, actual);
 		}
 
 		// null
 		path = null;
-		assertNull("7.0", manager.resolvePath(path));
+		assertNull(manager.resolvePath(path));
 
 	}
 
@@ -465,50 +465,50 @@ public class IPathVariableTest {
 
 		IPath actual = convertToRelative(manager, file, false, "ONE");
 		IPath expected = file;
-		assertEquals("1.0", expected, actual);
+		assertEquals(expected, actual);
 
 		manager.setValue("TWO", pathTwo);
 		actual = convertToRelative(manager, file, false, "ONE");
 
 		expected = file;
-		assertEquals("2.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = convertToRelative(manager, file, false, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
-		assertEquals("3.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// force the path to be relative to "ONE"
 		actual = convertToRelative(manager, file, true, "ONE");
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
-		assertEquals("4.0", expected, actual);
+		assertEquals(expected, actual);
 
 		// the second time should be re-using "FOO"
 		actual = convertToRelative(manager, file, true, "ONE");
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
-		assertEquals("5.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = convertToRelative(manager, file, true, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
-		assertEquals("6.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = convertToRelative(manager, file, true, "TWO");
 		expected = IPath.fromOSString("TWO/file.txt");
-		assertEquals("7.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = convertToRelative(manager, file, false, null);
 		expected = IPath.fromOSString("TWO/file.txt");
-		assertEquals("8.0", expected, actual);
+		assertEquals(expected, actual);
 
 		manager.setValue("TWO", (IPath) null);
 
 		// now without any direct reference
 		actual = convertToRelative(manager, file, false, null);
 		expected = file;
-		assertEquals("9.0", expected, actual);
+		assertEquals(expected, actual);
 
 		actual = convertToRelative(manager, file, true, null);
 		expected = IPath.fromOSString("PARENT-1-ONE/other/file.txt");
-		assertEquals("10.0", expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	/**
@@ -517,17 +517,17 @@ public class IPathVariableTest {
 	@Test
 	public void testValidateName() {
 		// valid names
-		assertTrue("0.0", manager.validateName("ECLIPSEHOME").isOK());
-		assertTrue("0.1", manager.validateName("ECLIPSE_HOME").isOK());
-		assertTrue("0.2", manager.validateName("ECLIPSE_HOME_1").isOK());
-		assertTrue("0.3", manager.validateName("_").isOK());
+		assertTrue(manager.validateName("ECLIPSEHOME").isOK());
+		assertTrue(manager.validateName("ECLIPSE_HOME").isOK());
+		assertTrue(manager.validateName("ECLIPSE_HOME_1").isOK());
+		assertTrue(manager.validateName("_").isOK());
 
 		// invalid names
-		assertTrue("1.0", !manager.validateName("1FOO").isOK());
-		assertTrue("1.1", !manager.validateName("FOO%BAR").isOK());
-		assertTrue("1.2", !manager.validateName("FOO$BAR").isOK());
-		assertTrue("1.3", !manager.validateName(" FOO").isOK());
-		assertTrue("1.4", !manager.validateName("FOO ").isOK());
+		assertFalse(manager.validateName("1FOO").isOK());
+		assertFalse(manager.validateName("FOO%BAR").isOK());
+		assertFalse(manager.validateName("FOO$BAR").isOK());
+		assertFalse(manager.validateName(" FOO").isOK());
+		assertFalse(manager.validateName("FOO ").isOK());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,21 +34,20 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.internal.builders.CustomTriggerBuilder;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests protocol of IProjectDescription and other specified behavior
  * that relates to the project description.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class IProjectDescriptionTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testDescriptionConstant() {
-		assertEquals("1.0", ".project", IProjectDescription.DESCRIPTION_FILE_NAME);
+		assertEquals(".project", IProjectDescription.DESCRIPTION_FILE_NAME);
 	}
 
 	/**
@@ -60,7 +59,7 @@ public class IProjectDescriptionTest {
 		createInWorkspace(project);
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		assertTrue("1.0", descriptionFile.exists());
+		assertTrue(descriptionFile.exists());
 
 		// Add a builder to the build command.
 		IProjectDescription desc = project.getDescription();
@@ -72,7 +71,7 @@ public class IProjectDescriptionTest {
 		project.build(IncrementalProjectBuilder.FULL_BUILD, null);
 
 		// Get a non-cloned version of the project desc build spec, and check for the builder
-		assertTrue("2.0", ((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
+		assertTrue(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
 
 		// Now reset the build command. The builder shouldn't disappear.
 		desc = project.getDescription();
@@ -80,7 +79,7 @@ public class IProjectDescriptionTest {
 		project.setDescription(desc, null);
 
 		// builder should still be there
-		assertTrue("3.0", ((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
+		assertTrue(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
 	}
 
 	/**
@@ -94,7 +93,7 @@ public class IProjectDescriptionTest {
 		IProject target2 = getWorkspace().getRoot().getProject("target2");
 		createInWorkspace(project);
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
-		assertTrue("1.0", descriptionFile.exists());
+		assertTrue(descriptionFile.exists());
 
 		long timestamp = descriptionFile.getLocalTimeStamp();
 
@@ -113,14 +112,14 @@ public class IProjectDescriptionTest {
 		project.setDescription(description, IResource.NONE, null);
 
 		//the timestamp should be the same
-		assertEquals("2.0", timestamp, descriptionFile.getLocalTimeStamp());
+		assertEquals(timestamp, descriptionFile.getLocalTimeStamp());
 
 		//adding a dynamic reference should not dirty the file
 		description = project.getDescription();
 		description.setDynamicReferences(new IProject[] { target1, target2 });
 		project.setDescription(description, IResource.NONE, null);
 
-		assertEquals("2.1", timestamp, descriptionFile.getLocalTimeStamp());
+		assertEquals(timestamp, descriptionFile.getLocalTimeStamp());
 	}
 
 	/**
@@ -154,7 +153,7 @@ public class IProjectDescriptionTest {
 		description.setBuildSpec(new ICommand[] { command });
 		project.setDescription(description, IResource.NONE, null);
 
-		assertTrue("3.0", modificationStamp != projectDescription.getModificationStamp());
+		assertTrue(modificationStamp != projectDescription.getModificationStamp());
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_092108.java
@@ -21,17 +21,15 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that obtaining file info works on the root directory on windows.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class Bug_092108 {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testBug() throws CoreException {


### PR DESCRIPTION
- Remove obsolete assertion messages
- Use JUnit 5 test annotations
- Migrate assertions to JUnit 5
- Replace test rules with according test extensions