### PR TITLE
Migrate resource performance tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchCopyFile.java
@@ -13,34 +13,46 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources.perf;
 
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class BenchCopyFile {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final int COUNT = 5000;
 
+	private TestInfo testInfo;
+	private IFileStore fileStore;
+
+	@BeforeEach
+	void setUp(TestInfo info) {
+		testInfo = info;
+		fileStore = EFS.getLocalFileSystem().getStore(getRandomLocation(getTempDir()));
+	}
+
+	@AfterEach
+	void tearDown() throws CoreException {
+		fileStore.delete(EFS.NONE, null);
+	}
+
 	@Test
 	public void testCopyFile() throws Exception {
-		IFileStore input = workspaceRule.getTempStore();
-		createInFileSystem(input);
+		createInFileSystem(fileStore);
 		IFileStore[] output = new IFileStore[COUNT];
 		for (int i = 0; i < output.length; i++) {
-			output[i] = workspaceRule.getTempStore();
+			output[i] = fileStore;
 		}
 
 		new PerformanceTestRunner() {
@@ -48,10 +60,10 @@ public class BenchCopyFile {
 
 			@Override
 			protected void test() throws CoreException {
-				input.copy(output[rep], EFS.NONE, null);
+				fileStore.copy(output[rep], EFS.NONE, null);
 				rep++;
 			}
-		}.run(getClass(), testName.getMethodName(), 1, COUNT);
+		}.run(getClass(), testInfo.getDisplayName(), 1, COUNT);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchElementTree.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchElementTree.java
@@ -18,17 +18,14 @@ import java.util.ArrayList;
 import org.eclipse.core.internal.watson.ElementTree;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Benchmarks for <code>ElementTree</code>.
  */
 public class BenchElementTree {
-
-	@Rule
-	public TestName testName = new TestName();
 
 	static String[] javaLangUnits = {"AbstractMethodError.java", "ArithmeticException.java", "ArrayIndexOutOfBoundsException.java", "ArrayStoreException.java", "Boolean.java", //
 			"Byte.java", "Character.java", "Class.java", "ClassCastException.java", "ClassCircularityError.java", "ClassFormatError.java", "ClassLoader.java", "ClassNotFoundException.java", //
@@ -46,6 +43,13 @@ public class BenchElementTree {
 	static final IPath folder = project.append("folder");
 	static final IPath[] files = getFilePaths();
 
+	private TestInfo testInfo;
+
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
+
 	/**
 	 * Tests the performance of the createElement operation.
 	 */
@@ -56,7 +60,7 @@ public class BenchElementTree {
 			protected void test() {
 				createTestTree(false);
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 400);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 400);
 	}
 
 	/**
@@ -81,7 +85,7 @@ public class BenchElementTree {
 				}
 				rep++;
 			}
-		}.run(getClass(), testName.getMethodName(), 1, repeat);
+		}.run(getClass(), testInfo.getDisplayName(), 1, repeat);
 	}
 
 	/**
@@ -98,7 +102,7 @@ public class BenchElementTree {
 					tree.getElementData(file);
 				}
 			}
-		}.run(getClass(), testName.getMethodName(), 1, 500);
+		}.run(getClass(), testInfo.getDisplayName(), 1, 500);
 	}
 
 	/**
@@ -124,7 +128,7 @@ public class BenchElementTree {
 				bases[rep].mergeDeltaChain(folder, chains[rep]);
 				rep++;
 			}
-		}.run(getClass(), testName.getMethodName(), 1, repeat);
+		}.run(getClass(), testInfo.getDisplayName(), 1, repeat);
 	}
 
 	/**
@@ -138,7 +142,7 @@ public class BenchElementTree {
 			protected void test() {
 				doRoutineOperations();
 			}
-		}.run(getClass(), testName.getMethodName(), 1, 75);
+		}.run(getClass(), testInfo.getDisplayName(), 1, 75);
 	}
 
 	/**
@@ -156,7 +160,7 @@ public class BenchElementTree {
 					tree.setElementData(file, data);
 				}
 			}
-		}.run(getClass(), testName.getMethodName(), 1, 500);
+		}.run(getClass(), testInfo.getDisplayName(), 1, 500);
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchFileStore.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchFileStore.java
@@ -23,22 +23,26 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.filesystem.local.LocalFileNativesManager;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Benchmarks basic operations on the IFileStore interface
  */
 public class BenchFileStore {
 
-	@Rule
-	public TestName testName = new TestName();
-
 	private static final int LOOP_SIZE = 5000;
 
 	private static final int REPEATS = 300;
+
+	private TestInfo testInfo;
+
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	class StoreTestRunner extends PerformanceTestRunner {
 		private final boolean exits;
@@ -78,7 +82,7 @@ public class BenchFileStore {
 	@Test
 	public void testStoreExitsNative() throws Throwable{
 		withNatives(true, () -> {
-			new StoreTestRunner(true).run(getClass(), testName.getMethodName(), REPEATS, LOOP_SIZE);
+			new StoreTestRunner(true).run(getClass(), testInfo.getDisplayName(), REPEATS, LOOP_SIZE);
 		});
 
 	}
@@ -86,14 +90,14 @@ public class BenchFileStore {
 	@Test
 	public void testStoreNotExitsNative() throws Throwable {
 		withNatives(true, () -> {
-			new StoreTestRunner(false).run(getClass(), testName.getMethodName(), REPEATS, LOOP_SIZE);
+			new StoreTestRunner(false).run(getClass(), testInfo.getDisplayName(), REPEATS, LOOP_SIZE);
 		});
 	}
 
 	@Test
 	public void testStoreExitsNio() throws Throwable {
 		withNatives(false, () -> {
-			new StoreTestRunner(true).run(getClass(), testName.getMethodName(), REPEATS, LOOP_SIZE);
+			new StoreTestRunner(true).run(getClass(), testInfo.getDisplayName(), REPEATS, LOOP_SIZE);
 		});
 
 	}
@@ -101,7 +105,7 @@ public class BenchFileStore {
 	@Test
 	public void testStoreNotExitsNio() throws Throwable {
 		withNatives(false, () -> {
-			new StoreTestRunner(false).run(getClass(), testName.getMethodName(), REPEATS, LOOP_SIZE);
+			new StoreTestRunner(false).run(getClass(), testInfo.getDisplayName(), REPEATS, LOOP_SIZE);
 		});
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchMiscWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchMiscWorkspace.java
@@ -21,18 +21,21 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class BenchMiscWorkspace {
 
-	@Rule
-	public TestName testName = new TestName();
+	private TestInfo testInfo;
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	/**
 	 * Benchmarks performing many empty operations.
@@ -51,7 +54,7 @@ public class BenchMiscWorkspace {
 			protected void test() throws CoreException {
 				ws.run(noop, null);
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 100000);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 100000);
 	}
 
 	@Test
@@ -64,7 +67,7 @@ public class BenchMiscWorkspace {
 					root.getProject(Integer.toString(i));
 				}
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 1000);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 1000);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BenchWorkspace.java
@@ -31,23 +31,19 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class BenchWorkspace {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final int FILES_PER_FOLDER = 20;
 	private static final int NUM_FOLDERS = 400;//must be multiple of 10
 	IProject project;
+	private TestInfo testInfo;
 
 	/**
 	 * Creates the given number of problem markers on each resource in the workspace.
@@ -114,8 +110,9 @@ public class BenchWorkspace {
 		return root.findMaxProblemSeverity(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	public void setUp(TestInfo info) throws Exception {
+		testInfo = info;
 		IWorkspaceRunnable runnable = monitor -> {
 			//create resources
 			project = getWorkspace().getRoot().getProject("TestProject");
@@ -142,7 +139,7 @@ public class BenchWorkspace {
 			protected void test() {
 				workspace.countResources(root.getFullPath(), IResource.DEPTH_INFINITE, true);
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 100);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 100);
 	}
 
 	/**
@@ -168,7 +165,7 @@ public class BenchWorkspace {
 					protected void test() {
 						workspace.countResources(project.getFullPath(), IResource.DEPTH_INFINITE, true);
 					}
-				}.run(getClass(), testName.getMethodName(), 10, 10);
+				}.run(getClass(), testInfo.getDisplayName(), 10, 10);
 			} catch (CoreException e) {
 				throw e;
 			} catch (Exception e) {
@@ -191,6 +188,6 @@ public class BenchWorkspace {
 			protected void test() throws CoreException {
 				findMaxProblemSeverity2(root);
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 100);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 100);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/BuilderPerformanceTest.java
@@ -28,7 +28,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.internal.builders.SortBuilder;
 import org.eclipse.core.tests.internal.builders.TestBuilder;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Automated performance tests for builders.
@@ -77,9 +79,9 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 	}
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	public void setUp(TestInfo info) throws Exception {
+		super.setUp(info);
 		otherProjects = new IProject[PROJECT_COUNT];
 		for (int i = 0; i < otherProjects.length; i++) {
 			otherProjects[i] = getWorkspace().getRoot().getProject("Project " + i);
@@ -92,6 +94,7 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 	 * Tests performing manual project-level increment builds when autobuild is on.
 	 * See bug 261225 for details.
 	 */
+	@Test
 	public void testManualBuildWithAutobuildOn() throws Exception {
 		PerformanceTestRunner runner = new PerformanceTestRunner() {
 			IProject[] projects;
@@ -117,6 +120,6 @@ public class BuilderPerformanceTest extends WorkspacePerformanceTest {
 		};
 		//this test simulates a manual build before launch with autobuild enabled
 		runner.setFingerprintName("Build workspace before launch");
-		runner.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		runner.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ConcurrencyPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ConcurrencyPerformanceTest.java
@@ -18,18 +18,21 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ConcurrencyPerformanceTest {
 
-	@Rule
-	public TestName testName = new TestName();
+	private TestInfo testInfo;
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	@Test
 	public void testSimpleCalls() throws Exception {
@@ -41,7 +44,7 @@ public class ConcurrencyPerformanceTest {
 			protected void test() throws CoreException {
 				getWorkspace().run(job, null);
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 50);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 50);
 	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/ContentDescriptionPerformanceTest.java
@@ -15,8 +15,10 @@ package org.eclipse.core.tests.resources.perf;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Set;
 import org.eclipse.core.resources.IFile;
@@ -27,18 +29,12 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ContentDescriptionPerformanceTest {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private final static String DEFAULT_DESCRIPTION_FILE_NAME = "default.xml";
 	private final static String NO_DESCRIPTION_FILE_NAME = "none.some-uncommon-file-extension";
@@ -63,18 +59,20 @@ public class ContentDescriptionPerformanceTest {
 
 	void assertHasExpectedDescription(String fileName, IContentDescription description) {
 		if (fileName.endsWith(DEFAULT_DESCRIPTION_FILE_NAME)) {
-			assertTrue("description for " + fileName, description == description.getContentType().getDefaultDescription());
+			assertSame(description, description.getContentType().getDefaultDescription(),
+					"description for " + fileName);
 		} else if (fileName.endsWith(NON_DEFAULT_DESCRIPTION_FILE_NAME)) {
-			assertTrue("description for " + fileName, description != description.getContentType().getDefaultDescription());
+			assertNotSame(description, description.getContentType().getDefaultDescription(),
+					"description for " + fileName);
 		} else {
-			assertNull("description for " + fileName, description);
+			assertNull(description, "description for " + fileName);
 		}
 	}
 
 	void createFiles() throws CoreException {
 		// create a project with thousands of files
 		IProject bigProject = ResourcesPlugin.getWorkspace().getRoot().getProject("bigproject");
-		assertTrue("1.0", !bigProject.exists());
+		assertFalse(bigProject.exists());
 		bigProject.create(createTestMonitor());
 		bigProject.open(createTestMonitor());
 		for (int i = 0; i < SUBDIRS; i++) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/FileSystemPerformanceTest.java
@@ -24,17 +24,14 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Automated performance tests for file system operations.
  */
 public class FileSystemPerformanceTest {
-
-	@Rule
-	public TestName testName = new TestName();
 
 	private static final String chars = "abcdefghijklmnopqrstuvwxyz";
 	private static final int FILE_COUNT = 100;
@@ -45,6 +42,13 @@ public class FileSystemPerformanceTest {
 
 	private final Random random = new Random();
 	private IFileStore baseStore;
+
+	private TestInfo testInfo;
+
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	public String createString(int length) {
 		StringBuilder buf = new StringBuilder(length);
@@ -90,7 +94,7 @@ public class FileSystemPerformanceTest {
 				setAttributesOnTree();
 			}
 		};
-		runner.run(getClass(), testName.getMethodName(), OUTER, INNER);
+		runner.run(getClass(), testInfo.getDisplayName(), OUTER, INNER);
 		baseStore.delete(EFS.NONE, null);
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/HistoryStorePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/HistoryStorePerformanceTest.java
@@ -21,18 +21,16 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class HistoryStorePerformanceTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		project.create(createTestMonitor());
@@ -44,7 +42,7 @@ public class HistoryStorePerformanceTest {
 		getWorkspace().setDescription(description);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		project.clearHistory(createTestMonitor());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/LocalHistoryPerformanceTest.java
@@ -34,24 +34,26 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.core.tests.internal.localstore.HistoryStoreTest;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Contains a set of use case-oriented performance tests for the local history.
  *
  * @since 3.1
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class LocalHistoryPerformanceTest {
+	private TestInfo testInfo;
 
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	void cleanHistory() {
 		((Workspace) getWorkspace()).getFileSystemManager().getHistoryStore().clean(createTestMonitor());
@@ -90,7 +92,7 @@ public class LocalHistoryPerformanceTest {
 		return currentDescription;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		HistoryStoreTest.wipeHistoryStore(createTestMonitor());
 	}
@@ -116,7 +118,7 @@ public class LocalHistoryPerformanceTest {
 			protected void test() throws CoreException {
 				file.setContents(createRandomContentsStream(), IResource.KEEP_HISTORY, createTestMonitor());
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 30);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 30);
 	}
 
 	@Test
@@ -157,7 +159,7 @@ public class LocalHistoryPerformanceTest {
 				file1.move(file2.getFullPath(), true, true, createTestMonitor());
 				file2.move(file1.getFullPath(), true, true, createTestMonitor());
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 5);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 5);
 	}
 
 	private void testClearHistory(final int filesPerFolder, final int statesPerFile) throws Exception {
@@ -188,7 +190,7 @@ public class LocalHistoryPerformanceTest {
 			protected void test() throws CoreException {
 				base.clearHistory(createTestMonitor());
 			}
-		}.run(getClass(), testName.getMethodName(), 4, 3);
+		}.run(getClass(), testInfo.getDisplayName(), 4, 3);
 	}
 
 	@Test
@@ -220,7 +222,7 @@ public class LocalHistoryPerformanceTest {
 				tmpProject[0].copy(newProject.getFullPath(), true, createTestMonitor());
 				tmpProject[0] = newProject;
 			}
-		}.run(getClass(), testName.getMethodName(), 10, 1);
+		}.run(getClass(), testInfo.getDisplayName(), 10, 1);
 	}
 
 	@Test
@@ -250,7 +252,7 @@ public class LocalHistoryPerformanceTest {
 			protected void test() throws CoreException {
 				tmpProject.findDeletedMembersWithHistory(IResource.DEPTH_INFINITE, createTestMonitor());
 			}
-		}.run(getClass(), testName.getMethodName(), 2, 5);
+		}.run(getClass(), testInfo.getDisplayName(), 2, 5);
 	}
 
 	@Test
@@ -281,7 +283,7 @@ public class LocalHistoryPerformanceTest {
 			protected void test() throws CoreException {
 				file.getHistory(createTestMonitor());
 			}
-		}.run(getClass(), testName.getMethodName(), 1, 150);
+		}.run(getClass(), testInfo.getDisplayName(), 1, 150);
 	}
 
 	private void testHistoryCleanUp(final int filesPerFolder, final int statesPerFile) throws Exception {
@@ -313,7 +315,7 @@ public class LocalHistoryPerformanceTest {
 				cleanHistory();
 			}
 
-		}.run(getClass(), testName.getMethodName(), 5, 1);
+		}.run(getClass(), testInfo.getDisplayName(), 5, 1);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/MarkerPerformanceTest.java
@@ -23,25 +23,22 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class MarkerPerformanceTest {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	IProject project;
 	IFile file;
 	IMarker[] markers;
 	final int NUM_MARKERS = 5000;
 	final int REPEAT = 100;
+
+	private TestInfo testInfo;
 
 	@Test
 	public void testSetAttributes1() throws Exception {
@@ -61,7 +58,7 @@ public class MarkerPerformanceTest {
 			}
 		};
 		runner.setFingerprintName("Set marker attributes");
-		runner.run(getClass(), testName.getMethodName(), 1, 1);
+		runner.run(getClass(), testInfo.getDisplayName(), 1, 1);
 	}
 
 	@Test
@@ -80,11 +77,12 @@ public class MarkerPerformanceTest {
 			protected void test() throws CoreException {
 				getWorkspace().run(runnable, null);
 			}
-		}.run(getClass(), testName.getMethodName(), 1, 1);
+		}.run(getClass(), testInfo.getDisplayName(), 1, 1);
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	public void setUp(TestInfo info) throws Exception {
+		testInfo = info;
 		final IMarker[] createdMarkers = new IMarker[NUM_MARKERS];
 		IWorkspaceRunnable runnable = monitor -> {
 			//create resources

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/PropertyManagerPerformanceTest.java
@@ -18,7 +18,7 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.PI_RESOURCES_TESTS;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,18 +31,21 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class PropertyManagerPerformanceTest {
 
-	@Rule
-	public TestName testName = new TestName();
+	private TestInfo testInfo;
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@BeforeEach
+	void storeTestInfo(TestInfo info) {
+		testInfo = info;
+	}
 
 	public static String getPropertyValue(int size) {
 		StringBuilder value = new StringBuilder(size);
@@ -97,7 +100,7 @@ public class PropertyManagerPerformanceTest {
 					}
 				}
 			}
-		}.run(getClass(), testName.getMethodName(), measurements, repetitions);
+		}.run(getClass(), testInfo.getDisplayName(), measurements, repetitions);
 		((Workspace) getWorkspace()).getPropertyManager().deleteProperties(folder1, IResource.DEPTH_INFINITE);
 
 	}
@@ -137,7 +140,7 @@ public class PropertyManagerPerformanceTest {
 							getPropertyValue(200));
 				}
 			}
-		}.run(getClass(), testName.getMethodName(), measurements, repetitions);
+		}.run(getClass(), testInfo.getDisplayName(), measurements, repetitions);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/perf/WorkspacePerformanceTest.java
@@ -35,22 +35,17 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Basic performance calculations for standard workspace operations.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class WorkspacePerformanceTest {
-
-	@Rule
-	public TestName testName = new TestName();
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String chars = "abcdefghijklmnopqrstuvwxyz";
 	static final int REPEATS = 5;
@@ -60,6 +55,7 @@ public class WorkspacePerformanceTest {
 	private final Random random = new Random();
 	IFolder testFolder;
 	IProject testProject;
+	TestInfo testInfo;
 
 	IFolder copyFolder() throws CoreException {
 		IFolder destination = testProject.getFolder("CopyDestination");
@@ -143,10 +139,11 @@ public class WorkspacePerformanceTest {
 		}
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	public void setUp(TestInfo info) throws Exception {
 		testProject = getWorkspace().getRoot().getProject("Project");
 		testFolder = testProject.getFolder("TopFolder");
+		testInfo = info;
 	}
 
 	/**
@@ -170,7 +167,7 @@ public class WorkspacePerformanceTest {
 				createAndPopulateProject(DEFAULT_TOTAL_RESOURCES);
 			}
 		};
-		runner.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		runner.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	@Test
@@ -188,7 +185,7 @@ public class WorkspacePerformanceTest {
 				testProject.delete(IResource.NONE, null);
 			}
 		};
-		runner.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		runner.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	@Test
@@ -210,7 +207,7 @@ public class WorkspacePerformanceTest {
 			protected void test() throws CoreException {
 				copyFolder();
 			}
-		}.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		}.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	@Test
@@ -232,7 +229,7 @@ public class WorkspacePerformanceTest {
 			protected void test() throws CoreException {
 				moveFolder();
 			}
-		}.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		}.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	@Test
@@ -256,7 +253,7 @@ public class WorkspacePerformanceTest {
 			}
 		};
 		runner.setFingerprintName("Refresh Project");
-		runner.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		runner.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	@Test
@@ -279,7 +276,7 @@ public class WorkspacePerformanceTest {
 				testProject.close(null);
 				testProject.open(null);
 			}
-		}.run(getClass(), testName.getMethodName(), REPEATS, 3);
+		}.run(getClass(), testInfo.getDisplayName(), REPEATS, 3);
 	}
 
 	@Test
@@ -313,7 +310,7 @@ public class WorkspacePerformanceTest {
 				testProject.loadSnapshot(IProject.SNAPSHOT_TREE, snapshotLocation, null);
 				testProject.open(null);
 			}
-		}.run(getClass(), testName.getMethodName(), REPEATS, 1);
+		}.run(getClass(), testInfo.getDisplayName(), REPEATS, 1);
 	}
 
 	/**


### PR DESCRIPTION
- Switch to JUnit 5 test annotations and assertions
- Use test extensions replacing JUnit 4 test rules

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903

Tests are not executed in CI but still run fine:
<img width="466" height="344" alt="image" src="https://github.com/user-attachments/assets/8e82ee21-0cca-4503-9113-d52f569347e5" />
