### PR TITLE
Migrate external tool tests to JUnit 5

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/BuilderCoreUtilsTests.java
@@ -13,20 +13,26 @@
  *******************************************************************************/
 package org.eclipse.ant.tests.ui.externaltools;
 
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.EXT_BUILD_FILE_NAME;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.createBuildCommand;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.createExternalToolBuilder;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.createExternalToolBuilderWorkingCopy;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.get20AntArgumentMap;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getBuildFile;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getLaunchManager;
 import static org.eclipse.ant.tests.ui.testplugin.AntUITestUtil.getProject;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.ant.internal.launching.AntLaunchingUtil;
 import org.eclipse.ant.launching.IAntLaunchConstants;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.externaltools.internal.model.BuilderCoreUtils;
 import org.eclipse.core.resources.ICommand;
@@ -34,8 +40,8 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BuilderCoreUtils}
@@ -43,12 +49,11 @@ import org.junit.Test;
  * @since 3.5.100 org.eclipse.ant.tests.ui
  */
 @SuppressWarnings("restriction")
-public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
+@AntUITest
+public class BuilderCoreUtilsTests {
 
-	@Before
-	@Override
+	@BeforeEach
 	public void setUp() throws Exception {
-		super.setUp();
 		// create the external tool builder dir
 		BuilderCoreUtils.getBuilderFolder(getProject(), true);
 	}
@@ -62,7 +67,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	public void testConfigFromBuildCommandArgs1() throws Exception {
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), new HashMap<>(), new String[] {
 				BuilderCoreUtils.VERSION_1_0 });
