### PR TITLE
Migrate org.eclipse.core.tests.resources to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/CharsetTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -1389,7 +1390,7 @@ public class CharsetTest {
 	 * This verifier succeeds if either all expected changes are received in a
 	 * single delta, or if each expected change is received in a delta of its own.
 	 */
-	private class MultipleDeltasCharsetVerifier extends org.junit.Assert implements IResourceChangeListener {
+	private class MultipleDeltasCharsetVerifier implements IResourceChangeListener {
 
 		private final int flags;
 		private final CharsetVerifier singleDeltaVerifier;
@@ -1482,7 +1483,7 @@ public class CharsetTest {
 						failMessage.append(deltaVerifier.getMessage());
 						failMessage.append(System.lineSeparator());
 					}
-					assertTrue(failMessage.toString(), validDeltas);
+					assertTrue(validDeltas, failMessage.toString());
 				}
 			}
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -22,7 +22,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -49,9 +49,12 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the following API methods:
@@ -61,12 +64,14 @@ import org.junit.Test;
  * This test tests resource filters with projects, folders, linked resource folders,
  * and moving those resources to different parents.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class FilteredResourceTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	private static final String REGEX_FILTER_PROVIDER = "org.eclipse.core.resources.regexFilterMatcher";
+
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
+
 	protected String childName = "File.txt";
 	protected IProject closedProject;
 	protected IFile existingFileInExistingProject;
@@ -106,7 +111,7 @@ public class FilteredResourceTest {
 		return uri;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		otherExistingProject = getWorkspace().getRoot().getProject("OtherExistingProject");
@@ -122,7 +127,7 @@ public class FilteredResourceTest {
 		nonExistingFileInOtherExistingProject = otherExistingProject.getFile("nonExistingFileInOtherExistingProject");
 		nonExistingFileInExistingFolder = existingFolderInExistingProject.getFile("nonExistingFileInExistingFolder");
 		localFolder = getRandomLocation();
-		workspaceRule.deleteOnTearDown(resolve(localFolder));
+		fileStoreExtension.deleteOnTearDown(resolve(localFolder));
 		localFile = localFolder.append(childName);
 		doCleanup();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFileTest.java
@@ -30,10 +30,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -31,13 +31,13 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueStri
 import static org.eclipse.core.tests.resources.ResourceTestUtil.getLineSeparatorFromFile;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -65,16 +65,20 @@ import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IProjectTest  {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	private final FussyProgressMonitor monitor = new FussyProgressMonitor();
 
@@ -97,13 +101,13 @@ public class IProjectTest  {
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
-		assertTrue("get not equal set", target.getPersistentProperty(name).equals(value));
+		assertTrue(target.getPersistentProperty(name).equals(value), "get not equal set");
 		// see what happens if we get a non-existant property
 		name = new QualifiedName("eclipse-test", "testNonProperty");
-		assertNull("non-existant persistent property not missing", target.getPersistentProperty(name));
+		assertNull(target.getPersistentProperty(name), "non-existant persistent property not missing");
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		monitor.prepare();
 	}
@@ -233,7 +237,7 @@ public class IProjectTest  {
 		}
 		for (String name : names) {
 			IProject project = root.getProject(name);
-			assertFalse(name, project.exists());
+			assertFalse(project.exists(), name);
 			assertThrows(CoreException.class, () -> {
 				monitor.prepare();
 				project.create(monitor);
@@ -242,8 +246,8 @@ public class IProjectTest  {
 				project.open(monitor);
 				monitor.assertUsedUp();
 			});
-			assertFalse(name, project.exists());
-			assertFalse(name, project.isOpen());
+			assertFalse(project.exists(), name);
+			assertFalse(project.isOpen(), name);
 		}
 
 		//do some tests with valid names that are *almost* invalid
@@ -256,15 +260,15 @@ public class IProjectTest  {
 		}
 		for (String name : names) {
 			IProject project = root.getProject(name);
-			assertFalse(name, project.exists());
+			assertFalse(project.exists(), name);
 			monitor.prepare();
 			project.create(monitor);
 			monitor.assertUsedUp();
 			monitor.prepare();
 			project.open(monitor);
 			monitor.assertUsedUp();
-			assertTrue(name, project.exists());
-			assertTrue(name, project.isOpen());
+			assertTrue(project.exists(), name);
+			assertTrue(project.isOpen(), name);
 		}
 	}
 
@@ -641,7 +645,7 @@ public class IProjectTest  {
 	 */
 	@Test
 	public void testProjectCreationLocationExistsWithDifferentCase() throws CoreException {
-		assumeTrue("only relevant on Windows", OS.isWindows());
+		assumeTrue(OS.isWindows(), "only relevant on Windows");
 
 		String projectName = createUniqueString() + "a";
 		IProject project = getWorkspace().getRoot().getProject(projectName);
@@ -1099,7 +1103,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1125,7 +1129,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1149,7 +1153,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1173,7 +1177,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1197,7 +1201,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
@@ -1221,7 +1225,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1260,7 +1264,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1291,7 +1295,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1320,7 +1324,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1347,7 +1351,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
@@ -1376,7 +1380,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
@@ -1404,7 +1408,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1695,7 +1699,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1717,7 +1721,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1737,7 +1741,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1756,7 +1760,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1777,7 +1781,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
@@ -1797,7 +1801,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1832,7 +1836,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1860,7 +1864,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = ALWAYS
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1886,7 +1890,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1912,7 +1916,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = NEVER
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -1936,7 +1940,7 @@ public class IProjectTest  {
 		 * Force = TRUE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(new IResource[] {project, file});
@@ -1961,7 +1965,7 @@ public class IProjectTest  {
 		 * Force = FALSE
 		 * Delete content = DEFAULT
 		 * =======================================================================*/
-		projectStore = workspaceRule.getTempStore();
+		projectStore = fileStoreExtension.getTempStore();
 		description.setLocationURI(projectStore.toURI());
 		ensureExistsInWorkspace(project, description);
 		createInWorkspace(file);
@@ -2119,7 +2123,7 @@ public class IProjectTest  {
 		IProjectDescription desc = getWorkspace().newProjectDescription(project1.getName());
 		desc.setLocation(location);
 		project1.create(desc, monitor);
-		workspaceRule.deleteOnTearDown(location);
+		fileStoreExtension.deleteOnTearDown(location);
 		monitor.assertUsedUp();
 		project1.open(null);
 
@@ -2145,7 +2149,7 @@ public class IProjectTest  {
 		IProjectDescription destination = project.getDescription();
 		IPath oldPath = project.getLocation();
 		IPath newPath = getTempDir().append(Long.toString(System.currentTimeMillis()));
-		workspaceRule.deleteOnTearDown(newPath);
+		fileStoreExtension.deleteOnTearDown(newPath);
 		destination.setLocation(newPath);
 		monitor.prepare();
 		project.move(destination, false, monitor);
@@ -2337,7 +2341,7 @@ public class IProjectTest  {
 		IResource[] resources = buildResources(project, children);
 		// create the project at an external location
 		IProjectDescription description = getWorkspace().newProjectDescription(project.getName());
-		description.setLocationURI(workspaceRule.getTempStore().toURI());
+		description.setLocationURI(fileStoreExtension.getTempStore().toURI());
 		monitor.prepare();
 		project.create(description, monitor);
 		monitor.assertUsedUp();
@@ -2388,7 +2392,7 @@ public class IProjectTest  {
 		IProject target = getWorkspace().getRoot().getProject("testReplaceLocation");
 		createInWorkspace(target);
 
-		IFileStore projectStore = workspaceRule.getTempStore();
+		IFileStore projectStore = fileStoreExtension.getTempStore();
 		IFileStore childFile = projectStore.getChild("File.txt");
 
 		// add some content to the current location

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeEventTest.java
@@ -30,17 +30,16 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class tests the public API of IResourceChangeEvent.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class IResourceChangeEventTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/* some random resource handles */
 	protected IProject project1;
@@ -61,7 +60,7 @@ public class IResourceChangeEventTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// Create some resource handles
 		project1 = getWorkspace().getRoot().getProject("Project" + 1);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceDeltaTest.java
@@ -17,9 +17,9 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -30,17 +30,16 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the public API of IResourceDelta
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class IResourceDeltaTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/* some random resource handles */
 	protected IProject project1;
@@ -58,7 +57,7 @@ public class IResourceDeltaTest {
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// Create some resource handles
 		project1 = getWorkspace().getRoot().getProject("Project" + 1);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ISynchronizerTest.java
@@ -22,11 +22,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -61,18 +61,22 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ISynchronizerTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	public static int NUMBER_OF_PARTNERS = 100;
 	public IResource[] resources;
+
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	/*
 	 * Internal method used for flushing all sync information for a particular resource
@@ -95,14 +99,14 @@ public class ISynchronizerTest {
 		getWorkspace().run(body, null);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		resources = buildResources(getWorkspace().getRoot(),
 				new String[] { "/", "1/", "1/1", "1/2/", "1/2/1", "1/2/2/", "2/", "2/1", "2/2/", "2/2/1", "2/2/2/" });
 		createInWorkspace(resources);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// remove all registered sync partners so we don't create
 		// phantoms when we delete
@@ -179,7 +183,7 @@ public class ISynchronizerTest {
 
 		// sync info should be gone since projects can't become phantoms
 		visitor = resource -> {
-			assertNull(resource.getFullPath().toString(), synchronizer.getSyncInfo(qname, resource));
+			assertNull(synchronizer.getSyncInfo(qname, resource), resource.getFullPath().toString());
 			return true;
 		};
 		getWorkspace().getRoot().accept(visitor);
@@ -256,7 +260,7 @@ public class ISynchronizerTest {
 			if (type == IResource.FILE && resource.getParent().getType() == IResource.PROJECT && resource.getName().equals(IProjectDescription.DESCRIPTION_FILE_NAME)) {
 				return true;
 			}
-			assertNull(resource.getFullPath().toString(), synchronizer.getSyncInfo(qname, resource));
+			assertNull(synchronizer.getSyncInfo(qname, resource), resource.getFullPath().toString());
 			return true;
 		};
 
@@ -395,7 +399,7 @@ public class ISynchronizerTest {
 		// write out the data
 		IPath syncInfoPath = Platform.getLocation().append(".testsyncinfo");
 		File file = syncInfoPath.toFile();
-		workspaceRule.deleteOnTearDown(syncInfoPath);
+		fileStoreExtension.deleteOnTearDown(syncInfoPath);
 		try (OutputStream fileOutput = new FileOutputStream(file)) {
 			try (DataOutputStream output = new DataOutputStream(fileOutput)) {
 				final List<QualifiedName> list = new ArrayList<>(5);
@@ -500,7 +504,7 @@ public class ISynchronizerTest {
 		// there shouldn't be any info yet
 		visitor = resource -> {
 			byte[] actual = synchronizer.getSyncInfo(qname, resource);
-			assertNull("3.0." + resource.getFullPath(), actual);
+			assertNull(actual, resource.getFullPath().toString());
 			return true;
 		};
 		getWorkspace().getRoot().accept(visitor);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -21,12 +21,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -47,26 +47,30 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IWorkspaceRootTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
 	@Test
 	public void testFindFilesNonCanonicalPath() throws Exception {
-		assumeTrue("only relevant on Windows", OS.isWindows());
+		assumeTrue(OS.isWindows(), "only relevant on Windows");
 
 		IProject project = getWorkspace().getRoot().getProject("testFindFilesNonCanonicalPath");
 		createInWorkspace(project);
 
 		IFile link = project.getFile("file.txt");
-		IFileStore fileStore = workspaceRule.getTempStore();
+		IFileStore fileStore = fileStoreExtension.getTempStore();
 		createInFileSystem(fileStore);
 		assertEquals(EFS.SCHEME_FILE, fileStore.getFileSystem().getScheme());
 		IPath fileLocationLower = URIUtil.toPath(fileStore.toURI());
@@ -144,7 +148,7 @@ public class IWorkspaceRootTest {
 		assertThrows(RuntimeException.class, () -> root.findContainersForLocationURI(relative));
 		//linked folder that does not overlap a project location
 		IFolder otherLink = p1.getFolder("otherLink");
-		IFileStore linkStore = workspaceRule.getTempStore();
+		IFileStore linkStore = fileStoreExtension.getTempStore();
 		URI location = linkStore.toURI();
 		linkStore.mkdir(EFS.NONE, createTestMonitor());
 		otherLink.createLink(location, IResource.NONE, createTestMonitor());
@@ -225,7 +229,7 @@ public class IWorkspaceRootTest {
 
 		//linked resource
 		IFolder link = project.getFolder("link");
-		IFileStore linkStore = workspaceRule.getTempStore();
+		IFileStore linkStore = fileStoreExtension.getTempStore();
 		URI location = linkStore.toURI();
 		linkStore.mkdir(EFS.NONE, createTestMonitor());
 		link.createLink(location, IResource.NONE, createTestMonitor());
@@ -274,7 +278,7 @@ public class IWorkspaceRootTest {
 	@Test
 	public void testGetFileForLocation() {
 		IWorkspaceRoot root = getWorkspace().getRoot();
-		assertTrue(root.getFileForLocation(root.getLocation()) == null);
+		assertNull(root.getFileForLocation(root.getLocation()));
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -43,13 +43,13 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -73,16 +73,15 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class IWorkspaceTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IResource[] buildResourceHierarchy() throws CoreException {
 		return buildResources(getWorkspace().getRoot(),
@@ -625,7 +624,7 @@ public class IWorkspaceTest {
 		assertTrue(oneMoreFile.exists());
 		assertTrue(folder.getFile(file1.getName()).exists());
 		assertTrue(folder.getFile(anotherFile.getName()).exists());
-		assertTrue("Fails because of 1FVFOOQ", folder.getFile(oneMoreFile.getName()).exists());
+		assertTrue(folder.getFile(oneMoreFile.getName()).exists(), "Fails because of 1FVFOOQ");
 
 		/* copy projects should not be allowed */
 		IResource destination = getWorkspace().getRoot().getProject("destination");
@@ -811,28 +810,28 @@ public class IWorkspaceTest {
 			assertFalse(getWorkspace().validateName("...", IResource.PROJECT).isOK());
 			assertFalse(getWorkspace().validateName("foo.", IResource.FILE).isOK());
 			for (int i = 0; i <= 31; i++) {
-				assertFalse("Windows should NOT accept character #" + i,
-						getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK());
+				assertFalse(getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK(),
+						"Windows should NOT accept character #" + i);
 			}
-			assertTrue("Windows should accept character #" + 32,
-					getWorkspace().validateName("anything" + ((char) 32) + "something", IResource.FILE).isOK());
-			assertFalse("Windows should NOT accept space at the end",
-					getWorkspace().validateName("foo ", IResource.FILE).isOK());
-			assertTrue("Windows should accept space in the middle",
-					getWorkspace().validateName("fo o", IResource.FILE).isOK());
-			assertTrue("Windows should accept space in at the beginning",
-					getWorkspace().validateName(" foo", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validateName("anything" + ((char) 32) + "something", IResource.FILE).isOK(),
+					"Windows should accept character #" + 32);
+			assertFalse(getWorkspace().validateName("foo ", IResource.FILE).isOK(),
+					"Windows should NOT accept space at the end");
+			assertTrue(getWorkspace().validateName("fo o", IResource.FILE).isOK(),
+					"Windows should accept space in the middle");
+			assertTrue(getWorkspace().validateName(" foo", IResource.FILE).isOK(),
+					"Windows should accept space in at the beginning");
 		} else {
 			//trailing dots are ok on other platforms
 			assertTrue(getWorkspace().validateName("...", IResource.FILE).isOK());
 			assertTrue(getWorkspace().validateName("....", IResource.PROJECT).isOK());
 			assertTrue(getWorkspace().validateName("abc.", IResource.FILE).isOK());
 			for (int i = 1; i <= 32; i++) {
-				assertTrue("Unix-style filesystems should accept character #" + i,
-						getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK());
+				assertTrue(getWorkspace().validateName("anything" + ((char) i) + "something", IResource.FILE).isOK(),
+						"Unix-style filesystems should accept character #" + i);
 			}
-			assertTrue("Unix-style filesystems should accept space at the end",
-					getWorkspace().validateName("foo ", IResource.FILE).isOK());
+			assertTrue(getWorkspace().validateName("foo ", IResource.FILE).isOK(),
+					"Unix-style filesystems should accept space at the end");
 		}
 		/* invalid characters on all platforms */
 		assertFalse(getWorkspace().validateName("/dsasf", IResource.FILE).isOK());
@@ -860,14 +859,14 @@ public class IWorkspaceTest {
 		String[][] invalid = getInvalidNatureSets();
 		for (int i = 0; i < invalid.length; i++) {
 			IStatus result = ws.validateNatureSet(invalid[i]);
-			assertFalse("invalid (severity): " + i, result.isOK());
-			assertNotEquals("invalid (code): " + i, IStatus.OK, result.getCode());
+			assertFalse(result.isOK(), "invalid (severity): " + i);
+			assertNotEquals(IStatus.OK, result.getCode(), "invalid (code): " + i);
 		}
 		String[][] valid = getValidNatureSets();
 		for (int i = 0; i < valid.length; i++) {
 			IStatus result = ws.validateNatureSet(valid[i]);
-			assertTrue("valid (severity): " + i, result.isOK());
-			assertEquals("valid (code): " + i, IStatus.OK, result.getCode());
+			assertTrue(result.isOK(), "valid (severity): " + i);
+			assertEquals(IStatus.OK, result.getCode(), "valid (code): " + i);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedDotProjectTest.java
@@ -14,13 +14,13 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_EARTH;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_MISSING;
 import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.NATURE_SIMPLE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -35,13 +35,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class LinkedDotProjectTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void linkDotProject(IProject project) throws CoreException {
 		IFile dotProject = project.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceSyncMoveAndCopyTest.java
@@ -22,10 +22,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.URIUtil;
@@ -39,15 +39,19 @@ import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class LinkedResourceSyncMoveAndCopyTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	protected IProject existingProject;
 	protected IProject otherExistingProject;
@@ -66,7 +70,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		return uri;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		otherExistingProject = getWorkspace().getRoot().getProject("OtherExistingProject");
@@ -113,7 +117,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(fileLink, IResource.NONE, false);
 
 		createInFileSystem(fileLocation);
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 
 		exception = assertThrows(CoreException.class, () -> fileLink
 				.setContents(createRandomString().getBytes(), IResource.NONE, createTestMonitor()));
@@ -138,7 +142,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
 
 		createInFileSystem(fileLocation);
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 
 		assertFalse(fileLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(fileLink, IResource.SHALLOW, true);
@@ -159,7 +163,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folderLink, IResource.NONE, false);
 
 		folderLocation.toFile().mkdir();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		assertFalse(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.NONE, true);
@@ -180,7 +184,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
 
 		folderLocation.toFile().mkdir();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		assertFalse(folderLink.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folderLink, IResource.SHALLOW, true);
@@ -224,7 +228,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 	 * Tests bug 299024.
 	 */
 	@Test
-	@Ignore("see bug 299024")
+	@Disabled("see bug 299024")
 	public void testCopyFolderWithLinksToNonExistingLocations_withShallow() throws CoreException {
 		// create a folder
 		IFolder folderWithLinks = existingProject.getFolder(createUniqueString());
@@ -263,7 +267,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
 
 		createInFileSystem(fileLocation);
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
@@ -288,7 +292,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
 
 		createInFileSystem(fileLocation);
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
@@ -313,7 +317,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folder, IResource.NONE, false);
 
 		folderLocation.toFile().mkdir();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.NONE, true);
@@ -338,7 +342,7 @@ public class LinkedResourceSyncMoveAndCopyTest {
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);
 
 		folderLocation.toFile().mkdir();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		assertFalse(folder.isSynchronized(IResource.DEPTH_INFINITE));
 		internalMovedAndCopyTest(folder, IResource.SHALLOW, true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceWithPathVariableTest.java
@@ -25,12 +25,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStrea
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,9 +54,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class extends <code>LinkedResourceTest</code> in order to use
@@ -73,20 +73,20 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 	private IFileStore toSetWritable = null;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		IPath base = FileSystemHelper.getRandomLocation();
-		workspaceRule.deleteOnTearDown(base);
+		fileStoreExtension.deleteOnTearDown(base);
 		getWorkspace().getPathVariableManager().setURIValue(VARIABLE_NAME, URIUtil.toURI(base));
 		base = FileSystemHelper.getRandomLocation();
-		workspaceRule.deleteOnTearDown(base);
+		fileStoreExtension.deleteOnTearDown(base);
 		super.setUp();
 		existingProject.getPathVariableManager().setURIValue(PROJECT_VARIABLE_NAME, URIUtil.toURI(base));
 		existingProject.getPathVariableManager().setURIValue(PROJECT_RELATIVE_VARIABLE_NAME,
 				URIUtil.toURI(IPath.fromPortableString(PROJECT_RELATIVE_VARIABLE_VALUE)));
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (toSetWritable != null) {
 			IFileInfo info = toSetWritable.fetchInfo();
@@ -155,7 +155,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 			}
 			path = FileSystemHelper.computeRandomLocation(parent);
 		}
-		workspaceRule.deleteOnTearDown(pathVars.resolvePath(path));
+		fileStoreExtension.deleteOnTearDown(pathVars.resolvePath(path));
 		return URIUtil.toURI(path);
 	}
 
@@ -172,7 +172,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 			}
 			path = FileSystemHelper.computeRandomLocation(parent);
 		}
-		workspaceRule.deleteOnTearDown(pathVars.resolvePath(path));
+		fileStoreExtension.deleteOnTearDown(pathVars.resolvePath(path));
 		return URIUtil.toURI(path);
 	}
 
@@ -189,7 +189,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 			}
 			path = FileSystemHelper.computeRandomLocation(parent);
 		}
-		workspaceRule.deleteOnTearDown(pathVars.resolvePath(path));
+		fileStoreExtension.deleteOnTearDown(pathVars.resolvePath(path));
 		return URIUtil.toURI(path);
 	}
 
@@ -348,7 +348,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		if (!targetPath.toFile().exists()) {
 			targetPath.toFile().createNewFile();
 		}
-		workspaceRule.deleteOnTearDown(targetPath);
+		fileStoreExtension.deleteOnTearDown(targetPath);
 
 		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 
@@ -364,8 +364,8 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		IFile newFile = nonExistingFileInExistingFolder;
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace(newFile);
-		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
-		assertEquals("3,3", newFile.getLocation(), resolvedPath);
+		assertFalse(newFile.getLocation().equals(newFile.getRawLocation()));
+		assertEquals(newFile.getLocation(), resolvedPath);
 	}
 
 	private IPath convertToRelative(IPath path, IResource res, boolean force, String variableHint) throws CoreException {
@@ -396,7 +396,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		if (!targetPath.toFile().exists()) {
 			targetPath.toFile().createNewFile();
 		}
-		workspaceRule.deleteOnTearDown(targetPath);
+		fileStoreExtension.deleteOnTearDown(targetPath);
 
 		existingProjectInSubDirectory.getPathVariableManager().setURIValue("P_RELATIVE",
 				URIUtil.toURI(IPath.fromPortableString("${PARENT-3-PROJECT_LOC}")));
@@ -415,14 +415,14 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace(newFile);
 		URI newLocation = newFile.getLocationURI();
-		assertTrue("3,2", !newLocation.equals(newFile.getRawLocationURI()));
+		assertFalse(newLocation.equals(newFile.getRawLocationURI()));
 		URI newRawLocation = newFile.getRawLocationURI();
 		/* we cannot test the value of the location since the test machines generate an incorrect value
 		IPath newValue = newFile.getProject().getPathVariableManager().getValue("P_RELATIVE");
 		assertEquals("3,3", Path.fromPortableString("${PARENT-1-PROJECT_LOC}/sub"), newValue);
 		*/
-		assertTrue("3,4", newRawLocation.equals(variableBasedLocation));
-		assertTrue("3,5", newLocation.equals(resolvedPath));
+		assertTrue(newRawLocation.equals(variableBasedLocation));
+		assertTrue(newLocation.equals(resolvedPath));
 	}
 
 	/**
@@ -453,10 +453,10 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// removes the variable - the location will be undefined (null)
 		file.move(newFile.getFullPath(), IResource.SHALLOW, null);
 		assertExistsInWorkspace(newFile);
-		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
-		assertTrue("3,3", newFile.getRawLocationURI().equals(variableBasedLocation));
-		assertTrue("3,4", newFile.getRawLocationURI().equals(variableBasedLocation));
-		assertTrue("3,5", newFile.getLocationURI().equals(resolvedPath));
+		assertFalse(newFile.getLocation().equals(newFile.getRawLocation()));
+		assertTrue(newFile.getRawLocationURI().equals(variableBasedLocation));
+		assertTrue(newFile.getRawLocationURI().equals(variableBasedLocation));
+		assertTrue(newFile.getLocationURI().equals(resolvedPath));
 	}
 
 	/**
@@ -487,9 +487,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		// moves the variable - the location will be undefined (null)
 		file.move(newFile.getFullPath(), IResource.SHALLOW, createTestMonitor());
 		assertExistsInWorkspace(newFile);
-		assertTrue("3,2", !newFile.getLocation().equals(newFile.getRawLocation()));
-		assertTrue("3,3", newFile.getRawLocationURI().equals(variableBasedLocation));
-		assertTrue("3,4", newFile.getLocationURI().equals(resolvedPath));
+		assertFalse(newFile.getLocation().equals(newFile.getRawLocation()));
+		assertTrue(newFile.getRawLocationURI().equals(variableBasedLocation));
+		assertTrue(newFile.getLocationURI().equals(resolvedPath));
 	}
 
 	/**
@@ -824,7 +824,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// changes the variable value - the file location will change
 		IPath newLocation = FileSystemHelper.getRandomLocation();
-		workspaceRule.deleteOnTearDown(newLocation);
+		fileStoreExtension.deleteOnTearDown(newLocation);
 		manager.setURIValue(VARIABLE_NAME, URIUtil.toURI(newLocation));
 
 		// try to change resource's contents
@@ -890,7 +890,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		// changes the variable value - the file location will change
 		IPath newLocation = FileSystemHelper.getRandomLocation();
-		workspaceRule.deleteOnTearDown(newLocation);
+		fileStoreExtension.deleteOnTearDown(newLocation);
 		manager.setURIValue(PROJECT_VARIABLE_NAME, URIUtil.toURI(newLocation));
 
 		// try to change resource's contents
@@ -944,7 +944,7 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 		if (!targetPath.toFile().exists()) {
 			targetPath.toFile().createNewFile();
 		}
-		workspaceRule.deleteOnTearDown(targetPath);
+		fileStoreExtension.deleteOnTearDown(targetPath);
 
 		variableBasedLocation = convertToRelative(targetPath, file, true, null);
 		IPath resolvedPath = URIUtil.toPath(pathVariableManager.resolveURI(URIUtil.toURI(variableBasedLocation)));
@@ -984,9 +984,9 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		for (int i = 0; i < table.length; i++) {
 			String result = pathVariableManager.convertToUserEditableFormat(toOS(table[i][0]), false);
-			assertEquals(i + "", toOS(table[i][1]), result);
+			assertEquals(toOS(table[i][1]), result, i + "");
 			String original = pathVariableManager.convertFromUserEditableFormat(result, false);
-			assertEquals(i + "", toOS(table[i].length == 2 ? table[i][0] : table[i][2]), original);
+			assertEquals(toOS(table[i].length == 2 ? table[i][0] : table[i][2]), original, i + "");
 		}
 
 		String[][] tableLocationFormat = { // format: {internal-format, user-editable-format [, internal-format-reconverted]
@@ -1009,11 +1009,11 @@ public class LinkedResourceWithPathVariableTest extends LinkedResourceTest {
 
 		for (int i = 0; i < table.length; i++) {
 			String result = pathVariableManager.convertToUserEditableFormat(toOS(tableLocationFormat[i][0]), true);
-			assertEquals(i + "", toOS(tableLocationFormat[i][1]), result);
+			assertEquals(toOS(tableLocationFormat[i][1]), result, i + "");
 			String original = pathVariableManager.convertFromUserEditableFormat(result, true);
-			assertEquals(i + "",
+			assertEquals(
 					toOS(tableLocationFormat[i].length == 2 ? tableLocationFormat[i][0] : tableLocationFormat[i][2]),
-					original);
+					original, i + "");
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerAttributeChangeListener.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerAttributeChangeListener.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,11 +64,11 @@ public class MarkerAttributeChangeListener implements IResourceChangeListener {
 	private void checkDelta(IMarkerDelta[] deltas) {
 		int expectedCount = attributeMap.size();
 		int actualCount = deltas.length;
-		assertEquals("wrong number of changes", expectedCount, actualCount);
+		assertEquals(expectedCount, actualCount, "wrong number of changes");
 		for (IMarkerDelta delta : deltas) {
 			Map<String, Object> expected = attributeMap.get(Long.valueOf(delta.getId()));
 			Map<String, Object> actual = delta.getAttributes();
-			assertEquals("Changes different from expecations", expected, actual);
+			assertEquals(expected, actual, "Changes different from expecations");
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerSetTest.java
@@ -16,13 +16,13 @@ package org.eclipse.core.tests.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -31,13 +31,12 @@ import org.eclipse.core.internal.resources.MarkerAttributeMap;
 import org.eclipse.core.internal.resources.MarkerInfo;
 import org.eclipse.core.internal.resources.MarkerSet;
 import org.eclipse.core.resources.IMarker;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class MarkerSetTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void assertMarkerElementsEqual(IMarkerSetElement[] array1, IMarkerSetElement[] array2) {
 		assertNotNull(array1);
@@ -79,16 +78,16 @@ public class MarkerSetTest {
 		for (int i = 0; i < infos.length; i++) {
 			info = infos[i];
 			set.add(info);
-			assertTrue(i + "", set.contains(info.getId()));
-			assertEquals(i + "", i + 1, set.size());
+			assertTrue(set.contains(info.getId()), i + "");
+			assertEquals(set.size(), i + 1, i + "");
 		}
 
 		// make sure they are all still there
 		assertEquals(max, set.size());
 		for (int i = 0; i < infos.length; i++) {
 			info = infos[i];
-			assertTrue(i + "", set.contains(info.getId()));
-			assertNotNull(i + "", set.get(info.getId()));
+			assertTrue(set.contains(info.getId()), i + "");
+			assertNotNull(set.get(info.getId()), i + "");
 		}
 	}
 
@@ -130,11 +129,11 @@ public class MarkerSetTest {
 		for (int i = max - 1; i >= 0; i--) {
 			info = infos[i];
 			set.remove(info);
-			assertFalse(i + "", set.contains(info.getId()));
-			assertEquals(i + "", i, set.size());
+			assertFalse(set.contains(info.getId()), i + "");
+			assertEquals(i, set.size(), i + "");
 			// check that the others still exist
 			for (int j = 0; j < i; j++) {
-				assertTrue(j + "", set.contains(infos[j].getId()));
+				assertTrue(set.contains(infos[j].getId()), j + "");
 			}
 		}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NatureTest.java
@@ -25,7 +25,7 @@ import static org.eclipse.core.tests.resources.ResourceTestPluginConstants.getVa
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -52,21 +52,20 @@ import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.internal.resources.SimpleNature;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Tests all aspects of project natures.  These tests only
  * exercise API classes and methods.  Note that the nature-related
  * APIs on IWorkspace are tested by IWorkspaceTest.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class NatureTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	IProject project;
 
@@ -94,22 +93,22 @@ public class NatureTest {
 		} else {
 			flags = IResource.KEEP_HISTORY;
 		}
-		ThrowingRunnable descriptionSetter = () -> project.setDescription(desc, flags, createTestMonitor());
+		Executable descriptionSetter = () -> project.setDescription(desc, flags, createTestMonitor());
 		if (shouldFail) {
 			assertThrows(CoreException.class, descriptionSetter);
 		} else {
-			descriptionSetter.run();
+			descriptionSetter.execute();
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		project.delete(true, null);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).putInt(ResourcesPlugin.PREF_MISSING_NATURE_MARKER_SEVERITY, PreferenceInitializer.PREF_MISSING_NATURE_MARKER_SEVERITY_DEFAULT);
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES).flush();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.project = ResourcesPlugin.getWorkspace().getRoot().getProject(createUniqueString());
 	}
@@ -186,7 +185,7 @@ public class NatureTest {
 		desc.setNatureIds(new String[] { NATURE_SIMPLE, NATURE_SIMPLE });
 		// This should not throw IllegalArgumentException when hasPrivateChanges is called
 		project.setDescription(desc, IResource.KEEP_HISTORY, createTestMonitor());
-		
+
 		// After deduplication, only one instance of the nature should remain
 		assertHasEnabledNature(NATURE_SIMPLE);
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/NonLocalLinkedResourceTest.java
@@ -18,8 +18,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -33,18 +33,22 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.internal.filesystem.bogus.BogusFileSystem;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryFileSystem;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests behaviour of manipulating linked resources that are not linked into
  * the local file system.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class NonLocalLinkedResourceTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	/**
 	 * Creates a folder in the test file system with the given name
@@ -60,7 +64,7 @@ public class NonLocalLinkedResourceTest {
 		return EFS.getFileSystem(MemoryFileSystem.SCHEME_MEMORY);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		MemoryTree.TREE.deleteAll();
 	}
@@ -179,7 +183,7 @@ public class NonLocalLinkedResourceTest {
 	protected IFileStore createBogusFolderStore(String name) throws CoreException {
 		IFileSystem system = getBogusFileSystem();
 		IFileStore store = system.getStore(IPath.ROOT.append(name));
-		workspaceRule.deleteOnTearDown(
+		fileStoreExtension.deleteOnTearDown(
 					IPath.fromOSString(system.getStore(IPath.ROOT).toLocalFile(EFS.NONE, createTestMonitor()).getPath()));
 		store.mkdir(EFS.NONE, createTestMonitor());
 		return store;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -31,28 +31,27 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
 import org.eclipse.osgi.util.NLS;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for integration of marker
  * {@link org.eclipse.core.resources.ResourcesPlugin#PREF_MISSING_ENCODING_MARKER_SEVERITY}.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectEncodingTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final int IGNORE = -1;
 
 	private IProject project;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (project != null) {
 			project.delete(true, true, null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectOrderTest.java
@@ -27,18 +27,17 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Performs black box testing of the following API methods:
  * <code>IWorkspace.computeProjectOrder(IProject[])</code>
  * <code>IWorkspace.computePrerequisiteOrder(IProject[])</code>
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectOrderTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Adds a project reference from the given source project, which must

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectScopeTest.java
@@ -15,17 +15,16 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectScopeTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testEqualsAndHashCode() {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectSnapshotPerfManualTest.java
@@ -16,7 +16,8 @@ package org.eclipse.core.tests.resources;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.net.URI;
@@ -31,9 +32,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Measure speed of a project "Import with Snapshot" operation compared
@@ -44,10 +45,8 @@ import org.junit.Test;
  * to be available on a slow file system (bigSiteLocation). Modify
  * bigSiteLocation to suit your needs, then run-as &gt; JUnit Plug-in Test.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectSnapshotPerfManualTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/** big site default volume (windows) */
 	public static final String bigSiteDevice = "c:";
@@ -85,7 +84,7 @@ public class ProjectSnapshotPerfManualTest {
 	@Test
 	public void testSnapshotImportPerformance() throws Exception {
 		// test if the test can be done in this machine
-		Assume.assumeTrue(bigSiteLocation.toFile().isDirectory());
+		assumeTrue(bigSiteLocation.toFile().isDirectory());
 
 		// create common objects
 		final IProject project = getWorkspace().getRoot().getProject("MyTestProject");
@@ -145,7 +144,7 @@ public class ProjectSnapshotPerfManualTest {
 			}
 		}.run(getClass(), "Forced refresh only", 1, 1);
 		verifier[0].verifyDelta(null);
-		assertTrue(verifier[0].getMessage(), verifier[0].isDeltaValid());
+		assertTrue(verifier[0].isDeltaValid(), verifier[0].getMessage());
 
 		// close and delete project but leave contents
 		project.close(null);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceAttributeTest.java
@@ -27,11 +27,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSuppo
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import org.eclipse.core.filesystem.EFS;
@@ -41,47 +41,46 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ResourceAttributeTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void setArchive(IResource resource, boolean value) throws CoreException {
 		ResourceAttributes attributes = resource.getResourceAttributes();
-		assertNotNull("setAchive for null attributes", attributes);
+		assertNotNull(attributes);
 		attributes.setArchive(value);
 		resource.setResourceAttributes(attributes);
 	}
 
 	private void setExecutable(IResource resource, boolean value) throws CoreException {
 		ResourceAttributes attributes = resource.getResourceAttributes();
-		assertNotNull("setExecutable for null attributes", attributes);
+		assertNotNull(attributes);
 		attributes.setExecutable(value);
 		resource.setResourceAttributes(attributes);
 	}
 
 	private void setHidden(IResource resource, boolean value) throws CoreException {
 		ResourceAttributes attributes = resource.getResourceAttributes();
-		assertNotNull("setHidden for null attributes", attributes);
+		assertNotNull(attributes);
 		attributes.setHidden(value);
 		resource.setResourceAttributes(attributes);
 	}
 
 	private void setSymlink(IResource resource, boolean value) throws CoreException {
 		ResourceAttributes attributes = resource.getResourceAttributes();
-		assertNotNull("setSymlink for null attributes", attributes);
+		assertNotNull(attributes);
 		attributes.setSymbolicLink(value);
 		resource.setResourceAttributes(attributes);
 	}
 
 	@Test
 	public void testAttributeArchive() throws CoreException {
-		assumeTrue("only relevant for platforms supporting archive attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_ARCHIVE));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_ARCHIVE),
+				"only relevant for platforms supporting archive attribute");
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
@@ -104,8 +103,8 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeExecutable() throws CoreException {
-		assumeTrue("only relevant for platforms supporting executable attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE),
+				"only relevant for platforms supporting executable attribute");
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
@@ -129,8 +128,8 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeHidden() throws CoreException {
-		assumeTrue("only relevant for platforms supporting hidden attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_HIDDEN),
+				"only relevant for platforms supporting hidden attribute");
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
@@ -153,8 +152,8 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeReadOnly() throws CoreException {
-		assumeTrue("only relevant for platforms supporting read-only attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_READ_ONLY));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_READ_ONLY),
+				"only relevant for platforms supporting read-only attribute");
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile file = project.getFile("target");
@@ -217,10 +216,10 @@ public class ResourceAttributeTest {
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=397353
 	 */
 	@Test
-	@Ignore("currently failing on Hudson: see https://bugs.eclipse.org/bugs/show_bug.cgi?id=397353")
+	@Disabled("currently failing on Hudson: see https://bugs.eclipse.org/bugs/show_bug.cgi?id=397353")
 	public void testRefreshExecutableOnFolder() throws CoreException {
-		assumeTrue("only relevant for platforms supporting executable attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE),
+				"only relevant for platforms supporting executable attribute");
 
 		IProject project = getWorkspace().getRoot().getProject("testRefreshExecutableOnFolder");
 		IFolder folder = project.getFolder("folder");
@@ -247,7 +246,7 @@ public class ResourceAttributeTest {
 
 	@Test
 	public void testAttributeSymlink() throws Exception {
-		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
+		assumeTrue(canCreateSymLinks(), "only relevant for platforms supporting symbolic links");
 
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFile link = project.getFile("link");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceDeltaVerifier.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Hashtable;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceURLTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,16 +32,15 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test suites for {@link org.eclipse.core.internal.resources.PlatformURLResourceConnection}
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ResourceURLTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private final String[] resourcePaths = new String[] { "/", "/1/", "/1/1", "/1/2", "/1/3", "/2/", "/2/1", "/2/2",
 			"/2/3", "/3/", "/3/1", "/3/2", "/3/3", "/4/", "/5" };

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TeamPrivateMemberTest.java
@@ -22,8 +22,8 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonito
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -36,13 +36,12 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class TeamPrivateMemberTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testRefreshLocal() throws Exception {
@@ -61,7 +60,7 @@ public class TeamPrivateMemberTest {
 			setTeamPrivateMember(folder, true, IResource.DEPTH_ZERO);
 			ensureOutOfSync(subFile);
 			project.refreshLocal(IResource.DEPTH_INFINITE, createTestMonitor());
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
 		}
@@ -188,19 +187,19 @@ public class TeamPrivateMemberTest {
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		// set the folder to be team private. It and its children should
 		// be ignored by the visitor
@@ -212,7 +211,7 @@ public class TeamPrivateMemberTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(project);
@@ -221,27 +220,27 @@ public class TeamPrivateMemberTest {
 		visitor.addExpected(settings);
 		visitor.addExpected(prefs);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 		// should see all resources if we include the flag
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 		// should NOT visit the folder and its members if we call accept on it directly
 		visitor.reset();
 		folder.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(folder);
 		visitor.addExpected(subFile);
 		folder.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		// now set all file/folder resources to be team private.
 		setTeamPrivateMember(project, true, IResource.DEPTH_INFINITE);
@@ -250,18 +249,18 @@ public class TeamPrivateMemberTest {
 		// projects are never team private
 		visitor.addExpected(project);
 		project.accept(visitor);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 
 		visitor.reset();
 		visitor.addExpected(project);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IResource.NONE);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 		// should see all resources if we include the flag
 		visitor.reset();
 		visitor.addExpected(resources);
 		visitor.addExpected(description);
 		project.accept(visitor, IResource.DEPTH_INFINITE, IContainer.INCLUDE_TEAM_PRIVATE_MEMBERS);
-		assertTrue(visitor.getMessage(), visitor.isValid());
+		assertTrue(visitor.isValid(), visitor.getMessage());
 	}
 
 	@Test
@@ -452,7 +451,7 @@ public class TeamPrivateMemberTest {
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, createTestMonitor());
 			waitForBuild();
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
@@ -470,7 +469,7 @@ public class TeamPrivateMemberTest {
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, createTestMonitor());
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);
@@ -488,7 +487,7 @@ public class TeamPrivateMemberTest {
 			listener.addExpectedChange(project, IResourceDelta.ADDED, IResourceDelta.OPEN);
 			listener.addExpectedChange(description, IResourceDelta.ADDED, IResource.NONE);
 			getWorkspace().run(body, createTestMonitor());
-			assertTrue(listener.getMessage(), listener.isDeltaValid());
+			assertTrue(listener.isDeltaValid(), listener.getMessage());
 			removeFromWorkspace(resources);
 		} finally {
 			getWorkspace().removeResourceChangeListener(listener);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TestPerformer.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/TestPerformer.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Arrays;
 import java.util.Random;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.junit.Assert;
 
 /**
  * Abstract superclass of inner classes used for black-box testing
@@ -73,7 +75,7 @@ public abstract class TestPerformer {
 				if (shouldFail(args, count)) {
 					try {
 						invokeMethod(args, count);
-						Assert.fail(getFailMessagePrefixForCurrentInvocation(args)
+						fail(getFailMessagePrefixForCurrentInvocation(args)
 								+ "invocation did not fail although it should"
 								+ (reasonForExpectedFail != null ? ": " + reasonForExpectedFail : ""));
 					} catch (Exception ex) {
@@ -102,8 +104,8 @@ public abstract class TestPerformer {
 					} catch (Exception ex) {
 						ex.printStackTrace();
 					}
-					Assert.assertTrue(getFailMessagePrefixForCurrentInvocation(args)
-							+ "invocation should succeed but did not produce desired result", success);
+					assertTrue(success, getFailMessagePrefixForCurrentInvocation(args)
+							+ "invocation should succeed but did not produce desired result");
 				}
 				cleanUp(args, count);
 				count++;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/VirtualFolderTest.java
@@ -26,11 +26,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -42,23 +42,27 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests Virtual Folders
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class VirtualFolderTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	protected IProject existingProject;
 	protected IFolder existingVirtualFolderInExistingProject;
 
-	@Before
-	public void setUp() throws Exception {
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
+
+	@BeforeEach
+	void setUp() throws Exception {
 		existingProject = getWorkspace().getRoot().getProject("ExistingProject");
 		existingVirtualFolderInExistingProject = existingProject.getFolder("existingVirtualFolderInExistingProject");
 		createInWorkspace(new IResource[] { existingProject });
@@ -160,9 +164,9 @@ public class VirtualFolderTest {
 	@Test
 	public void testCopyProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		IFile linkedFile = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		IFolder linkedFolder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
@@ -204,9 +208,9 @@ public class VirtualFolderTest {
 	@Test
 	public void testMoveProjectWithVirtualFolder() throws Exception {
 		IPath fileLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(fileLocation);
+		fileStoreExtension.deleteOnTearDown(fileLocation);
 		IPath folderLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		IFile file = existingVirtualFolderInExistingProject.getFile(createUniqueString());
 		IFolder folder = existingVirtualFolderInExistingProject.getFolder(createUniqueString());
@@ -267,7 +271,7 @@ public class VirtualFolderTest {
 	@Test
 	public void testDeleteProjectWithVirtualFolderAndLink() throws CoreException {
 		IPath folderLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(folderLocation);
+		fileStoreExtension.deleteOnTearDown(folderLocation);
 
 		IFolder virtualFolder = existingProject.getFolder(createUniqueString());
 		IFolder linkedFolder = virtualFolder.getFolder("a_link");
@@ -330,9 +334,9 @@ public class VirtualFolderTest {
 		IFolder virtualFolder = subFolder.getFolder("virtualFolder");
 
 		IPath linkedFolderLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(linkedFolderLocation);
+		fileStoreExtension.deleteOnTearDown(linkedFolderLocation);
 		IPath subFolderLocation = linkedFolderLocation.append(subFolder.getName());
-		workspaceRule.deleteOnTearDown(subFolderLocation);
+		fileStoreExtension.deleteOnTearDown(subFolderLocation);
 
 		// create the structure on disk
 		linkedFolderLocation.toFile().mkdir();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTest.java
@@ -27,11 +27,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.InputStream;
@@ -46,18 +46,22 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * This class should be refactored into the black box tests for
  * solution, project, folder and file.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class WorkspaceTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	protected IProject getTestProject() {
 		return getWorkspace().getRoot().getProject("testProject");
@@ -72,10 +76,10 @@ public class WorkspaceTest {
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		target.setPersistentProperty(name, value);
 		// see if we can get the property
-		assertTrue("get not equal set", target.getPersistentProperty(name).equals(value));
+		assertTrue(target.getPersistentProperty(name).equals(value), "get not equal set");
 		// see what happens if we get a non-existant property
 		name = new QualifiedName("itp-test", "testNonProperty");
-		assertNull("non-existant persistent property not missing", target.getPersistentProperty(name));
+		assertNull(target.getPersistentProperty(name), "non-existant persistent property not missing");
 	}
 
 	@Test
@@ -295,7 +299,7 @@ public class WorkspaceTest {
 		assertTrue(!target.exists());
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		IProject target = getTestProject();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
@@ -333,18 +337,18 @@ public class WorkspaceTest {
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		target.delete(true, monitor);
 		monitor.assertUsedUp();
-		assertTrue("Project Deletion failed", !target.exists());
+		assertFalse(target.exists(), "Project Deletion failed");
 	}
 
 	@Test
 	public void testWorkingLocationDeletion_bug433061() throws Throwable {
-		assumeTrue("only relevant for platforms supporting symbolic links", canCreateSymLinks());
+		assumeTrue(canCreateSymLinks(), "only relevant for platforms supporting symbolic links");
 
 		IProject project = getTestProject();
 		FussyProgressMonitor monitor = new FussyProgressMonitor();
 		IPath workingLocation = project.getWorkingLocation("org.eclipse.core.tests.resources");
 		IPath linkTarget = getRandomLocation();
-		workspaceRule.deleteOnTearDown(linkTarget);
+		fileStoreExtension.deleteOnTearDown(linkTarget);
 		linkTarget.toFile().mkdirs();
 		File file = linkTarget.append("aFile").toFile();
 		assertTrue(file.createNewFile());
@@ -355,9 +359,9 @@ public class WorkspaceTest {
 		monitor.prepare();
 		project.delete(true, monitor);
 		monitor.assertUsedUp();
-		assertTrue("Project deletion failed", !project.exists());
-		assertTrue("Working location was not deleted", !workingLocation.toFile().exists());
-		assertTrue("File inside a symlinked directory got deleted", file.exists());
+		assertFalse(project.exists(), "Project deletion failed");
+		assertFalse(workingLocation.toFile().exists(), "Working location was not deleted");
+		assertTrue(file.exists(), "File inside a symlinked directory got deleted");
 	}
 
 	@Test
@@ -435,7 +439,7 @@ public class WorkspaceTest {
 		String value = "this is a test property value";
 		QualifiedName name = new QualifiedName("itp-test", "testProperty");
 		target.setPersistentProperty(name, value);
-		assertTrue("get not equal set", target.getPersistentProperty(name).equals(value));
+		assertTrue(target.getPersistentProperty(name).equals(value), "get not equal set");
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTestRule.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/WorkspaceTestRule.java
@@ -20,7 +20,7 @@ import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -71,7 +71,7 @@ public class WorkspaceTestRule extends ExternalResource {
 		// Wait for any pending refresh operation, in particular from startup
 		waitForRefresh();
 		TestUtil.log(IStatus.INFO, testName, "setUp");
-		assertNotNull("Workspace was not setup", getWorkspace());
+		assertNotNull(getWorkspace(), "Workspace was not setup");
 		FreezeMonitor.expectCompletionInAMinute();
 		waitForRefresh();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/FileStoreAutoDeleteExtension.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/util/FileStoreAutoDeleteExtension.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.resources.util;
+
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
+import static org.eclipse.core.tests.harness.FileSystemHelper.getTempDir;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.runtime.IPath;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A test extension that automatically deletes file stores that are either
+ * retrieved from the extension itself or passed to it via one of the
+ * {@code deleteOnTearDown()} methods.
+ */
+public class FileStoreAutoDeleteExtension implements AfterEachCallback {
+
+	private final Set<IFileStore> storesToDelete = new HashSet<>();
+
+	/**
+	 * {@return a temporary file store backed by storage in a temporary location
+	 * which will be automatically deleted when the test is completed}
+	 */
+	public IFileStore getTempStore() {
+		IFileStore store = EFS.getLocalFileSystem().getStore(getRandomLocation(getTempDir()));
+		deleteOnTearDown(store);
+		return store;
+	}
+
+	/**
+	 * Ensures that the store for the given path in the local file system is deleted
+	 * when the test is completed.
+	 *
+	 * @param path
+	 *            the path to the file store to delete after test execution
+	 */
+	public void deleteOnTearDown(IPath path) {
+		storesToDelete.add(EFS.getLocalFileSystem().getStore(path));
+	}
+
+	/**
+	 * Ensures that the given store is deleted when the test is completed.
+	 *
+	 * @param store
+	 *            the store to delete after test execution
+	 */
+	public void deleteOnTearDown(IFileStore store) {
+		storesToDelete.add(store);
+
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		getWorkspace().run((IWorkspaceRunnable) monitor -> {
+			getWorkspace().getRoot().delete(true, true, createTestMonitor());
+			// clear stores in workspace runnable to avoid interaction with resource jobs
+			for (IFileStore element : storesToDelete) {
+				element.delete(EFS.NONE, null);
+			}
+			storesToDelete.clear();
+		}, null);
+	}
+
+}


### PR DESCRIPTION
- Introduce `FileStoreAutoDeleteExtension` for file store auto-deletion functionality that was so far provided by the JUnit 4 rule `WorkspaceTestRule`
- Use `WorkspaceResetExtension` instead of `WorkspaceTestRule`
- Switch to JUnit 5 test annotations
- Migrate to JUnit 5 assertions and simply some assertions and their messages

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903