### PR TITLE
Clean up resource tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -642,133 +642,6 @@ public class CharsetTest {
 			assertTrue(isDerivedEncodingStoredSeparately(project1));
 			assertTrue(derivedPrefs.isDerived());
 
-			//			//8 - manually changing preference 'true'->'false'
-			//			verifier.reset();
-			//			backgroundVerifier.reset();
-			//			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			//			backgroundVerifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(new IResource[] {project1, a1, b1, a, regularPrefs.getParent(), regularPrefs}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.REMOVED, 0);
-			//			assertTrue("7.99", isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				regularPrefs.setContents(new ByteArrayInputStream(SAMPLE_DERIVED_ENCODING_TO_FALSE_REGULAR_PREFS.getBytes()), 0, getMonitor());
-			//			} catch (CoreException e) {
-			//				fail("8.0", e);
-			//			}
-			//			assertTrue("8.1.1", verifier.waitForEvent(10000));
-			//			assertTrue("8.1.2", backgroundVerifier.waitForEvent(10000));
-			//			assertTrue("8.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			//			assertTrue("8.2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			//			assertExistsInWorkspace("8.3", regularPrefs);
-			//			//checkPreferencesContent("8.3.1", regularPrefs, SAMPLE_DERIVED_ENCODING_AFTER_FALSE_REGULAR_PREFS);
-			//			assertDoesNotExistInWorkspace("8.4", derivedPrefs);
-			//			assertTrue("8.5", !isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				assertCharsetIs("8.6", "UTF-8", new IResource[] {a}, true);
-			//			} catch (CoreException e) {
-			//				fail("8.6.1", e);
-			//			}
-			//
-			//			//9 - manually changing preference 'false'->'true'
-			//			verifier.reset();
-			//			backgroundVerifier.reset();
-			//			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			//			//backgroundVerifier.addExpectedChange(new IResource[] {project1, a1, b1, a, regularPrefs.getParent(), regularPrefs}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.ADDED, 0);
-			//			assertDoesNotExistInWorkspace("8.98", derivedPrefs);
-			//			assertTrue("8.99", !isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				regularPrefs.setContents(new ByteArrayInputStream(SAMPLE_DERIVED_ENCODING_TO_TRUE_REGULAR_PREFS.getBytes()), 0, getMonitor());
-			//			} catch (CoreException e) {
-			//				fail("9.0", e);
-			//			}
-			//			assertTrue("9.1.1", verifier.waitForEvent(10000));
-			//			assertTrue("9.1.2", backgroundVerifier.waitForEvent(10000));
-			//			assertTrue("9.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			//			assertTrue("9.2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			//			//updating prefs is run in separate job so wait some time for completion
-			//			backgroundVerifier.waitForEvent(10000);
-			//			assertExistsInWorkspace("9.3", regularPrefs);
-			//			//checkPreferencesContent("9.3.1", regularPrefs, SAMPLE_DERIVED_ENCODING_AFTER_TRUE_REGULAR_PREFS);
-			//			assertExistsInWorkspace("9.4", derivedPrefs);
-			//			checkPreferencesContent("9.4.1", derivedPrefs, SAMPLE_DERIVED_ENCODING_AFTER_TRUE_DERIVED_PREFS);
-			//			assertTrue("9.5", isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				assertCharsetIs("9.6", "UTF-8", new IResource[] {a}, true);
-			//			} catch (CoreException e) {
-			//				fail("9.6.1", e);
-			//			}
-			//			assertTrue("9.7", derivedPrefs.isDerived());
-			//
-			//			//10 - manually changing preference 'true'->'false' outside Eclipse
-			//			verifier.reset();
-			//			backgroundVerifier.reset();
-			//			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			//			backgroundVerifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(new IResource[] {project1, a1, b1, a, regularPrefs.getParent(), regularPrefs}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.REMOVED, 0);
-			//			assertTrue("9.99", isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				File file = regularPrefs.getLocation().toFile();
-			//				BufferedWriter bw = new BufferedWriter(new FileWriter(file));
-			//				bw.write(SAMPLE_DERIVED_ENCODING_TO_FALSE_REGULAR_PREFS);
-			//				bw.close();
-			//				regularPrefs.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-			//			} catch (IOException e) {
-			//				fail("10.0.1", e);
-			//			} catch (CoreException e) {
-			//				fail("10.0.2", e);
-			//			}
-			//			assertTrue("10.1.1", verifier.waitForEvent(10000));
-			//			assertTrue("10.1.2", backgroundVerifier.waitForEvent(10000));
-			//			assertTrue("10.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			//			assertTrue("10.2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			//			assertExistsInWorkspace("10.3", regularPrefs);
-			//			//checkPreferencesContent("10.3.1", regularPrefs, SAMPLE_DERIVED_ENCODING_AFTER_FALSE_REGULAR_PREFS);
-			//			assertDoesNotExistInWorkspace("10.4", derivedPrefs);
-			//			assertTrue("10.5", !isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				assertCharsetIs("10.6", "UTF-8", new IResource[] {a}, true);
-			//			} catch (CoreException e) {
-			//				fail("10.6.1", e);
-			//			}
-			//
-			//			//11 - manually changing preference 'false'->'true' outside Eclipse
-			//			verifier.reset();
-			//			backgroundVerifier.reset();
-			//			verifier.addExpectedChange(regularPrefs, IResourceDelta.CHANGED, IResourceDelta.CONTENT);
-			//			//backgroundVerifier.addExpectedChange(new IResource[] {project1, a1, b1, a, regularPrefs.getParent(), regularPrefs}, IResourceDelta.CHANGED, IResourceDelta.ENCODING);
-			//			backgroundVerifier.addExpectedChange(derivedPrefs, IResourceDelta.ADDED, 0);
-			//			assertDoesNotExistInWorkspace("10.98", derivedPrefs);
-			//			assertTrue("10.99", !isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				File file = regularPrefs.getLocation().toFile();
-			//				BufferedWriter bw = new BufferedWriter(new FileWriter(file));
-			//				bw.write(SAMPLE_DERIVED_ENCODING_TO_TRUE_REGULAR_PREFS);
-			//				bw.close();
-			//				regularPrefs.refreshLocal(IResource.DEPTH_ZERO, getMonitor());
-			//			} catch (IOException e) {
-			//				fail("11.0.1", e);
-			//			} catch (CoreException e) {
-			//				fail("11.0.2", e);
-			//			}
-			//			assertTrue("11.1.1", verifier.waitForEvent(10000));
-			//			assertTrue("11.1.2", backgroundVerifier.waitForEvent(10000));
-			//			assertTrue("11.2.1 " + verifier.getMessage(), verifier.isDeltaValid());
-			//			assertTrue("11.2.2 " + backgroundVerifier.getMessage(), backgroundVerifier.isDeltaValid());
-			//			//updating prefs is run in separate job so wait some time for completion
-			//			backgroundVerifier.waitForEvent(10000);
-			//			assertExistsInWorkspace("11.3", regularPrefs);
-			//			//checkPreferencesContent("11.3.1", regularPrefs, SAMPLE_DERIVED_ENCODING_AFTER_TRUE_REGULAR_PREFS);
-			//			assertExistsInWorkspace("11.4", derivedPrefs);
-			//			checkPreferencesContent("11.4.1", derivedPrefs, SAMPLE_DERIVED_ENCODING_AFTER_TRUE_DERIVED_PREFS);
-			//			assertTrue("11.5", isDerivedEncodingStoredSeparately(project1));
-			//			try {
-			//				assertCharsetIs("11.6", "UTF-8", new IResource[] {a}, true);
-			//			} catch (CoreException e) {
-			//				fail("11.6.1", e);
-			//			}
-			//			assertTrue("11.7", derivedPrefs.isDerived());
 		} finally {
 			workspace.removeResourceChangeListener(verifier);
 			backgroundVerifier.removeResourceChangeListeners();
@@ -1607,6 +1480,7 @@ public class CharsetTest {
 						failMessage.append("verifier.isValidDelta(): " + isValidDelta);
 						failMessage.append(System.lineSeparator());
 						failMessage.append(deltaVerifier.getMessage());
+						failMessage.append(System.lineSeparator());
 					}
 					assertTrue(failMessage.toString(), validDeltas);
 				}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,7 +72,7 @@ public class IProjectDescriptionTest {
 		project.build(IncrementalProjectBuilder.FULL_BUILD, null);
 
 		// Get a non-cloned version of the project desc build spec, and check for the builder
-		assertTrue(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
+		assertNotNull(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders());
 
 		// Now reset the build command. The builder shouldn't disappear.
 		desc = project.getDescription();
@@ -79,7 +80,7 @@ public class IProjectDescriptionTest {
 		project.setDescription(desc, null);
 
 		// builder should still be there
-		assertTrue(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders() != null);
+		assertNotNull(((BuildCommand) project.internalGetDescription().getBuildSpec(false)[0]).getBuilders());
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -122,11 +122,11 @@ public class IProjectTest  {
 		project.createMarker(IMarker.TASK);
 		IProject destination = getWorkspace().getRoot().getProject("Destination");
 
-		assertFalse("1.0", destination.exists());
+		assertFalse(destination.exists());
 		monitor.prepare();
 		project.copy(destination.getFullPath(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.1", destination.exists());
+		assertTrue(destination.exists());
 		assertThat(destination.findMarkers(IMarker.TASK, true, IResource.DEPTH_INFINITE)).isEmpty();
 	}
 
@@ -151,9 +151,9 @@ public class IProjectTest  {
 		project.open(monitor);
 		monitor.assertUsedUp();
 		//getNature on open project with no natures
-		assertNull("3.0", project.getNature(NATURE_SIMPLE));
-		assertNull("3.1", project.getNature(NATURE_MISSING));
-		assertNull("3.2", project.getNature(NATURE_EARTH));
+		assertNull(project.getNature(NATURE_SIMPLE));
+		assertNull(project.getNature(NATURE_MISSING));
+		assertNull(project.getNature(NATURE_EARTH));
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_SIMPLE });
 		monitor.prepare();
@@ -161,10 +161,10 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 		//getNature on open project with natures
 		IProjectNature nature = project.getNature(NATURE_SIMPLE);
-		assertNotNull("5.0", nature);
-		assertNull("5.1", project.getNature(NATURE_MISSING));
-		assertNull("5.2", project.getNature(NATURE_EARTH));
-		assertEquals("6.0", project, nature.getProject());
+		assertNotNull(nature);
+		assertNull(project.getNature(NATURE_MISSING));
+		assertNull(project.getNature(NATURE_EARTH));
+		assertEquals(project, nature.getProject());
 
 		//ensure nature is preserved on copy
 		IProject project2 = getWorkspace().getRoot().getProject("testGetNature.Destination");
@@ -173,9 +173,9 @@ public class IProjectTest  {
 		project.copy(project2.getFullPath(), IResource.NONE, monitor);
 		monitor.assertUsedUp();
 		nature2 = project2.getNature(NATURE_SIMPLE);
-		assertNotNull("7.0", nature2);
-		assertEquals("7.1", project2, nature2.getProject());
-		assertEquals("7.2", project, nature.getProject());
+		assertNotNull(nature2);
+		assertEquals(project2, nature2.getProject());
+		assertEquals(project, nature.getProject());
 	}
 
 	/**
@@ -199,18 +199,18 @@ public class IProjectTest  {
 		project.open(monitor);
 		monitor.assertUsedUp();
 		//hasNature on open project with no natures
-		assertFalse("3.0", project.hasNature(NATURE_SIMPLE));
-		assertFalse("3.1", project.hasNature(NATURE_MISSING));
-		assertFalse("3.2", project.hasNature(NATURE_EARTH));
+		assertFalse(project.hasNature(NATURE_SIMPLE));
+		assertFalse(project.hasNature(NATURE_MISSING));
+		assertFalse(project.hasNature(NATURE_EARTH));
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_SIMPLE });
 		monitor.prepare();
 		project.setDescription(desc, monitor);
 		monitor.assertUsedUp();
 		//hasNature on open project with natures
-		assertTrue("5.0", project.hasNature(NATURE_SIMPLE));
-		assertFalse("5.1", project.hasNature(NATURE_MISSING));
-		assertFalse("5.2", project.hasNature(NATURE_EARTH));
+		assertTrue(project.hasNature(NATURE_SIMPLE));
+		assertFalse(project.hasNature(NATURE_MISSING));
+		assertFalse(project.hasNature(NATURE_EARTH));
 	}
 
 	/**
@@ -233,7 +233,7 @@ public class IProjectTest  {
 		}
 		for (String name : names) {
 			IProject project = root.getProject(name);
-			assertFalse("1.0 " + name, project.exists());
+			assertFalse(name, project.exists());
 			assertThrows(CoreException.class, () -> {
 				monitor.prepare();
 				project.create(monitor);
@@ -242,8 +242,8 @@ public class IProjectTest  {
 				project.open(monitor);
 				monitor.assertUsedUp();
 			});
-			assertFalse("1.2 " + name, project.exists());
-			assertFalse("1.3 " + name, project.isOpen());
+			assertFalse(name, project.exists());
+			assertFalse(name, project.isOpen());
 		}
 
 		//do some tests with valid names that are *almost* invalid
@@ -256,15 +256,15 @@ public class IProjectTest  {
 		}
 		for (String name : names) {
 			IProject project = root.getProject(name);
-			assertFalse("2.0 " + name, project.exists());
+			assertFalse(name, project.exists());
 			monitor.prepare();
 			project.create(monitor);
 			monitor.assertUsedUp();
 			monitor.prepare();
 			project.open(monitor);
 			monitor.assertUsedUp();
-			assertTrue("2.2 " + name, project.exists());
-			assertTrue("2.3 " + name, project.isOpen());
+			assertTrue(name, project.exists());
+			assertTrue(name, project.isOpen());
 		}
 	}
 
@@ -289,18 +289,18 @@ public class IProjectTest  {
 		project.open(monitor);
 		monitor.assertUsedUp();
 		//isNatureEnabled on open project with no natures
-		assertFalse("3.0", project.isNatureEnabled(NATURE_SIMPLE));
-		assertFalse("3.1", project.isNatureEnabled(NATURE_MISSING));
-		assertFalse("3.2", project.isNatureEnabled(NATURE_EARTH));
+		assertFalse(project.isNatureEnabled(NATURE_SIMPLE));
+		assertFalse(project.isNatureEnabled(NATURE_MISSING));
+		assertFalse(project.isNatureEnabled(NATURE_EARTH));
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_SIMPLE });
 		monitor.prepare();
 		project.setDescription(desc, monitor);
 		monitor.assertUsedUp();
 		// isNatureEnabled on open project with natures
-		assertTrue("5.0", project.isNatureEnabled(NATURE_SIMPLE));
-		assertFalse("5.1", project.isNatureEnabled(NATURE_MISSING));
-		assertFalse("5.2", project.isNatureEnabled(NATURE_EARTH));
+		assertTrue(project.isNatureEnabled(NATURE_SIMPLE));
+		assertFalse(project.isNatureEnabled(NATURE_MISSING));
+		assertFalse(project.isNatureEnabled(NATURE_EARTH));
 	}
 
 	/**
@@ -326,11 +326,11 @@ public class IProjectTest  {
 		project.open(monitor);
 		monitor.assertUsedUp();
 
-		assertEquals("1.0", varValue, getWorkspace().getPathVariableManager().getValue(varName));
-		assertTrue("1.1", project.exists());
-		assertTrue("1.2", project.isOpen());
-		assertEquals("1.3", rawLocation, project.getRawLocation());
-		assertEquals("1.4", varValue.append(rawLocation.lastSegment()), project.getLocation());
+		assertEquals(varValue, getWorkspace().getPathVariableManager().getValue(varName));
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
+		assertEquals(rawLocation, project.getRawLocation());
+		assertEquals(varValue.append(rawLocation.lastSegment()), project.getLocation());
 	}
 
 	@Test
@@ -342,15 +342,15 @@ public class IProjectTest  {
 
 		target.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.1", target.exists());
-		assertFalse("1.2", target.isOpen());
-		assertFalse("1.3", folder.exists());
+		assertTrue(target.exists());
+		assertFalse(target.isOpen());
+		assertFalse(folder.exists());
 
 		monitor.prepare();
 		target.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("2.1", target.isOpen());
-		assertTrue("2.2", folder.exists());
+		assertTrue(target.isOpen());
+		assertTrue(folder.exists());
 	}
 
 	@Test
@@ -385,8 +385,8 @@ public class IProjectTest  {
 		// ensure the properties were copied ok
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
-		assertNotNull("1.8", actual);
-		assertEquals("1.9", value, actual);
+		assertNotNull(actual);
+		assertEquals(value, actual);
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);
@@ -416,8 +416,8 @@ public class IProjectTest  {
 		// ensure the properties were copied ok
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
-		assertNotNull("2.8", actual);
-		assertEquals("2.9", value, actual);
+		assertNotNull(actual);
+		assertEquals(value, actual);
 		// cleanup
 		monitor.prepare();
 		getWorkspace().getRoot().delete(false, monitor);
@@ -470,22 +470,22 @@ public class IProjectTest  {
 		IProject target = getWorkspace().getRoot().getProject("Project");
 		target.create(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.1", target.exists());
+		assertTrue(target.exists());
 
 		monitor.prepare();
 		target.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("2.1", target.isOpen());
+		assertTrue(target.isOpen());
 
 		monitor.prepare();
 		target.close(monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.1", target.isOpen());
+		assertFalse(target.isOpen());
 
 		monitor.prepare();
 		target.delete(true, true, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.1", target.exists());
+		assertFalse(target.exists());
 	}
 
 	@Test
@@ -494,12 +494,12 @@ public class IProjectTest  {
 
 		target.create(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.0", target.exists());
-		assertFalse("1.2", target.isOpen());
+		assertTrue(target.exists());
+		assertFalse(target.isOpen());
 		monitor.prepare();
 		target.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("2.0", target.isOpen());
+		assertTrue(target.isOpen());
 	}
 
 	@Test
@@ -532,7 +532,7 @@ public class IProjectTest  {
 		try {
 			createInWorkspace(project);
 			// new .project should have OS default line separator
-			assertEquals("1.0", systemValue, getLineSeparatorFromFile(file));
+			assertEquals(systemValue, getLineSeparatorFromFile(file));
 
 			// set instance-specific line separator
 			instanceNode.put(Platform.PREF_LINE_SEPARATOR, newInstanceValue);
@@ -543,14 +543,14 @@ public class IProjectTest  {
 			project.setDescription(description, monitor);
 			monitor.assertUsedUp();
 			// existing .project should use existing line separator
-			assertEquals("2.0", systemValue, getLineSeparatorFromFile(file));
+			assertEquals(systemValue, getLineSeparatorFromFile(file));
 			monitor.prepare();
 			project.delete(true, monitor);
 			monitor.assertUsedUp();
 
 			createInWorkspace(project);
 			// new .project should have instance-specific line separator
-			assertEquals("3.0", newInstanceValue, getLineSeparatorFromFile(file));
+			assertEquals(newInstanceValue, getLineSeparatorFromFile(file));
 
 			// remove preference for the next step
 			if (oldInstanceValue == null) {
@@ -565,14 +565,14 @@ public class IProjectTest  {
 			project.setDescription(description, monitor);
 			monitor.assertUsedUp();
 			// existing .project should use existing line separator
-			assertEquals("4.0", newInstanceValue, getLineSeparatorFromFile(file));
+			assertEquals(newInstanceValue, getLineSeparatorFromFile(file));
 			monitor.prepare();
 			project.delete(true, monitor);
 			monitor.assertUsedUp();
 
 			createInWorkspace(project);
 			// new .project should have OS default line separator
-			assertEquals("5.0", systemValue, getLineSeparatorFromFile(file));
+			assertEquals(systemValue, getLineSeparatorFromFile(file));
 
 			// set project-specific line separator
 			Preferences projectNode = rootNode.node(ProjectScope.SCOPE).node(project.getName()).node(Platform.PI_RUNTIME);
@@ -582,7 +582,7 @@ public class IProjectTest  {
 			monitor.prepare();
 			file.delete(true, monitor);
 			monitor.assertUsedUp();
-			assertFalse("6.0", file.exists());
+			assertFalse(file.exists());
 			// workspace save should recreate .project file with project-specific line delimiter
 			monitor.prepare();
 			getWorkspace().save(true, monitor);
@@ -591,9 +591,9 @@ public class IProjectTest  {
 			monitor.prepare();
 			project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 			monitor.assertUsedUp();
-			assertTrue("7.0", file.exists());
+			assertTrue(file.exists());
 			// new .project should have project-specific line separator
-			assertEquals("8.0", newProjectValue, getLineSeparatorFromFile(file));
+			assertEquals(newProjectValue, getLineSeparatorFromFile(file));
 		} finally {
 			// revert instance preference to original value
 			if (oldInstanceValue == null) {
@@ -690,27 +690,27 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", file.exists());
-		assertTrue("1.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.4", project.exists());
-		assertFalse("1.5", project.isOpen());
-		assertFalse("1.6", project.isAccessible());
-		assertFalse("1.7", file.exists());
-		assertFalse("1.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.10", project.exists());
-		assertFalse("1.11", file.exists());
-		assertFalse("1.12", otherFile.exists());
-		assertFalse("1.13", projectStore.fetchInfo().exists());
-		assertFalse("1.14", fileStore.fetchInfo().exists());
-		assertFalse("1.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -720,27 +720,27 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("2.0", project.exists());
-		assertTrue("2.1", file.exists());
-		assertTrue("2.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("2.4", project.exists());
-		assertFalse("2.5", project.isOpen());
-		assertFalse("2.6", project.isAccessible());
-		assertFalse("2.7", file.exists());
-		assertFalse("2.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		updateFlags = IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.10", project.exists());
-		assertFalse("2.11", file.exists());
-		assertFalse("2.12", otherFile.exists());
-		assertFalse("2.13", projectStore.fetchInfo().exists());
-		assertFalse("2.14", fileStore.fetchInfo().exists());
-		assertFalse("2.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -750,28 +750,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", file.exists());
-		assertTrue("3.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("3.4", project.exists());
-		assertFalse("3.5", project.isOpen());
-		assertFalse("3.6", project.isAccessible());
-		assertFalse("3.7", file.exists());
-		assertFalse("3.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		updateFlags = IResource.FORCE;
 		updateFlags |= IResource.NEVER_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.10", project.exists());
-		assertFalse("3.11", file.exists());
-		assertFalse("3.12", otherFile.exists());
-		assertTrue("3.13", projectStore.fetchInfo().exists());
-		assertTrue("3.14", fileStore.fetchInfo().exists());
-		assertTrue("3.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -783,27 +783,27 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("4.0", project.exists());
-		assertTrue("4.1", file.exists());
-		assertTrue("4.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("4.4", project.exists());
-		assertFalse("4.5", project.isOpen());
-		assertFalse("4.6", project.isAccessible());
-		assertFalse("4.7", file.exists());
-		assertFalse("4.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		updateFlags = IResource.NEVER_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.10", project.exists());
-		assertFalse("4.11", file.exists());
-		assertFalse("4.12", otherFile.exists());
-		assertTrue("4.13", projectStore.fetchInfo().exists());
-		assertTrue("4.14", fileStore.fetchInfo().exists());
-		assertTrue("4.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -815,27 +815,27 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("5.0", project.exists());
-		assertTrue("5.1", file.exists());
-		assertTrue("5.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("5.4", project.exists());
-		assertFalse("5.5", project.isOpen());
-		assertFalse("5.6", project.isAccessible());
-		assertFalse("5.7", file.exists());
-		assertFalse("5.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		updateFlags = IResource.FORCE;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.10", project.exists());
-		assertFalse("5.11", file.exists());
-		assertFalse("5.12", otherFile.exists());
-		assertTrue("5.13", projectStore.fetchInfo().exists());
-		assertTrue("5.14", fileStore.fetchInfo().exists());
-		assertTrue("5.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -847,27 +847,27 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("6.0", project.exists());
-		assertTrue("6.1", file.exists());
-		assertTrue("6.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertTrue(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertTrue("6.4", project.exists());
-		assertFalse("6.5", project.isOpen());
-		assertFalse("6.6", project.isAccessible());
-		assertFalse("6.7", file.exists());
-		assertFalse("6.8", otherFile.exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		updateFlags = IResource.NONE;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.10", project.exists());
-		assertFalse("6.11", file.exists());
-		assertFalse("6.12", otherFile.exists());
-		assertTrue("6.13", projectStore.fetchInfo().exists());
-		assertTrue("6.14", fileStore.fetchInfo().exists());
-		assertTrue("6.15", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 	}
@@ -893,30 +893,30 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", file.exists());
-		assertFalse("1.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("1.5", otherFileStore.fetchInfo().exists());
-		assertTrue("1.6", project.exists());
-		assertFalse("1.7", project.isOpen());
-		assertFalse("1.8", project.isAccessible());
-		assertFalse("1.9", file.exists());
-		assertFalse("1.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.12", project.exists());
-		assertFalse("1.13", file.exists());
-		assertFalse("1.14", otherFile.exists());
-		assertFalse("1.15", projectStore.fetchInfo().exists());
-		assertFalse("1.16", fileStore.fetchInfo().exists());
-		assertFalse("1.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -926,28 +926,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("2.0", project.exists());
-		assertTrue("2.1", file.exists());
-		assertFalse("2.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("2.5", otherFileStore.fetchInfo().exists());
-		assertTrue("2.6", project.exists());
-		assertFalse("2.7", project.isOpen());
-		assertFalse("2.8", project.isAccessible());
-		assertFalse("2.9", file.exists());
-		assertFalse("2.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.12", project.exists());
-		assertFalse("2.13", file.exists());
-		assertFalse("2.14", otherFile.exists());
-		assertFalse("2.15", projectStore.fetchInfo().exists());
-		assertFalse("2.16", fileStore.fetchInfo().exists());
-		assertFalse("2.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -957,28 +957,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", file.exists());
-		assertFalse("3.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("3.5", otherFileStore.fetchInfo().exists());
-		assertTrue("3.6", project.exists());
-		assertFalse("3.7", project.isOpen());
-		assertFalse("3.8", project.isAccessible());
-		assertFalse("3.9", file.exists());
-		assertFalse("3.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.12", project.exists());
-		assertFalse("3.13", file.exists());
-		assertFalse("3.14", otherFile.exists());
-		assertTrue("3.15", projectStore.fetchInfo().exists());
-		assertTrue("3.16", fileStore.fetchInfo().exists());
-		assertTrue("3.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -990,28 +990,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("4.0", project.exists());
-		assertTrue("4.1", file.exists());
-		assertFalse("4.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("4.5", otherFileStore.fetchInfo().exists());
-		assertTrue("4.6", project.exists());
-		assertFalse("4.7", project.isOpen());
-		assertFalse("4.8", project.isAccessible());
-		assertFalse("4.9", file.exists());
-		assertFalse("4.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.12", project.exists());
-		assertFalse("4.13", file.exists());
-		assertFalse("4.14", otherFile.exists());
-		assertTrue("4.15", projectStore.fetchInfo().exists());
-		assertTrue("4.16", fileStore.fetchInfo().exists());
-		assertTrue("4.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1023,28 +1023,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("5.0", project.exists());
-		assertTrue("5.1", file.exists());
-		assertFalse("5.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("5.5", otherFileStore.fetchInfo().exists());
-		assertTrue("5.6", project.exists());
-		assertFalse("5.7", project.isOpen());
-		assertFalse("5.8", project.isAccessible());
-		assertFalse("5.9", file.exists());
-		assertFalse("5.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.12", project.exists());
-		assertFalse("5.13", file.exists());
-		assertFalse("5.14", otherFile.exists());
-		assertTrue("5.15", projectStore.fetchInfo().exists());
-		assertTrue("5.16", fileStore.fetchInfo().exists());
-		assertTrue("5.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1056,28 +1056,28 @@ public class IProjectTest  {
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("6.0", project.exists());
-		assertTrue("6.1", file.exists());
-		assertFalse("6.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		createInFileSystem(otherFileStore);
-		assertTrue("6.5", otherFileStore.fetchInfo().exists());
-		assertTrue("6.6", project.exists());
-		assertFalse("6.7", project.isOpen());
-		assertFalse("6.8", project.isAccessible());
-		assertFalse("6.9", file.exists());
-		assertFalse("6.10", otherFile.exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
+		assertFalse(project.isAccessible());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.12", project.exists());
-		assertFalse("6.13", file.exists());
-		assertFalse("6.14", otherFile.exists());
-		assertTrue("6.15", projectStore.fetchInfo().exists());
-		assertTrue("6.16", fileStore.fetchInfo().exists());
-		assertTrue("6.17", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 	}
@@ -1104,8 +1104,8 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("1.2", project.exists());
-		assertTrue("1.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
@@ -1114,11 +1114,11 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.6", project.exists());
-		assertFalse("1.7", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("1.8", projectStore.fetchInfo().exists());
-		assertFalse("1.9", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1130,19 +1130,19 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("2.2", project.exists());
-		assertTrue("2.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.6", project.exists());
-		assertFalse("2.7", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("2.8", projectStore.fetchInfo().exists());
-		assertFalse("2.9", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1154,18 +1154,18 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("3.2", project.exists());
-		assertTrue("3.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.6", project.exists());
-		assertFalse("3.7", file.exists());
-		assertTrue("3.8", projectStore.fetchInfo().exists());
-		assertTrue("3.9", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1178,18 +1178,18 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("4.2", project.exists());
-		assertTrue("4.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.6", project.exists());
-		assertFalse("4.7", file.exists());
-		assertTrue("4.8", projectStore.fetchInfo().exists());
-		assertTrue("4.9", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1202,18 +1202,18 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
 		fileStore = ((Resource) file).getStore();
-		assertTrue("5.2", project.exists());
-		assertTrue("5.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.6", project.exists());
-		assertFalse("5.7", file.exists());
-		assertTrue("5.8", projectStore.fetchInfo().exists());
-		assertTrue("5.9", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1226,18 +1226,18 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("6.2", project.exists());
-		assertTrue("6.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.6", project.exists());
-		assertFalse("6.7", file.exists());
-		assertTrue("6.8", projectStore.fetchInfo().exists());
-		assertTrue("6.9", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 	}
@@ -1267,9 +1267,9 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", file.exists());
-		assertFalse("1.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
@@ -1278,13 +1278,13 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.5", project.exists());
-		assertFalse("1.6", file.exists());
-		assertFalse("1.7", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("1.8", projectStore.fetchInfo().exists());
-		assertFalse("1.9", fileStore.fetchInfo().exists());
-		assertFalse("1.10", otherFileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1298,22 +1298,22 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("2.0", project.exists());
-		assertTrue("2.1", file.exists());
-		assertFalse("2.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.5", project.exists());
-		assertFalse("2.6", file.exists());
-		assertFalse("2.7", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("2.8", projectStore.fetchInfo().exists());
-		assertFalse("2.9", fileStore.fetchInfo().exists());
-		assertFalse("2.10", otherFileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1327,21 +1327,21 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", file.exists());
-		assertFalse("3.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.5", project.exists());
-		assertFalse("3.6", file.exists());
-		assertFalse("3.7", otherFile.exists());
-		assertTrue("3.8", projectStore.fetchInfo().exists());
-		assertTrue("3.9", fileStore.fetchInfo().exists());
-		assertTrue("3.10", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1355,9 +1355,9 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("4.0", project.exists());
-		assertTrue("4.1", file.exists());
-		assertFalse("4.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 
 		monitor.prepare();
 		project.close(monitor);
@@ -1365,12 +1365,12 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.5", project.exists());
-		assertFalse("4.6", file.exists());
-		assertFalse("4.7", otherFile.exists());
-		assertTrue("4.8", projectStore.fetchInfo().exists());
-		assertTrue("4.9", fileStore.fetchInfo().exists());
-		assertTrue("4.10", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1383,22 +1383,22 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("5.0", project.exists());
-		assertTrue("5.1", file.exists());
-		assertFalse("5.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.5", project.exists());
-		assertFalse("5.6", file.exists());
-		assertFalse("5.7", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// don't delete the directory itself since the location is user-defined, but delete the contents
-		assertTrue("5.8", projectStore.fetchInfo().exists());
-		assertTrue("5.9", fileStore.fetchInfo().exists());
-		assertTrue("5.10", otherFileStore.fetchInfo().exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1412,23 +1412,23 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("6.0", project.exists());
-		assertTrue("6.1", file.exists());
-		assertFalse("6.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
 		monitor.prepare();
 		project.delete(IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.5", project.exists());
+		assertFalse(project.exists());
 		// delete was best effort so this file should be gone.
-		assertFalse("6.6", file.exists());
-		assertFalse("6.7", otherFile.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// don't delete the directory itself since its user-defined, but delete the contents
-		assertTrue("6.8", projectStore.fetchInfo().exists());
-		assertTrue("6.9", fileStore.fetchInfo().exists());
-		assertTrue("6.10", otherFileStore.fetchInfo().exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 	}
@@ -1452,16 +1452,16 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.3", project.exists());
-		assertFalse("1.4", file.exists());
-		assertFalse("1.5", projectStore.fetchInfo().exists());
-		assertFalse("1.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1470,15 +1470,15 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("2.0", project.exists());
-		assertTrue("2.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.3", project.exists());
-		assertFalse("2.4", file.exists());
-		assertFalse("2.5", projectStore.fetchInfo().exists());
-		assertFalse("2.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1487,15 +1487,15 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.3", project.exists());
-		assertFalse("3.4", file.exists());
-		assertTrue("3.5", projectStore.fetchInfo().exists());
-		assertTrue("3.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1504,15 +1504,15 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("4.0", project.exists());
-		assertTrue("4.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.3", project.exists());
-		assertFalse("4.4", file.exists());
-		assertTrue("4.5", projectStore.fetchInfo().exists());
-		assertTrue("4.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1521,15 +1521,15 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("5.0", project.exists());
-		assertTrue("5.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.3", project.exists());
-		assertFalse("5.4", file.exists());
-		assertFalse("5.5", projectStore.fetchInfo().exists());
-		assertFalse("5.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1538,15 +1538,15 @@ public class IProjectTest  {
 		createInWorkspace(new IResource[] {project, file});
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("6.0", project.exists());
-		assertTrue("6.1", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.3", project.exists());
-		assertFalse("6.4", file.exists());
-		assertFalse("6.5", projectStore.fetchInfo().exists());
-		assertFalse("6.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 	}
 
 	/**
@@ -1569,17 +1569,17 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("1.0", project.exists());
-		assertFalse("1.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.3", project.exists());
-		assertFalse("1.4", file.exists());
-		assertFalse("1.5", projectStore.fetchInfo().exists());
-		assertFalse("1.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1589,15 +1589,15 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("2.0", project.exists());
-		assertFalse("2.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.3", project.exists());
-		assertFalse("2.4", file.exists());
-		assertFalse("2.5", projectStore.fetchInfo().exists());
-		assertFalse("2.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1607,15 +1607,15 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("3.0", project.exists());
-		assertFalse("3.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.3", project.exists());
-		assertFalse("3.4", file.exists());
-		assertTrue("3.5", projectStore.fetchInfo().exists());
-		assertTrue("3.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1627,15 +1627,15 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("4.0", project.exists());
-		assertFalse("4.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.3", project.exists());
-		assertFalse("4.4", file.exists());
-		assertTrue("4.5", projectStore.fetchInfo().exists());
-		assertTrue("4.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1647,15 +1647,15 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("5.0", project.exists());
-		assertFalse("5.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.3", project.exists());
-		assertFalse("5.4", file.exists());
-		assertFalse("5.5", projectStore.fetchInfo().exists());
-		assertFalse("5.6", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1666,17 +1666,17 @@ public class IProjectTest  {
 		createInFileSystem(file);
 		projectStore = ((Resource) project).getStore();
 		fileStore = ((Resource) file).getStore();
-		assertTrue("6.0", project.exists());
-		assertFalse("6.1", file.exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
 		assertThrows(CoreException.class, () -> {
 			monitor.prepare();
 			project.delete(IResource.NONE, monitor);
 			monitor.assertUsedUp();
 		});
-		assertTrue("6.3", project.exists());
-		assertFalse("6.4", file.exists());
-		assertTrue("6.5", projectStore.fetchInfo().exists());
-		assertTrue("6.6", fileStore.fetchInfo().exists());
+		assertTrue(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 	}
 
 	/**
@@ -1700,18 +1700,18 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("1.2", project.exists());
-		assertTrue("1.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.5", project.exists());
-		assertFalse("1.6", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("1.7", projectStore.fetchInfo().exists());
-		assertFalse("1.8", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1722,16 +1722,16 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("2.2", project.exists());
-		assertTrue("2.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.5", project.exists());
-		assertFalse("2.6", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("2.7", projectStore.fetchInfo().exists());
-		assertFalse("2.8", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1742,15 +1742,15 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("3.2", project.exists());
-		assertTrue("3.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.5", project.exists());
-		assertFalse("3.6", file.exists());
-		assertTrue("3.7", projectStore.fetchInfo().exists());
-		assertTrue("3.8", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1761,15 +1761,15 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("4.2", project.exists());
-		assertTrue("4.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.5", project.exists());
-		assertFalse("4.6", file.exists());
-		assertTrue("4.7", projectStore.fetchInfo().exists());
-		assertTrue("4.8", fileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1782,16 +1782,16 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
 		fileStore = ((Resource) file).getStore();
-		assertTrue("5.2", project.exists());
-		assertTrue("5.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.5", project.exists());
-		assertFalse("5.6", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("5.7", projectStore.fetchInfo().exists());
-		assertFalse("5.8", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1802,16 +1802,16 @@ public class IProjectTest  {
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
 		fileStore = ((Resource) file).getStore();
-		assertTrue("6.2", project.exists());
-		assertTrue("6.3", file.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
 		monitor.prepare();
 		project.delete(IResource.NONE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("6.5", project.exists());
-		assertFalse("6.6", file.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("6.7", projectStore.fetchInfo().exists());
-		assertFalse("6.8", fileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
 	}
 
 	/**
@@ -1839,21 +1839,21 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("1.0", project.exists());
-		assertTrue("1.1", file.exists());
-		assertFalse("1.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		int updateFlags = IResource.FORCE;
 		updateFlags |= IResource.ALWAYS_DELETE_PROJECT_CONTENT;
 		monitor.prepare();
 		project.delete(updateFlags, monitor);
 		monitor.assertUsedUp();
-		assertFalse("1.4", project.exists());
-		assertFalse("1.5", file.exists());
-		assertFalse("1.6", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("1.7", projectStore.fetchInfo().exists());
-		assertFalse("1.8", fileStore.fetchInfo().exists());
-		assertFalse("1.9", otherFileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1867,19 +1867,19 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("2.0", project.exists());
-		assertTrue("2.1", file.exists());
-		assertFalse("2.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("2.4", project.exists());
-		assertFalse("2.5", file.exists());
-		assertFalse("2.6", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("2.7", projectStore.fetchInfo().exists());
-		assertFalse("2.8", fileStore.fetchInfo().exists());
-		assertFalse("2.9", otherFileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 		projectStore.delete(EFS.NONE, null);
 
 		/* ======================================================================
@@ -1893,18 +1893,18 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("3.0", project.exists());
-		assertTrue("3.1", file.exists());
-		assertFalse("3.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE | IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("3.4", project.exists());
-		assertFalse("3.5", file.exists());
-		assertFalse("3.6", otherFile.exists());
-		assertTrue("3.7", projectStore.fetchInfo().exists());
-		assertTrue("3.8", fileStore.fetchInfo().exists());
-		assertTrue("3.9", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 		// cleanup
 		projectStore.delete(EFS.NONE, null);
 
@@ -1919,18 +1919,18 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("4.0", project.exists());
-		assertTrue("4.1", file.exists());
-		assertFalse("4.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, monitor);
 		monitor.assertUsedUp();
-		assertFalse("4.4", project.exists());
-		assertFalse("4.5", file.exists());
-		assertFalse("4.6", otherFile.exists());
-		assertTrue("4.7", projectStore.fetchInfo().exists());
-		assertTrue("4.8", fileStore.fetchInfo().exists());
-		assertTrue("4.9", otherFileStore.fetchInfo().exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertTrue(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = TRUE
@@ -1943,19 +1943,19 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("5.0", project.exists());
-		assertTrue("5.1", file.exists());
-		assertFalse("5.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertFalse("5.4", project.exists());
-		assertFalse("5.5", file.exists());
-		assertFalse("5.6", otherFile.exists());
+		assertFalse(project.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// ensure the project directory and files no longer exist
-		assertFalse("5.7", projectStore.fetchInfo().exists());
-		assertFalse("5.8", fileStore.fetchInfo().exists());
-		assertFalse("5.9", otherFileStore.fetchInfo().exists());
+		assertFalse(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertFalse(otherFileStore.fetchInfo().exists());
 
 		/* ======================================================================
 		 * Force = FALSE
@@ -1969,22 +1969,22 @@ public class IProjectTest  {
 		createInFileSystem(otherFile);
 		fileStore = ((Resource) file).getStore();
 		otherFileStore = ((Resource) otherFile).getStore();
-		assertTrue("6.0", project.exists());
-		assertTrue("6.1", file.exists());
-		assertFalse("6.2", otherFile.exists());
+		assertTrue(project.exists());
+		assertTrue(file.exists());
+		assertFalse(otherFile.exists());
 		assertThrows(CoreException.class, () -> {
 			monitor.prepare();
 			project.delete(IResource.NONE, monitor);
 			monitor.assertUsedUp();
 		});
-		assertTrue("6.4", project.exists());
+		assertTrue(project.exists());
 		// delete was best effort so this file should be gone.
-		assertFalse("6.5", file.exists());
-		assertFalse("6.6", otherFile.exists());
+		assertFalse(file.exists());
+		assertFalse(otherFile.exists());
 		// don't delete the directory itself since its user-defined, but delete the contents
-		assertTrue("6.7", projectStore.fetchInfo().exists());
-		assertFalse("6.8", fileStore.fetchInfo().exists());
-		assertTrue("6.9", otherFileStore.fetchInfo().exists());
+		assertTrue(projectStore.fetchInfo().exists());
+		assertFalse(fileStore.fetchInfo().exists());
+		assertTrue(otherFileStore.fetchInfo().exists());
 	}
 
 	/**
@@ -2026,7 +2026,7 @@ public class IProjectTest  {
 		IProject project2 = getWorkspace().getRoot().getProject("P2");
 
 		//project name
-		assertEquals("1.0", "foo", desc.getName());
+		assertEquals("foo", desc.getName());
 
 		//project references
 		assertThat(desc.getReferencedProjects()).isEmpty();
@@ -2054,13 +2054,13 @@ public class IProjectTest  {
 		IProject project1 = getWorkspace().getRoot().getProject("Project1");
 		IPath root = getWorkspace().getRoot().getLocation().removeLastSegments(1).append("temp");
 		IPath path = root.append("foo");
-		assertTrue("1.0", getWorkspace().validateProjectLocation(project1, path).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project1, path).isOK());
 		// but not if its in the default default area of another project
 		path = Platform.getLocation().append("Project2");
-		assertFalse("1.1", getWorkspace().validateProjectLocation(project1, path).isOK());
+		assertFalse(getWorkspace().validateProjectLocation(project1, path).isOK());
 		// Project's own default default area is ok.
 		path = Platform.getLocation().append(project1.getName());
-		assertTrue("1.2", getWorkspace().validateProjectLocation(project1, path).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project1, path).isOK());
 		// create the first project with its default default mapping
 		project1.create(monitor);
 		monitor.assertUsedUp();
@@ -2069,7 +2069,7 @@ public class IProjectTest  {
 		IProjectDescription desc = getWorkspace().newProjectDescription("Project2");
 		IProject project2 = getWorkspace().getRoot().getProject("Project2");
 		path = root.append("project2");
-		assertTrue("2.0", getWorkspace().validateProjectLocation(project2, path).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project2, path).isOK());
 		desc.setLocation(path);
 		monitor.prepare();
 		project2.create(desc, monitor);
@@ -2082,20 +2082,20 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 		// it should be ok to re-set a current project's location.
 		path = root.append("project3");
-		assertTrue("3.1", getWorkspace().validateProjectLocation(project3, path).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project3, path).isOK());
 
 		// other cases
-		assertTrue("4.0", getWorkspace().validateProjectLocation(project3, root).isOK());
-		assertFalse("4.1", getWorkspace().validateProjectLocation(project3, root.append("project2")).isOK());
-		assertTrue("4.2", getWorkspace().validateProjectLocation(project3, root.append("project2/foo")).isOK());
-		assertTrue("4.3", getWorkspace().validateProjectLocation(project3, null).isOK());
-		assertTrue("4.4", getWorkspace().validateProjectLocation(project3, root.append("%20foo")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project3, root).isOK());
+		assertFalse(getWorkspace().validateProjectLocation(project3, root.append("project2")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project3, root.append("project2/foo")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project3, null).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(project3, root.append("%20foo")).isOK());
 
 		// Validation of a path without a project context.
-		assertTrue("5.0", getWorkspace().validateProjectLocation(null, root).isOK());
-		assertFalse("5.1", getWorkspace().validateProjectLocation(null, root.append("project2")).isOK());
-		assertTrue("5.2", getWorkspace().validateProjectLocation(null, root.append("project2/foo")).isOK());
-		assertTrue("5.3", getWorkspace().validateProjectLocation(null, root.append("%20foo")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(null, root).isOK());
+		assertFalse(getWorkspace().validateProjectLocation(null, root.append("project2")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(null, root.append("project2/foo")).isOK());
+		assertTrue(getWorkspace().validateProjectLocation(null, root.append("%20foo")).isOK());
 
 		monitor.prepare();
 		project1.delete(true, true, monitor);
@@ -2123,10 +2123,10 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 		project1.open(null);
 
-		assertTrue("1.0", project1.exists());
-		assertTrue("1.1", project1.isAccessible());
-		assertEquals("1.2", location, project1.getLocation());
-		assertEquals("1.3", location, project1.getRawLocation());
+		assertTrue(project1.exists());
+		assertTrue(project1.isAccessible());
+		assertEquals(location, project1.getLocation());
+		assertEquals(location, project1.getRawLocation());
 
 		monitor.prepare();
 		project1.delete(IResource.FORCE, monitor);
@@ -2154,7 +2154,7 @@ public class IProjectTest  {
 
 		// ensure that the new description was set correctly and the locations
 		// aren't the same
-		assertFalse("2.0", oldPath.equals(newPath));
+		assertFalse(oldPath.equals(newPath));
 
 		// make sure all the resources still exist.
 		IResourceVisitor visitor = resource -> {
@@ -2200,8 +2200,8 @@ public class IProjectTest  {
 		// ensure properties are moved too
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
-		assertNotNull("1.7", actual);
-		assertEquals("1.8", value, actual);
+		assertNotNull(actual);
+		assertEquals(value, actual);
 		// ensure the marker was moved
 		markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertThat(markers).hasSize(1);
@@ -2236,8 +2236,8 @@ public class IProjectTest  {
 		// ensure properties are moved too
 		destChild = resources[1];
 		actual = destChild.getPersistentProperty(qname);
-		assertNotNull("2.10", actual);
-		assertEquals("2.11", value, actual);
+		assertNotNull(actual);
+		assertEquals(value, actual);
 		// ensure the marker was moved
 		markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertThat(markers).hasSize(1);
@@ -2292,7 +2292,7 @@ public class IProjectTest  {
 			monitor.assertUsedUp();
 		});
 
-		assertEquals("3.0", originalLocation, originalProject.getLocation());
+		assertEquals(originalLocation, originalProject.getLocation());
 
 		//cleanup
 		monitor.prepare();
@@ -2323,7 +2323,7 @@ public class IProjectTest  {
 			monitor.assertUsedUp();
 		});
 
-		assertEquals("7.0", destinationLocation, destinationProject.getLocation());
+		assertEquals(destinationLocation, destinationProject.getLocation());
 	}
 
 	/**
@@ -2368,8 +2368,8 @@ public class IProjectTest  {
 		// ensure properties are moved too
 		IResource destChild = resources[1];
 		actualPropertyValue = destChild.getPersistentProperty(qname);
-		assertNotNull("2.10", actualPropertyValue);
-		assertEquals("2.11", propertyValue, actualPropertyValue);
+		assertNotNull(actualPropertyValue);
+		assertEquals(propertyValue, actualPropertyValue);
 		// ensure the marker was moved
 		IMarker[] markers = destChild.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertThat(markers).hasSize(1);
@@ -2408,9 +2408,9 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 
 		// existing contents should no longer exist
-		assertFalse("2.0", folder.exists());
-		assertFalse("2.1", file.exists());
-		assertTrue("2.2", newFile.exists());
+		assertFalse(folder.exists());
+		assertFalse(file.exists());
+		assertTrue(newFile.exists());
 
 		// move back to default location
 		description = target.getDescription();
@@ -2420,9 +2420,9 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 
 		// old resources should now exist
-		assertTrue("3.0", folder.exists());
-		assertTrue("3.1", file.exists());
-		assertFalse("3.2", newFile.exists());
+		assertTrue(folder.exists());
+		assertTrue(file.exists());
+		assertFalse(newFile.exists());
 	}
 
 	@Test
@@ -2436,11 +2436,11 @@ public class IProjectTest  {
 	public void testWorkspaceNotificationClose() throws CoreException {
 		final int[] count = new int[1];
 		IResourceChangeListener listener = event -> {
-			assertEquals("1.0", IResourceChangeEvent.PRE_CLOSE, event.getType());
+			assertEquals(IResourceChangeEvent.PRE_CLOSE, event.getType());
 			count[0]++;
-			assertEquals("1.1", IResource.PROJECT, event.getResource().getType());
-			assertTrue("1.2", event.getResource().exists());
-			assertTrue("1.3", ((IProject) event.getResource()).isOpen());
+			assertEquals(IResource.PROJECT, event.getResource().getType());
+			assertTrue(event.getResource().exists());
+			assertTrue(((IProject) event.getResource()).isOpen());
 		};
 		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.PRE_CLOSE);
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -2450,14 +2450,14 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.5", project.exists());
-		assertTrue("1.6", project.isOpen());
+		assertTrue(project.exists());
+		assertTrue(project.isOpen());
 		monitor.prepare();
 		project.close(monitor);
 		monitor.assertUsedUp();
-		assertEquals("1.8", 1, count[0]);
-		assertTrue("1.9", project.exists());
-		assertFalse("1.10", project.isOpen());
+		assertEquals(1, count[0]);
+		assertTrue(project.exists());
+		assertFalse(project.isOpen());
 		getWorkspace().removeResourceChangeListener(listener);
 	}
 
@@ -2465,10 +2465,10 @@ public class IProjectTest  {
 	public void testWorkspaceNotificationDelete() throws CoreException {
 		final int[] count = new int[1];
 		IResourceChangeListener listener = event -> {
-			assertEquals("1.0", IResourceChangeEvent.PRE_DELETE, event.getType());
+			assertEquals(IResourceChangeEvent.PRE_DELETE, event.getType());
 			count[0]++;
-			assertEquals("1.1", IResource.PROJECT, event.getResource().getType());
-			assertTrue("1.2", event.getResource().exists());
+			assertEquals(IResource.PROJECT, event.getResource().getType());
+			assertTrue(event.getResource().exists());
 		};
 		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.PRE_DELETE);
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -2478,12 +2478,12 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.4", project.exists());
+		assertTrue(project.exists());
 		monitor.prepare();
 		project.delete(IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertEquals("1.6", 1, count[0]);
-		assertFalse("1.7", project.exists());
+		assertEquals(1, count[0]);
+		assertFalse(project.exists());
 		getWorkspace().removeResourceChangeListener(listener);
 	}
 
@@ -2491,10 +2491,10 @@ public class IProjectTest  {
 	public void testWorkspaceNotificationMove() throws CoreException {
 		final int[] count = new int[1];
 		IResourceChangeListener listener = event -> {
-			assertEquals("1.0", IResourceChangeEvent.PRE_DELETE, event.getType());
+			assertEquals(IResourceChangeEvent.PRE_DELETE, event.getType());
 			count[0]++;
-			assertEquals("1.1", IResource.PROJECT, event.getResource().getType());
-			assertTrue("1.2", event.getResource().exists());
+			assertEquals(IResource.PROJECT, event.getResource().getType());
+			assertTrue(event.getResource().exists());
 		};
 		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.PRE_DELETE);
 		IProject project = getWorkspace().getRoot().getProject("MyProject");
@@ -2504,12 +2504,12 @@ public class IProjectTest  {
 		monitor.prepare();
 		project.open(monitor);
 		monitor.assertUsedUp();
-		assertTrue("1.4", project.exists());
+		assertTrue(project.exists());
 		monitor.prepare();
 		project.move(IPath.fromOSString("MyNewProject"), IResource.FORCE, monitor);
 		monitor.assertUsedUp();
-		assertEquals("1.6", 1, count[0]);
-		assertFalse("1.7", project.exists());
+		assertEquals(1, count[0]);
+		assertFalse(project.exists());
 		getWorkspace().removeResourceChangeListener(listener);
 	}
 
@@ -2522,7 +2522,7 @@ public class IProjectTest  {
 		hiddenProject.create(null, IResource.HIDDEN, monitor);
 		monitor.assertUsedUp();
 
-		assertTrue("2.0", hiddenProject.isHidden());
+		assertTrue(hiddenProject.isHidden());
 
 		// try to delete and recreate the project
 		monitor.prepare();
@@ -2533,7 +2533,7 @@ public class IProjectTest  {
 		monitor.assertUsedUp();
 
 		// it should not be hidden
-		assertFalse("4.0", hiddenProject.isHidden());
+		assertFalse(hiddenProject.isHidden());
 	}
 
 	@Test
@@ -2557,7 +2557,7 @@ public class IProjectTest  {
 		project.delete(true, monitor);
 		monitor.assertUsedUp();
 		IPath p = ((Workspace) getWorkspace()).getMetaArea().locationFor(project);
-		assertFalse("1.0", p.toFile().exists());
+		assertFalse(p.toFile().exists());
 
 		IProject otherProject = getWorkspace().getRoot().getProject(createUniqueString());
 		createInWorkspace(otherProject);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -29,8 +29,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -66,6 +66,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -197,7 +198,7 @@ public class IResourceChangeListenerTest {
 	void assertNotDeltaIncludes(IResourceDelta delta, IResource[] resources) {
 		IResource deltaResource = delta.getResource();
 		for (IResource resource : resources) {
-			assertTrue(!deltaResource.equals(resource));
+			assertFalse(deltaResource.equals(resource));
 		}
 		IResourceDelta[] children = delta.getAffectedChildren();
 		for (IResourceDelta element : children) {
@@ -213,7 +214,7 @@ public class IResourceChangeListenerTest {
 		delta.accept(delta2 -> {
 			IResource deltaResource = delta2.getResource();
 			for (IResource resource : resources) {
-				assertTrue(!deltaResource.equals(resource));
+				assertFalse(deltaResource.equals(resource));
 			}
 			return true;
 		});
@@ -423,7 +424,7 @@ public class IResourceChangeListenerTest {
 			} catch (CoreException e) {
 				return;
 			}
-			listenerInMainThreadCallback.set(() -> fail("1.0"));
+			listenerInMainThreadCallback.set(Assert::fail);
 		};
 		// register the listener with the workspace.
 		getWorkspace().addResourceChangeListener(listener, IResourceChangeEvent.POST_CHANGE);
@@ -467,23 +468,23 @@ public class IResourceChangeListenerTest {
 					file1.touch(null);
 					workspace.build(trigger, monitor);
 				}, createTestMonitor());
-				assertEquals("1.0." + i, workspace, preBuild.source);
-				assertEquals("1.1." + i, workspace, postBuild.source);
-				assertEquals("1.2." + i, workspace, postChange.source);
-				assertEquals("1.3." + i, trigger, preBuild.trigger);
-				assertEquals("1.4." + i, trigger, postBuild.trigger);
-				assertEquals("1.5." + i, 0, postChange.trigger);
+				assertEquals(i + "", workspace, preBuild.source);
+				assertEquals(i + "", workspace, postBuild.source);
+				assertEquals(i + "", workspace, postChange.source);
+				assertEquals(i + "", trigger, preBuild.trigger);
+				assertEquals(i + "", trigger, postBuild.trigger);
+				assertEquals(i + "", 0, postChange.trigger);
 
 				workspace.run((IWorkspaceRunnable) monitor -> {
 					file1.touch(null);
 					project1.build(trigger, createTestMonitor());
 				}, createTestMonitor());
-				assertEquals("2.0." + i, project1, preBuild.source);
-				assertEquals("2.2." + i, project1, postBuild.source);
-				assertEquals("2.2." + i, workspace, postChange.source);
-				assertEquals("2.3." + i, trigger, preBuild.trigger);
-				assertEquals("2.4." + i, trigger, postBuild.trigger);
-				assertEquals("2.5." + i, 0, postChange.trigger);
+				assertEquals(i + "", project1, preBuild.source);
+				assertEquals(i + "", project1, postBuild.source);
+				assertEquals(i + "", workspace, postChange.source);
+				assertEquals(i + "", trigger, preBuild.trigger);
+				assertEquals(i + "", trigger, postBuild.trigger);
+				assertEquals(i + "", 0, postChange.trigger);
 
 			}
 
@@ -492,12 +493,12 @@ public class IResourceChangeListenerTest {
 			file1.touch(null);
 			waitForBuild();
 			int trigger = IncrementalProjectBuilder.AUTO_BUILD;
-			assertEquals("1.0", workspace, preBuild.source);
-			assertEquals("1.1", workspace, postBuild.source);
-			assertEquals("1.2", workspace, postChange.source);
-			assertEquals("1.3", trigger, preBuild.trigger);
-			assertEquals("1.4", trigger, postBuild.trigger);
-			assertEquals("1.5", 0, postChange.trigger);
+			assertEquals(workspace, preBuild.source);
+			assertEquals(workspace, postBuild.source);
+			assertEquals(workspace, postChange.source);
+			assertEquals(trigger, preBuild.trigger);
+			assertEquals(trigger, postBuild.trigger);
+			assertEquals(0, postChange.trigger);
 
 		} finally {
 			workspace.removeResourceChangeListener(preBuild);
@@ -752,7 +753,7 @@ public class IResourceChangeListenerTest {
 						listener.wait(1000);
 					} catch (InterruptedException e) {
 					}
-					assertTrue("2.0", ++i < 60);
+					assertTrue(++i < 60);
 				}
 			}
 		} finally {
@@ -771,8 +772,8 @@ public class IResourceChangeListenerTest {
 		project2.create(createTestMonitor());
 		project2.open(createTestMonitor());
 
-		assertTrue("1.0", project1.isOpen());
-		assertTrue("2.0", project2.isOpen());
+		assertTrue(project1.isOpen());
+		assertTrue(project2.isOpen());
 
 		final IFolder f = project1.getFolder(createUniqueString());
 		f.create(true, true, createTestMonitor());
@@ -835,8 +836,8 @@ public class IResourceChangeListenerTest {
 		project1.create(null);
 		project1.open(null);
 
-		assertTrue("1.0", p.isOpen());
-		assertTrue("2.0", project1.isOpen());
+		assertTrue(p.isOpen());
+		assertTrue(project1.isOpen());
 
 		// the listener checks if an attempt to modify the tree succeeds if made in a job
 		// that belongs to FAMILY_MANUAL_REFRESH
@@ -919,7 +920,7 @@ public class IResourceChangeListenerTest {
 		project1.create(null);
 		project1.open(null);
 
-		assertTrue("1.0", project1.isOpen());
+		assertTrue(project1.isOpen());
 
 		class Listener1 implements IResourceChangeListener {
 			public volatile boolean wasPerformed = false;
@@ -944,17 +945,17 @@ public class IResourceChangeListenerTest {
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
-			assertTrue("2.0", listener1.wasPerformed);
-			assertEquals("3.0", getWorkspace(), listener1.eventSource);
-			assertEquals("4.0", null, listener1.eventResource);
+			assertTrue(listener1.wasPerformed);
+			assertEquals(getWorkspace(), listener1.eventSource);
+			assertEquals(null, listener1.eventResource);
 
 			project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 			Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_MANUAL_REFRESH);
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, null);
 
-			assertTrue("5.0", listener1.wasPerformed);
-			assertEquals("6.0", project1, listener1.eventSource);
-			assertEquals("7.0", project1, listener1.eventResource);
+			assertTrue(listener1.wasPerformed);
+			assertEquals(project1, listener1.eventSource);
+			assertEquals(project1, listener1.eventResource);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener1);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -91,31 +91,31 @@ public class IResourceDeltaTest {
 		IResourceChangeListener listener = event -> {
 			//delta relative to root
 			IResourceDelta delta = event.getDelta();
-			assertNotNull("1.0", delta.findMember(project1.getFullPath()));
-			assertNotNull("1.1", delta.findMember(file1.getFullPath()));
-			assertNotNull("1.2", delta.findMember(folder2.getFullPath()));
-			assertNotNull("1.3", delta.findMember(file3.getFullPath()));
-			assertNotNull("1.4", delta.findMember(file4.getFullPath()));
-			assertNull("1.5", delta.findMember(project2.getFullPath()));
-			assertNull("1.6", delta.findMember(file2.getFullPath()));
-			assertNull("1.7", delta.findMember(folder3.getFullPath()));
+			assertNotNull(delta.findMember(project1.getFullPath()));
+			assertNotNull(delta.findMember(file1.getFullPath()));
+			assertNotNull(delta.findMember(folder2.getFullPath()));
+			assertNotNull(delta.findMember(file3.getFullPath()));
+			assertNotNull(delta.findMember(file4.getFullPath()));
+			assertNull(delta.findMember(project2.getFullPath()));
+			assertNull(delta.findMember(file2.getFullPath()));
+			assertNull(delta.findMember(folder3.getFullPath()));
 
 			//delta relative to project
 			delta = delta.findMember(project1.getFullPath());
-			assertNotNull("2.1", delta.findMember(file1.getProjectRelativePath()));
-			assertNotNull("2.2", delta.findMember(folder2.getProjectRelativePath()));
-			assertNotNull("2.3", delta.findMember(file3.getProjectRelativePath()));
-			assertNotNull("2.4", delta.findMember(file4.getProjectRelativePath()));
-			assertNull("2.5", delta.findMember(project2.getFullPath()));
-			assertNull("2.6", delta.findMember(file2.getProjectRelativePath()));
-			assertNull("2.7", delta.findMember(folder3.getProjectRelativePath()));
-			assertNull("2.8", delta.findMember(project1.getFullPath()));
-			assertNull("2.9", delta.findMember(file1.getFullPath()));
+			assertNotNull(delta.findMember(file1.getProjectRelativePath()));
+			assertNotNull(delta.findMember(folder2.getProjectRelativePath()));
+			assertNotNull(delta.findMember(file3.getProjectRelativePath()));
+			assertNotNull(delta.findMember(file4.getProjectRelativePath()));
+			assertNull(delta.findMember(project2.getFullPath()));
+			assertNull(delta.findMember(file2.getProjectRelativePath()));
+			assertNull(delta.findMember(folder3.getProjectRelativePath()));
+			assertNull(delta.findMember(project1.getFullPath()));
+			assertNull(delta.findMember(file1.getFullPath()));
 
 			//delta with no children
 			delta = delta.findMember(file1.getProjectRelativePath());
-			assertEquals("3.1", delta, delta.findMember(IPath.ROOT));
-			assertNull("3.2", delta.findMember(IPath.fromOSString("foo")));
+			assertEquals(delta, delta.findMember(IPath.ROOT));
+			assertNull(delta.findMember(IPath.fromOSString("foo")));
 		};
 		getWorkspace().addResourceChangeListener(listener);
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -726,32 +725,16 @@ public class IResourceTest {
 		createInWorkspace(project);
 
 		// pass DEPTH_ONE to avoid using proxy visitor
-		assertThrows(CoreException.class, () -> a.accept((IResourceVisitor) resource -> {
-			// we should not get that far if the resource does not exist
-			fail("1.0");
-			return true;
-		}, IResource.DEPTH_ONE, IResource.NONE));
+		assertThrows(CoreException.class, () -> a.accept((IResourceVisitor) resource -> true, IResource.DEPTH_ONE, IResource.NONE));
 
-		assertThrows(CoreException.class, () -> a.accept(proxy -> {
-			// we should not get that far if the resource does not exist
-			fail("2.0");
-			return true;
-		}, IResource.NONE));
+		assertThrows(CoreException.class, () -> a.accept(proxy -> true, IResource.NONE));
 
 		// pass DEPTH_ONE to avoid using proxy visitor
 		// if we don't check for existence, then no exception should be thrown
-		a.accept((IResourceVisitor) resource -> {
-			// we should not get that far if the resource does not exist
-			fail("3.0");
-			return true;
-		}, IResource.DEPTH_ONE, IContainer.DO_NOT_CHECK_EXISTENCE);
+		a.accept((IResourceVisitor) resource -> true, IResource.DEPTH_ONE, IContainer.DO_NOT_CHECK_EXISTENCE);
 
 		// if we don't check for existence, then no exception should be thrown
-		a.accept(proxy -> {
-			// we should not get that far if the resource does not exist
-			fail("4.0");
-			return true;
-		}, IContainer.DO_NOT_CHECK_EXISTENCE);
+		a.accept(proxy -> true, IContainer.DO_NOT_CHECK_EXISTENCE);
 	}
 
 	@Test
@@ -780,20 +763,20 @@ public class IResourceTest {
 		toVisit.addAll(Arrays.asList(new IResource[] {a}));
 		toVisitCount[0] = 1;
 		a.accept(visitor, IResource.DEPTH_ZERO, IResource.NONE);
-		assertTrue("1.0", toVisit.isEmpty());
-		assertEquals("1.1", 0, toVisitCount[0]);
+		assertTrue(toVisit.isEmpty());
+		assertEquals(0, toVisitCount[0]);
 
 		toVisit.addAll(Arrays.asList(a, a1, a2, b));
 		toVisitCount[0] = 4;
 		a.accept(visitor, IResource.DEPTH_ONE, IResource.NONE);
-		assertTrue("2.0", toVisit.isEmpty());
-		assertEquals("2.1", 0, toVisitCount[0]);
+		assertTrue(toVisit.isEmpty());
+		assertEquals(0, toVisitCount[0]);
 
 		toVisit.addAll(Arrays.asList(a, a1, a2, b, b1, b2, c, c1, c2));
 		toVisitCount[0] = 9;
 		a.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue("3.0", toVisit.isEmpty());
-		assertEquals("3.1", 0, toVisitCount[0]);
+		assertTrue(toVisit.isEmpty());
+		assertEquals(0, toVisitCount[0]);
 	}
 
 	/**
@@ -815,10 +798,10 @@ public class IResourceTest {
 
 		project1.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		project2.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertTrue("1.1", project1.exists());
-		assertTrue("1.2", project1.isSynchronized(IResource.DEPTH_INFINITE));
-		assertFalse("1.3", project2.exists());
-		assertTrue("1.4", project2.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(project1.exists());
+		assertTrue(project1.isSynchronized(IResource.DEPTH_INFINITE));
+		assertFalse(project2.exists());
+		assertTrue(project2.isSynchronized(IResource.DEPTH_INFINITE));
 	}
 
 	/**
@@ -826,28 +809,28 @@ public class IResourceTest {
 	@Test
 	public void testConstants() {
 		// IResource constants (all have fixed values)
-		assertEquals("1.0", 0, IResource.NONE);
+		assertEquals(0, IResource.NONE);
 
-		assertEquals("2.1", 0x1, IResource.FILE);
-		assertEquals("2.2", 0x2, IResource.FOLDER);
-		assertEquals("2.3", 0x4, IResource.PROJECT);
-		assertEquals("2.4", 0x8, IResource.ROOT);
+		assertEquals(0x1, IResource.FILE);
+		assertEquals(0x2, IResource.FOLDER);
+		assertEquals(0x4, IResource.PROJECT);
+		assertEquals(0x8, IResource.ROOT);
 
-		assertEquals("3.1", 0, IResource.DEPTH_ZERO);
-		assertEquals("3.2", 1, IResource.DEPTH_ONE);
-		assertEquals("3.1", 2, IResource.DEPTH_INFINITE);
+		assertEquals(0, IResource.DEPTH_ZERO);
+		assertEquals(1, IResource.DEPTH_ONE);
+		assertEquals(2, IResource.DEPTH_INFINITE);
 
-		assertEquals("4.1", -1, IResource.NULL_STAMP);
+		assertEquals(-1, IResource.NULL_STAMP);
 
-		assertEquals("5.1", 0x1, IResource.FORCE);
-		assertEquals("5.2", 0x2, IResource.KEEP_HISTORY);
-		assertEquals("5.3", 0x4, IResource.ALWAYS_DELETE_PROJECT_CONTENT);
-		assertEquals("5.4", 0x8, IResource.NEVER_DELETE_PROJECT_CONTENT);
+		assertEquals(0x1, IResource.FORCE);
+		assertEquals(0x2, IResource.KEEP_HISTORY);
+		assertEquals(0x4, IResource.ALWAYS_DELETE_PROJECT_CONTENT);
+		assertEquals(0x8, IResource.NEVER_DELETE_PROJECT_CONTENT);
 
 		// IContainer constants (all have fixed values)
-		assertEquals("6.1", 0x1, IContainer.INCLUDE_PHANTOMS);
-		assertEquals("6.2", 0x2, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
-		assertEquals("6.2", 0x8, IContainer.INCLUDE_HIDDEN);
+		assertEquals(0x1, IContainer.INCLUDE_PHANTOMS);
+		assertEquals(0x2, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
+		assertEquals(0x8, IContainer.INCLUDE_HIDDEN);
 	}
 
 	/**
@@ -1261,89 +1244,89 @@ public class IResourceTest {
 		// default; check each type
 
 		// root - cannot be marked as derived
-		assertFalse("2.1.1", root.isDerived());
-		assertFalse("2.1.2", project.isDerived());
-		assertFalse("2.1.3", folder.isDerived());
-		assertFalse("2.1.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		root.setDerived(true, new NullProgressMonitor());
-		assertFalse("2.2.1", root.isDerived());
-		assertFalse("2.2.2", project.isDerived());
-		assertFalse("2.2.3", folder.isDerived());
-		assertFalse("2.2.4", file.isDerived());
-		assertTrue("2.2.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		root.setDerived(false, new NullProgressMonitor());
-		assertFalse("2.3.1", root.isDerived());
-		assertFalse("2.3.2", project.isDerived());
-		assertFalse("2.3.3", folder.isDerived());
-		assertFalse("2.3.4", file.isDerived());
-		assertTrue("2.3.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		// project - cannot be marked as derived
 		project.setDerived(true, new NullProgressMonitor());
-		assertFalse("3.1.1", root.isDerived());
-		assertFalse("3.1.2", project.isDerived());
-		assertFalse("3.1.3", folder.isDerived());
-		assertFalse("3.1.4", file.isDerived());
-		assertTrue("3.1.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		project.setDerived(false, new NullProgressMonitor());
-		assertFalse("3.2.1", root.isDerived());
-		assertFalse("3.2.2", project.isDerived());
-		assertFalse("3.2.3", folder.isDerived());
-		assertFalse("3.2.4", file.isDerived());
-		assertTrue("3.2.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		// folder
 		verifier.addExpectedChange(folder, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
 		folder.setDerived(true, new NullProgressMonitor());
-		assertFalse("4.1.1", root.isDerived());
-		assertFalse("4.1.2", project.isDerived());
-		assertTrue("4.1.3", folder.isDerived());
-		assertFalse("4.1.4", file.isDerived());
-		assertTrue("4.1.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertTrue(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		verifier.addExpectedChange(folder, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
 		folder.setDerived(false, new NullProgressMonitor());
-		assertFalse("4.2.1", root.isDerived());
-		assertFalse("4.2.2", project.isDerived());
-		assertFalse("4.2.3", folder.isDerived());
-		assertFalse("4.2.4", file.isDerived());
-		assertTrue("4.2.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		// file
 		verifier.addExpectedChange(file, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
 		file.setDerived(true, new NullProgressMonitor());
-		assertFalse("5.1.1", root.isDerived());
-		assertFalse("5.1.2", project.isDerived());
-		assertFalse("5.1.3", folder.isDerived());
-		assertTrue("5.1.4", file.isDerived());
-		assertTrue("5.1.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertTrue(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		verifier.addExpectedChange(file, IResourceDelta.CHANGED, IResourceDelta.DERIVED_CHANGED);
 		file.setDerived(false, new NullProgressMonitor());
-		assertFalse("5.2.1", root.isDerived());
-		assertFalse("5.2.2", project.isDerived());
-		assertFalse("5.2.3", folder.isDerived());
-		assertFalse("5.2.4", file.isDerived());
-		assertTrue("5.2.5" + verifier.getMessage(), verifier.isDeltaValid());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		verifier.reset();
 
 		/* remove trash */
 		project.delete(true, createTestMonitor());
 
 		// isDerived should return false when resource does not exist
-		assertFalse("8.1", project.isDerived());
-		assertFalse("8.2", folder.isDerived());
-		assertFalse("8.3", file.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		// setDerived should fail when resource does not exist
 		assertThrows(CoreException.class, () -> project.setDerived(false, new NullProgressMonitor()));
@@ -1370,64 +1353,64 @@ public class IResourceTest {
 		// default; check each type
 
 		// root - cannot be marked as derived
-		assertFalse("2.1.1", root.isDerived());
-		assertFalse("2.1.2", project.isDerived());
-		assertFalse("2.1.3", folder.isDerived());
-		assertFalse("2.1.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 		root.setDerived(true);
-		assertFalse("2.2.1", root.isDerived());
-		assertFalse("2.2.2", project.isDerived());
-		assertFalse("2.2.3", folder.isDerived());
-		assertFalse("2.2.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 		root.setDerived(false);
-		assertFalse("2.3.1", root.isDerived());
-		assertFalse("2.3.2", project.isDerived());
-		assertFalse("2.3.3", folder.isDerived());
-		assertFalse("2.3.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		// project - cannot be marked as derived
 		project.setDerived(true);
-		assertFalse("3.1.1", root.isDerived());
-		assertFalse("3.1.2", project.isDerived());
-		assertFalse("3.1.3", folder.isDerived());
-		assertFalse("3.1.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 		project.setDerived(false);
-		assertFalse("3.2.1", root.isDerived());
-		assertFalse("3.2.2", project.isDerived());
-		assertFalse("3.2.3", folder.isDerived());
-		assertFalse("3.2.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		// folder
 		folder.setDerived(true);
-		assertFalse("4.1.1", root.isDerived());
-		assertFalse("4.1.2", project.isDerived());
-		assertTrue("4.1.3", folder.isDerived());
-		assertFalse("4.1.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertTrue(folder.isDerived());
+		assertFalse(file.isDerived());
 		folder.setDerived(false);
-		assertFalse("4.2.1", root.isDerived());
-		assertFalse("4.2.2", project.isDerived());
-		assertFalse("4.2.3", folder.isDerived());
-		assertFalse("4.2.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		// file
 		file.setDerived(true);
-		assertFalse("5.1.1", root.isDerived());
-		assertFalse("5.1.2", project.isDerived());
-		assertFalse("5.1.3", folder.isDerived());
-		assertTrue("5.1.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertTrue(file.isDerived());
 		file.setDerived(false);
-		assertFalse("5.2.1", root.isDerived());
-		assertFalse("5.2.2", project.isDerived());
-		assertFalse("5.2.3", folder.isDerived());
-		assertFalse("5.2.4", file.isDerived());
+		assertFalse(root.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		/* remove trash */
 		project.delete(true, true, createTestMonitor());
 
 		// isDerived should return false when resource does not exist
-		assertFalse("8.1", project.isDerived());
-		assertFalse("8.2", folder.isDerived());
-		assertFalse("8.3", file.isDerived());
+		assertFalse(project.isDerived());
+		assertFalse(folder.isDerived());
+		assertFalse(file.isDerived());
 
 		// setDerived should fail when resource does not exist
 		assertThrows(CoreException.class, () -> project.setDerived(false));
@@ -1453,48 +1436,48 @@ public class IResourceTest {
 		// initial values should be false
 		for (IResource resource2 : resources) {
 			IResource resource = resource2;
-			assertFalse("1.0: " + resource.getFullPath(), resource.isDerived());
+			assertFalse(resource.getFullPath().toString(), resource.isDerived());
 		}
 
 		// now set the root as derived
 		root.setDerived(true, new NullProgressMonitor());
 
 		// we can't mark the root as derived, so none of its children should be derived
-		assertFalse("2.1: " + root.getFullPath(), root.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("2.2: " + project.getFullPath(), project.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("2.3: " + folder.getFullPath(), folder.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("2.4: " + file1.getFullPath(), file1.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("2.5: " + file2.getFullPath(), file2.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(root.getFullPath().toString(), root.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(project.getFullPath().toString(), project.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(folder.getFullPath().toString(), folder.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(file1.getFullPath().toString(), file1.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(file2.getFullPath().toString(), file2.isDerived(IResource.CHECK_ANCESTORS));
 
 		// now set the project as derived
 		project.setDerived(true, new NullProgressMonitor());
 
 		// we can't mark a project as derived, so none of its children should be derived
 		// even when CHECK_ANCESTORS is used
-		assertFalse("3.0: " + project.getFullPath(), project.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("3.1: " + folder.getFullPath(), folder.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("3.2: " + file1.getFullPath(), file1.isDerived(IResource.CHECK_ANCESTORS));
-		assertFalse("3.3: " + file2.getFullPath(), file2.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(project.getFullPath().toString(), project.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(folder.getFullPath().toString(), folder.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(file1.getFullPath().toString(), file1.isDerived(IResource.CHECK_ANCESTORS));
+		assertFalse(file2.getFullPath().toString(), file2.isDerived(IResource.CHECK_ANCESTORS));
 
 		// now set the folder as derived
 		folder.setDerived(true, new NullProgressMonitor());
 
 		// first check if isDerived() returns valid values
-		assertTrue("4.1: " + folder.getFullPath(), folder.isDerived());
-		assertFalse("4.2: " + file1.getFullPath(), file1.isDerived());
-		assertFalse("4.3: " + file2.getFullPath(), file2.isDerived());
+		assertTrue(folder.getFullPath().toString(), folder.isDerived());
+		assertFalse(file1.getFullPath().toString(), file1.isDerived());
+		assertFalse(file2.getFullPath().toString(), file2.isDerived());
 
 		// check if isDerived(IResource.CHECK_ANCESTORS) returns valid values
-		assertTrue("4.4: " + folder.getFullPath(), folder.isDerived(IResource.CHECK_ANCESTORS));
-		assertTrue("4.5: " + file1.getFullPath(), file1.isDerived(IResource.CHECK_ANCESTORS));
-		assertTrue("4.6: " + file2.getFullPath(), file2.isDerived(IResource.CHECK_ANCESTORS));
+		assertTrue(folder.getFullPath().toString(), folder.isDerived(IResource.CHECK_ANCESTORS));
+		assertTrue(file1.getFullPath().toString(), file1.isDerived(IResource.CHECK_ANCESTORS));
+		assertTrue(file2.getFullPath().toString(), file2.isDerived(IResource.CHECK_ANCESTORS));
 
 		// clear the values
 		folder.setDerived(false, new NullProgressMonitor());
 
 		// values should be false again
 		for (IResource resource2 : resources) {
-			assertFalse("7.0: " + resource2.getFullPath(), resource2.isDerived());
+			assertFalse(resource2.getFullPath().toString(), resource2.isDerived());
 		}
 	}
 
@@ -1623,7 +1606,7 @@ public class IResourceTest {
 
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
-				assertEquals("1.0." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, resource.getModificationStamp());
 			}
 		}
 
@@ -1634,24 +1617,25 @@ public class IResourceTest {
 		for (IProject project2 : projects) {
 			project = project2;
 			project.create(createTestMonitor());
-			assertEquals("2.1." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
+			assertEquals(project.getFullPath().toString(), IResource.NULL_STAMP, project.getModificationStamp());
 		}
 
 		// open the project(s) and create the resources. none should have a
 		// null stamp anymore.
 		for (IProject project2 : projects) {
 			project = project2;
-			assertEquals("3.1." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
+			assertEquals(project.getFullPath().toString(), IResource.NULL_STAMP, project.getModificationStamp());
 			project.open(createTestMonitor());
-			assertNotEquals("3.3." + project.getFullPath(), IResource.NULL_STAMP, project.getModificationStamp());
+			assertNotEquals(project.getFullPath().toString(), IResource.NULL_STAMP, project.getModificationStamp());
 			// cache the value for later use
 			table.put(project.getFullPath(), Long.valueOf(project.getModificationStamp()));
 		}
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.PROJECT) {
-				assertEquals("3.4." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, resource.getModificationStamp());
 				createInWorkspace(resource);
-				assertNotEquals("3.5." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP,
+						resource.getModificationStamp());
 				// cache the value for later use
 				table.put(resource.getFullPath(), Long.valueOf(resource.getModificationStamp()));
 			}
@@ -1664,7 +1648,7 @@ public class IResourceTest {
 		}
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
-				assertEquals("4.1." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, resource.getModificationStamp());
 			}
 		}
 
@@ -1676,9 +1660,9 @@ public class IResourceTest {
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.PROJECT) {
 				Object v = table.get(resource.getFullPath());
-				assertNotNull("5.1." + resource.getFullPath(), v);
+				assertNotNull(resource.getFullPath().toString(), v);
 				long old = ((Long) v).longValue();
-				assertEquals("5.2." + resource.getFullPath(), old, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), old, resource.getModificationStamp());
 			}
 		}
 
@@ -1689,9 +1673,9 @@ public class IResourceTest {
 				resource.touch(createTestMonitor());
 				long stamp = resource.getModificationStamp();
 				Object v = table.get(resource.getFullPath());
-				assertNotNull("6.0." + resource.getFullPath(), v);
+				assertNotNull(resource.getFullPath().toString(), v);
 				long old = ((Long) v).longValue();
-				assertNotEquals("6.1." + resource.getFullPath(), old, stamp);
+				assertNotEquals(resource.getFullPath().toString(), old, stamp);
 				// cache for next time
 				tempTable.put(resource.getFullPath(), Long.valueOf(stamp));
 			}
@@ -1705,9 +1689,10 @@ public class IResourceTest {
 		IResourceVisitor visitor = resource -> {
 			//projects and root are always local
 			if (resource.getType() == IResource.ROOT || resource.getType() == IResource.PROJECT) {
-				assertNotEquals("7.2" + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP,
+						resource.getModificationStamp());
 			} else {
-				assertEquals("7.3." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, resource.getModificationStamp());
 			}
 			return true;
 		};
@@ -1721,11 +1706,11 @@ public class IResourceTest {
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
 				long stamp = resource.getModificationStamp();
-				assertNotEquals("8.2." + resource.getFullPath(), IResource.NULL_STAMP, stamp);
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, stamp);
 				Object v = table.get(resource.getFullPath());
-				assertNotNull("8.3." + resource.getFullPath(), v);
+				assertNotNull(resource.getFullPath().toString(), v);
 				long old = ((Long) v).longValue();
-				assertNotEquals("8.4." + resource.getFullPath(), IResource.NULL_STAMP, old);
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, old);
 				tempTable.put(resource.getFullPath(), Long.valueOf(stamp));
 			}
 		}
@@ -1737,11 +1722,11 @@ public class IResourceTest {
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
 				long newStamp = resource.getModificationStamp();
-				assertNotEquals("9.2." + resource.getFullPath(), IResource.NULL_STAMP, newStamp);
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, newStamp);
 				Object v = table.get(resource.getFullPath());
-				assertNotNull("9.3." + resource.getFullPath(), v);
+				assertNotNull(resource.getFullPath().toString(), v);
 				long oldStamp = ((Long) v).longValue();
-				assertEquals("9.4." + resource.getFullPath(), oldStamp, newStamp);
+				assertEquals(resource.getFullPath().toString(), oldStamp, newStamp);
 			}
 		}
 
@@ -1752,7 +1737,7 @@ public class IResourceTest {
 		// should be null
 		for (IResource resource : resources) {
 			if (resource.getType() != IResource.ROOT) {
-				assertEquals("10.1" + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+				assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP, resource.getModificationStamp());
 			}
 		}
 
@@ -1771,11 +1756,12 @@ public class IResourceTest {
 				case IResource.ROOT :
 					break;
 				case IResource.PROJECT :
-					assertNotEquals("11.1." + resource.getFullPath(), IResource.NULL_STAMP,
+					assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP,
 							resource.getModificationStamp());
 					break;
 				default :
-					assertEquals("11.2." + resource.getFullPath(), IResource.NULL_STAMP, resource.getModificationStamp());
+					assertEquals(resource.getFullPath().toString(), IResource.NULL_STAMP,
+							resource.getModificationStamp());
 					break;
 			}
 		}
@@ -1783,7 +1769,7 @@ public class IResourceTest {
 		getWorkspace().getRoot().setLocal(true, IResource.DEPTH_INFINITE, createTestMonitor());
 		visitor = resource -> {
 			if (resource.getType() != IResource.ROOT) {
-				assertNotEquals("12.1." + resource.getFullPath(), IResource.NULL_STAMP,
+				assertNotEquals(resource.getFullPath().toString(), IResource.NULL_STAMP,
 						resource.getModificationStamp());
 			}
 			return true;
@@ -1800,7 +1786,7 @@ public class IResourceTest {
 		final IFile file = getWorkspace().getRoot().getFile(IPath.fromOSString("/project/f"));
 		createInWorkspace(file);
 		long modificationStamp = file.getModificationStamp();
-		assertNotEquals("1.1", modificationStamp, IResource.NULL_STAMP);
+		assertNotEquals(modificationStamp, IResource.NULL_STAMP);
 
 		// Remove and re-create the file in a workspace operation
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
@@ -1808,7 +1794,7 @@ public class IResourceTest {
 			file.create(nullInputStream(), true, createTestMonitor());
 		}, createTestMonitor());
 
-		assertNotEquals("1.0", modificationStamp, file.getModificationStamp());
+		assertNotEquals(modificationStamp, file.getModificationStamp());
 	}
 
 	/**
@@ -1824,29 +1810,29 @@ public class IResourceTest {
 		IResource[] allResources = { project, topFolder, topFile, deepFile };
 
 		//non existing project
-		assertNull("2.0", project.getRawLocation());
+		assertNull(project.getRawLocation());
 
 		//resources in non-existing project
-		assertNull("2.1", topFolder.getRawLocation());
-		assertNull("2.2", topFile.getRawLocation());
-		assertNull("2.3", deepFile.getRawLocation());
+		assertNull(topFolder.getRawLocation());
+		assertNull(topFile.getRawLocation());
+		assertNull(deepFile.getRawLocation());
 
 		createInWorkspace(allResources);
 		//open project
-		assertNull("2.0", project.getRawLocation());
+		assertNull(project.getRawLocation());
 		//resources in open project
 		final IPath workspaceLocation = getWorkspace().getRoot().getLocation();
-		assertEquals("2.1", workspaceLocation.append(topFolder.getFullPath()), topFolder.getRawLocation());
-		assertEquals("2.2", workspaceLocation.append(topFile.getFullPath()), topFile.getRawLocation());
-		assertEquals("2.3", workspaceLocation.append(deepFile.getFullPath()), deepFile.getRawLocation());
+		assertEquals(workspaceLocation.append(topFolder.getFullPath()), topFolder.getRawLocation());
+		assertEquals(workspaceLocation.append(topFile.getFullPath()), topFile.getRawLocation());
+		assertEquals(workspaceLocation.append(deepFile.getFullPath()), deepFile.getRawLocation());
 
 		project.close(createTestMonitor());
 		//closed project
-		assertNull("3.0", project.getRawLocation());
+		assertNull(project.getRawLocation());
 		//resource in closed project
-		assertEquals("3.1", workspaceLocation.append(topFolder.getFullPath()), topFolder.getRawLocation());
-		assertEquals("3.2", workspaceLocation.append(topFile.getFullPath()), topFile.getRawLocation());
-		assertEquals("3.3", workspaceLocation.append(deepFile.getFullPath()), deepFile.getRawLocation());
+		assertEquals(workspaceLocation.append(topFolder.getFullPath()), topFolder.getRawLocation());
+		assertEquals(workspaceLocation.append(topFile.getFullPath()), topFile.getRawLocation());
+		assertEquals(workspaceLocation.append(deepFile.getFullPath()), deepFile.getRawLocation());
 
 		IPath projectLocation = getRandomLocation();
 		workspaceRule.deleteOnTearDown(projectLocation);
@@ -1866,20 +1852,20 @@ public class IResourceTest {
 			project.move(description, IResource.NONE, createTestMonitor());
 
 			//open project not in default location
-			assertEquals("4.0", projectLocation, project.getRawLocation());
+			assertEquals(projectLocation, project.getRawLocation());
 			//resource in open project not in default location
-			assertEquals("4.1", projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
-			assertEquals("4.2", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
-			assertEquals("4.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
+			assertEquals(projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
+			assertEquals(projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
+			assertEquals(projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
 			project.close(createTestMonitor());
 
 			//closed project not in default location
-			assertEquals("5.0", projectLocation, project.getRawLocation());
+			assertEquals(projectLocation, project.getRawLocation());
 			//resource in closed project not in default location
-			assertEquals("5.1", projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
-			assertEquals("5.2", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
-			assertEquals("5.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
+			assertEquals(projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
+			assertEquals(projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
+			assertEquals(projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
 			project.open(createTestMonitor());
 			removeFromWorkspace(topFolder);
@@ -1891,21 +1877,21 @@ public class IResourceTest {
 			createInWorkspace(deepFile);
 
 			//linked file
-			assertEquals("6.0", fileLocation, topFile.getRawLocation());
+			assertEquals(fileLocation, topFile.getRawLocation());
 			//linked folder
-			assertEquals("6.1", folderLocation, topFolder.getRawLocation());
+			assertEquals(folderLocation, topFolder.getRawLocation());
 			//resource below linked folder
-			assertEquals("6.2", folderLocation.append(deepFile.getName()), deepFile.getRawLocation());
+			assertEquals(folderLocation.append(deepFile.getName()), deepFile.getRawLocation());
 
 			project.close(createTestMonitor());
 
 			//linked file in closed project (should default to project
 			// location)
-			assertEquals("7.0", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
+			assertEquals(projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
 			//linked folder in closed project
-			assertEquals("7.1", projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
+			assertEquals(projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
 			//resource below linked folder in closed project
-			assertEquals("7.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
+			assertEquals(projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 
 			project.open(createTestMonitor());
 			IPath variableFolderLocation = IPath.fromOSString(variableName).append("/VarFolderName");
@@ -1919,20 +1905,21 @@ public class IResourceTest {
 			createInWorkspace(deepFile);
 
 			//linked file with variable
-			assertEquals("8.0", variableFileLocation, topFile.getRawLocation());
+			assertEquals(variableFileLocation, topFile.getRawLocation());
 			//linked folder with variable
-			assertEquals("8.1", variableFolderLocation, topFolder.getRawLocation());
+			assertEquals(variableFolderLocation, topFolder.getRawLocation());
 			//resource below linked folder with variable
-			assertEquals("8.3", varMan.resolvePath(variableFolderLocation).append(deepFile.getName()), deepFile.getRawLocation());
+			assertEquals(varMan.resolvePath(variableFolderLocation).append(deepFile.getName()),
+					deepFile.getRawLocation());
 
 			project.close(createTestMonitor());
 
 			//linked file in closed project with variable
-			assertEquals("9.0", projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
+			assertEquals(projectLocation.append(topFile.getProjectRelativePath()), topFile.getRawLocation());
 			//linked folder in closed project with variable
-			assertEquals("9.1", projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
+			assertEquals(projectLocation.append(topFolder.getProjectRelativePath()), topFolder.getRawLocation());
 			//resource below linked folder in closed project with variable
-			assertEquals("9.3", projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
+			assertEquals(projectLocation.append(deepFile.getProjectRelativePath()), deepFile.getRawLocation());
 		} finally {
 			varMan.setValue(variableName, null);
 		}
@@ -2266,18 +2253,18 @@ public class IResourceTest {
 		file.create(createRandomContentsStream(), true, createTestMonitor());
 
 		// file
-		assertFalse("1.0", file.isReadOnly());
+		assertFalse(file.isReadOnly());
 		file.setReadOnly(true);
-		assertTrue("1.2", file.isReadOnly());
+		assertTrue(file.isReadOnly());
 		file.setReadOnly(false);
-		assertFalse("1.4", file.isReadOnly());
+		assertFalse(file.isReadOnly());
 
 		// folder
-		assertFalse("2.0", project.isReadOnly());
+		assertFalse(project.isReadOnly());
 		project.setReadOnly(true);
-		assertTrue("2.2", project.isReadOnly());
+		assertTrue(project.isReadOnly());
 		project.setReadOnly(false);
-		assertFalse("2.4", project.isReadOnly());
+		assertFalse(project.isReadOnly());
 	}
 
 	/**
@@ -2385,12 +2372,12 @@ public class IResourceTest {
 			resource.touch(null);
 			long newStamp = resource.getModificationStamp();
 			if (resource.getType() == IResource.ROOT) {
-				assertEquals("1.0." + resource.getFullPath(), oldStamp, newStamp);
+				assertEquals(resource.getFullPath().toString(), oldStamp, newStamp);
 			} else {
-				assertNotEquals("1.0." + resource.getFullPath(), oldStamp, newStamp);
+				assertNotEquals(resource.getFullPath().toString(), oldStamp, newStamp);
 			}
 			resource.revertModificationStamp(oldStamp);
-			assertEquals("1.1." + resource.getFullPath(), oldStamp, resource.getModificationStamp());
+			assertEquals(resource.getFullPath().toString(), oldStamp, resource.getModificationStamp());
 			return true;
 		});
 
@@ -2488,64 +2475,64 @@ public class IResourceTest {
 		// all non-TPM by default; check each type
 
 		// root - cannot be made team private member
-		assertFalse("2.1.1", root.isTeamPrivateMember());
-		assertFalse("2.1.2", project.isTeamPrivateMember());
-		assertFalse("2.1.3", folder.isTeamPrivateMember());
-		assertFalse("2.1.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 		root.setTeamPrivateMember(true);
-		assertFalse("2.2.1", root.isTeamPrivateMember());
-		assertFalse("2.2.2", project.isTeamPrivateMember());
-		assertFalse("2.2.3", folder.isTeamPrivateMember());
-		assertFalse("2.2.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 		root.setTeamPrivateMember(false);
-		assertFalse("2.3.1", root.isTeamPrivateMember());
-		assertFalse("2.3.2", project.isTeamPrivateMember());
-		assertFalse("2.3.3", folder.isTeamPrivateMember());
-		assertFalse("2.3.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 
 		// project - cannot be made team private member
 		project.setTeamPrivateMember(true);
-		assertFalse("3.1.1", root.isTeamPrivateMember());
-		assertFalse("3.1.2", project.isTeamPrivateMember());
-		assertFalse("3.1.3", folder.isTeamPrivateMember());
-		assertFalse("3.1.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 		project.setTeamPrivateMember(false);
-		assertFalse("3.2.1", root.isTeamPrivateMember());
-		assertFalse("3.2.2", project.isTeamPrivateMember());
-		assertFalse("3.2.3", folder.isTeamPrivateMember());
-		assertFalse("3.2.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 
 		// folder
 		folder.setTeamPrivateMember(true);
-		assertFalse("4.1.1", root.isTeamPrivateMember());
-		assertFalse("4.1.2", project.isTeamPrivateMember());
-		assertTrue("4.1.3", folder.isTeamPrivateMember());
-		assertFalse("4.1.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertTrue(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 		folder.setTeamPrivateMember(false);
-		assertFalse("4.2.1", root.isTeamPrivateMember());
-		assertFalse("4.2.2", project.isTeamPrivateMember());
-		assertFalse("4.2.3", folder.isTeamPrivateMember());
-		assertFalse("4.2.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 
 		// file
 		file.setTeamPrivateMember(true);
-		assertFalse("5.1.1", root.isTeamPrivateMember());
-		assertFalse("5.1.2", project.isTeamPrivateMember());
-		assertFalse("5.1.3", folder.isTeamPrivateMember());
-		assertTrue("5.1.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertTrue(file.isTeamPrivateMember());
 		file.setTeamPrivateMember(false);
-		assertFalse("5.2.1", root.isTeamPrivateMember());
-		assertFalse("5.2.2", project.isTeamPrivateMember());
-		assertFalse("5.2.3", folder.isTeamPrivateMember());
-		assertFalse("5.2.4", file.isTeamPrivateMember());
+		assertFalse(root.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 
 		/* remove trash */
 		project.delete(true, createTestMonitor());
 
 		// isTeamPrivateMember should return false when resource does not exist
-		assertFalse("8.1", project.isTeamPrivateMember());
-		assertFalse("8.2", folder.isTeamPrivateMember());
-		assertFalse("8.3", file.isTeamPrivateMember());
+		assertFalse(project.isTeamPrivateMember());
+		assertFalse(folder.isTeamPrivateMember());
+		assertFalse(file.isTeamPrivateMember());
 
 		// setTeamPrivateMember should fail when resource does not exist
 		assertThrows(CoreException.class, () -> project.setTeamPrivateMember(false));
@@ -2577,7 +2564,7 @@ public class IResourceTest {
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
 
 		List<IResource> expectedOrder = Arrays.asList(project, project.getFile(".project"),  settings, prefs, a, a1, a2, b, b2, b1);
-		assertEquals("1.0", expectedOrder.toString(), actualOrder.toString());
+		assertEquals(expectedOrder.toString(), actualOrder.toString());
 	}
 
 	private static class LogListener implements ILogListener {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -255,7 +256,7 @@ public class ISynchronizerTest {
 			if (type == IResource.FILE && resource.getParent().getType() == IResource.PROJECT && resource.getName().equals(IProjectDescription.DESCRIPTION_FILE_NAME)) {
 				return true;
 			}
-			assertNull("5.0." + resource.getFullPath(), synchronizer.getSyncInfo(qname, resource));
+			assertNull(resource.getFullPath().toString(), synchronizer.getSyncInfo(qname, resource));
 			return true;
 		};
 
@@ -337,8 +338,8 @@ public class ISynchronizerTest {
 		// rename the file and ensure that the sync info is moved with it
 		IProject destProject = getWorkspace().getRoot().getProject("newProject");
 		sourceProject.move(destProject.getFullPath(), true, createTestMonitor());
-		assertNull("7.1", synchronizer.getSyncInfo(qname, sourceProject));
-		assertNull("7.2", synchronizer.getSyncInfo(qname, sourceFile));
+		assertNull(synchronizer.getSyncInfo(qname, sourceProject));
+		assertNull(synchronizer.getSyncInfo(qname, sourceFile));
 		syncInfo = synchronizer.getSyncInfo(qname, destProject.getFile(sourceFile.getName()));
 		assertThat(syncInfo).as("sync info for resource: %s", sourceFile.getFullPath()).isNotNull().isEqualTo(b);
 		syncInfo = synchronizer.getSyncInfo(qname, destProject);
@@ -460,136 +461,6 @@ public class ISynchronizerTest {
 	}
 
 	@Test
-	public void testSnap() {
-		/*
-		 final Hashtable table = new Hashtable(10);
-		 final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
-		 final Synchronizer synchronizer = (Synchronizer) ResourcesPlugin.getWorkspace().getSynchronizer();
-
-		 // register the sync partner and set the sync info on the resources
-		 synchronizer.add(qname);
-		 IResourceVisitor visitor = new IResourceVisitor() {
-		 public boolean visit(IResource resource) throws CoreException {
-		 if (resource.getType() == IResource.ROOT)
-		 return true;
-		 try {
-		 byte[] b = getRandomString().getBytes();
-		 synchronizer.setSyncInfo(qname, resource, b);
-		 table.put(resource.getFullPath(), b);
-		 } catch (CoreException e) {
-		 fail("0.0." + resource.getFullPath(), e);
-		 }
-		 return true;
-		 }
-		 };
-		 try {
-		 getWorkspace().getRoot().accept(visitor);
-		 } catch (CoreException e) {
-		 fail("0.1", e);
-		 }
-
-		 // write out the data
-		 File file = Platform.getLocation().append(".testsyncinfo.snap").toFile();
-		 SafeChunkyOutputStream safeOutput = null;
-		 DataOutputStream o1 = null;
-		 try {
-		 safeOutput = new SafeChunkyOutputStream(file);
-		 o1 = new DataOutputStream(safeOutput);
-		 } catch (IOException e) {
-		 if (safeOutput != null)
-		 try {
-		 safeOutput.close();
-		 } catch (IOException e2) {
-		 }
-		 fail("1.0", e);
-		 }
-		 final DataOutputStream output = o1;
-		 visitor = new IResourceVisitor() {
-		 public boolean visit(IResource resource) throws CoreException {
-		 try {
-		 synchronizer.snapSyncInfo(resource, output);
-		 } catch (IOException e) {
-		 fail("1.1", e);
-		 }
-		 return true;
-		 }
-		 };
-		 try {
-		 getWorkspace().getRoot().accept(visitor);
-		 safeOutput.succeed();
-		 } catch (CoreException e) {
-		 fail("1.2", e);
-		 } catch (IOException e) {
-		 fail("1.3", e);
-		 } finally {
-		 try {
-		 output.close();
-		 } catch (IOException e) {
-		 fail("1.4", e);
-		 }
-		 }
-
-		 // flush the sync info in memory
-		 try {
-		 flushAllSyncInfo(getWorkspace().getRoot());
-		 } catch (CoreException e) {
-		 fail("2.0", e);
-		 }
-
-		 // read in the data
-		 try {
-		 InputStream safeInput = new SafeChunkyInputStream(file);
-		 final DataInputStream input = new DataInputStream(safeInput);
-		 IWorkspaceRunnable body = new IWorkspaceRunnable() {
-		 public void run(IProgressMonitor monitor) throws CoreException {
-		 SyncInfoSnapReader reader = new SyncInfoSnapReader((Workspace) getWorkspace(), synchronizer);
-		 try {
-		 reader.readSyncInfo(input);
-		 } catch (IOException e) {
-		 fail("3.0", e);
-		 }
-		 }
-		 };
-		 try {
-		 getWorkspace().run(body, getMonitor());
-		 } finally {
-		 try {
-		 input.close();
-		 } catch (IOException e) {
-		 fail("3.1", e);
-		 }
-		 }
-		 } catch (FileNotFoundException e) {
-		 fail("3.2", e);
-		 } catch (IOException e) {
-		 fail("3.3", e);
-		 } catch (CoreException e) {
-		 fail("3.4", e);
-		 }
-
-		 // confirm the sync bytes are the same
-		 visitor = new IResourceVisitor() {
-		 public boolean visit(IResource resource) throws CoreException {
-		 byte[] actual = synchronizer.getSyncInfo(qname, resource);
-		 if (resource.getType() == IResource.ROOT) {
-		 assertNull("4.0", actual);
-		 return true;
-		 } else
-		 assertNotNull("4.1." + resource.getFullPath(), actual);
-		 byte[] expected = (byte[]) table.get(resource.getFullPath());
-		 assertEquals("4.2." + resource.getFullPath(), expected, actual);
-		 return true;
-		 }
-		 };
-		 try {
-		 getWorkspace().getRoot().accept(visitor);
-		 } catch (CoreException e) {
-		 fail("4.3", e);
-		 }
-		 */
-	}
-
-	@Test
 	public void testSyncInfo() throws CoreException {
 		final QualifiedName qname = new QualifiedName("org.eclipse.core.tests.resources", "myTarget");
 		final ISynchronizer synchronizer = ResourcesPlugin.getWorkspace().getSynchronizer();
@@ -706,38 +577,38 @@ public class ISynchronizerTest {
 		synchronizer.setSyncInfo(partner, file2, createRandomString().getBytes());
 
 		// 1) tests with one child first
-		assertTrue("1.1", file1.exists());
-		assertTrue("1.2", !file1.isPhantom());
+		assertTrue(file1.exists());
+		assertFalse(file1.isPhantom());
 		// deletes file
 		file1.delete(true, createTestMonitor());
 		// file is now a phantom resource
-		assertTrue("2.1", !file1.exists());
-		assertTrue("2.2", file1.isPhantom());
+		assertFalse(file1.exists());
+		assertTrue(file1.isPhantom());
 		// removes sync info
 		synchronizer.setSyncInfo(partner, file1, null);
 		// phantom should not exist any more
-		assertTrue("3.1", !file1.exists());
-		assertTrue("3.2", !file1.isPhantom());
+		assertFalse(file1.exists());
+		assertFalse(file1.isPhantom());
 
 		// 2) tests with the folder and remaining child
-		assertTrue("4.1", folder.exists());
-		assertTrue("4.2", !folder.isPhantom());
-		assertTrue("4.3", file2.exists());
-		assertTrue("4.4", !file2.isPhantom());
+		assertTrue(folder.exists());
+		assertFalse(folder.isPhantom());
+		assertTrue(file2.exists());
+		assertFalse(file2.isPhantom());
 		// deletes the folder and its only child
 		folder.delete(true, createTestMonitor());
 		// both resources are now phantom resources
-		assertTrue("5.1", !folder.exists());
-		assertTrue("5.2", folder.isPhantom());
-		assertTrue("5.3", !file2.exists());
-		assertTrue("5.4", file2.isPhantom());
+		assertFalse(folder.exists());
+		assertTrue(folder.isPhantom());
+		assertFalse(file2.exists());
+		assertTrue(file2.isPhantom());
 		// removes only folder sync info
 		synchronizer.setSyncInfo(partner, folder, null);
 		// phantoms should not exist any more
-		assertTrue("6.1", !folder.exists());
-		assertTrue("6.2", !folder.isPhantom());
-		assertTrue("6.3", !file2.exists());
-		assertTrue("6.4", !file2.isPhantom());
+		assertFalse(folder.exists());
+		assertFalse(folder.isPhantom());
+		assertFalse(file2.exists());
+		assertFalse(file2.isPhantom());
 
 		// clean-up
 		synchronizer.remove(partner);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -67,7 +68,7 @@ public class IWorkspaceRootTest {
 		IFile link = project.getFile("file.txt");
 		IFileStore fileStore = workspaceRule.getTempStore();
 		createInFileSystem(fileStore);
-		assertEquals("0.1", EFS.SCHEME_FILE, fileStore.getFileSystem().getScheme());
+		assertEquals(EFS.SCHEME_FILE, fileStore.getFileSystem().getScheme());
 		IPath fileLocationLower = URIUtil.toPath(fileStore.toURI());
 		fileLocationLower = fileLocationLower.setDevice(fileLocationLower.getDevice().toLowerCase());
 		IPath fileLocationUpper = fileLocationLower.setDevice(fileLocationLower.getDevice().toUpperCase());
@@ -121,22 +122,22 @@ public class IWorkspaceRootTest {
 		IFolder link = parent.getFolder("link");
 		createInWorkspace(new IResource[] {p1, p2, parent});
 		link.createLink(p1.getLocationURI(), IResource.NONE, createTestMonitor());
-		assertResources("2.0", p1, link, root.findContainersForLocation(p1.getLocation()));
+		assertResources(p1, link, root.findContainersForLocation(p1.getLocation()));
 
 		//existing folder
 		IFolder existing = p2.getFolder("existing");
 		createInWorkspace(existing);
-		assertResources("3.0", existing, root.findContainersForLocation(existing.getLocation()));
-		assertResources("3.1", existing, root.findContainersForLocationURI(existing.getLocationURI()));
+		assertResources(existing, root.findContainersForLocation(existing.getLocation()));
+		assertResources(existing, root.findContainersForLocationURI(existing.getLocationURI()));
 
 		//non-existing
 		IFolder nonExisting = p2.getFolder("nonExisting");
-		assertResources("3.2", nonExisting, root.findContainersForLocation(nonExisting.getLocation()));
-		assertResources("3.3", nonExisting, root.findContainersForLocationURI(nonExisting.getLocationURI()));
+		assertResources(nonExisting, root.findContainersForLocation(nonExisting.getLocation()));
+		assertResources(nonExisting, root.findContainersForLocationURI(nonExisting.getLocationURI()));
 
 		//relative path
-		assertResources("3.4", existing, root.findContainersForLocation(existing.getLocation().makeRelative()));
-		assertResources("3.5", nonExisting, root.findContainersForLocation(nonExisting.getLocation().makeRelative()));
+		assertResources(existing, root.findContainersForLocation(existing.getLocation().makeRelative()));
+		assertResources(nonExisting, root.findContainersForLocation(nonExisting.getLocation().makeRelative()));
 
 		//relative URI is illegal
 		URI relative = new URI(null, "hello", null);
@@ -148,13 +149,13 @@ public class IWorkspaceRootTest {
 		linkStore.mkdir(EFS.NONE, createTestMonitor());
 		otherLink.createLink(location, IResource.NONE, createTestMonitor());
 		result = root.findContainersForLocationURI(location);
-		assertResources("5.1", otherLink, result);
+		assertResources(otherLink, result);
 
 		//child of linked folder
 		IFolder child = otherLink.getFolder("link-child");
 		URI childLocation = linkStore.getChild(child.getName()).toURI();
 		result = root.findContainersForLocationURI(childLocation);
-		assertResources("5.1", child, result);
+		assertResources(child, result);
 
 	}
 
@@ -196,30 +197,30 @@ public class IWorkspaceRootTest {
 		//existing file
 		final IPath existingFileLocation = existing.getLocation();
 		result = root.findFilesForLocation(existingFileLocation);
-		assertResources("2.0", existing, result);
+		assertResources(existing, result);
 		result = root.findFilesForLocationURI(existing.getLocationURI());
-		assertResources("2.1", existing, result);
+		assertResources(existing, result);
 
 		//non-existing file
 		IFile nonExisting = project.getFile("nonExisting");
 		result = root.findFilesForLocation(nonExisting.getLocation());
-		assertResources("3.1", nonExisting, result);
+		assertResources(nonExisting, result);
 		result = root.findFilesForLocationURI(nonExisting.getLocationURI());
-		assertResources("3.2", nonExisting, result);
+		assertResources(nonExisting, result);
 
 		//relative path
 		result = root.findFilesForLocation(existingFileLocation.makeRelative());
-		assertResources("4.0", existing, result);
+		assertResources(existing, result);
 		result = root.findFilesForLocation(nonExisting.getLocation().makeRelative());
-		assertResources("4.1", nonExisting, result);
+		assertResources(nonExisting, result);
 
 		//existing file with different case
 		if (!Workspace.caseSensitive) {
 			IPath differentCase = IPath.fromOSString(existingFileLocation.toOSString().toUpperCase());
 			result = root.findFilesForLocation(differentCase);
-			assertResources("5.0", existing, result);
+			assertResources(existing, result);
 			result = root.findFilesForLocationURI(existing.getLocationURI());
-			assertResources("5.1", existing, result);
+			assertResources(existing, result);
 		}
 
 		//linked resource
@@ -231,21 +232,21 @@ public class IWorkspaceRootTest {
 		IFile child = link.getFile("link-child.txt");
 		URI childLocation = linkStore.getChild(child.getName()).toURI();
 		result = root.findFilesForLocationURI(childLocation);
-		assertResources("2.1", child, result);
+		assertResources(child, result);
 	}
 
 	/**
 	 * Asserts that the given result array contains only the given resource.
 	 */
-	private void assertResources(String message, IResource expected, IResource[] actual) {
-		assertThat(actual).describedAs(message).containsExactly(expected);
+	private void assertResources(IResource expected, IResource[] actual) {
+		assertThat(actual).containsExactly(expected);
 	}
 
 	/**
 	 * Asserts that the given result array contains only the two given resources
 	 */
-	private void assertResources(String message, IResource expected0, IResource expected1, IResource[] actual) {
-		assertThat(actual).describedAs(message).containsExactlyInAnyOrder(expected0, expected1);
+	private void assertResources(IResource expected0, IResource expected1, IResource[] actual) {
+		assertThat(actual).containsExactlyInAnyOrder(expected0, expected1);
 	}
 
 	/**
@@ -254,7 +255,7 @@ public class IWorkspaceRootTest {
 	@Test
 	public void testGetContainerForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		assertEquals("1.0", root, root.getContainerForLocation(root.getLocation()));
+		assertEquals(root, root.getContainerForLocation(root.getLocation()));
 	}
 
 	/**
@@ -264,7 +265,7 @@ public class IWorkspaceRootTest {
 	public void testGetFile() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IFile file = root.getFile(IPath.fromOSString("//P1/a.txt"));
-		assertTrue("1.0", !file.getFullPath().isUNC());
+		assertFalse(file.getFullPath().isUNC());
 	}
 
 	/**
@@ -273,7 +274,7 @@ public class IWorkspaceRootTest {
 	@Test
 	public void testGetFileForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		assertTrue("1.0", root.getFileForLocation(root.getLocation()) == null);
+		assertTrue(root.getFileForLocation(root.getLocation()) == null);
 	}
 
 	@Test
@@ -284,11 +285,11 @@ public class IWorkspaceRootTest {
 		root.setPersistentProperty(name, value);
 
 		String storedValue = root.getPersistentProperty(name);
-		assertEquals("2.0", value, storedValue);
+		assertEquals(value, storedValue);
 
 		name = new QualifiedName("test", "testNonProperty");
 		storedValue = root.getPersistentProperty(name);
-		assertEquals("3.0", null, storedValue);
+		assertEquals(null, storedValue);
 	}
 
 	/**
@@ -306,13 +307,13 @@ public class IWorkspaceRootTest {
 		final String[] storedValue = new String[1];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> storedValue[0] = root.getPersistentProperty(name),
 				createTestMonitor());
-		assertEquals("2.0", value, storedValue[0]);
+		assertEquals(value, storedValue[0]);
 
 		final QualifiedName name2 = new QualifiedName("test", "testNonProperty");
 		final String[] changedStoredValue = new String[1];
 		getWorkspace().run((IWorkspaceRunnable) monitor -> changedStoredValue[0] = root.getPersistentProperty(name2),
 				createTestMonitor());
-		assertEquals("3.0", null, changedStoredValue[0]);
+		assertEquals(null, changedStoredValue[0]);
 	}
 
 	@Test
@@ -381,11 +382,11 @@ public class IWorkspaceRootTest {
 
 		IPath fileLocation = subProjectLocation.append("file.txt");
 		IFile file = root.getFileForLocation(fileLocation);
-		assertEquals("1.0", project, file.getProject());
+		assertEquals(project, file.getProject());
 
 		IPath containerLocation = subProjectLocation.append("folder");
 		IContainer container = root.getContainerForLocation(containerLocation);
-		assertEquals("1.1", project, container.getProject());
+		assertEquals(project, container.getProject());
 
 		IProject subProject = root.getProject(subProjectName);
 		IProjectDescription newProjectDescription = getWorkspace().newProjectDescription(subProjectName);
@@ -394,12 +395,12 @@ public class IWorkspaceRootTest {
 		subProject.create(newProjectDescription, createTestMonitor());
 
 		file = root.getFileForLocation(fileLocation);
-		assertNotNull("2.0", file);
-		assertEquals("2.1", subProject, file.getProject());
+		assertNotNull(file);
+		assertEquals(subProject, file.getProject());
 
 		container = root.getContainerForLocation(containerLocation);
-		assertNotNull("2.2", container);
-		assertEquals("2.3", subProject, container.getProject());
+		assertNotNull(container);
+		assertEquals(subProject, container.getProject());
 	}
 
 	/*

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -161,7 +161,7 @@ public class IWorkspaceTest {
 				() -> getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor()));
 
 		//make sure the first copy worked
-		assertTrue("1.5", fileCopy.exists());
+		assertTrue(fileCopy.exists());
 		fileCopy.delete(true, createTestMonitor());
 
 		// create the files
@@ -195,7 +195,7 @@ public class IWorkspaceTest {
 
 		//make sure the first copy worked
 		fileCopy = folder2.getFile("File");
-		assertTrue("2.2", fileCopy.exists());
+		assertTrue(fileCopy.exists());
 		fileCopy.delete(true, createTestMonitor());
 
 		//resource out of sync with filesystem
@@ -212,14 +212,14 @@ public class IWorkspaceTest {
 
 		//copy single file
 		getWorkspace().copy(new IResource[] { file }, folder2.getFullPath(), false, createTestMonitor());
-		assertTrue("3.2", fileCopy.exists());
+		assertTrue(fileCopy.exists());
 		removeFromWorkspace(fileCopy);
 		removeFromFileSystem(fileCopy);
 
 		//copy two files
 		getWorkspace().copy(new IResource[] { file, file2 }, folder2.getFullPath(), false, createTestMonitor());
-		assertTrue("3.4", fileCopy.exists());
-		assertTrue("3.5", file2Copy.exists());
+		assertTrue(fileCopy.exists());
+		assertTrue(file2Copy.exists());
 		removeFromWorkspace(fileCopy);
 		removeFromWorkspace(file2Copy);
 		removeFromFileSystem(fileCopy);
@@ -227,7 +227,7 @@ public class IWorkspaceTest {
 
 		//copy a folder
 		getWorkspace().copy(new IResource[] { folder }, folder2.getFullPath(), false, createTestMonitor());
-		assertTrue("3.7", folderCopy.exists());
+		assertTrue(folderCopy.exists());
 		assertThat(folderCopy.members()).hasSizeGreaterThan(0);
 		removeFromWorkspace(folderCopy);
 		removeFromFileSystem(folderCopy);
@@ -307,43 +307,43 @@ public class IWorkspaceTest {
 		IProjectNatureDescriptor[] descriptors = getWorkspace().getNatureDescriptors();
 
 		IProjectNatureDescriptor current = findNature(descriptors, NATURE_SIMPLE);
-		assertNotNull("2.0", current);
-		assertEquals("2.1", NATURE_SIMPLE, current.getNatureId());
-		assertEquals("2.2", "Simple", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_SIMPLE, current.getNatureId());
+		assertEquals("Simple", current.getLabel());
 		assertThat(current.getRequiredNatureIds()).isEmpty();
 		assertThat(current.getNatureSetIds()).isEmpty();
 
 		current = findNature(descriptors, NATURE_SNOW);
-		assertNotNull("3.0", current);
-		assertEquals("3.1", NATURE_SNOW, current.getNatureId());
-		assertEquals("3.2", "Snow", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_SNOW, current.getNatureId());
+		assertEquals("Snow", current.getLabel());
 		String[] required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_WATER);
 		String[] sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = findNature(descriptors, NATURE_WATER);
-		assertNotNull("4.0", current);
-		assertEquals("4.1", NATURE_WATER, current.getNatureId());
-		assertEquals("4.2", "Water", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_WATER, current.getNatureId());
+		assertEquals("Water", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_STATE);
 
 		current = findNature(descriptors, NATURE_EARTH);
-		assertNotNull("5.0", current);
-		assertEquals("5.1", NATURE_EARTH, current.getNatureId());
-		assertEquals("5.2", "Earth", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_EARTH, current.getNatureId());
+		assertEquals("Earth", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_STATE);
 
 		current = findNature(descriptors, NATURE_MUD);
-		assertNotNull("6.0", current);
-		assertEquals("6.1", NATURE_MUD, current.getNatureId());
-		assertEquals("6.2", "Mud", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_MUD, current.getNatureId());
+		assertEquals("Mud", current.getLabel());
 		required = current.getRequiredNatureIds();
 		//water and earth are required for mud
 		assertThat(required).containsExactlyInAnyOrder(NATURE_WATER, NATURE_EARTH);
@@ -351,36 +351,36 @@ public class IWorkspaceTest {
 		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = findNature(descriptors, NATURE_INVALID);
-		assertNotNull("7.0", current);
-		assertEquals("7.1", NATURE_INVALID, current.getNatureId());
-		assertEquals("7.2", "", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_INVALID, current.getNatureId());
+		assertEquals("", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE1);
-		assertNotNull("8.0", current);
-		assertEquals("8.1", NATURE_CYCLE1, current.getNatureId());
-		assertEquals("8.2", "Cycle1", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE1, current.getNatureId());
+		assertEquals("Cycle1", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE2);
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE2);
-		assertNotNull("5.0", current);
-		assertEquals("9.1", NATURE_CYCLE2, current.getNatureId());
-		assertEquals("9.2", "Cycle2", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE2, current.getNatureId());
+		assertEquals("Cycle2", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE3);
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = findNature(descriptors, NATURE_CYCLE3);
-		assertNotNull("10.0", current);
-		assertEquals("10.1", NATURE_CYCLE3, current.getNatureId());
-		assertEquals("10.2", "Cycle3", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE3, current.getNatureId());
+		assertEquals("Cycle3", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE1);
 		sets = current.getNatureSetIds();
@@ -397,79 +397,79 @@ public class IWorkspaceTest {
 		IWorkspace ws = getWorkspace();
 
 		IProjectNatureDescriptor current = ws.getNatureDescriptor(NATURE_SIMPLE);
-		assertNotNull("2.0", current);
-		assertEquals("2.1", NATURE_SIMPLE, current.getNatureId());
-		assertEquals("2.2", "Simple", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_SIMPLE, current.getNatureId());
+		assertEquals("Simple", current.getLabel());
 		assertThat(current.getRequiredNatureIds()).isEmpty();
 		assertThat(current.getNatureSetIds()).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_SNOW);
-		assertNotNull("3.0", current);
-		assertEquals("3.1", NATURE_SNOW, current.getNatureId());
-		assertEquals("3.2", "Snow", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_SNOW, current.getNatureId());
+		assertEquals("Snow", current.getLabel());
 		String[] required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_WATER);
 		String[] sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = ws.getNatureDescriptor(NATURE_WATER);
-		assertNotNull("4.0", current);
-		assertEquals("4.1", NATURE_WATER, current.getNatureId());
-		assertEquals("4.2", "Water", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_WATER, current.getNatureId());
+		assertEquals("Water", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_STATE);
 
 		current = ws.getNatureDescriptor(NATURE_EARTH);
-		assertNotNull("5.0", current);
-		assertEquals("5.1", NATURE_EARTH, current.getNatureId());
-		assertEquals("5.2", "Earth", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_EARTH, current.getNatureId());
+		assertEquals("Earth", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_STATE);
 
 		current = ws.getNatureDescriptor(NATURE_MUD);
-		assertNotNull("6.0", current);
-		assertEquals("6.1", NATURE_MUD, current.getNatureId());
-		assertEquals("6.2", "Mud", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_MUD, current.getNatureId());
+		assertEquals("Mud", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactlyInAnyOrder(NATURE_WATER, NATURE_EARTH);
 		sets = current.getNatureSetIds();
 		assertThat(sets).containsExactly(SET_OTHER);
 
 		current = ws.getNatureDescriptor(NATURE_INVALID);
-		assertNotNull("7.0", current);
-		assertEquals("7.1", NATURE_INVALID, current.getNatureId());
-		assertEquals("7.2", "", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_INVALID, current.getNatureId());
+		assertEquals("", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).isEmpty();
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE1);
-		assertNotNull("8.0", current);
-		assertEquals("8.1", NATURE_CYCLE1, current.getNatureId());
-		assertEquals("8.2", "Cycle1", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE1, current.getNatureId());
+		assertEquals("Cycle1", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE2);
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE2);
-		assertNotNull("5.0", current);
-		assertEquals("9.1", NATURE_CYCLE2, current.getNatureId());
-		assertEquals("9.2", "Cycle2", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE2, current.getNatureId());
+		assertEquals("Cycle2", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE3);
 		sets = current.getNatureSetIds();
 		assertThat(sets).isEmpty();
 
 		current = ws.getNatureDescriptor(NATURE_CYCLE3);
-		assertNotNull("10.0", current);
-		assertEquals("10.1", NATURE_CYCLE3, current.getNatureId());
-		assertEquals("10.2", "Cycle3", current.getLabel());
+		assertNotNull(current);
+		assertEquals(NATURE_CYCLE3, current.getNatureId());
+		assertEquals("Cycle3", current.getLabel());
 		required = current.getRequiredNatureIds();
 		assertThat(required).containsExactly(NATURE_CYCLE1);
 		sets = current.getNatureSetIds();
@@ -493,36 +493,36 @@ public class IWorkspaceTest {
 		/* normal case */
 		IResource[] resources = {file, anotherFile, oneMoreFile};
 		getWorkspace().move(resources, folder.getFullPath(), true, createTestMonitor());
-		assertFalse("1.1", file.exists());
-		assertFalse("1.2", anotherFile.exists());
-		assertFalse("1.3", oneMoreFile.exists());
-		assertTrue("1.4", folder.getFile(file.getName()).exists());
-		assertTrue("1.5", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("1.6", folder.getFile(oneMoreFile.getName()).exists());
+		assertFalse(file.exists());
+		assertFalse(anotherFile.exists());
+		assertFalse(oneMoreFile.exists());
+		assertTrue(folder.getFile(file.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists());
 
 		/* test duplicates */
 		resources = new IResource[] {folder.getFile(file.getName()), folder.getFile(anotherFile.getName()), folder.getFile(oneMoreFile.getName()), folder.getFile(oneMoreFile.getName())};
 		IStatus status = getWorkspace().move(resources, project.getFullPath(), true, createTestMonitor());
-		assertTrue("2.1", status.isOK());
-		assertTrue("2.3", file.exists());
-		assertTrue("2.4", anotherFile.exists());
-		assertTrue("2.5", oneMoreFile.exists());
-		assertFalse("2.6", folder.getFile(file.getName()).exists());
-		assertFalse("2.7", folder.getFile(anotherFile.getName()).exists());
-		assertFalse("2.8", folder.getFile(oneMoreFile.getName()).exists());
+		assertTrue(status.isOK());
+		assertTrue(file.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertFalse(folder.getFile(file.getName()).exists());
+		assertFalse(folder.getFile(anotherFile.getName()).exists());
+		assertFalse(folder.getFile(oneMoreFile.getName()).exists());
 
 		/* test no simblings */
 		IResource[] resources2 = new IResource[] { file, anotherFile, oneMoreFile, project };
 		CoreException ex = assertThrows(CoreException.class,
 				() -> getWorkspace().move(resources2, folder.getFullPath(), true, createTestMonitor()));
-		assertFalse("3.1", ex.getStatus().isOK());
+		assertFalse(ex.getStatus().isOK());
 		assertThat(ex.getStatus().getChildren()).hasSize(1);
-		assertFalse("3.3", file.exists());
-		assertFalse("3.4", anotherFile.exists());
-		assertFalse("3.5", oneMoreFile.exists());
-		assertTrue("3.6", folder.getFile(file.getName()).exists());
-		assertTrue("3.7", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("3.8", folder.getFile(oneMoreFile.getName()).exists());
+		assertFalse(file.exists());
+		assertFalse(anotherFile.exists());
+		assertFalse(oneMoreFile.exists());
+		assertTrue(folder.getFile(file.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists());
 
 		/* inexisting resource */
 		IResource[] resources3 = new IResource[] { folder.getFile(file.getName()),
@@ -530,13 +530,13 @@ public class IWorkspaceTest {
 				folder.getFile(oneMoreFile.getName()) };
 		CoreException ex2 = assertThrows(CoreException.class,
 				() -> getWorkspace().move(resources3, project.getFullPath(), true, createTestMonitor()));
-		assertFalse("4.1", ex2.getStatus().isOK());
-		assertTrue("4.3", file.exists());
-		assertTrue("4.4", anotherFile.exists());
-		assertTrue("4.5", oneMoreFile.exists());
-		assertFalse("4.6", folder.getFile(file.getName()).exists());
-		assertFalse("4.7", folder.getFile(anotherFile.getName()).exists());
-		assertFalse("4.8", folder.getFile(oneMoreFile.getName()).exists());
+		assertFalse(ex2.getStatus().isOK());
+		assertTrue(file.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertFalse(folder.getFile(file.getName()).exists());
+		assertFalse(folder.getFile(anotherFile.getName()).exists());
+		assertFalse(folder.getFile(oneMoreFile.getName()).exists());
 	}
 
 	/**
@@ -565,12 +565,12 @@ public class IWorkspaceTest {
 		/* normal case */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile};
 		getWorkspace().copy(resources, folder.getFullPath(), true, createTestMonitor());
-		assertTrue("1.1", file1.exists());
-		assertTrue("1.2", anotherFile.exists());
-		assertTrue("1.3", oneMoreFile.exists());
-		assertTrue("1.4", folder.getFile(file1.getName()).exists());
-		assertTrue("1.5", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("1.6", folder.getFile(oneMoreFile.getName()).exists());
+		assertTrue(file1.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertTrue(folder.getFile(file1.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists());
 		removeFromWorkspace(folder.getFile(file1.getName()));
 		removeFromWorkspace(folder.getFile(anotherFile.getName()));
 		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
@@ -581,12 +581,12 @@ public class IWorkspaceTest {
 		/* test duplicates */
 		resources = new IResource[] {file1, anotherFile, oneMoreFile, file1};
 		getWorkspace().copy(resources, folder.getFullPath(), true, createTestMonitor());
-		assertTrue("2.2", file1.exists());
-		assertTrue("2.3", anotherFile.exists());
-		assertTrue("2.4", oneMoreFile.exists());
-		assertTrue("2.5", folder.getFile(file1.getName()).exists());
-		assertTrue("2.6", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("2.7", folder.getFile(oneMoreFile.getName()).exists());
+		assertTrue(file1.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertTrue(folder.getFile(file1.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists());
 		removeFromWorkspace(folder.getFile(file1.getName()));
 		removeFromWorkspace(folder.getFile(anotherFile.getName()));
 		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
@@ -599,14 +599,14 @@ public class IWorkspaceTest {
 		CoreException e = assertThrows(CoreException.class,
 				() -> getWorkspace().copy(resources2, folder.getFullPath(), true, createTestMonitor()));
 		IStatus status = e.getStatus();
-		assertFalse("3.1", status.isOK());
+		assertFalse(status.isOK());
 		assertThat(status.getChildren()).hasSize(1);
-		assertTrue("3.3", file1.exists());
-		assertTrue("3.4", anotherFile.exists());
-		assertTrue("3.5", oneMoreFile.exists());
-		assertTrue("3.6", folder.getFile(file1.getName()).exists());
-		assertTrue("3.7", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("3.8", folder.getFile(oneMoreFile.getName()).exists());
+		assertTrue(file1.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertTrue(folder.getFile(file1.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists());
 		removeFromWorkspace(folder.getFile(file1.getName()));
 		removeFromWorkspace(folder.getFile(anotherFile.getName()));
 		removeFromWorkspace(folder.getFile(oneMoreFile.getName()));
@@ -619,20 +619,20 @@ public class IWorkspaceTest {
 		CoreException ex = assertThrows(CoreException.class,
 				() -> getWorkspace().copy(resources3, folder.getFullPath(), true, createTestMonitor()));
 		status = ex.getStatus();
-		assertFalse("4.1", status.isOK());
-		assertTrue("4.2", file1.exists());
-		assertTrue("4.3", anotherFile.exists());
-		assertTrue("4.4", oneMoreFile.exists());
-		assertTrue("4.5", folder.getFile(file1.getName()).exists());
-		assertTrue("4.6", folder.getFile(anotherFile.getName()).exists());
-		assertTrue("4.7 Fails because of 1FVFOOQ", folder.getFile(oneMoreFile.getName()).exists());
+		assertFalse(status.isOK());
+		assertTrue(file1.exists());
+		assertTrue(anotherFile.exists());
+		assertTrue(oneMoreFile.exists());
+		assertTrue(folder.getFile(file1.getName()).exists());
+		assertTrue(folder.getFile(anotherFile.getName()).exists());
+		assertTrue("Fails because of 1FVFOOQ", folder.getFile(oneMoreFile.getName()).exists());
 
 		/* copy projects should not be allowed */
 		IResource destination = getWorkspace().getRoot().getProject("destination");
 		CoreException ex2 = assertThrows(CoreException.class,
 				() -> getWorkspace().copy(new IResource[] { project }, destination.getFullPath(), true, createTestMonitor()));
 		status = ex2.getStatus();
-		assertFalse("5.1", status.isOK());
+		assertFalse(status.isOK());
 		assertThat(status.getChildren()).hasSize(1);
 	}
 
@@ -729,7 +729,7 @@ public class IWorkspaceTest {
 		IFile descriptionFile = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
 		descriptionFile.delete(IResource.NONE, null);
 		IStatus result = getWorkspace().save(true, createTestMonitor());
-		assertEquals("1.0", IStatus.WARNING, result.getSeverity());
+		assertEquals(IStatus.WARNING, result.getSeverity());
 	}
 
 	/**
@@ -774,11 +774,11 @@ public class IWorkspaceTest {
 		IFile file = project.getFile("myfile.txt");
 		createInWorkspace(new IResource[] {project, file});
 		IStatus result = getWorkspace().validateEdit(new IFile[] {file}, null);
-		assertTrue("1.0", result.isOK());
+		assertTrue(result.isOK());
 		file.setReadOnly(true);
 		result = getWorkspace().validateEdit(new IFile[] {file}, null);
-		assertEquals("1.1", IStatus.ERROR, result.getSeverity());
-		//	assertEquals("1.2", IResourceStatus.READ_ONLY_LOCAL, result.getCode());
+		assertEquals(IStatus.ERROR, result.getSeverity());
+		// assertEquals(IResourceStatus.READ_ONLY_LOCAL, result.getCode());
 		// remove the read-only status so test cleanup will work ok
 		file.setReadOnly(false);
 	}
@@ -796,56 +796,56 @@ public class IWorkspaceTest {
 	@Test
 	public void testValidateName() {
 		/* normal name */
-		assertTrue("1.1", getWorkspace().validateName("abcdef", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("abcdef", IResource.FILE).isOK());
 		/* invalid characters (windows only) */
 		if (OS.isWindows()) {
-			assertFalse("2.1", getWorkspace().validateName("dsa:sf", IResource.FILE).isOK());
-			assertFalse("2.2", getWorkspace().validateName("*dsasf", IResource.FILE).isOK());
-			assertFalse("2.3", getWorkspace().validateName("?dsasf", IResource.FILE).isOK());
-			assertFalse("2.4", getWorkspace().validateName("\"dsasf", IResource.FILE).isOK());
-			assertFalse("2.5", getWorkspace().validateName("<dsasf", IResource.FILE).isOK());
-			assertFalse("2.6", getWorkspace().validateName(">dsasf", IResource.FILE).isOK());
-			assertFalse("2.7", getWorkspace().validateName("|dsasf", IResource.FILE).isOK());
-			assertFalse("2.8", getWorkspace().validateName("\"dsasf", IResource.FILE).isOK());
-			assertFalse("2.10", getWorkspace().validateName("\\dsasf", IResource.FILE).isOK());
-			assertFalse("2.11", getWorkspace().validateName("...", IResource.PROJECT).isOK());
-			assertFalse("2.12", getWorkspace().validateName("foo.", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("dsa:sf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("*dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("?dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("\"dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("<dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName(">dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("|dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("\"dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("\\dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validateName("...", IResource.PROJECT).isOK());
+			assertFalse(getWorkspace().validateName("foo.", IResource.FILE).isOK());
 			for (int i = 0; i <= 31; i++) {
-				assertFalse("2.13 Windows should NOT accept character #" + i,
+				assertFalse("Windows should NOT accept character #" + i,
 						getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK());
 			}
-			assertTrue("2.14 Windows should accept character #" + 32,
+			assertTrue("Windows should accept character #" + 32,
 					getWorkspace().validateName("anything" + ((char) 32) + "something", IResource.FILE).isOK());
-			assertFalse("2.15 Windows should NOT accept space at the end",
+			assertFalse("Windows should NOT accept space at the end",
 					getWorkspace().validateName("foo ", IResource.FILE).isOK());
-			assertTrue("2.16 Windows should accept space in the middle",
+			assertTrue("Windows should accept space in the middle",
 					getWorkspace().validateName("fo o", IResource.FILE).isOK());
-			assertTrue("2.17 Windows should accept space in at the beginning",
+			assertTrue("Windows should accept space in at the beginning",
 					getWorkspace().validateName(" foo", IResource.FILE).isOK());
 		} else {
 			//trailing dots are ok on other platforms
-			assertTrue("3.3", getWorkspace().validateName("...", IResource.FILE).isOK());
-			assertTrue("3.4", getWorkspace().validateName("....", IResource.PROJECT).isOK());
-			assertTrue("3.7", getWorkspace().validateName("abc.", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validateName("...", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validateName("....", IResource.PROJECT).isOK());
+			assertTrue(getWorkspace().validateName("abc.", IResource.FILE).isOK());
 			for (int i = 1; i <= 32; i++) {
-				assertTrue("3.8 Unix-style filesystems should accept character #" + i,
+				assertTrue("Unix-style filesystems should accept character #" + i,
 						getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK());
 			}
-			assertTrue("3.9 Unix-style filesystems should accept space at the end",
+			assertTrue("Unix-style filesystems should accept space at the end",
 					getWorkspace().validateName("foo ", IResource.FILE).isOK());
 		}
 		/* invalid characters on all platforms */
-		assertFalse("2.9", getWorkspace().validateName("/dsasf", IResource.FILE).isOK());
-		assertFalse("2.9", getWorkspace().validateName("", IResource.FILE).isOK());
+		assertFalse(getWorkspace().validateName("/dsasf", IResource.FILE).isOK());
+		assertFalse(getWorkspace().validateName("", IResource.FILE).isOK());
 
 		/* dots */
-		assertFalse("3.1", getWorkspace().validateName(".", IResource.FILE).isOK());
-		assertFalse("3.2", getWorkspace().validateName("..", IResource.FILE).isOK());
-		assertTrue("3.3", getWorkspace().validateName("...z", IResource.FILE).isOK());
-		assertTrue("3.4", getWorkspace().validateName("....z", IResource.FILE).isOK());
-		assertTrue("3.5", getWorkspace().validateName("....abc", IResource.FILE).isOK());
-		assertTrue("3.6", getWorkspace().validateName("abc....def", IResource.FILE).isOK());
-		assertTrue("3.7", getWorkspace().validateName("abc.d...z", IResource.FILE).isOK());
+		assertFalse(getWorkspace().validateName(".", IResource.FILE).isOK());
+		assertFalse(getWorkspace().validateName("..", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("...z", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("....z", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("....abc", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("abc....def", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validateName("abc.d...z", IResource.FILE).isOK());
 	}
 
 	/**
@@ -878,55 +878,55 @@ public class IWorkspaceTest {
 	@Test
 	public void testValidatePath() {
 		/* normal path */
-		assertTrue("1.1", getWorkspace().validatePath("/one/two/three/four/", IResource.FILE | IResource.FOLDER).isOK());
+		assertTrue(getWorkspace().validatePath("/one/two/three/four/", IResource.FILE | IResource.FOLDER).isOK());
 
 		/* invalid characters (windows only) */
 		final boolean WINDOWS = OS.isWindows();
 		if (WINDOWS) {
-			assertFalse("2.1", (getWorkspace().validatePath("\\dsa:sf", IResource.FILE).isOK()));
-			assertFalse("2.2", (getWorkspace().validatePath("/abc/*dsasf", IResource.FILE).isOK()));
-			assertFalse("2.3", (getWorkspace().validatePath("/abc/?dsasf", IResource.FILE).isOK()));
-			assertFalse("2.4", (getWorkspace().validatePath("/abc/\"dsasf", IResource.FILE).isOK()));
-			assertFalse("2.5", (getWorkspace().validatePath("/abc/<dsasf", IResource.FILE).isOK()));
-			assertFalse("2.6", (getWorkspace().validatePath("/abc/>dsasf", IResource.FILE).isOK()));
-			assertFalse("2.7", (getWorkspace().validatePath("/abc/|dsasf", IResource.FILE).isOK()));
-			assertFalse("2.8", (getWorkspace().validatePath("/abc/\"dsasf", IResource.FILE).isOK()));
+			assertFalse(getWorkspace().validatePath("\\dsa:sf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/*dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/?dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/\"dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/<dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/>dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/|dsasf", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/\"dsasf", IResource.FILE).isOK());
 
-			assertFalse("5.2", (getWorkspace().validatePath("\\", IResource.FILE).isOK()));
-			assertFalse("5.4", (getWorkspace().validatePath("device:/abc/123", IResource.FILE).isOK()));
+			assertFalse(getWorkspace().validatePath("\\", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("device:/abc/123", IResource.FILE).isOK());
 
 			//trailing dots in segments names not allowed on Windows
-			assertFalse("3.1", getWorkspace().validatePath("/abc/.../defghi", IResource.FILE).isOK());
-			assertFalse("3.2", getWorkspace().validatePath("/abc/..../defghi", IResource.FILE).isOK());
-			assertFalse("3.3", getWorkspace().validatePath("/abc/def..../ghi", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/.../defghi", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/..../defghi", IResource.FILE).isOK());
+			assertFalse(getWorkspace().validatePath("/abc/def..../ghi", IResource.FILE).isOK());
 		} else {
-			assertTrue("3.1", getWorkspace().validatePath("/abc/.../defghi", IResource.FILE).isOK());
-			assertTrue("3.2", getWorkspace().validatePath("/abc/..../defghi", IResource.FILE).isOK());
-			assertTrue("3.3", getWorkspace().validatePath("/abc/def..../ghi", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validatePath("/abc/.../defghi", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validatePath("/abc/..../defghi", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validatePath("/abc/def..../ghi", IResource.FILE).isOK());
 		}
 
 		/* dots */
-		assertTrue("3.4", getWorkspace().validatePath("/abc/../ghi/j", IResource.FILE).isOK());
-		assertTrue("3.5", getWorkspace().validatePath("/abc/....def/ghi", IResource.FILE).isOK());
-		assertTrue("3.6", getWorkspace().validatePath("/abc/def....ghi/jkl", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/abc/../ghi/j", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/abc/....def/ghi", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/abc/def....ghi/jkl", IResource.FILE).isOK());
 
 		/* test hiding incorrect characters using .. and device separator : */
-		assertTrue("4.1", getWorkspace().validatePath("/abc/.?./../def/as", IResource.FILE).isOK());
-		assertTrue("4.2", getWorkspace().validatePath("/abc/;*?\"'/../def/safd", IResource.FILE).isOK());
-		assertTrue("4.3", getWorkspace().validatePath("/abc;*?\"':/def/asdf/sadf", IResource.FILE).isOK() != WINDOWS);
+		assertTrue(getWorkspace().validatePath("/abc/.?./../def/as", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/abc/;*?\"'/../def/safd", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/abc;*?\"':/def/asdf/sadf", IResource.FILE).isOK() != WINDOWS);
 
 		/* other invalid paths */
-		assertFalse("5.1", (getWorkspace().validatePath("/", IResource.FILE).isOK()));
-		assertFalse("5.3", (getWorkspace().validatePath("", IResource.FILE).isOK()));
+		assertFalse(getWorkspace().validatePath("/", IResource.FILE).isOK());
+		assertFalse(getWorkspace().validatePath("", IResource.FILE).isOK());
 
 		/* test types / segments */
-		assertTrue("6.6", getWorkspace().validatePath("/asf", IResource.PROJECT).isOK());
-		assertFalse("6.7", (getWorkspace().validatePath("/asf", IResource.FILE).isOK()));
+		assertTrue(getWorkspace().validatePath("/asf", IResource.PROJECT).isOK());
+		assertFalse((getWorkspace().validatePath("/asf", IResource.FILE).isOK()));
 		// note this is value for a file OR project (note the logical OR)
-		assertTrue("6.8", getWorkspace().validatePath("/asf", IResource.PROJECT | IResource.FILE).isOK());
-		assertTrue("6.10", getWorkspace().validatePath("/project/.metadata", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/asf", IResource.PROJECT | IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/project/.metadata", IResource.FILE).isOK());
 		// FIXME: Should this be valid?
-		assertTrue("6.11", getWorkspace().validatePath("/.metadata/project", IResource.FILE).isOK());
+		assertTrue(getWorkspace().validatePath("/.metadata/project", IResource.FILE).isOK());
 	}
 
 	/**
@@ -939,66 +939,63 @@ public class IWorkspaceTest {
 		IProject project = workspace.getRoot().getProject("Project");
 
 		/* normal path */
-		assertTrue("1.1", workspace.validateProjectLocation(project, IPath.fromOSString("/one/two/three/four/")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/one/two/three/four/")).isOK());
 
 		/* invalid characters (windows only) */
 		final boolean WINDOWS = OS.isWindows();
 		if (WINDOWS) {
-			assertFalse("2.1", workspace.validateProjectLocation(project, IPath.fromOSString("d:\\dsa:sf")).isOK());
-			assertFalse("2.2", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/*dsasf")).isOK());
-			assertFalse("2.3", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/?dsasf")).isOK());
-			assertFalse("2.4", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/\"dsasf")).isOK());
-			assertFalse("2.5", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/<dsasf")).isOK());
-			assertFalse("2.6", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/>dsasf")).isOK());
-			assertFalse("2.7", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/|dsasf")).isOK());
-			assertFalse("2.8", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/\"dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("d:\\dsa:sf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/*dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/?dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/\"dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/<dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/>dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/|dsasf")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/\"dsasf")).isOK());
 
 			//trailing dots invalid on Windows
-			assertFalse("3.1", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.../defghi")).isOK());
-			assertFalse("3.2", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/..../defghi")).isOK());
-			assertFalse("3.3", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def..../ghi")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.../defghi")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/..../defghi")).isOK());
+			assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def..../ghi")).isOK());
 		} else {
-			assertTrue("3.1", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.../defghi")).isOK());
-			assertTrue("3.2", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/..../defghi")).isOK());
-			assertTrue("3.3", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def..../ghi")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.../defghi")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/..../defghi")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def..../ghi")).isOK());
 		}
 
 		/* dots */
-		assertTrue("3.4", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/....def/ghi")).isOK());
-		assertTrue("3.5", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def....ghi/jkl")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/....def/ghi")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/def....ghi/jkl")).isOK());
 
 		/* test hiding incorrect characters using .. and device separator : */
-		assertTrue("4.1", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.?./../def/as")).isOK());
-		assertTrue("4.2", workspace.validateProjectLocation(project, IPath.fromOSString("/abc/;*?\"'/../def/safd")).isOK());
-		assertFalse("4.3",
-				(workspace.validateProjectLocation(project, IPath.fromOSString("c:/abc;*?\"':/def/asdf/sadf")).isOK()));
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/.?./../def/as")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/abc/;*?\"'/../def/safd")).isOK());
+		assertFalse(
+				workspace.validateProjectLocation(project, IPath.fromOSString("c:/abc;*?\"':/def/asdf/sadf")).isOK());
 
 		// cannot overlap the platform directory
 		IPath platformLocation = Platform.getLocation();
-		assertFalse("5.1",
-				(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "/")).isOK()));
-		assertFalse("5.2",
-				(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "\\")).isOK()));
-		assertFalse("5.3",
-				(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "")).isOK()));
-		assertFalse("5.4", (workspace.validateProjectLocation(project, platformLocation).isOK()));
-		assertFalse("5.5", (workspace.validateProjectLocation(project, platformLocation.append("foo")).isOK()));
+		assertFalse(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "/")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "\\")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, new Path(platformLocation.getDevice(), "")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, platformLocation).isOK());
+		assertFalse(workspace.validateProjectLocation(project, platformLocation.append("foo")).isOK());
 
 		//can overlap platform directory on another device
 		IPath anotherDevice = platformLocation.setDevice("u:");
-		assertTrue("6.1", workspace.validateProjectLocation(project, new Path("u:", "/")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, new Path("u:", "/")).isOK());
 		if (WINDOWS) {
-			assertTrue("6.2", workspace.validateProjectLocation(project, new Path("u:", "\\")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, new Path("u:", "\\")).isOK());
 		}
-		assertTrue("6.4", workspace.validateProjectLocation(project, anotherDevice).isOK());
-		assertTrue("6.5", workspace.validateProjectLocation(project, anotherDevice.append("foo")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, anotherDevice).isOK());
+		assertTrue(workspace.validateProjectLocation(project, anotherDevice.append("foo")).isOK());
 
 		//cannot be a relative path
-		assertFalse("7.1", workspace.validateProjectLocation(project, new Path("u:", "")).isOK());
-		assertFalse("7.2", workspace.validateProjectLocation(project, IPath.fromOSString("c:")).isOK());
-		assertFalse("7.3", workspace.validateProjectLocation(project, IPath.fromOSString("c:foo")).isOK());
-		assertFalse("7.4", workspace.validateProjectLocation(project, IPath.fromOSString("foo/bar")).isOK());
-		assertFalse("7.5", workspace.validateProjectLocation(project, IPath.fromOSString("c:foo/bar")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, new Path("u:", "")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("c:")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("c:foo")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("foo/bar")).isOK());
+		assertFalse(workspace.validateProjectLocation(project, IPath.fromOSString("c:foo/bar")).isOK());
 
 		//may be relative to an existing path variable
 		final String PATH_VAR_NAME = "FOOVAR";
@@ -1006,9 +1003,9 @@ public class IWorkspaceTest {
 		try {
 			IPath varPath = IPath.fromOSString(PATH_VAR_NAME);
 			workspace.getPathVariableManager().setValue(PATH_VAR_NAME, PATH_VAR_VALUE);
-			assertTrue("8.1", workspace.validateProjectLocation(project, varPath).isOK());
-			assertTrue("8.2", workspace.validateProjectLocation(project, varPath.append("test")).isOK());
-			assertTrue("8.3", workspace.validateProjectLocation(project, varPath.append("test/ing")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, varPath).isOK());
+			assertTrue(workspace.validateProjectLocation(project, varPath.append("test")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, varPath.append("test/ing")).isOK());
 		} finally {
 			workspace.getPathVariableManager().setValue(PATH_VAR_NAME, null);
 		}
@@ -1032,29 +1029,29 @@ public class IWorkspaceTest {
 			desc.setReferencedProjects(new IProject[] {project});
 			open.setDescription(desc, IResource.FORCE, createTestMonitor());
 
-			assertFalse("9.1", workspace.validateProjectLocation(project, openProjectLocation).isOK());
-			assertFalse("9.2", workspace.validateProjectLocation(project, closedProjectLocation).isOK());
+			assertFalse(workspace.validateProjectLocation(project, openProjectLocation).isOK());
+			assertFalse(workspace.validateProjectLocation(project, closedProjectLocation).isOK());
 
 			//for an existing project, it cannot overlap itself, but its own location is valid
-			assertTrue("9.3", workspace.validateProjectLocation(open, openProjectLocation).isOK());
-			assertFalse("9.4", workspace.validateProjectLocation(open, openProjectLocation.append("sub")).isOK());
+			assertTrue(workspace.validateProjectLocation(open, openProjectLocation).isOK());
+			assertFalse(workspace.validateProjectLocation(open, openProjectLocation.append("sub")).isOK());
 
 			//an existing project cannot overlap the location of any linked resource in that project
 			linkLocation.toFile().mkdirs();
-			assertTrue("10.1", workspace.validateProjectLocation(open, linkLocation).isOK());
+			assertTrue(workspace.validateProjectLocation(open, linkLocation).isOK());
 			IFolder link = open.getFolder("link");
 			link.createLink(linkLocation, IResource.NONE, createTestMonitor());
-			assertFalse("10.2", workspace.validateProjectLocation(open, linkLocation).isOK());
-			assertFalse("10.3", workspace.validateProjectLocation(open, linkLocation.append("sub")).isOK());
+			assertFalse(workspace.validateProjectLocation(open, linkLocation).isOK());
+			assertFalse(workspace.validateProjectLocation(open, linkLocation.append("sub")).isOK());
 
 			//however another project can overlap an existing link location
-			assertTrue("10.4", workspace.validateProjectLocation(project, linkLocation).isOK());
+			assertTrue(workspace.validateProjectLocation(project, linkLocation).isOK());
 
 			// A new project cannot overlap the default locations of other projects, but its own location is valid
 			IPath defaultProjectLocation = workspace.getRoot().getLocation();
-			assertTrue("11.1", workspace.validateProjectLocation(project, defaultProjectLocation.append(project.getName())).isOK());
-			assertFalse("11.2",
-					workspace.validateProjectLocation(project, defaultProjectLocation.append("foo")).isOK());
+			assertTrue(workspace.validateProjectLocation(project, defaultProjectLocation.append(project.getName()))
+					.isOK());
+			assertFalse(workspace.validateProjectLocation(project, defaultProjectLocation.append("foo")).isOK());
 		} finally {
 			Workspace.clear(linkLocation.toFile());
 			//make sure we clean up project directories
@@ -1068,17 +1065,17 @@ public class IWorkspaceTest {
 		}
 
 		// cannot overlap .metadata folder from the current workspace
-		assertFalse("12.1", (workspace.validateProjectLocation(project,
+		assertFalse((workspace.validateProjectLocation(project,
 				platformLocation.addTrailingSeparator().append(".metadata"))).isOK());
 
 		IProject metadataProject = workspace.getRoot().getProject(".metadata");
-		assertFalse("12.2", (workspace.validateProjectLocation(metadataProject, null)).isOK());
+		assertFalse((workspace.validateProjectLocation(metadataProject, null)).isOK());
 
 		// FIXME: Should this be valid?
-		assertTrue("23.1", workspace.validateProjectLocation(project, IPath.fromOSString("/asf")).isOK());
-		assertTrue("23.2", workspace.validateProjectLocation(project, IPath.fromOSString("/project/.metadata")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/asf")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/project/.metadata")).isOK());
 		// FIXME: Should this be valid?
-		assertTrue("23.3", workspace.validateProjectLocation(project, IPath.fromOSString("/.metadata/project")).isOK());
+		assertTrue(workspace.validateProjectLocation(project, IPath.fromOSString("/.metadata/project")).isOK());
 	}
 
 	/**
@@ -1091,27 +1088,27 @@ public class IWorkspaceTest {
 		IProject project = workspace.getRoot().getProject("Project");
 		// URI with no scheme
 		URI uri = new URI("eferfsdfwer");
-		assertFalse("1.0", workspace.validateProjectLocationURI(project, uri).isOK());
+		assertFalse(workspace.validateProjectLocationURI(project, uri).isOK());
 		// URI with unknown scheme
 		uri = new URI("blorts://foo.com?bad");
-		assertFalse("1.1", workspace.validateProjectLocationURI(project, uri).isOK());
+		assertFalse(workspace.validateProjectLocationURI(project, uri).isOK());
 	}
 
 	@Test
 	public void testWorkspaceService() {
 		final BundleContext context = FrameworkUtil.getBundle(IWorkspaceTest.class).getBundleContext();
 		ServiceReference<IWorkspace> ref = context.getServiceReference(IWorkspace.class);
-		assertNotNull("1.0", ref);
+		assertNotNull(ref);
 		IWorkspace ws = context.getService(ref);
-		assertNotNull("1.1", ws);
+		assertNotNull(ws);
 	}
 
 	@Test
 	public void testGetFilterMatcherDescriptor() {
 		IFilterMatcherDescriptor descriptor = getWorkspace().getFilterMatcherDescriptor("");
-		assertNull("1.0", descriptor);
+		assertNull(descriptor);
 		descriptor = getWorkspace().getFilterMatcherDescriptor("org.eclipse.core.resources.regexFilterMatcher");
-		assertNotNull("1.1", descriptor);
+		assertNotNull(descriptor);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
@@ -82,16 +82,16 @@ public class LinkedDotProjectTest {
 		linkDotProject(project);
 		assertFalse(project.getLocation().isPrefixOf(project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocation()));
 		//getNature on open project with no natures
-		assertNull("3.1", project.getNature(NATURE_MISSING));
-		assertNull("3.2", project.getNature(NATURE_EARTH));
+		assertNull(project.getNature(NATURE_MISSING));
+		assertNull(project.getNature(NATURE_EARTH));
 		IProjectDescription desc = project.getDescription();
 		desc.setNatureIds(new String[] { NATURE_EARTH });
 		project.setDescription(desc, null);
 		//getNature on open project with natures
 		IProjectNature nature = project.getNature(NATURE_EARTH);
-		assertNotNull("5.0", nature);
-		assertNull("5.1", project.getNature(NATURE_MISSING));
-		assertEquals("6.0", project, nature.getProject());
+		assertNotNull(nature);
+		assertNull(project.getNature(NATURE_MISSING));
+		assertEquals(project, nature.getProject());
 		assertFalse(project.getLocation().isPrefixOf(project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocation()));
 
 		//ensure nature is preserved on copy
@@ -101,9 +101,9 @@ public class LinkedDotProjectTest {
 		assertNotEquals(project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocationURI(), project2.getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocationURI());
 		assertTrue(project2.getLocation().isPrefixOf(project2.getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocation()));
 		nature2 = project2.getNature(NATURE_EARTH);
-		assertNotNull("7.0", nature2);
-		assertEquals("7.1", project2, nature2.getProject());
-		assertEquals("7.2", project, nature.getProject());
+		assertNotNull(nature2);
+		assertEquals(project2, nature2.getProject());
+		assertEquals(project, nature.getProject());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -107,9 +107,9 @@ public class LinkedResourceSyncMoveAndCopyTest {
 
 		CoreException exception = assertThrows(CoreException.class, () -> fileLink
 				.setContents(createRandomString().getBytes(), IResource.NONE, createTestMonitor()));
-		assertEquals("1.2", IResourceStatus.NOT_FOUND_LOCAL, exception.getStatus().getCode());
+		assertEquals(IResourceStatus.NOT_FOUND_LOCAL, exception.getStatus().getCode());
 
-		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, false);
 
 		createInFileSystem(fileLocation);
@@ -117,14 +117,14 @@ public class LinkedResourceSyncMoveAndCopyTest {
 
 		exception = assertThrows(CoreException.class, () -> fileLink
 				.setContents(createRandomString().getBytes(), IResource.NONE, createTestMonitor()));
-		assertEquals("2.2", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
+		assertEquals(IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
-		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertFalse(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, false);
 
 		fileLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("5.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.NONE, true);
 	}
 
@@ -134,18 +134,18 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		IPath fileLocation = getRandomLocation();
 		fileLink.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("2.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 
 		createInFileSystem(fileLocation);
 		workspaceRule.deleteOnTearDown(fileLocation);
 
-		assertFalse("3.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertFalse(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 
 		fileLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("5.0", fileLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 	}
 
@@ -155,18 +155,18 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		IPath folderLocation = getRandomLocation();
 		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, false);
 
 		folderLocation.toFile().mkdir();
 		workspaceRule.deleteOnTearDown(folderLocation);
 
-		assertFalse("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertFalse(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, true);
 
 		folderLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("5.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, true);
 	}
 
@@ -176,18 +176,18 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		IPath folderLocation = getRandomLocation();
 		folderLink.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("2.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
 
 		folderLocation.toFile().mkdir();
 		workspaceRule.deleteOnTearDown(folderLocation);
 
-		assertFalse("3.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertFalse(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
 
 		folderLink.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("5.0", folderLink.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
 	}
 
@@ -216,8 +216,8 @@ public class LinkedResourceSyncMoveAndCopyTest {
 				.move(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should not exist
-		assertFalse("5.0", folderWithLinks.exists());
-		assertFalse("6.0", linkedFile.exists());
+		assertFalse(folderWithLinks.exists());
+		assertFalse(linkedFile.exists());
 	}
 
 	/**
@@ -245,8 +245,8 @@ public class LinkedResourceSyncMoveAndCopyTest {
 				.copy(otherExistingProject.getFolder(createUniqueString()).getFullPath(), IResource.NONE, createTestMonitor()));
 
 		// both the folder and link in the source project should exist
-		assertTrue("5.0", folderWithLinks.exists());
-		assertTrue("6.0", linkedFile.exists());
+		assertTrue(folderWithLinks.exists());
+		assertTrue(linkedFile.exists());
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -210,8 +210,8 @@ public class LinkedResourceTest {
 
 		//now try to create with the flag (should succeed)
 		folder.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		assertEquals("1.2", resolve(location), folder.getLocation());
-		assertTrue("1.3", !resolve(location).toFile().exists());
+		assertEquals(resolve(location), folder.getLocation());
+		assertFalse(resolve(location).toFile().exists());
 		//getting children should succeed (and be empty)
 		assertThat(folder.members()).isEmpty();
 
@@ -228,8 +228,8 @@ public class LinkedResourceTest {
 		IPath canonicalPathLocation = FileUtil.canonicalPath(nonExistentLocation);
 		assertThrows(CoreException.class, () -> folder.createLink(canonicalPathLocation, IResource.NONE, createTestMonitor()));
 		folder.createLink(canonicalPathLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		assertEquals("2.3", canonicalPathLocation, folder.getLocation());
-		assertTrue("2.4", !canonicalPathLocation.toFile().exists());
+		assertEquals(canonicalPathLocation, folder.getLocation());
+		assertFalse(canonicalPathLocation.toFile().exists());
 
 		// creating child should fail
 		assertThrows(CoreException.class,
@@ -253,27 +253,29 @@ public class LinkedResourceTest {
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//the blocked file should not exist in the workspace
-		assertTrue("1.2", !blockedFile.exists());
-		assertTrue("1.3", nonExistingFolderInExistingProject.exists());
-		assertTrue("1.4", nonExistingFolderInExistingProject.getFile(childName).exists());
-		assertEquals("1.5", nonExistingFolderInExistingProject.getLocation(), resolve(localFolder));
+		assertFalse(blockedFile.exists());
+		assertTrue(nonExistingFolderInExistingProject.exists());
+		assertTrue(nonExistingFolderInExistingProject.getFile(childName).exists());
+		assertEquals(nonExistingFolderInExistingProject.getLocation(), resolve(localFolder));
 
 		//now delete the link
 		nonExistingFolderInExistingProject.delete(IResource.NONE, createTestMonitor());
 		//the blocked file and the linked folder should not exist in the workspace
-		assertTrue("2.0", !blockedFile.exists());
-		assertTrue("2.1", !nonExistingFolderInExistingProject.exists());
-		assertTrue("2.2", !nonExistingFolderInExistingProject.getFile(childName).exists());
-		assertEquals("2.3", nonExistingFolderInExistingProject.getLocation(), existingProject.getLocation().append(nonExistingFolderInExistingProject.getName()));
+		assertFalse(blockedFile.exists());
+		assertFalse(nonExistingFolderInExistingProject.exists());
+		assertFalse(nonExistingFolderInExistingProject.getFile(childName).exists());
+		assertEquals(nonExistingFolderInExistingProject.getLocation(),
+				existingProject.getLocation().append(nonExistingFolderInExistingProject.getName()));
 
 		//now refresh again to discover the blocked resource
 		existingProject.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
 		//the blocked file should now exist
-		assertTrue("3.0", blockedFile.exists());
-		assertTrue("3.1", nonExistingFolderInExistingProject.exists());
-		assertTrue("3.2", !nonExistingFolderInExistingProject.getFile(childName).exists());
-		assertEquals("3.3", nonExistingFolderInExistingProject.getLocation(), existingProject.getLocation().append(nonExistingFolderInExistingProject.getName()));
+		assertTrue(blockedFile.exists());
+		assertTrue(nonExistingFolderInExistingProject.exists());
+		assertFalse(nonExistingFolderInExistingProject.getFile(childName).exists());
+		assertEquals(nonExistingFolderInExistingProject.getLocation(),
+				existingProject.getLocation().append(nonExistingFolderInExistingProject.getName()));
 
 		//attempting to link again will fail because the folder exists in the workspace
 		assertThrows(CoreException.class,
@@ -297,20 +299,20 @@ public class LinkedResourceTest {
 		createInFileSystem(resolvedLocation);
 		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("3.0", !folder.exists());
-		assertTrue("3.1", file.exists());
-		assertTrue("3.2", file.isLinked());
-		assertEquals("3.3", resolvedLocation, file.getLocation());
+		assertFalse(folder.exists());
+		assertTrue(file.exists());
+		assertTrue(file.isLinked());
+		assertEquals(resolvedLocation, file.getLocation());
 
 		//change back to folder
 		removeFromFileSystem(resolvedLocation.toFile());
 		resolvedLocation.toFile().mkdirs();
 
 		folder.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertTrue("4.0", folder.exists());
-		assertTrue("4.1", !file.exists());
-		assertTrue("4.2", folder.isLinked());
-		assertEquals("4.3", resolvedLocation, folder.getLocation());
+		assertTrue(folder.exists());
+		assertFalse(file.exists());
+		assertTrue(folder.isLinked());
+		assertEquals(resolvedLocation, folder.getLocation());
 	}
 
 	@Test
@@ -545,9 +547,9 @@ public class LinkedResourceTest {
 
 		IFile dest = existingProject.getFile("FailedCopyDest");
 		assertThrows(CoreException.class, () -> linkedFile.copy(dest.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("2.1", !dest.exists());
+		assertFalse(dest.exists());
 		assertThrows(CoreException.class, () -> linkedFile.copy(dest.getFullPath(), IResource.FORCE, createTestMonitor()));
-		assertTrue("2.3", !dest.exists());
+		assertFalse(dest.exists());
 	}
 
 	/**
@@ -561,9 +563,9 @@ public class LinkedResourceTest {
 
 		IFolder dest = existingProject.getFolder("FailedCopyDest");
 		assertThrows(CoreException.class, () -> linkedFolder.copy(dest.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("2.1", !dest.exists());
+		assertFalse(dest.exists());
 		assertThrows(CoreException.class, () -> linkedFolder.copy(dest.getFullPath(), IResource.FORCE, createTestMonitor()));
-		assertTrue("2.3", !dest.exists());
+		assertFalse(dest.exists());
 	}
 
 	@Test
@@ -581,35 +583,35 @@ public class LinkedResourceTest {
 		existingProject.copy(destination.getFullPath(), IResource.SHALLOW, createTestMonitor());
 
 		IFile newFile = destination.getFile(linkedFile.getProjectRelativePath());
-		assertTrue("3.0", newFile.isLinked());
-		assertEquals("3.1", linkedFile.getLocation(), newFile.getLocation());
+		assertTrue(newFile.isLinked());
+		assertEquals(linkedFile.getLocation(), newFile.getLocation());
 
 		IFolder newFolder = destination.getFolder(linkedFolder.getProjectRelativePath());
-		assertTrue("4.0", newFolder.isLinked());
-		assertEquals("4.1", linkedFolder.getLocation(), newFolder.getLocation());
+		assertTrue(newFolder.isLinked());
+		assertEquals(linkedFolder.getLocation(), newFolder.getLocation());
 
 		// test project deep copy
 		destination.delete(IResource.NONE, createTestMonitor());
 		existingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
-		assertTrue("5.1", !newFile.isLinked());
-		assertEquals("5.2", destination.getLocation().append(newFile.getProjectRelativePath()), newFile.getLocation());
-		assertTrue("5.3", !newFolder.isLinked());
-		assertEquals("5.4", destination.getLocation().append(newFolder.getProjectRelativePath()),
+		assertFalse(newFile.isLinked());
+		assertEquals(destination.getLocation().append(newFile.getProjectRelativePath()), newFile.getLocation());
+		assertFalse(newFolder.isLinked());
+		assertEquals(destination.getLocation().append(newFolder.getProjectRelativePath()),
 				newFolder.getLocation());
 
 		// test copy project when linked resources don't exist with force=false
 		destination.delete(IResource.NONE, createTestMonitor());
-		assertTrue("6.0", resolve(fileLocation).toFile().delete());
+		assertTrue(resolve(fileLocation).toFile().delete());
 
 		assertThrows(CoreException.class,
 				() -> existingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
 		// all members except the missing link should have been copied
-		assertTrue("6.2", destination.exists());
-		assertTrue("6.2.1", !destination.getFile(linkedFile.getName()).exists());
+		assertTrue(destination.exists());
+		assertFalse(destination.getFile(linkedFile.getName()).exists());
 		IResource[] srcChildren = existingProject.members();
 		for (int i = 0; i < srcChildren.length; i++) {
 			if (!srcChildren[i].equals(linkedFile)) {
-				assertNotNull("6.3." + i, destination.findMember(srcChildren[i].getProjectRelativePath()));
+				assertNotNull(i + "", destination.findMember(srcChildren[i].getProjectRelativePath()));
 			}
 		}
 		// test copy project when linked resources don't exist with force=true
@@ -618,13 +620,13 @@ public class LinkedResourceTest {
 		destination.delete(IResource.NONE, createTestMonitor());
 		assertThrows(CoreException.class,
 				() -> existingProject.copy(destination.getFullPath(), IResource.FORCE, createTestMonitor()));
-		assertTrue("6.7", destination.exists());
+		assertTrue(destination.exists());
 		assertTrue("6.7.1", !destination.getFile(linkedFile.getName()).exists());
 		// all members except the missing link should have been copied
 		srcChildren = existingProject.members();
 		for (int i = 0; i < srcChildren.length; i++) {
 			if (!srcChildren[i].equals(linkedFile)) {
-				assertNotNull("6.8." + i, destination.findMember(srcChildren[i].getProjectRelativePath()));
+				assertNotNull(i + "", destination.findMember(srcChildren[i].getProjectRelativePath()));
 			}
 		}
 	}
@@ -643,10 +645,10 @@ public class LinkedResourceTest {
 		link.createLink(rootStore.toURI(), IResource.BACKGROUND_REFRESH, createTestMonitor());
 		waitForRefresh();
 		IFile linkChild = link.getFile(childStore.getName());
-		assertTrue("1.0", link.exists());
-		assertTrue("1.1", link.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("1.2", linkChild.exists());
-		assertTrue("1.3", linkChild.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(link.exists());
+		assertTrue(link.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(linkChild.exists());
+		assertTrue(linkChild.isSynchronized(IResource.DEPTH_INFINITE));
 	}
 
 	/**
@@ -706,9 +708,9 @@ public class LinkedResourceTest {
 		project.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
 		project.create(createTestMonitor());
 		project.open(IResource.BACKGROUND_REFRESH, createTestMonitor());
-		assertTrue("1.0", folder.exists());
-		assertTrue("1.1", parent.exists());
-		assertTrue("1.2", parent.isLocal(IResource.DEPTH_INFINITE));
+		assertTrue(folder.exists());
+		assertTrue(parent.exists());
+		assertTrue(parent.isLocal(IResource.DEPTH_INFINITE));
 	}
 
 	/**
@@ -723,8 +725,8 @@ public class LinkedResourceTest {
 		folder.createLink(localFolder, IResource.HIDDEN, createTestMonitor());
 		file.createLink(localFile, IResource.HIDDEN, createTestMonitor());
 
-		assertTrue("3.0", folder.isHidden());
-		assertTrue("4.0", file.isHidden());
+		assertTrue(folder.isHidden());
+		assertTrue(file.isHidden());
 	}
 
 	@Test
@@ -751,17 +753,17 @@ public class LinkedResourceTest {
 		existingProject.move(destination.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(newResources);
 		assertDoesNotExistInWorkspace(oldResources);
-		assertTrue("3.2", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("3.3", destination.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(existingProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(destination.isSynchronized(IResource.DEPTH_INFINITE));
 
-		assertTrue("3.4", !newFile.isLinked());
-		assertEquals("3.5", destination.getLocation().append(newFile.getProjectRelativePath()), newFile.getLocation());
+		assertFalse(newFile.isLinked());
+		assertEquals(destination.getLocation().append(newFile.getProjectRelativePath()), newFile.getLocation());
 
-		assertTrue("3.6", !newFolder.isLinked());
-		assertEquals("3.7", destination.getLocation().append(newFolder.getProjectRelativePath()),
+		assertFalse(newFolder.isLinked());
+		assertEquals(destination.getLocation().append(newFolder.getProjectRelativePath()),
 				newFolder.getLocation());
 
-		assertTrue("3.8", destination.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(destination.isSynchronized(IResource.DEPTH_INFINITE));
 	}
 
 	/**
@@ -778,18 +780,18 @@ public class LinkedResourceTest {
 		childStore = EFS.getStore(linkChild.getLocationURI());
 
 		//everything should exist at this point
-		assertTrue("1.0", linkParent.exists());
-		assertTrue("1.1", link.exists());
-		assertTrue("1.2", linkChild.exists());
+		assertTrue(linkParent.exists());
+		assertTrue(link.exists());
+		assertTrue(linkChild.exists());
 
 		//delete the parent of the link
 		linkParent.delete(IResource.KEEP_HISTORY, createTestMonitor());
 
 		//resources should not exist, but link content should exist on disk
-		assertTrue("2.0", !linkParent.exists());
-		assertTrue("2.1", !link.exists());
-		assertTrue("2.2", !linkChild.exists());
-		assertTrue("2.3", childStore.fetchInfo().exists());
+		assertFalse(linkParent.exists());
+		assertFalse(link.exists());
+		assertFalse(linkChild.exists());
+		assertTrue(childStore.fetchInfo().exists());
 	}
 
 	/**
@@ -803,14 +805,14 @@ public class LinkedResourceTest {
 		existingProject.create(createTestMonitor());
 
 		//link should not exist until the project is open
-		assertTrue("1.0", !link.exists());
+		assertFalse(link.exists());
 
 		existingProject.open(createTestMonitor());
 
 		//link should now exist
-		assertTrue("2.0", link.exists());
-		assertTrue("2.1", link.isLinked());
-		assertEquals("2.2", resolve(localFolder), link.getLocation());
+		assertTrue(link.exists());
+		assertTrue(link.isLinked());
+		assertEquals(resolve(localFolder), link.getLocation());
 	}
 
 	/**
@@ -831,15 +833,15 @@ public class LinkedResourceTest {
 
 		try {
 			assertThrows(CoreException.class, () -> link.delete(false, createTestMonitor()));
-			assertTrue("2.0", link.exists());
-			assertTrue("3.0", link.isLinked());
+			assertTrue(link.exists());
+			assertTrue(link.isLinked());
 
 			HashMap<IPath, LinkDescription> links = ((Project) project).internalGetDescription().getLinks();
-			assertNotNull("4.0", links);
-			assertEquals("5.0", 1, links.size());
+			assertNotNull(links);
+			assertEquals(1, links.size());
 
 			LinkDescription linkDesc = links.values().iterator().next();
-			assertEquals("6.0", link.getProjectRelativePath(), linkDesc.getProjectRelativePath());
+			assertEquals(link.getProjectRelativePath(), linkDesc.getProjectRelativePath());
 
 			// try to delete again
 			// if the project description in memory is ok, it should fail
@@ -866,20 +868,20 @@ public class LinkedResourceTest {
 
 		HashMap<IPath, LinkDescription> links = ((Project) project).internalGetDescription().getLinks();
 		LinkDescription linkDescription1 = links.get(file1.getProjectRelativePath());
-		assertNotNull("1.0", linkDescription1);
-		assertEquals("1.1", URIUtil.toURI(localFile), linkDescription1.getLocationURI());
+		assertNotNull(linkDescription1);
+		assertEquals(URIUtil.toURI(localFile), linkDescription1.getLocationURI());
 		LinkDescription linkDescription2 = links.get(file2.getProjectRelativePath());
-		assertNotNull("2.0", linkDescription2);
-		assertEquals("2.1", URIUtil.toURI(localFile), linkDescription2.getLocationURI());
+		assertNotNull(linkDescription2);
+		assertEquals(URIUtil.toURI(localFile), linkDescription2.getLocationURI());
 
 		folder.delete(true, createTestMonitor());
 
 		links = ((Project) project).internalGetDescription().getLinks();
 		linkDescription1 = links.get(file1.getProjectRelativePath());
-		assertNull("3.0", linkDescription1);
+		assertNull(linkDescription1);
 		linkDescription2 = links.get(file2.getProjectRelativePath());
-		assertNotNull("4.0", linkDescription2);
-		assertEquals("4.1", URIUtil.toURI(localFile), linkDescription2.getLocationURI());
+		assertNotNull(linkDescription2);
+		assertEquals(URIUtil.toURI(localFile), linkDescription2.getLocationURI());
 	}
 
 	/**
@@ -909,21 +911,21 @@ public class LinkedResourceTest {
 		//initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
 		for (IResource t : toTest) {
-			assertTrue("1.0 " + t, !t.isLinked());
-			assertTrue("1.1 " + t, !t.isLinked(IResource.NONE));
-			assertTrue("1.2 " + t, !t.isLinked(IResource.CHECK_ANCESTORS));
+			assertFalse(t.toString(), t.isLinked());
+			assertFalse(t.toString(), t.isLinked(IResource.NONE));
+			assertFalse(t.toString(), t.isLinked(IResource.CHECK_ANCESTORS));
 		}
 		// create a link
 		IFolder link = nonExistingFolderInExistingProject;
 		link.createLink(localFolder, IResource.NONE, createTestMonitor());
 		IFile child = link.getFile(childName);
-		assertTrue("2.0", child.exists());
-		assertTrue("2.1", link.isLinked());
-		assertTrue("2.2", link.isLinked(IResource.NONE));
-		assertTrue("2.3", link.isLinked(IResource.CHECK_ANCESTORS));
-		assertTrue("2.1", !child.isLinked());
-		assertTrue("2.2", !child.isLinked(IResource.NONE));
-		assertTrue("2.3", child.isLinked(IResource.CHECK_ANCESTORS));
+		assertTrue(child.exists());
+		assertTrue(link.isLinked());
+		assertTrue(link.isLinked(IResource.NONE));
+		assertTrue(link.isLinked(IResource.CHECK_ANCESTORS));
+		assertFalse(child.isLinked());
+		assertFalse(child.isLinked(IResource.NONE));
+		assertTrue(child.isLinked(IResource.CHECK_ANCESTORS));
 
 	}
 
@@ -932,27 +934,27 @@ public class LinkedResourceTest {
 		// initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
 		for (IResource toTest1 : toTest) {
-			assertTrue("1.0 " + toTest1, !toTest1.isLinked());
-			assertTrue("1.1 " + toTest1, !toTest1.isLinked(IResource.NONE));
-			assertTrue("1.2 " + toTest1, !toTest1.isLinked(IResource.CHECK_ANCESTORS));
+			assertFalse(toTest1.toString(), toTest1.isLinked());
+			assertFalse(toTest1.toString(), toTest1.isLinked(IResource.NONE));
+			assertFalse(toTest1.toString(), toTest1.isLinked(IResource.CHECK_ANCESTORS));
 		}
 		// create a link
 		IFolder link = nonExistingFolderInExistingProject;
 		link.createLink(localFolder, IResource.NONE, createTestMonitor());
 		IFile child = link.getFile(childName);
-		assertTrue("2.0", child.exists());
-		assertTrue("2.1", link.isLinked());
-		assertTrue("2.2", link.isLinked(IResource.NONE));
-		assertTrue("2.3", link.isLinked(IResource.CHECK_ANCESTORS));
-		assertTrue("2.1", !child.isLinked());
-		assertTrue("2.2", !child.isLinked(IResource.NONE));
-		assertTrue("2.3", child.isLinked(IResource.CHECK_ANCESTORS));
+		assertTrue(child.exists());
+		assertTrue(link.isLinked());
+		assertTrue(link.isLinked(IResource.NONE));
+		assertTrue(link.isLinked(IResource.CHECK_ANCESTORS));
+		assertFalse(child.isLinked());
+		assertFalse(child.isLinked(IResource.NONE));
+		assertTrue(child.isLinked(IResource.CHECK_ANCESTORS));
 
 		link.createLink(existingFileInExistingProject.getLocationURI(), IResource.REPLACE, createTestMonitor());
-		assertTrue("3.1", link.isLinked());
-		assertTrue("3.2", link.isLinked(IResource.NONE));
-		assertTrue("3.3", link.isLinked(IResource.CHECK_ANCESTORS));
-		assertTrue("3.4", link.getLocation().equals(existingFileInExistingProject.getLocation()));
+		assertTrue(link.isLinked());
+		assertTrue(link.isLinked(IResource.NONE));
+		assertTrue(link.isLinked(IResource.CHECK_ANCESTORS));
+		assertTrue(link.getLocation().equals(existingFileInExistingProject.getLocation()));
 	}
 
 	/**
@@ -993,27 +995,27 @@ public class LinkedResourceTest {
 		//initially nothing is linked
 		IResource[] toTest = new IResource[] {closedProject, existingFileInExistingProject, existingFolderInExistingFolder, existingFolderInExistingProject, existingProject, nonExistingFileInExistingFolder, nonExistingFileInExistingProject, nonExistingFileInOtherExistingProject, nonExistingFolderInExistingFolder, nonExistingFolderInExistingProject, nonExistingFolderInNonExistingFolder, nonExistingFolderInNonExistingProject, nonExistingFolderInOtherExistingProject, nonExistingProject, otherExistingProject};
 		for (IResource toTest1 : toTest) {
-			assertTrue("1.0 " + toTest1, !toTest1.isLinked());
-			assertTrue("1.1 " + toTest1, !toTest1.isLinked(IResource.NONE));
-			assertTrue("1.2 " + toTest1, !toTest1.isLinked(IResource.CHECK_ANCESTORS));
+			assertFalse(toTest1.toString(), toTest1.isLinked());
+			assertFalse(toTest1.toString(), toTest1.isLinked(IResource.NONE));
+			assertFalse(toTest1.toString(), toTest1.isLinked(IResource.CHECK_ANCESTORS));
 		}
 		//create a link
 		IFolder link = nonExistingFolderInExistingProject;
 		link.createLink(localFolder, IResource.NONE, createTestMonitor());
 		IFile child = link.getFile(childName);
-		assertTrue("2.0", child.exists());
-		assertTrue("2.1", link.isLinked());
-		assertTrue("2.2", link.isLinked(IResource.NONE));
-		assertTrue("2.3", link.isLinked(IResource.CHECK_ANCESTORS));
-		assertTrue("2.1", !child.isLinked());
-		assertTrue("2.2", !child.isLinked(IResource.NONE));
-		assertTrue("2.3", child.isLinked(IResource.CHECK_ANCESTORS));
+		assertTrue(child.exists());
+		assertTrue(link.isLinked());
+		assertTrue(link.isLinked(IResource.NONE));
+		assertTrue(link.isLinked(IResource.CHECK_ANCESTORS));
+		assertFalse(child.isLinked());
+		assertFalse(child.isLinked(IResource.NONE));
+		assertTrue(child.isLinked(IResource.CHECK_ANCESTORS));
 
 		link.createLink(existingFileInExistingProject.getLocation(), IResource.REPLACE, createTestMonitor());
-		assertTrue("3.1", link.isLinked());
-		assertTrue("3.2", link.isLinked(IResource.NONE));
-		assertTrue("3.3", link.isLinked(IResource.CHECK_ANCESTORS));
-		assertTrue("3.4", link.getLocation().equals(existingFileInExistingProject.getLocation()));
+		assertTrue(link.isLinked());
+		assertTrue(link.isLinked(IResource.NONE));
+		assertTrue(link.isLinked(IResource.CHECK_ANCESTORS));
+		assertTrue(link.getLocation().equals(existingFileInExistingProject.getLocation()));
 	}
 
 	/**
@@ -1043,13 +1045,13 @@ public class LinkedResourceTest {
 		linkedFile.createLink(fileStore.toURI(), IResource.NONE, createTestMonitor());
 
 		//assert locations
-		assertEquals("1.0", folderLocation, linkedFolder.getLocation());
-		assertEquals("1.1", folderLocation.append(subFolder.getName()), subFolder.getLocation());
-		assertEquals("1.2", fileLocation, linkedFile.getLocation());
+		assertEquals(folderLocation, linkedFolder.getLocation());
+		assertEquals(folderLocation.append(subFolder.getName()), subFolder.getLocation());
+		assertEquals(fileLocation, linkedFile.getLocation());
 		//assert URIs
-		assertEquals("1.0", folderStore.toURI(), linkedFolder.getLocationURI());
-		assertEquals("1.1", subFolderStore.toURI(), subFolder.getLocationURI());
-		assertEquals("1.2", fileStore.toURI(), linkedFile.getLocationURI());
+		assertEquals(folderStore.toURI(), linkedFolder.getLocationURI());
+		assertEquals(subFolderStore.toURI(), subFolder.getLocationURI());
+		assertEquals(fileStore.toURI(), linkedFile.getLocationURI());
 	}
 
 	/**
@@ -1265,9 +1267,9 @@ public class LinkedResourceTest {
 		IPath newLocation = IPath.fromOSString("");
 		URI newLocationURI = URIUtil.toURI(newLocation);
 		IStatus linkedResourceStatus = getWorkspace().validateLinkLocation(folder, newLocation);
-		assertEquals("1.0", IStatus.ERROR, linkedResourceStatus.getSeverity());
+		assertEquals(IStatus.ERROR, linkedResourceStatus.getSeverity());
 		linkedResourceStatus = getWorkspace().validateLinkLocationURI(folder, newLocationURI);
-		assertEquals("1.1", IStatus.ERROR, linkedResourceStatus.getSeverity());
+		assertEquals(IStatus.ERROR, linkedResourceStatus.getSeverity());
 	}
 
 	/**
@@ -1282,7 +1284,7 @@ public class LinkedResourceTest {
 		// so this is treated as relative to an undefined path variable called "c:".
 		IPath location = IPath.fromOSString("c:/temp");
 		folder.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		assertEquals("1.0", location, folder.getRawLocation());
+		assertEquals(location, folder.getRawLocation());
 	}
 
 	/**
@@ -1295,16 +1297,16 @@ public class LinkedResourceTest {
 		workspaceRule.deleteOnTearDown(location);
 		IFile linkedFile = nonExistingFileInExistingProject;
 		linkedFile.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
-		assertEquals("1.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
+		assertEquals(IResource.NULL_STAMP, linkedFile.getModificationStamp());
 		// create local file
 		resolve(location).toFile().createNewFile();
 		linkedFile.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertTrue("2.0", linkedFile.getModificationStamp() >= 0);
+		assertTrue(linkedFile.getModificationStamp() >= 0);
 
 		// delete local file
 		removeFromFileSystem(resolve(location).toFile());
 		linkedFile.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-		assertEquals("4.0", IResource.NULL_STAMP, linkedFile.getModificationStamp());
+		assertEquals(IResource.NULL_STAMP, linkedFile.getModificationStamp());
 	}
 
 	@Test
@@ -1516,9 +1518,9 @@ public class LinkedResourceTest {
 
 		IFile dest = existingProject.getFile("FailedMoveDest");
 		assertThrows(CoreException.class, () -> linkedFile.move(dest.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("2.1", !dest.exists());
+		assertFalse(dest.exists());
 		assertThrows(CoreException.class, () -> linkedFile.move(dest.getFullPath(), IResource.FORCE, createTestMonitor()));
-		assertTrue("2.3", !dest.exists());
+		assertFalse(dest.exists());
 	}
 
 	/**
@@ -1532,9 +1534,9 @@ public class LinkedResourceTest {
 
 		IFolder dest = existingProject.getFolder("FailedMoveDest");
 		assertThrows(CoreException.class, () -> linkedFolder.move(dest.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("2.1", !dest.exists());
+		assertFalse(dest.exists());
 		assertThrows(CoreException.class, () -> linkedFolder.move(dest.getFullPath(), IResource.FORCE, createTestMonitor()));
-		assertTrue("2.3", !dest.exists());
+		assertFalse(dest.exists());
 	}
 
 	@Test
@@ -1562,25 +1564,25 @@ public class LinkedResourceTest {
 		assertExistsInWorkspace(newResources);
 		assertDoesNotExistInWorkspace(oldResources);
 
-		assertTrue("3.2", newFile.isLinked());
-		assertEquals("3.3", resolve(fileLocation), newFile.getLocation());
+		assertTrue(newFile.isLinked());
+		assertEquals(resolve(fileLocation), newFile.getLocation());
 
-		assertTrue("3.4", newFolder.isLinked());
-		assertEquals("3.5", resolve(localFolder), newFolder.getLocation());
+		assertTrue(newFolder.isLinked());
+		assertEquals(resolve(localFolder), newFolder.getLocation());
 
-		assertTrue("3.6", destination.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(destination.isSynchronized(IResource.DEPTH_INFINITE));
 
 		// now do a deep move back to the original project
 		destination.move(existingProject.getFullPath(), IResource.NONE, createTestMonitor());
 		assertExistsInWorkspace(oldResources);
 		assertDoesNotExistInWorkspace(newResources);
-		assertTrue("5.3", !file.isLinked());
-		assertTrue("5.4", !folder.isLinked());
-		assertEquals("5.5", existingProject.getLocation().append(file.getProjectRelativePath()), file.getLocation());
-		assertEquals("5.6", existingProject.getLocation().append(folder.getProjectRelativePath()),
+		assertFalse(file.isLinked());
+		assertFalse(folder.isLinked());
+		assertEquals(existingProject.getLocation().append(file.getProjectRelativePath()), file.getLocation());
+		assertEquals(existingProject.getLocation().append(folder.getProjectRelativePath()),
 				folder.getLocation());
-		assertTrue("5.7", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("5.8", destination.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(existingProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(destination.isSynchronized(IResource.DEPTH_INFINITE));
 	}
 
 	/**
@@ -1599,8 +1601,8 @@ public class LinkedResourceTest {
 		existingProject.move(destination.getFullPath(), IResource.SHALLOW, createTestMonitor());
 
 		IFile newFile = destination.getFile(linkedFile.getProjectRelativePath());
-		assertTrue("3.0", newFile.isLinked());
-		assertEquals("3.1", resolve(fileLocation), newFile.getLocation());
+		assertTrue(newFile.isLinked());
+		assertEquals(resolve(fileLocation), newFile.getLocation());
 	}
 
 	/**
@@ -1622,23 +1624,23 @@ public class LinkedResourceTest {
 
 		// there should be an entry in .project for the linked file
 		String string = readStringInFileSystem(existingProject.getFile(".project"));
-		assertTrue("3.0", string.contains(linkedFile.getProjectRelativePath().toString()));
+		assertTrue(string.contains(linkedFile.getProjectRelativePath().toString()));
 
 		// move the folder
 		folderWithLinks.move(otherExistingProject.getFolder(createUniqueString()).getFullPath(),
 				IResource.SHALLOW | IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
 		// both the folder and link in the source project should not exist
-		assertFalse("5.0", folderWithLinks.exists());
-		assertFalse("6.0", linkedFile.exists());
+		assertFalse(folderWithLinks.exists());
+		assertFalse(linkedFile.exists());
 
 		// the project description should not contain links
 		HashMap<IPath, LinkDescription> links = ((ProjectDescription) existingProject.getDescription()).getLinks();
-		assertNull("8.0", links);
+		assertNull(links);
 
 		// and the entry from .project should be removed
 		string = readStringInFileSystem(existingProject.getFile(".project"));
-		assertEquals("9.0", -1, string.indexOf(linkedFile.getProjectRelativePath().toString()));
+		assertEquals(-1, string.indexOf(linkedFile.getProjectRelativePath().toString()));
 	}
 
 	@Test
@@ -1684,24 +1686,24 @@ public class LinkedResourceTest {
 		store2.mkdir(EFS.NONE, createTestMonitor());
 		link.createLink(location1, IResource.NONE, createTestMonitor());
 		linkChild.createLink(location2, IResource.NONE, createTestMonitor());
-		assertTrue("1.0", link.exists());
-		assertTrue("1.1", link.isLinked());
-		assertTrue("1.2", linkChild.exists());
-		assertTrue("1.3", linkChild.isLinked());
-		assertEquals("1.4", location1, link.getLocationURI());
-		assertEquals("1.5", location2, linkChild.getLocationURI());
+		assertTrue(link.exists());
+		assertTrue(link.isLinked());
+		assertTrue(linkChild.exists());
+		assertTrue(linkChild.isLinked());
+		assertEquals(location1, link.getLocationURI());
+		assertEquals(location2, linkChild.getLocationURI());
 
 		//now delete and recreate the project
 		existingProject.delete(IResource.NEVER_DELETE_PROJECT_CONTENT, createTestMonitor());
 		existingProject.create(createTestMonitor());
 		existingProject.open(IResource.NONE, createTestMonitor());
 
-		assertTrue("2.0", link.exists());
-		assertTrue("2.1", link.isLinked());
-		assertTrue("2.2", linkChild.exists());
-		assertTrue("2.3", linkChild.isLinked());
-		assertEquals("2.4", location1, link.getLocationURI());
-		assertEquals("2.5", location2, linkChild.getLocationURI());
+		assertTrue(link.exists());
+		assertTrue(link.isLinked());
+		assertTrue(linkChild.exists());
+		assertTrue(linkChild.isLinked());
+		assertEquals(location1, link.getLocationURI());
+		assertEquals(location2, linkChild.getLocationURI());
 	}
 
 	/**
@@ -1715,14 +1717,14 @@ public class LinkedResourceTest {
 		IFile linkChild = link.getFile(localChild.lastSegment());
 		createInFileSystem(resolve(localChild));
 		link.createLink(linkLocation, IResource.NONE, createTestMonitor());
-		assertTrue("1.0", link.exists());
-		assertTrue("1.1", linkChild.exists());
+		assertTrue(link.exists());
+		assertTrue(linkChild.exists());
 
 		IProject project = link.getProject();
 		project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 
-		assertTrue("2.0", link.exists());
-		assertTrue("2.1", linkChild.exists());
+		assertTrue(link.exists());
+		assertTrue(linkChild.exists());
 	}
 
 	@Test
@@ -1731,13 +1733,13 @@ public class LinkedResourceTest {
 
 		IPath projectLocation = existingProject.getLocation();
 		IFolder folderByIPath = existingProject.getFolder("overlappingLinkedFolderByIPath");
-		assertTrue("1.1", !workspace.validateLinkLocation(folderByIPath, projectLocation).isOK());
+		assertFalse(workspace.validateLinkLocation(folderByIPath, projectLocation).isOK());
 		assertThrows(CoreException.class,
 				() -> folderByIPath.createLink(projectLocation, IResource.NONE, createTestMonitor()));
 
 		URI projectLocationURI = existingProject.getLocationURI();
 		IFolder folderByURI = existingProject.getFolder("overlappingLinkedFolderByURI");
-		assertTrue("2.1", !workspace.validateLinkLocationURI(folderByURI, projectLocationURI).isOK());
+		assertFalse(workspace.validateLinkLocationURI(folderByURI, projectLocationURI).isOK());
 		assertThrows(CoreException.class,
 				() -> folderByURI.createLink(projectLocationURI, IResource.NONE, createTestMonitor()));
 
@@ -1745,13 +1747,13 @@ public class LinkedResourceTest {
 
 		IPath projectLocationWithoutDevice = projectLocation.setDevice(null);
 		IFolder folderByUnixLikeIPath = existingProject.getFolder("overlappingLinkedFolderByUnixLikeIPath");
-		assertTrue("3.1", !workspace.validateLinkLocation(folderByUnixLikeIPath, projectLocationWithoutDevice).isOK());
+		assertFalse(workspace.validateLinkLocation(folderByUnixLikeIPath, projectLocationWithoutDevice).isOK());
 		assertThrows(CoreException.class,
 				() -> folderByUnixLikeIPath.createLink(projectLocationWithoutDevice, IResource.NONE, createTestMonitor()));
 
 		URI projectLocationURIWithoutDevice = URIUtil.toURI(projectLocationWithoutDevice.toString());
 		IFolder folderByUnixLikeURI = existingProject.getFolder("overlappingLinkedFolderByUnixLikeURI");
-		assertTrue("4.1", !workspace.validateLinkLocationURI(folderByUnixLikeURI, projectLocationURIWithoutDevice).isOK());
+		assertFalse(workspace.validateLinkLocationURI(folderByUnixLikeURI, projectLocationURIWithoutDevice).isOK());
 		assertThrows(CoreException.class,
 				() -> folderByUnixLikeURI.createLink(projectLocationURIWithoutDevice, IResource.NONE, createTestMonitor()));
 	}
@@ -1775,7 +1777,7 @@ public class LinkedResourceTest {
 		IFolder folder = nonExistingFolderInExistingProject;
 		folder.createLink(linkChildLocation, IResource.NONE, createTestMonitor());
 		// Check that the symlink is preserved.
-		assertEquals("1.2", resolvedLinkChildLocation, folder.getLocation());
+		assertEquals(resolvedLinkChildLocation, folder.getLocation());
 	}
 
 	/**
@@ -1797,21 +1799,21 @@ public class LinkedResourceTest {
 		IFolder folder = nonExistingFolderInExistingProject;
 		IPath symLink = linkParentDir.append("symlink");
 		folder.createLink(symLink, IResource.NONE, createTestMonitor());
-		assertTrue("1.1", folder.exists());
-		assertTrue("1.2", folder.getFolder("B/C").exists());
-		assertEquals("1.3", symLink, folder.getLocation());
+		assertTrue(folder.exists());
+		assertTrue(folder.getFolder("B/C").exists());
+		assertEquals(symLink, folder.getLocation());
 		// Delete the symlink and the directory that contains it.
 		symLink.toFile().delete();
 		linkParentDir.toFile().delete();
 		// Check that the directory that contained the symlink has been deleted.
-		assertFalse("2.1", linkParentDir.toFile().exists());
+		assertFalse(linkParentDir.toFile().exists());
 		// Refresh the project.
 		folder.getParent().refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
 		// Check that the linked folder still exists.
-		assertTrue("3.1", folder.exists());
+		assertTrue(folder.exists());
 		// Check that the contents of the linked folder no longer exist.
-		assertFalse("3.2", folder.getFolder("B").exists());
-		assertFalse("3.3", folder.getFolder("B/C").exists());
+		assertFalse(folder.getFolder("B").exists());
+		assertFalse(folder.getFolder("B/C").exists());
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -26,6 +26,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -208,15 +209,15 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		URI value = manager.getURIValue(PROJECT_VARIABLE_NAME);
 		URI relativeValue = manager.getURIValue(PROJECT_RELATIVE_VARIABLE_NAME);
 
-		assertTrue("1.0", !value.equals(relativeValue));
+		assertFalse(value.equals(relativeValue));
 
 		URI resolvedValue = manager.resolveURI(value);
-		assertTrue("1.1", value.equals(resolvedValue));
+		assertTrue(value.equals(resolvedValue));
 
 		URI resolvedRelativeValue = manager.resolveURI(relativeValue);
-		assertTrue("1.2", !relativeValue.equals(resolvedRelativeValue));
+		assertFalse(relativeValue.equals(resolvedRelativeValue));
 
-		assertTrue("1.3", resolvedValue.equals(resolvedRelativeValue));
+		assertTrue(resolvedValue.equals(resolvedRelativeValue));
 	}
 
 	/**
@@ -259,7 +260,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		assertExistsInWorkspace(file);
 		// the location is null
-		assertNull("3.6", file.getLocation());
+		assertNull(file.getLocation());
 
 		// try validating another link location while there is a link with null location
 		IFile other = existingProject.getFile("OtherVar");
@@ -269,10 +270,10 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		manager.setURIValue(VARIABLE_NAME, URIUtil.toURI(existingValue));
 
 		assertExistsInWorkspace(file);
-		assertNotNull("5.1", file.getLocation());
+		assertNotNull(file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertEquals("5.3", "contents for a file", file.readString());
+		assertEquals("contents for a file", file.readString());
 	}
 
 	/**
@@ -315,7 +316,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		assertExistsInWorkspace(file);
 		// the location is null
-		assertNull("3.6", file.getLocation());
+		assertNull(file.getLocation());
 
 		// try validating another link location while there is a link with null
 		// location
@@ -326,10 +327,10 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		manager.setURIValue(PROJECT_VARIABLE_NAME, URIUtil.toURI(existingValue));
 
 		assertExistsInWorkspace(file);
-		assertNotNull("5.1", file.getLocation());
+		assertNotNull(file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertEquals("5.3", "contents for a file", file.readString());
+		assertEquals("contents for a file", file.readString());
 	}
 
 	/**
@@ -531,7 +532,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		assertExistsInWorkspace(file);
 		// the location is null
-		assertNull("3.6", file.getLocation());
+		assertNull(file.getLocation());
 
 		// try validating another link location while there is a link with null
 		// location
@@ -542,10 +543,10 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		manager.setURIValue(PROJECT_RELATIVE_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace(file);
-		assertNotNull("5.1", file.getLocation());
+		assertNotNull(file.getLocation());
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertEquals("5.3", "contents for a file", file.readString());
+		assertEquals("contents for a file", file.readString());
 	}
 
 	/**
@@ -590,7 +591,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
 		assertThrows(CoreException.class,
 				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("3.6", !destination.exists());
+		assertFalse(destination.exists());
 
 		//try to create a sub-file
 		assertThrows(CoreException.class, () -> destination.create(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
@@ -606,13 +607,13 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		assertExistsInWorkspace(folder);
 		// the location is null
-		assertNull("4.2", folder.getLocation());
+		assertNull(folder.getLocation());
 
 		// re-creates the variable with its previous value
 		manager.setURIValue(VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace(folder);
-		assertNotNull("6.1", folder.getLocation());
+		assertNotNull(folder.getLocation());
 		assertExistsInFileSystem(folder);
 		assertDoesNotExistInWorkspace(childFile);
 		assertExistsInFileSystem(childFile);
@@ -709,7 +710,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IFile destination = folder.getFile(existingFileInExistingProject.getName());
 		assertThrows(CoreException.class,
 				() -> existingFileInExistingProject.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));
-		assertTrue("3.6", !destination.exists());
+		assertFalse(destination.exists());
 
 		// try to create a sub-file
 		assertThrows(CoreException.class, () -> destination.create(createRandomContentsStream(), IResource.NONE, createTestMonitor()));
@@ -725,13 +726,13 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		assertExistsInWorkspace(folder);
 		// the location is null
-		assertNull("4.2", folder.getLocation());
+		assertNull(folder.getLocation());
 
 		// re-creates the variable with its previous value
 		manager.setURIValue(PROJECT_VARIABLE_NAME, existingValue);
 
 		assertExistsInWorkspace(folder);
-		assertNotNull("6.1", folder.getLocation());
+		assertNotNull(folder.getLocation());
 		assertExistsInFileSystem(folder);
 		assertDoesNotExistInWorkspace(childFile);
 		assertExistsInFileSystem(childFile);
@@ -757,8 +758,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertThrows(CoreException.class, () -> testFolder.createLink(folderLocation, IResource.NONE, createTestMonitor()));
 
 		//validate method should return warning
-		assertTrue("1.2", getWorkspace().validateLinkLocation(testFolder, folderLocation).getSeverity() == IStatus.WARNING);
-		assertTrue("1.3", getWorkspace().validateLinkLocation(testFile, fileLocation).getSeverity() == IStatus.WARNING);
+		assertTrue(getWorkspace().validateLinkLocation(testFolder, folderLocation).getSeverity() == IStatus.WARNING);
+		assertTrue(getWorkspace().validateLinkLocation(testFile, fileLocation).getSeverity() == IStatus.WARNING);
 
 		//should succeed with ALLOW_MISSING_LOCAL
 		testFile.createLink(fileLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
@@ -830,7 +831,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
 				() -> file.setContents(createInputStream("new contents"), IResource.NONE, createTestMonitor()));
-		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
+		assertEquals(IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
 		// the location is different - does not exist anymore
@@ -845,7 +846,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// its location must have changed reflecting the variable change
 		URI expectedNewLocation = manager.resolveURI(variableBasedLocation);
 		URI actualNewLocation = file.getLocationURI();
-		assertEquals("4.2", expectedNewLocation, actualNewLocation);
+		assertEquals(expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
 		assertEquals("contents in different location", file.readString());
@@ -859,7 +860,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertEquals("5.3", "contents for a file", file.readString());
+		assertEquals("contents for a file", file.readString());
 	}
 
 	/**
@@ -896,7 +897,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// Resource was out of sync - should not be able to change
 		CoreException exception = assertThrows(CoreException.class,
 				() -> file.setContents(createInputStream("new contents"), IResource.NONE, createTestMonitor()));
-		assertEquals("3.1", IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
+		assertEquals(IResourceStatus.OUT_OF_SYNC_LOCAL, exception.getStatus().getCode());
 
 		assertExistsInWorkspace(file);
 		// the location is different - does not exist anymore
@@ -911,7 +912,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// its location must have changed reflecting the variable change
 		URI expectedNewLocation = manager.resolveURI(variableBasedLocation);
 		URI actualNewLocation = file.getLocationURI();
-		assertEquals("4.2", expectedNewLocation, actualNewLocation);
+		assertEquals(expectedNewLocation, actualNewLocation);
 
 		// its contents are as just set
 		assertEquals("contents in different location", file.readString());
@@ -925,41 +926,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		assertExistsInWorkspace(file);
 		assertExistsInFileSystem(file);
 		// the contents must be the original ones
-		assertEquals("5.3", "contents for a file", file.readString());
+		assertEquals("contents for a file", file.readString());
 	}
-
-	/**
-	 * Tests a scenario where a variable used in a linked file location is
-	 * changed.
-	 */
-	//	public void testGetPathVariable() {
-	//		final IPathVariableManager manager = existingProject.getPathVariableManager();
-	//		IPathVariable variable = manager.getPathVariable("PROJECT_LOC");
-	//		assertTrue("1.0", variable != null);
-	//		assertTrue("1.1", variable.isReadOnly());
-	//		assertEquals("1.2", null, variable.getVariableHints());
-	//
-	//		variable = manager.getPathVariable("PROJECT_LOC_does_not_exist");
-	//		assertTrue("2.0", variable == null);
-	//
-	//		variable = manager.getPathVariable("PARENT");
-	//		assertTrue("3.0", variable != null);
-	//		assertTrue("3.1", variable.isReadOnly());
-	//		Object[] extensions = variable.getVariableHints();
-	//		assertTrue("3.2", extensions == null);
-	//
-	//		try {
-	//			IPath newLocation = FileSystemHelper.getRandomLocation();
-	//			toDelete.add(newLocation);
-	//			manager.setValue(PROJECT_VARIABLE_NAME, newLocation);
-	//		} catch (CoreException e) {
-	//			fail("4.1", e);
-	//		}
-	//		variable = manager.getPathVariable(PROJECT_VARIABLE_NAME);
-	//		assertTrue("4.0", variable != null);
-	//		assertTrue("4.1", !variable.isReadOnly());
-	//		assertEquals("4.2", null, variable.getVariableHints());
-	//	}
 
 	/**
 	 * Test Bug 288880 - Redundant path variables generated when converting some linked resources to path variable-relative
@@ -982,14 +950,14 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IPath resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
-		assertEquals("3.1", targetPath, resolvedPath);
+		assertEquals(targetPath, resolvedPath);
 
 		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 
 		resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
 		// the file should not exist yet
 		assertDoesNotExistInWorkspace(file);
-		assertEquals("5.1", targetPath, resolvedPath);
+		assertEquals(targetPath, resolvedPath);
 	}
 
 	@Test
@@ -1016,9 +984,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		for (int i = 0; i < table.length; i++) {
 			String result = pathVariableManager.convertToUserEditableFormat(toOS(table[i][0]), false);
-			assertEquals("1." + i, toOS(table[i][1]), result);
+			assertEquals(i + "", toOS(table[i][1]), result);
 			String original = pathVariableManager.convertFromUserEditableFormat(result, false);
-			assertEquals("2." + i, toOS(table[i].length == 2 ? table[i][0] : table[i][2]), original);
+			assertEquals(i + "", toOS(table[i].length == 2 ? table[i][0] : table[i][2]), original);
 		}
 
 		String[][] tableLocationFormat = { // format: {internal-format, user-editable-format [, internal-format-reconverted]
@@ -1041,9 +1009,11 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		for (int i = 0; i < table.length; i++) {
 			String result = pathVariableManager.convertToUserEditableFormat(toOS(tableLocationFormat[i][0]), true);
-			assertEquals("3." + i, toOS(tableLocationFormat[i][1]), result);
+			assertEquals(i + "", toOS(tableLocationFormat[i][1]), result);
 			String original = pathVariableManager.convertFromUserEditableFormat(result, true);
-			assertEquals("4." + i, toOS(tableLocationFormat[i].length == 2 ? tableLocationFormat[i][0] : tableLocationFormat[i][2]), original);
+			assertEquals(i + "",
+					toOS(tableLocationFormat[i].length == 2 ? tableLocationFormat[i][0] : tableLocationFormat[i][2]),
+					original);
 		}
 	}
 
@@ -1057,9 +1027,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	@Test
 	public void testPrefixVariablesAreNotConfused() {
 		URI uri = nonExistingFileInExistingFolder.getPathVariableManager().getURIValue("PARENT");
-		assertEquals("1.0", uri, null);
+		assertEquals(uri, null);
 		uri = nonExistingFileInExistingFolder.getPathVariableManager().getURIValue("PARENT_LOC");
-		assertNotNull("1.1", uri);
+		assertNotNull(uri);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
@@ -17,6 +17,7 @@ package org.eclipse.core.tests.resources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -78,16 +79,16 @@ public class MarkerSetTest {
 		for (int i = 0; i < infos.length; i++) {
 			info = infos[i];
 			set.add(info);
-			assertTrue("2.0." + i, set.contains(info.getId()));
-			assertEquals("2.1." + i, i + 1, set.size());
+			assertTrue(i + "", set.contains(info.getId()));
+			assertEquals(i + "", i + 1, set.size());
 		}
 
 		// make sure they are all still there
-		assertEquals("3.0", max, set.size());
+		assertEquals(max, set.size());
 		for (int i = 0; i < infos.length; i++) {
 			info = infos[i];
-			assertTrue("3.1." + i, set.contains(info.getId()));
-			assertNotNull("3.2." + i, set.get(info.getId()));
+			assertTrue(i + "", set.contains(info.getId()));
+			assertNotNull(i + "", set.get(info.getId()));
 		}
 	}
 
@@ -104,7 +105,7 @@ public class MarkerSetTest {
 			infos[i] = info;
 		}
 		set.addAll(infos);
-		assertEquals("1.0", max, set.size());
+		assertEquals(max, set.size());
 
 		// remove each element
 		assertMarkerElementsEqual(set.elements(), infos);
@@ -123,22 +124,22 @@ public class MarkerSetTest {
 			infos[i] = info;
 		}
 		set.addAll(infos);
-		assertEquals("1.0", max, set.size());
+		assertEquals(max, set.size());
 
 		// remove each element
 		for (int i = max - 1; i >= 0; i--) {
 			info = infos[i];
 			set.remove(info);
-			assertTrue("2.0." + i, !set.contains(info.getId()));
-			assertEquals("2.1," + i, i, set.size());
+			assertFalse(i + "", set.contains(info.getId()));
+			assertEquals(i + "", i, set.size());
 			// check that the others still exist
 			for (int j = 0; j < i; j++) {
-				assertTrue("2.2." + j, set.contains(infos[j].getId()));
+				assertTrue(j + "", set.contains(infos[j].getId()));
 			}
 		}
 
 		// all gone?
-		assertEquals("3.0", 0, set.size());
+		assertEquals(0, set.size());
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -110,12 +110,12 @@ public class NonLocalLinkedResourceTest {
 
 		//shallow copy to destination should succeed
 		source.copy(destination.getFullPath(), IResource.SHALLOW, createTestMonitor());
-		assertTrue("1.1", destination.exists());
+		assertTrue(destination.exists());
 
 		//deep copy to destination should succeed
 		destination.delete(IResource.NONE, createTestMonitor());
 		source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor());
-		assertTrue("2.1", destination.exists());
+		assertTrue(destination.exists());
 
 		//should fail when destination is occupied
 		assertThrows(CoreException.class, () -> source.copy(destination.getFullPath(), IResource.NONE, createTestMonitor()));

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
@@ -145,7 +145,7 @@ public class ProjectSnapshotPerfManualTest {
 			}
 		}.run(getClass(), "Forced refresh only", 1, 1);
 		verifier[0].verifyDelta(null);
-		assertTrue("1.0 " + verifier[0].getMessage(), verifier[0].isDeltaValid());
+		assertTrue(verifier[0].getMessage(), verifier[0].isDeltaValid());
 
 		// close and delete project but leave contents
 		project.close(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotTest.java
@@ -125,10 +125,10 @@ public class ProjectSnapshotTest {
 		IFolder folder = project.getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		assertTrue("1.1", file.exists());
-		assertTrue("1.2", folder.exists());
-		assertTrue("1.3", subfolder.exists());
-		assertTrue("1.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertTrue(subfolder.exists());
+		assertTrue(subfile.exists());
 	}
 
 	/*
@@ -176,12 +176,12 @@ public class ProjectSnapshotTest {
 		// perform refresh to create resource delta against snapshot
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		verifier.verifyDelta(null);
-		assertTrue("1.0 " + verifier.getMessage(), verifier.isDeltaValid());
+		assertTrue(verifier.getMessage(), verifier.isDeltaValid());
 		// verify that the resources are no longer thought to exist
-		assertTrue("1.1", !file.exists());
-		assertTrue("1.2", !folder.exists());
-		assertTrue("1.3", !subfolder.exists());
-		assertTrue("1.4", !subfile.exists());
+		assertFalse(file.exists());
+		assertFalse(folder.exists());
+		assertFalse(subfolder.exists());
+		assertFalse(subfile.exists());
 	}
 
 	/*
@@ -214,10 +214,10 @@ public class ProjectSnapshotTest {
 		IFolder folder = project.getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		assertTrue("1.1", file.exists());
-		assertTrue("1.2", folder.exists());
-		assertTrue("1.3", subfolder.exists());
-		assertTrue("1.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertTrue(subfolder.exists());
+		assertTrue(subfile.exists());
 	}
 
 	/*
@@ -259,10 +259,10 @@ public class ProjectSnapshotTest {
 		IFolder folder = project.getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		assertTrue("1.1", file.exists());
-		assertTrue("1.2", folder.exists());
-		assertTrue("1.3", subfolder.exists());
-		assertTrue("1.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertTrue(subfolder.exists());
+		assertTrue(subfile.exists());
 	}
 
 	@Test
@@ -273,11 +273,11 @@ public class ProjectSnapshotTest {
 		((ProjectDescription) description).setSnapshotLocationURI(URI.create("./relative/uri.zip"));
 		project.create(description, null);
 		createInFileSystem(project.getFolder("foo"));
-		assertFalse("1.0", project.getFolder("foo").exists());
+		assertFalse(project.getFolder("foo").exists());
 		// expect to see warning logged, but project open successfully and refresh
 		project.open(null);
-		assertTrue("1.1", project.isOpen());
-		assertTrue("1.2", project.getFolder("foo").exists());
+		assertTrue(project.isOpen());
+		assertTrue(project.getFolder("foo").exists());
 		assertThrows(CoreException.class, () -> project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD,
 				URI.create("NON_EXISTING/foo/bar.zip"), null));
 	}
@@ -290,11 +290,11 @@ public class ProjectSnapshotTest {
 		((ProjectDescription) description).setSnapshotLocationURI(workspaceRule.getTempStore().toURI());
 		project.create(description, null);
 		createInFileSystem(project.getFile("foo"));
-		assertFalse("1.0", project.getFile("foo").exists());
+		assertFalse(project.getFile("foo").exists());
 		project.open(null);
 		// expect warning logged but project open and refreshed
-		assertTrue("1.1", project.isOpen());
-		assertTrue("1.2", project.getFile("foo").exists());
+		assertTrue(project.isOpen());
+		assertTrue(project.getFile("foo").exists());
 	}
 
 	/*
@@ -345,10 +345,10 @@ public class ProjectSnapshotTest {
 		IFolder folder = project.getFolder("folder");
 		IFolder subfolder = folder.getFolder("subfolder");
 		IFile subfile = folder.getFile("subfile");
-		assertTrue("1.1", file.exists());
-		assertTrue("1.2", folder.exists());
-		assertTrue("1.3", subfolder.exists());
-		assertTrue("1.4", subfile.exists());
+		assertTrue(file.exists());
+		assertTrue(folder.exists());
+		assertTrue(subfolder.exists());
+		assertTrue(subfile.exists());
 	}
 
 	@Test
@@ -363,22 +363,22 @@ public class ProjectSnapshotTest {
 		ProjectDescription desc = (ProjectDescription) project.getDescription();
 		desc.setSnapshotLocationURI(null);
 		project.setDescription(desc, null);
-		assertEquals("1.0", stamp, projectFile.getModificationStamp());
+		assertEquals(stamp, projectFile.getModificationStamp());
 
 		// set or reset a snapshot -> .project file changed, unless setting to same existing URI
 		project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, tempURI, null);
-		assertEquals("2.0", tempURI, ((ProjectDescription) project.getDescription()).getSnapshotLocationURI());
+		assertEquals(tempURI, ((ProjectDescription) project.getDescription()).getSnapshotLocationURI());
 		long stamp2 = projectFile.getModificationStamp();
-		assertFalse("2.1", stamp == stamp2);
+		assertFalse(stamp == stamp2);
 		project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, tempURI, null);
-		assertEquals("2.2", stamp2, projectFile.getModificationStamp());
+		assertEquals(stamp2, projectFile.getModificationStamp());
 
 		//project.saveSnapshot(Project.SNAPSHOT_SET_AUTOLOAD, null, null);
 		desc = (ProjectDescription) project.getDescription();
 		desc.setSnapshotLocationURI(null);
 		project.setDescription(desc, null);
-		assertNull("3.0", ((ProjectDescription) project.getDescription()).getSnapshotLocationURI());
-		assertFalse("3.1", stamp2 == projectFile.getModificationStamp());
+		assertNull(((ProjectDescription) project.getDescription()).getSnapshotLocationURI());
+		assertFalse(stamp2 == projectFile.getModificationStamp());
 
 		// setting snapshot while project is closed is forbidden
 		project.close(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -88,18 +88,18 @@ public class ResourceAttributeTest {
 		createInWorkspace(file, createRandomString());
 
 		// file bit is set already for a new file
-		assertTrue("1.0", file.getResourceAttributes().isArchive());
+		assertTrue(file.getResourceAttributes().isArchive());
 		setArchive(file, false);
-		assertTrue("1.2", !file.getResourceAttributes().isArchive());
+		assertFalse(file.getResourceAttributes().isArchive());
 		setArchive(file, true);
-		assertTrue("1.4", file.getResourceAttributes().isArchive());
+		assertTrue(file.getResourceAttributes().isArchive());
 
 		// folder bit is not set already for a new folder
-		assertTrue("2.0", !project.getResourceAttributes().isArchive());
+		assertFalse(project.getResourceAttributes().isArchive());
 		setArchive(project, true);
-		assertTrue("2.2", project.getResourceAttributes().isArchive());
+		assertTrue(project.getResourceAttributes().isArchive());
 		setArchive(project, false);
-		assertTrue("2.4", !project.getResourceAttributes().isArchive());
+		assertFalse(project.getResourceAttributes().isArchive());
 	}
 
 	@Test
@@ -112,19 +112,19 @@ public class ResourceAttributeTest {
 		createInWorkspace(file, createRandomString());
 
 		// file
-		assertTrue("1.0", !file.getResourceAttributes().isExecutable());
+		assertFalse(file.getResourceAttributes().isExecutable());
 		setExecutable(file, true);
-		assertTrue("1.2", file.getResourceAttributes().isExecutable());
+		assertTrue(file.getResourceAttributes().isExecutable());
 		setExecutable(file, false);
-		assertTrue("1.4", !file.getResourceAttributes().isExecutable());
+		assertFalse(file.getResourceAttributes().isExecutable());
 
 		// folder
 		// folder is executable initially
-		assertTrue("2.0", project.getResourceAttributes().isExecutable());
+		assertTrue(project.getResourceAttributes().isExecutable());
 		setExecutable(project, false);
-		assertTrue("2.2", !project.getResourceAttributes().isExecutable());
+		assertFalse(project.getResourceAttributes().isExecutable());
 		setExecutable(project, true);
-		assertTrue("2.4", project.getResourceAttributes().isExecutable());
+		assertTrue(project.getResourceAttributes().isExecutable());
 	}
 
 	@Test
@@ -137,18 +137,18 @@ public class ResourceAttributeTest {
 		createInWorkspace(file, createRandomString());
 
 		// file
-		assertTrue("1.0", !file.getResourceAttributes().isHidden());
+		assertFalse(file.getResourceAttributes().isHidden());
 		setHidden(file, true);
-		assertTrue("1.2", file.getResourceAttributes().isHidden());
+		assertTrue(file.getResourceAttributes().isHidden());
 		setHidden(file, false);
-		assertTrue("1.4", !file.getResourceAttributes().isHidden());
+		assertFalse(file.getResourceAttributes().isHidden());
 
 		// folder
-		assertTrue("2.0", !project.getResourceAttributes().isHidden());
+		assertFalse(project.getResourceAttributes().isHidden());
 		setHidden(project, true);
-		assertTrue("2.2", project.getResourceAttributes().isHidden());
+		assertTrue(project.getResourceAttributes().isHidden());
 		setHidden(project, false);
-		assertTrue("2.4", !project.getResourceAttributes().isHidden());
+		assertFalse(project.getResourceAttributes().isHidden());
 	}
 
 	@Test
@@ -161,18 +161,18 @@ public class ResourceAttributeTest {
 		createInWorkspace(file, createRandomString());
 
 		// file
-		assertTrue("1.0", !file.getResourceAttributes().isReadOnly());
+		assertFalse(file.getResourceAttributes().isReadOnly());
 		setReadOnly(file, true);
-		assertTrue("1.2", file.getResourceAttributes().isReadOnly());
+		assertTrue(file.getResourceAttributes().isReadOnly());
 		setReadOnly(file, false);
-		assertTrue("1.4", !file.getResourceAttributes().isReadOnly());
+		assertFalse(file.getResourceAttributes().isReadOnly());
 
 		// folder
-		assertTrue("2.0", !project.getResourceAttributes().isReadOnly());
+		assertFalse(project.getResourceAttributes().isReadOnly());
 		setReadOnly(project, true);
-		assertTrue("2.2", project.getResourceAttributes().isReadOnly());
+		assertTrue(project.getResourceAttributes().isReadOnly());
 		setReadOnly(project, false);
-		assertTrue("2.4", !project.getResourceAttributes().isReadOnly());
+		assertFalse(project.getResourceAttributes().isReadOnly());
 	}
 
 	/**
@@ -183,7 +183,7 @@ public class ResourceAttributeTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
 		project.close(createTestMonitor());
-		assertNull("1.0", project.getResourceAttributes());
+		assertNull(project.getResourceAttributes());
 	}
 
 	@Test
@@ -193,17 +193,17 @@ public class ResourceAttributeTest {
 		IFolder folder = project.getFolder("folder");
 		IFile file = project.getFile("file");
 		removeFromWorkspace(project);
-		assertNull("1.0", project.getResourceAttributes());
-		assertNull("1.1", folder.getResourceAttributes());
-		assertNull("1.2", file.getResourceAttributes());
+		assertNull(project.getResourceAttributes());
+		assertNull(folder.getResourceAttributes());
+		assertNull(file.getResourceAttributes());
 
 		//now create the resources and ensure non-null result
 		createInWorkspace(project);
 		createInWorkspace(folder);
 		createInWorkspace(file);
-		assertNotNull("2.0", project.getResourceAttributes());
-		assertNotNull("2.1", folder.getResourceAttributes());
-		assertNotNull("2.2", file.getResourceAttributes());
+		assertNotNull(project.getResourceAttributes());
+		assertNotNull(folder.getResourceAttributes());
+		assertNotNull(file.getResourceAttributes());
 	}
 
 	/**
@@ -228,8 +228,8 @@ public class ResourceAttributeTest {
 		createInWorkspace(file, createRandomString());
 
 		// folder is executable initially and the file should exist
-		assertTrue("1.0", project.getResourceAttributes().isExecutable());
-		assertTrue("1.1", file.exists());
+		assertTrue(project.getResourceAttributes().isExecutable());
+		assertTrue(file.exists());
 
 		setExecutable(folder, false);
 		waitForRefresh();
@@ -241,8 +241,8 @@ public class ResourceAttributeTest {
 		// fail
 		setExecutable(folder, true);
 
-		assertTrue("2.1", !wasExecutable);
-		assertTrue("2.2", !fileExists);
+		assertFalse(wasExecutable);
+		assertFalse(fileExists);
 	}
 
 	@Test
@@ -255,11 +255,11 @@ public class ResourceAttributeTest {
 
 		// attempts to set the symbolic link attribute wont't affect
 		// the resource and the underlying file
-		assertTrue("1.0", !link.getResourceAttributes().isSymbolicLink());
+		assertFalse(link.getResourceAttributes().isSymbolicLink());
 		setSymlink(link, true);
-		assertTrue("2.0", !link.getResourceAttributes().isSymbolicLink());
+		assertFalse(link.getResourceAttributes().isSymbolicLink());
 		setSymlink(link, false);
-		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
+		assertFalse(link.getResourceAttributes().isSymbolicLink());
 
 		removeFromWorkspace(link);
 
@@ -271,12 +271,12 @@ public class ResourceAttributeTest {
 		// the resource in the workspace should have symbolic link attribute set
 		createSymLink(project.getLocation().toFile(), "link", "target", false);
 		createInWorkspace(link);
-		assertTrue("5.0", link.getResourceAttributes().isSymbolicLink());
+		assertTrue(link.getResourceAttributes().isSymbolicLink());
 
 		// attempts to clear the symbolic link attribute shouldn't affect
 		// the resource and the underlying file
 		setSymlink(link, false);
-		assertTrue("3.0", link.getResourceAttributes().isSymbolicLink());
+		assertTrue(link.getResourceAttributes().isSymbolicLink());
 
 		// remove the underlying file and add it again as a local file,
 		// the resource in the workspace should have the symbolic link attribute
@@ -285,7 +285,7 @@ public class ResourceAttributeTest {
 
 		link.getLocation().toFile().delete();
 		new File(s).createNewFile();
-		assertTrue("3.0", !link.getResourceAttributes().isSymbolicLink());
+		assertFalse(link.getResourceAttributes().isSymbolicLink());
 	}
 
 	@Test
@@ -306,21 +306,21 @@ public class ResourceAttributeTest {
 			ResourceAttributes resAttr = file.getResourceAttributes();
 			resAttr.set(attribute, true);
 			file.setResourceAttributes(resAttr);
-			assertTrue("1.0", file.getResourceAttributes().isSet(attribute));
+			assertTrue(file.getResourceAttributes().isSet(attribute));
 
 			resAttr.set(attribute, false);
 			file.setResourceAttributes(resAttr);
-			assertFalse("2.0", file.getResourceAttributes().isSet(attribute));
+			assertFalse(file.getResourceAttributes().isSet(attribute));
 
 			// folder
 			resAttr = project.getResourceAttributes();
 			resAttr.set(attribute, true);
 			project.setResourceAttributes(resAttr);
-			assertTrue("3.0", project.getResourceAttributes().isSet(attribute));
+			assertTrue(project.getResourceAttributes().isSet(attribute));
 
 			resAttr.set(attribute, false);
 			project.setResourceAttributes(resAttr);
-			assertFalse("4.0", project.getResourceAttributes().isSet(attribute));
+			assertFalse(project.getResourceAttributes().isSet(attribute));
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -73,8 +74,8 @@ public class VirtualFolderTest {
 
 		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 
-		assertTrue("2.0", virtualFolder.exists());
-		assertTrue("3.0", virtualFolder.isVirtual());
+		assertTrue(virtualFolder.exists());
+		assertTrue(virtualFolder.isVirtual());
 
 		// delete should succeed
 		virtualFolder.delete(IResource.NONE, createTestMonitor());
@@ -87,7 +88,7 @@ public class VirtualFolderTest {
 	public void testCreateFileUnderVirtualFolder() {
 		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		assertThrows(CoreException.class, () -> file.create(nullInputStream(), true, createTestMonitor()));
-		assertTrue("2.0", !file.exists());
+		assertFalse(file.exists());
 	}
 
 	/**
@@ -97,7 +98,7 @@ public class VirtualFolderTest {
 	public void testCreateFolderUnderVirtualFolder() {
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		assertThrows(CoreException.class, () -> folder.create(true, true, createTestMonitor()));
-		assertTrue("2.0", !folder.exists());
+		assertFalse(folder.exists());
 	}
 
 	/**
@@ -108,8 +109,8 @@ public class VirtualFolderTest {
 		IFolder virtualFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
 		virtualFolder.create(IResource.VIRTUAL, true, null);
 
-		assertTrue("2.0", virtualFolder.exists());
-		assertTrue("3.0", virtualFolder.isVirtual());
+		assertTrue(virtualFolder.exists());
+		assertTrue(virtualFolder.isVirtual());
 
 		// delete should succeed
 		virtualFolder.delete(IResource.NONE, createTestMonitor());
@@ -126,9 +127,9 @@ public class VirtualFolderTest {
 
 		linkedFolder.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("2.0", linkedFolder.exists());
-		assertEquals("3.0", location, linkedFolder.getLocation());
-		assertTrue("4.0", !location.toFile().exists());
+		assertTrue(linkedFolder.exists());
+		assertEquals(location, linkedFolder.getLocation());
+		assertFalse(location.toFile().exists());
 
 		// getting children should succeed (and be empty)
 		assertThat(linkedFolder.members()).isEmpty();
@@ -148,9 +149,9 @@ public class VirtualFolderTest {
 
 		file.createLink(location, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("2.0", file.exists());
-		assertEquals("3.0", location, file.getLocation());
-		assertTrue("4.0", !location.toFile().exists());
+		assertTrue(file.exists());
+		assertEquals(location, file.getLocation());
+		assertFalse(location.toFile().exists());
 
 		// delete should succeed
 		file.delete(IResource.NONE, createTestMonitor());
@@ -177,25 +178,25 @@ public class VirtualFolderTest {
 		existingProject.copy(destinationProject.getFullPath(), IResource.SHALLOW, createTestMonitor());
 
 		IFile newFile = destinationProject.getFile(linkedFile.getProjectRelativePath());
-		assertTrue("3.0", newFile.isLinked());
-		assertEquals("3.1", linkedFile.getLocation(), newFile.getLocation());
-		assertTrue("3.2", newFile.getParent().isVirtual());
+		assertTrue(newFile.isLinked());
+		assertEquals(linkedFile.getLocation(), newFile.getLocation());
+		assertTrue(newFile.getParent().isVirtual());
 
 		IFolder newFolder = destinationProject.getFolder(linkedFolder.getProjectRelativePath());
-		assertTrue("4.0", newFolder.isLinked());
-		assertEquals("4.1", linkedFolder.getLocation(), newFolder.getLocation());
-		assertTrue("4.2", newFolder.getParent().isVirtual());
+		assertTrue(newFolder.isLinked());
+		assertEquals(linkedFolder.getLocation(), newFolder.getLocation());
+		assertTrue(newFolder.getParent().isVirtual());
 
 		// test project deep copy
 		destinationProject.delete(IResource.NONE, createTestMonitor());
 		existingProject.copy(destinationProject.getFullPath(), IResource.NONE, createTestMonitor());
 
-		assertTrue("5.1", newFile.isLinked());
-		assertEquals("5.2", linkedFile.getLocation(), newFile.getLocation());
-		assertTrue("5.3", newFile.getParent().isVirtual());
-		assertTrue("5.4", newFolder.isLinked());
-		assertEquals("5.5", linkedFolder.getLocation(), newFolder.getLocation());
-		assertTrue("5.6", newFolder.getParent().isVirtual());
+		assertTrue(newFile.isLinked());
+		assertEquals(linkedFile.getLocation(), newFile.getLocation());
+		assertTrue(newFile.getParent().isVirtual());
+		assertTrue(newFolder.isLinked());
+		assertEquals(linkedFolder.getLocation(), newFolder.getLocation());
+		assertTrue(newFolder.getParent().isVirtual());
 
 		destinationProject.delete(IResource.NONE, createTestMonitor());
 	}
@@ -235,14 +236,14 @@ public class VirtualFolderTest {
 
 		assertExistsInWorkspace(newResources);
 		assertDoesNotExistInWorkspace(oldResources);
-		assertTrue("7.0", existingProject.isSynchronized(IResource.DEPTH_INFINITE));
-		assertTrue("8.0", destinationProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(existingProject.isSynchronized(IResource.DEPTH_INFINITE));
+		assertTrue(destinationProject.isSynchronized(IResource.DEPTH_INFINITE));
 
-		assertTrue("9.0", newFile.getParent().isVirtual());
-		assertTrue("10.0", newFile.isLinked());
+		assertTrue(newFile.getParent().isVirtual());
+		assertTrue(newFile.isLinked());
 
-		assertTrue("11.0", newFolder.isLinked());
-		assertTrue("12.0", newFolder.getParent().isVirtual());
+		assertTrue(newFolder.isLinked());
+		assertTrue(newFolder.getParent().isVirtual());
 	}
 
 	@Test
@@ -254,13 +255,13 @@ public class VirtualFolderTest {
 		existingProject.create(createTestMonitor());
 
 		// virtual folder should not exist until the project is open
-		assertTrue("2.0", !virtualFolder.exists());
+		assertFalse(virtualFolder.exists());
 
 		existingProject.open(createTestMonitor());
 
 		// virtual folder should now exist
-		assertTrue("4.0", virtualFolder.exists());
-		assertTrue("5.0", virtualFolder.isVirtual());
+		assertTrue(virtualFolder.exists());
+		assertTrue(virtualFolder.isVirtual());
 	}
 
 	@Test
@@ -278,20 +279,20 @@ public class VirtualFolderTest {
 		existingProject.create(createTestMonitor());
 
 		// virtual folder should not exist until the project is open
-		assertTrue("2.0", !virtualFolder.exists());
-		assertTrue("3.0", !linkedFolder.exists());
+		assertFalse(virtualFolder.exists());
+		assertFalse(linkedFolder.exists());
 
 		existingProject.open(createTestMonitor());
 
 		// virtual folder should now exist
-		assertTrue("5.0", virtualFolder.exists());
-		assertTrue("6.0", virtualFolder.isVirtual());
+		assertTrue(virtualFolder.exists());
+		assertTrue(virtualFolder.isVirtual());
 
 		// link should now exist
-		assertTrue("7.0", linkedFolder.exists());
-		assertTrue("8.0", linkedFolder.isLinked());
+		assertTrue(linkedFolder.exists());
+		assertTrue(linkedFolder.isLinked());
 
-		assertEquals("9.0", folderLocation, linkedFolder.getLocation());
+		assertEquals(folderLocation, linkedFolder.getLocation());
 	}
 
 	@Test
@@ -301,15 +302,15 @@ public class VirtualFolderTest {
 
 		folder.createLink(folderLocation, IResource.ALLOW_MISSING_LOCAL, createTestMonitor());
 
-		assertTrue("2.0", folder.exists());
-		assertEquals("3.0", folderLocation, folder.getLocation());
-		assertTrue("4.0", !folderLocation.toFile().exists());
+		assertTrue(folder.exists());
+		assertEquals(folderLocation, folder.getLocation());
+		assertFalse(folderLocation.toFile().exists());
 
 		// Check file store URI for the linked resource
 		IFileStore fs = EFS.getStore(existingVirtualFolderInExistingProject.getLocationURI());
 		fs = fs.getChild(folder.getName());
-		assertNotNull("5.0", fs);
-		assertNotNull("6.0", fs.toURI());
+		assertNotNull(fs);
+		assertNotNull(fs.toURI());
 	}
 
 	@Test
@@ -317,7 +318,7 @@ public class VirtualFolderTest {
 		// create a virtual folder
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 		virtualFolder.create(IResource.VIRTUAL, true, null);
-		assertTrue("2.0", virtualFolder.isVirtual());
+		assertTrue(virtualFolder.isVirtual());
 	}
 
 	@Test
@@ -343,25 +344,25 @@ public class VirtualFolderTest {
 		virtualFolder.create(IResource.VIRTUAL, true, createTestMonitor());
 
 		// assert locations
-		assertEquals("2.0", linkedFolderLocation, linkedFolder.getLocation());
-		assertEquals("3.0", linkedFolderLocation.append(subFolder.getName()), subFolder.getLocation());
-		assertTrue("4.0", virtualFolder.isVirtual());
-		assertTrue("5.0", virtualFolder.getLocation() == null);
+		assertEquals(linkedFolderLocation, linkedFolder.getLocation());
+		assertEquals(linkedFolderLocation.append(subFolder.getName()), subFolder.getLocation());
+		assertTrue(virtualFolder.isVirtual());
+		assertTrue(virtualFolder.getLocation() == null);
 
 		// assert URIs
-		assertEquals("6.0", URIUtil.toURI(linkedFolderLocation), linkedFolder.getLocationURI());
-		assertEquals("7.0", URIUtil.toURI(subFolderLocation), subFolder.getLocationURI());
-		// assertTrue("8.0", virtualFolder.getLocationURI() == null);
+		assertEquals(URIUtil.toURI(linkedFolderLocation), linkedFolder.getLocationURI());
+		assertEquals(URIUtil.toURI(subFolderLocation), subFolder.getLocationURI());
+		// assertTrue(virtualFolder.getLocationURI() == null);
 	}
 
 	/* Regression for Bug 296470 */
 	@Test
 	public void testGetVirtualFolderAttributes() {
 		long timeStamp = existingVirtualFolderInExistingProject.getLocalTimeStamp();
-		assertEquals("1.0", timeStamp, IResource.NULL_STAMP);
+		assertEquals(timeStamp, IResource.NULL_STAMP);
 
 		ResourceAttributes attributes = existingVirtualFolderInExistingProject.getResourceAttributes();
-		assertEquals("1.1", attributes, null);
+		assertEquals(attributes, null);
 	}
 
 }


### PR DESCRIPTION
- Remove obsolete assertion messages
- Replace assertTrue(!condition) with assertFalse(condition)
- Remove commented out code / long commented out test methods