-		assertNull("There should be no configuration returned without the config handle and arguments", config); //$NON-NLS-1$
+		assertNull(config, "There should be no configuration returned without the config handle and arguments"); //$NON-NLS-1$
 	}
 
 	/**
@@ -74,7 +79,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	public void testConfigFromBuildCommandArgs2() throws Exception {
 		Map<String, String> args = get20AntArgumentMap();
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNotNull("There should be a migrated configuration returned", config); //$NON-NLS-1$
+		assertNotNull(config, "There should be a migrated configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -87,7 +92,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "foo"); //$NON-NLS-1$
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNull("There should be no configuration returned", config); //$NON-NLS-1$
+		assertNull(config, "There should be no configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -102,7 +107,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "/.externalToolBuilders/testConfigFromBuildCommandArgs4.launch"); //$NON-NLS-1$
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNull("There should be no configuration returned", config); //$NON-NLS-1$
+		assertNull(config, "There should be no configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -117,7 +122,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "testConfigFromBuildCommandArgs5.launch"); //$NON-NLS-1$
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNotNull("There should be a configuration returned", config); //$NON-NLS-1$
+		assertNotNull(config, "There should be a configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -132,7 +137,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "<project>/testConfigFromBuildCommandArgs6.launch"); //$NON-NLS-1$
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNull("There should be no configuration returned", config); //$NON-NLS-1$
+		assertNull(config, "There should be no configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -146,7 +151,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		args.put(BuilderCoreUtils.LAUNCH_CONFIG_HANDLE, "<project>/.externalToolBuilders/testConfigFromBuildCommandArgs7.launch"); //$NON-NLS-1$
 		ILaunchConfiguration config = BuilderCoreUtils.configFromBuildCommandArgs(getProject(), args, new String[] { BuilderCoreUtils.VERSION_2_1 });
-		assertNotNull("There should be a configuration returned", config); //$NON-NLS-1$
+		assertNotNull(config, "There should be a configuration returned"); //$NON-NLS-1$
 	}
 
 	/**
@@ -162,12 +167,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_FULL);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers1", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building FULL builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD),
+				"the command must be building FULL builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - null given for target names", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - null given for target names"); //$NON-NLS-1$
 	}
 
 	/**
@@ -183,12 +189,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_FULL);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers2", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building FULL builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD),
+				"the command must be building FULL builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -206,13 +213,15 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_INCREMENTAL);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers3", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building INCREMENTAL builds", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building FULL builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD),
+				"the command must be building INCREMENTAL builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD),
+				"the command must be building FULL builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - null given for target names", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - null given for target names"); //$NON-NLS-1$
 	}
 
 	/**
@@ -230,13 +239,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_INCREMENTAL);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers4", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building INCREMENTAL builds", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building FULL builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD), "the command must be building INCREMENTAL builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD), "the command must be building FULL builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -252,12 +261,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_AUTO);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers5", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building AUTO builds", command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD),
+				"the command must be building AUTO builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - null given for target names", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - null given for target names"); //$NON-NLS-1$
 	}
 
 	/**
@@ -273,12 +283,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_AUTO);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers6", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building AUTO builds", command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD),
+				"the command must be building AUTO builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -294,12 +305,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_CLEAN);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers7", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - null given for target names", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - null given for target names"); //$NON-NLS-1$
 	}
 
 	/**
@@ -315,12 +327,13 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_LOCATION, getBuildFile(EXT_BUILD_FILE_NAME).getAbsolutePath());
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_CLEAN);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers6", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -339,13 +352,15 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, IExternalToolConstants.BUILD_TYPE_CLEAN + "," //$NON-NLS-1$
 				+ IExternalToolConstants.BUILD_TYPE_INCREMENTAL);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers9", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -369,15 +384,19 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 				IExternalToolConstants.BUILD_TYPE_FULL;
 		args.put(IExternalToolConstants.ATTR_RUN_BUILD_KINDS, kinds);
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testConfigureTriggers10", args); //$NON-NLS-1$
-		assertNotNull("the test builder must not be null", config); //$NON-NLS-1$
+		assertNotNull(config, "the test builder must not be null"); //$NON-NLS-1$
 		ICommand command = createBuildCommand(config);
-		assertNotNull("the test build command must not be null", command); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.FULL_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD)); //$NON-NLS-1$
-		assertTrue("the command must be building CLEAN builds", command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD)); //$NON-NLS-1$
+		assertNotNull(command, "the test build command must not be null"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.FULL_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.INCREMENTAL_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.CLEAN_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
+		assertTrue(command.isBuilding(IncrementalProjectBuilder.AUTO_BUILD),
+				"the command must be building CLEAN builds"); //$NON-NLS-1$
 		String[] names = AntLaunchingUtil.getTargetNames(config);
-		assertNull("should be no target names resolved from the config - only available during a build", names); //$NON-NLS-1$
+		assertNull(names, "should be no target names resolved from the config - only available during a build"); //$NON-NLS-1$
 	}
 
 	/**
@@ -389,7 +408,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 				.getLaunchConfigurationType(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE);
 		if (type != null) {
 			ILaunchConfigurationWorkingCopy config = type.newInstance(BuilderCoreUtils.getBuilderFolder(getProject(), true), "testIsUnmigratedConfig1"); //$NON-NLS-1$
-			assertTrue("should be considered 'unmigrated'", BuilderCoreUtils.isUnmigratedConfig(config)); //$NON-NLS-1$
+			assertTrue(BuilderCoreUtils.isUnmigratedConfig(config), "should be considered 'unmigrated'"); //$NON-NLS-1$
 		} else {
 			fail("could not find the Ant builder launch configuration type"); //$NON-NLS-1$
 		}
@@ -401,7 +420,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	@Test
 	public void testIsUnmigratedConfig2() throws Exception {
 		ILaunchConfiguration config = createExternalToolBuilder(getProject(), "testIsUnmigratedConfig2", null); //$NON-NLS-1$
-		assertFalse("Shoudl not be considered 'unmigrated'", BuilderCoreUtils.isUnmigratedConfig(config)); //$NON-NLS-1$
+		assertFalse(BuilderCoreUtils.isUnmigratedConfig(config), "Should not be considered 'unmigrated'"); //$NON-NLS-1$
 	}
 
 	/**
@@ -415,7 +434,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 	public void testToBuildCommand1() throws Exception {
 		ILaunchConfigurationWorkingCopy copy = createExternalToolBuilderWorkingCopy(getProject(), "testToBuildCommand1", null); //$NON-NLS-1$
 		ICommand command = BuilderCoreUtils.toBuildCommand(getProject(), copy, getProject().getDescription().newCommand());
-		assertNotNull("There should have been a new build command created", command); //$NON-NLS-1$
+		assertNotNull(command, "There should have been a new build command created"); //$NON-NLS-1$
 	}
 
 	/**
@@ -430,7 +449,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		ILaunchConfiguration copy = createExternalToolBuilder(getProject(), "testToBuildCommand2", args); //$NON-NLS-1$
 		ICommand command = BuilderCoreUtils.toBuildCommand(getProject(), copy, getProject().getDescription().newCommand());
-		assertNotNull("There should have been a new build command created", command); //$NON-NLS-1$
+		assertNotNull(command, "There should have been a new build command created"); //$NON-NLS-1$
 	}
 
 	/**
@@ -445,7 +464,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 		Map<String, String> args = new HashMap<>();
 		ILaunchConfiguration copy = createExternalToolBuilder(getProject(), "testToBuildCommand3", args); //$NON-NLS-1$
 		ICommand command = BuilderCoreUtils.toBuildCommand(getProject(), copy.getWorkingCopy(), getProject().getDescription().newCommand());
-		assertNotNull("There should have been a new build command created", command); //$NON-NLS-1$
+		assertNotNull(command, "There should have been a new build command created"); //$NON-NLS-1$
 	}
 
 	/**
@@ -458,7 +477,7 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 				IExternalToolConstants.BUILD_TYPE_AUTO + "," + //$NON-NLS-1$
 				IExternalToolConstants.BUILD_TYPE_FULL;
 		int[] array = BuilderCoreUtils.buildTypesToArray(kinds);
-		assertNotNull("The build kinds array cannot be null", array); //$NON-NLS-1$
+		assertNotNull(array, "The build kinds array cannot be null"); //$NON-NLS-1$
 		boolean contains = true;
 		for (int element : array) {
 			contains &= (element == IncrementalProjectBuilder.AUTO_BUILD) || (element == IncrementalProjectBuilder.CLEAN_BUILD) || (element == IncrementalProjectBuilder.FULL_BUILD) || (element == IncrementalProjectBuilder.INCREMENTAL_BUILD);
@@ -466,6 +485,6 @@ public class BuilderCoreUtilsTests extends AbstractExternalToolTest {
 				break;
 			}
 		}
-		assertTrue("All of the build kinds should have been found", contains); //$NON-NLS-1$
+		assertTrue(contains, "All of the build kinds should have been found"); //$NON-NLS-1$
 	}
 }

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/ExternalToolTestUtil.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/ExternalToolTestUtil.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.ant.launching.IAntLaunchConstants;
-import org.eclipse.ant.tests.ui.testplugin.AbstractAntUITest;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.externaltools.internal.model.BuilderCoreUtils;
 import org.eclipse.core.externaltools.internal.registry.ExternalToolMigration;
@@ -40,9 +39,12 @@ import junit.framework.Test;
  * @since 3.5.100 org.eclipse.ant.tests.ui
  */
 @SuppressWarnings("restriction")
-public abstract class AbstractExternalToolTest extends AbstractAntUITest {
+public final class ExternalToolTestUtil {
 
 	static final String EXT_BUILD_FILE_NAME = "ext-builders.xml"; //$NON-NLS-1$
+
+	private ExternalToolTestUtil() {
+	}
 
 	/**
 	 * Creates a new external tool builder for the given project from the given {@link ILaunchConfiguration}
@@ -55,7 +57,8 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *            the argument map to set in the new configuration
 	 * @return a new Ant build {@link ILaunchConfiguration} or <code>null</code>
 	 */
-	protected ILaunchConfiguration createExternalToolBuilder(IProject project, String name, Map<String, ? extends Object> args) throws Exception {
+	public static ILaunchConfiguration createExternalToolBuilder(IProject project, String name,
+			Map<String, ? extends Object> args) throws Exception {
 		IFolder dir = project.getFolder(BuilderCoreUtils.BUILDER_FOLDER_NAME);
 		if (!dir.exists()) {
 			dir.create(true, true, null);
@@ -73,7 +76,8 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	/**
 	 * Creates a new external tool Ant build configuration that has never been saved
 	 */
-	protected ILaunchConfigurationWorkingCopy createExternalToolBuilderWorkingCopy(IProject project, String name, Map<String, Object> args) throws Exception {
+	public static ILaunchConfigurationWorkingCopy createExternalToolBuilderWorkingCopy(IProject project, String name,
+			Map<String, Object> args) throws Exception {
 		IFolder dir = project.getFolder(BuilderCoreUtils.BUILDER_FOLDER_NAME);
 		if (!dir.exists()) {
 			dir.create(true, true, null);
@@ -93,7 +97,7 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *
 	 * @return the new builder {@link ICommand}
 	 */
-	protected ICommand createBuildCommand(ILaunchConfiguration config) throws Exception {
+	public static ICommand createBuildCommand(ILaunchConfiguration config) throws Exception {
 		return BuilderUtils.commandFromLaunchConfig(getProject(), config);
 	}
 
@@ -102,7 +106,7 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *
 	 * @return a map of 2.0 arguments for an Ant buildfile.
 	 */
-	protected Map<String, String> get20AntArgumentMap() {
+	public static Map<String, String> get20AntArgumentMap() {
 		HashMap<String, String> arguments = new HashMap<>();
 		arguments.put(ExternalToolMigration.TAG_VERSION, "2.0"); //$NON-NLS-1$
 		arguments.put(ExternalToolMigration.TAG_TOOL_TYPE, "org.eclipse.ui.externaltools.type.ant"); //$NON-NLS-1$
@@ -122,7 +126,7 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *
 	 * @return a map of 2.0 arguments for a program
 	 */
-	protected Map<String, String> get20ProgramArgumentMap() {
+	public static Map<String, String> get20ProgramArgumentMap() {
 		HashMap<String, String> arguments = new HashMap<>();
 		arguments.put(ExternalToolMigration.TAG_VERSION, "2.0"); //$NON-NLS-1$
 		arguments.put(ExternalToolMigration.TAG_TOOL_TYPE, "org.eclipse.ui.externaltools.type.program"); //$NON-NLS-1$
@@ -142,7 +146,7 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *
 	 * @return a map of 2.1 arguments for an Ant buildfile
 	 */
-	protected Map<String, String> get21AntArgumentMap() {
+	public static Map<String, String> get21AntArgumentMap() {
 		HashMap<String, String> arguments = new HashMap<>();
 		arguments.put(ExternalToolMigration.TAG_VERSION, "2.1"); //$NON-NLS-1$
 		arguments.put(ExternalToolMigration.TAG_NAME, "ant config"); //$NON-NLS-1$
@@ -167,7 +171,7 @@ public abstract class AbstractExternalToolTest extends AbstractAntUITest {
 	 *
 	 * @return a map of 2.1 arguments for a program
 	 */
-	protected Map<String, String> get21ProgramArgumentMap() {
+	public static Map<String, String> get21ProgramArgumentMap() {
 		HashMap<String, String> arguments = new HashMap<>();
 		arguments.put(ExternalToolMigration.TAG_VERSION, "2.1"); //$NON-NLS-1$
 		arguments.put(ExternalToolMigration.TAG_NAME, "program config"); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
+++ b/ant/org.eclipse.ant.tests.ui/External Tools/org/eclipse/ant/tests/ui/externaltools/MigrationTests.java
@@ -14,13 +14,18 @@
 package org.eclipse.ant.tests.ui.externaltools;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.get20AntArgumentMap;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.get20ProgramArgumentMap;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.get21AntArgumentMap;
+import static org.eclipse.ant.tests.ui.externaltools.ExternalToolTestUtil.get21ProgramArgumentMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Map;
 
 import org.eclipse.ant.internal.launching.AntLaunchingUtil;
 import org.eclipse.ant.launching.IAntLaunchConstants;
+import org.eclipse.ant.tests.ui.testplugin.AntUITest;
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.externaltools.internal.registry.ExternalToolMigration;
 import org.eclipse.core.runtime.CoreException;
@@ -28,13 +33,14 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.debug.ui.RefreshTab;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests migration of Ant and External Tool configurations from old formats to the current format.
  */
 @SuppressWarnings("restriction")
-public class MigrationTests extends AbstractExternalToolTest {
+@AntUITest
+public class MigrationTests {
 
 	/**
 	 * Tests migration of arguments from an Eclipse 2.0 Ant buildfile configuration to a current launch configuration.
@@ -43,14 +49,14 @@ public class MigrationTests extends AbstractExternalToolTest {
 	public void test20AntMigration() throws CoreException {
 		Map<String, String> argumentMap = get20AntArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
-		assertNotNull("Migration failed", config); //$NON-NLS-1$
+		assertNotNull(config, "Migration failed"); //$NON-NLS-1$
 
-		assertEquals("Wrong configuration type", IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier()); //$NON-NLS-1$
+		assertEquals(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier(), "Wrong configuration type"); //$NON-NLS-1$
 		assertEquals("ant tool", config.getName()); //$NON-NLS-1$
 		assertEquals("location", config.getAttribute(IExternalToolConstants.ATTR_LOCATION, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("refresh scope", config.getAttribute(RefreshTab.ATTR_REFRESH_SCOPE, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		String[] targets = AntLaunchingUtil.getTargetNames(config);
-		assertNotNull("No targets found", targets); //$NON-NLS-1$
+		assertNotNull(targets, "No targets found"); //$NON-NLS-1$
 		assertThat(targets).containsExactly("target1", "target2"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals(true, config.getAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, false));
 		assertEquals(true, config.getAttribute(IDebugUIConstants.ATTR_LAUNCH_IN_BACKGROUND, false));
@@ -66,7 +72,8 @@ public class MigrationTests extends AbstractExternalToolTest {
 	public void test20ProgramMigration() throws CoreException {
 		Map<String, String> argumentMap = get20ProgramArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
-		assertEquals("Wrong configuration type", IExternalToolConstants.ID_PROGRAM_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier()); //$NON-NLS-1$
+		assertEquals(IExternalToolConstants.ID_PROGRAM_BUILDER_LAUNCH_CONFIGURATION_TYPE,
+				config.getType().getIdentifier(), "Wrong configuration type"); //$NON-NLS-1$
 		assertEquals("program tool", config.getName()); //$NON-NLS-1$
 		assertEquals("location", config.getAttribute(IExternalToolConstants.ATTR_LOCATION, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("refresh scope", config.getAttribute(RefreshTab.ATTR_REFRESH_SCOPE, "")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -84,9 +91,10 @@ public class MigrationTests extends AbstractExternalToolTest {
 	public void test21AntMigration() throws CoreException {
 		Map<String, String> argumentMap = get21AntArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
-		assertNotNull("Migration failed", config); //$NON-NLS-1$
+		assertNotNull(config, "Migration failed"); //$NON-NLS-1$
 
-		assertEquals("Wrong config type", IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier()); //$NON-NLS-1$
+		assertEquals(IAntLaunchConstants.ID_ANT_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier(),
+				"Wrong config type"); //$NON-NLS-1$
 		assertEquals("ant config", config.getName()); //$NON-NLS-1$
 		assertEquals("location", config.getAttribute(IExternalToolConstants.ATTR_LOCATION, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("working directory", config.getAttribute(IExternalToolConstants.ATTR_WORKING_DIRECTORY, "")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -109,9 +117,10 @@ public class MigrationTests extends AbstractExternalToolTest {
 	public void test21ProgramMigration() throws CoreException {
 		Map<String, String> argumentMap = get21ProgramArgumentMap();
 		ILaunchConfigurationWorkingCopy config = ExternalToolMigration.configFromArgumentMap(argumentMap);
-		assertNotNull("Migration failed", config); //$NON-NLS-1$
+		assertNotNull(config, "Migration failed"); //$NON-NLS-1$
 
-		assertEquals("Wrong config type", IExternalToolConstants.ID_PROGRAM_BUILDER_LAUNCH_CONFIGURATION_TYPE, config.getType().getIdentifier()); //$NON-NLS-1$
+		assertEquals(IExternalToolConstants.ID_PROGRAM_BUILDER_LAUNCH_CONFIGURATION_TYPE,
+				config.getType().getIdentifier(), "Wrong config type"); //$NON-NLS-1$
 		assertEquals("program config", config.getName()); //$NON-NLS-1$
 		assertEquals("location", config.getAttribute(IExternalToolConstants.ATTR_LOCATION, "")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("working directory", config.getAttribute(IExternalToolConstants.ATTR_WORKING_DIRECTORY, "")); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
- Convert AbstractExternalToolTest into ExternalToolTestUtil class
- Use JUnit 5 test annotations
- Migrate assertions to JUnit 5