### PR TITLE
Migrate file system tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/CreateDirectoryTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/CreateDirectoryTest.java
@@ -16,12 +16,12 @@ package org.eclipse.core.tests.filesystem;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureDoesNotExist;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureExists;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.net.URI;
@@ -31,11 +31,11 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.filesystem.FileStoreCreationExtension.FileSystemType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Black box testing of mkdir method.
@@ -43,15 +43,16 @@ import org.junit.Test;
 public class CreateDirectoryTest {
 	protected IFileStore topDir, subDir, file, subFile;
 
-	@Rule
-	public final FileStoreCreationRule localFileStoreRule = new FileStoreCreationRule(FileSystemType.LOCAL);
+	@RegisterExtension
+	public final FileStoreCreationExtension localFileStoreExtension = new FileStoreCreationExtension(FileSystemType.LOCAL);
 
-	@Rule
-	public final FileStoreCreationRule inMemoryFileStoreRule = new FileStoreCreationRule(FileSystemType.IN_MEMORY);
+	@RegisterExtension
+	public final FileStoreCreationExtension inMemoryFileStoreExtension = new FileStoreCreationExtension(
+			FileSystemType.IN_MEMORY);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		IFileStore baseStore = inMemoryFileStoreRule.getFileStore();
+		IFileStore baseStore = inMemoryFileStoreExtension.getFileStore();
 		baseStore.mkdir(EFS.NONE, null);
 		topDir = baseStore.getChild("topDir");
 		subDir = topDir.getChild("subDir");
@@ -62,7 +63,7 @@ public class CreateDirectoryTest {
 		ensureDoesNotExist(file);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		ensureDoesNotExist(topDir);
 		ensureDoesNotExist(file);
@@ -126,7 +127,7 @@ public class CreateDirectoryTest {
 
 	@Test
 	public void testParentNotExistsShallowInLocalFile() throws CoreException {
-		IFileStore localFileBaseStore = localFileStoreRule.getFileStore();
+		IFileStore localFileBaseStore = localFileStoreExtension.getFileStore();
 		localFileBaseStore.delete(EFS.NONE, getMonitor());
 		CoreException e = assertThrows(CoreException.class, () -> {
 			IFileStore localFileTopDir = localFileBaseStore.getChild("topDir");
@@ -138,7 +139,7 @@ public class CreateDirectoryTest {
 
 	@Test
 	public void testTargetIsFileInLocalFile() throws Exception {
-		IFileStore localFileBaseStore = localFileStoreRule.getFileStore();
+		IFileStore localFileBaseStore = localFileStoreExtension.getFileStore();
 		localFileBaseStore.delete(EFS.NONE, getMonitor());
 		CoreException e = assertThrows(CoreException.class, () -> {
 			ensureExists(localFileBaseStore, true);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/DeleteTest.java
@@ -15,29 +15,31 @@ package org.eclipse.core.tests.filesystem;
 
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureExists;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.filesystem.FileStoreCreationExtension.FileSystemType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Black box testing of {@link IFileStore#delete(int, org.eclipse.core.runtime.IProgressMonitor)}.
  */
 public class DeleteTest {
-	@Rule
-	public final FileStoreCreationRule localFileStoreRule = new FileStoreCreationRule(FileSystemType.LOCAL);
+	@RegisterExtension
+	public final FileStoreCreationExtension localFileStoreExtension = new FileStoreCreationExtension(
+			FileSystemType.LOCAL);
 
-	@Rule
-	public final FileStoreCreationRule inMemoryFileStoreRule = new FileStoreCreationRule(FileSystemType.IN_MEMORY);
+	@RegisterExtension
+	public final FileStoreCreationExtension inMemoryFileStoreExtension = new FileStoreCreationExtension(
+			FileSystemType.IN_MEMORY);
 
 	@Test
 	public void testDeleteFile() throws Exception {
-		IFileStore baseStore = inMemoryFileStoreRule.getFileStore();
+		IFileStore baseStore = inMemoryFileStoreExtension.getFileStore();
 		IFileStore file = baseStore.getChild("child");
 		ensureExists(file, false);
 
@@ -48,7 +50,7 @@ public class DeleteTest {
 
 	@Test
 	public void testDeleteDirectory() throws Exception {
-		IFileStore baseStore = inMemoryFileStoreRule.getFileStore();
+		IFileStore baseStore = inMemoryFileStoreExtension.getFileStore();
 		IFileStore dir = baseStore.getChild("child");
 		ensureExists(dir, true);
 
@@ -59,7 +61,7 @@ public class DeleteTest {
 
 	@Test
 	public void testDeleteReadOnlyFile() throws Exception {
-		IFileStore localFileBaseStore = localFileStoreRule.getFileStore();
+		IFileStore localFileBaseStore = localFileStoreExtension.getFileStore();
 		ensureExists(localFileBaseStore, true);
 		IFileStore file = localFileBaseStore.getChild("child");
 		ensureExists(file, false);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/EFSTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/EFSTest.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.core.tests.filesystem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests public API methods of the class EFS.

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileCacheTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileCacheTest.java
@@ -15,9 +15,9 @@ package org.eclipse.core.tests.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.OutputStream;
@@ -27,21 +27,21 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryFileStore;
 import org.eclipse.core.tests.internal.filesystem.ram.MemoryTree;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the file caching provided by FileStore.toLocalFile.
  */
 public class FileCacheTest {
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		MemoryTree.TREE.deleteAll();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		MemoryTree.TREE.deleteAll();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileStoreTest.java
@@ -22,13 +22,13 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.getFileStore;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isAttributeSupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -157,8 +157,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
-				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
+		assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null, "only executable if at least two volumes are present");
 
 		/* build scenario */
 		// create source root folder
@@ -238,7 +238,7 @@ public class FileStoreTest {
 	public void testCaseInsensitive(int fileSize) throws Throwable {
 	IFileStore temp = createDir(randomUniqueNotExistingFileStore(), true);
 		boolean isCaseSensitive = temp.getFileSystem().isCaseSensitive();
-		assumeFalse("only relevant for platforms with case-sensitive file system", isCaseSensitive);
+		assumeFalse(isCaseSensitive, "only relevant for platforms with case-sensitive file system");
 
 		byte[] content = new byte[fileSize];
 		RANDOM.nextBytes(content);
@@ -317,8 +317,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
-				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
+		assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null, "only executable if at least two volumes are present");
 
 		/* build scenario */
 		/* get the source folder */
@@ -528,8 +528,8 @@ public class FileStoreTest {
 		IFileStore[] tempDirectories = getFileStoresOnTwoVolumes();
 
 		/* test if we are in the adequate environment */
-		assumeFalse("only executable if at least two volumes are present", tempDirectories == null
-				|| tempDirectories.length < 2 || tempDirectories[0] == null || tempDirectories[1] == null);
+		assumeFalse(tempDirectories == null || tempDirectories.length < 2 || tempDirectories[0] == null
+				|| tempDirectories[1] == null, "only executable if at least two volumes are present");
 
 		/* build scenario */
 		/* get the source folder */
@@ -641,7 +641,7 @@ public class FileStoreTest {
 	}
 
 	private void testAttribute(int attribute) throws Exception {
-		assumeTrue("only relevant for platforms supporting attribute: " + attribute, isAttributeSupported(attribute));
+		assumeTrue(isAttributeSupported(attribute), "only relevant for platforms supporting attribute: " + attribute);
 
 		IFileStore targetFolder = createDir(randomUniqueNotExistingFileStore(), true);
 		IFileStore targetFile = targetFolder.getChild("targetFile");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileSystemTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/FileSystemTestUtil.java
@@ -11,7 +11,8 @@
  *******************************************************************************/
 package org.eclipse.core.tests.filesystem;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,7 +30,7 @@ final class FileSystemTestUtil {
 
 	static void ensureDoesNotExist(IFileStore store) throws CoreException {
 		store.delete(EFS.NONE, getMonitor());
-		assertTrue("store was not properly deleted: " + store, !store.fetchInfo().exists());
+		assertFalse(store.fetchInfo().exists(), "store was not properly deleted: " + store);
 	}
 
 	/**
@@ -39,15 +40,15 @@ final class FileSystemTestUtil {
 		if (directory) {
 			store.mkdir(EFS.NONE, getMonitor());
 			final IFileInfo info = store.fetchInfo();
-			assertTrue("file info for store does not exist: " + store, info.exists());
-			assertTrue("created file for store is not a directory: " + store, info.isDirectory());
+			assertTrue(info.exists(), "file info for store does not exist: " + store);
+			assertTrue(info.isDirectory(), "created file for store is not a directory: " + store);
 		} else {
 			try (OutputStream out = store.openOutputStream(EFS.NONE, getMonitor())) {
 				out.write(5);
 			}
 			final IFileInfo info = store.fetchInfo();
-			assertTrue("file info for store does not exist: " + store, info.exists());
-			assertTrue("created file for store is not a directory: " + store, !info.isDirectory());
+			assertTrue(info.exists(), "file info for store does not exist: " + store);
+			assertFalse(info.isDirectory(), "created file for store is not a directory: " + store);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/OpenOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/OpenOutputStreamTest.java
@@ -16,10 +16,10 @@ package org.eclipse.core.tests.filesystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureDoesNotExist;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,17 +30,17 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.filesystem.FileStoreCreationExtension.FileSystemType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class OpenOutputStreamTest {
-	@Rule
-	public final FileStoreCreationRule fileStoreRule = new FileStoreCreationRule(FileSystemType.IN_MEMORY);
+	@RegisterExtension
+	public final FileStoreCreationExtension fileStoreExtension = new FileStoreCreationExtension(FileSystemType.IN_MEMORY);
 
 	@Test
 	public void testAppend() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore file = baseStore.getChild("file");
 		ensureDoesNotExist(file);
 
@@ -65,7 +65,7 @@ public class OpenOutputStreamTest {
 
 	@Test
 	public void testParentExists() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore file = baseStore.getChild("file");
 		ensureDoesNotExist(file);
 
@@ -80,7 +80,7 @@ public class OpenOutputStreamTest {
 
 	private static void assertExists(IFileStore store) throws CoreException {
 		IFileInfo info = store.fetchInfo();
-		assertTrue("store has no file info: " + store, info.exists());
+		assertTrue(info.exists(), "store has no file info: " + store);
 		// check that the parent knows about it
 		IFileInfo[] children = store.getParent().childInfos(EFS.NONE, getMonitor());
 		List<String> childrenNames = Stream.of(children).map(IFileInfo::getName).collect(Collectors.toList());
@@ -89,7 +89,7 @@ public class OpenOutputStreamTest {
 
 	@Test
 	public void testParentNotExists() throws CoreException {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore dir = baseStore.getChild("dir");
 		IFileStore file = dir.getChild("file");
 		ensureDoesNotExist(dir);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/PutInfoTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/PutInfoTest.java
@@ -15,33 +15,33 @@ package org.eclipse.core.tests.filesystem;
 
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureExists;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.filesystem.FileStoreCreationExtension.FileSystemType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Black box tests for {@link IFileStore#putInfo(IFileInfo, int, IProgressMonitor)}
  */
 public class PutInfoTest {
-	@Rule
-	public final FileStoreCreationRule fileStoreRule = new FileStoreCreationRule(FileSystemType.IN_MEMORY);
+	@RegisterExtension
+	public final FileStoreCreationExtension fileStoreExtension = new FileStoreCreationExtension(FileSystemType.IN_MEMORY);
 
-	@Before
+	@BeforeEach
 	public void setupStoreDirectory() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		baseStore.mkdir(EFS.NONE, null);
 	}
 
 	@Test
 	public void testSetFileLastModified() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore file = baseStore.getChild("file");
 		ensureExists(file, false);
 		IFileInfo info = file.fetchInfo();
@@ -57,7 +57,7 @@ public class PutInfoTest {
 
 	@Test
 	public void testSetReadOnly() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore file = baseStore.getChild("file");
 		ensureExists(file, false);
 		IFileInfo info = EFS.createFileInfo();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
@@ -26,12 +26,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureDoesNotExist;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.ensureExists;
 import static org.eclipse.core.tests.filesystem.FileSystemTestUtil.getMonitor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,11 +43,11 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
-import org.eclipse.core.tests.filesystem.FileStoreCreationRule.FileSystemType;
+import org.eclipse.core.tests.filesystem.FileStoreCreationExtension.FileSystemType;
 import org.eclipse.core.tests.harness.FileSystemHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SymlinkTest {
 	/**
@@ -65,13 +65,12 @@ public class SymlinkTest {
 	protected IFileStore lDir, lFile; //symlink to Dir, File
 	protected IFileStore llDir, llFile; //link to link to Dir, File
 
-	@Rule
-	public final FileStoreCreationRule fileStoreRule = new FileStoreCreationRule(FileSystemType.LOCAL);
+	@RegisterExtension
+	public final FileStoreCreationExtension fileStoreExtension = new FileStoreCreationExtension(FileSystemType.LOCAL);
 
-	@Before
+	@BeforeEach
 	public void assumeSymbolicLinksAvailable() throws Exception {
-		assumeTrue("only relevant for platforms supporting symbolic links",
-				FileSystemHelper.canCreateSymLinks());
+		assumeTrue(FileSystemHelper.canCreateSymLinks(), "only relevant for platforms supporting symbolic links");
 	}
 
 	protected void fetchFileInfos() {
@@ -88,7 +87,7 @@ public class SymlinkTest {
 	}
 
 	protected void makeLinkStructure() throws CoreException, IOException {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		aDir = baseStore.getChild("aDir");
 		aFile = baseStore.getChild("aFile");
 		lDir = baseStore.getChild("lDir");
@@ -155,7 +154,7 @@ public class SymlinkTest {
 	// Moving a broken symlink is possible.
 	@Test
 	public void testBrokenSymlinkMove() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		makeLinkStructure();
 		ensureDoesNotExist(aFile);
 		ensureDoesNotExist(aDir);
@@ -191,7 +190,7 @@ public class SymlinkTest {
 	// Removing a broken symlink is possible.
 	@Test
 	public void testBrokenSymlinkRemove() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		makeLinkStructure();
 		ensureDoesNotExist(aFile);
 		ensureDoesNotExist(aDir);
@@ -209,7 +208,7 @@ public class SymlinkTest {
 
 	@Test
 	public void testRecursiveSymlink() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		mkLink(baseStore, "l1", "l2", false);
 		mkLink(baseStore, "l2", "l1", false);
 		IFileStore l1 = baseStore.getChild("l1");
@@ -347,7 +346,7 @@ public class SymlinkTest {
 	 * TODO Fix this test.  See https://bugs.eclipse.org/bugs/show_bug.cgi?id=172346
 	 */
 	public void _testSymlinkExtendedChars() throws Exception {
-		IFileStore baseStore = fileStoreRule.getFileStore();
+		IFileStore baseStore = fileStoreExtension.getFileStore();
 		IFileStore childDir = baseStore.getChild(specialCharName);
 		ensureExists(childDir, true);
 		IFileStore childFile = baseStore.getChild("ff" + specialCharName);
@@ -373,7 +372,7 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutLastModified() throws Exception {
-		assumeFalse("setting EFS.SET_LAST_MODIFIED fails on Mac", OS.isMac());
+		assumeFalse(OS.isMac(), "setting EFS.SET_LAST_MODIFIED fails on Mac");
 
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
@@ -436,8 +435,8 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutExecutable() throws Exception {
-		assumeTrue("only relevant for platforms supporting hidden attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_EXECUTABLE),
+				"only relevant for platforms supporting hidden attribute");
 
 		//check that putInfo() "writes through" the symlink
 		makeLinkStructure();
@@ -462,8 +461,8 @@ public class SymlinkTest {
 
 	@Test
 	public void testSymlinkPutHidden() throws Exception {
-		assumeTrue("only relevant for platforms supporting hidden attribute",
-				isAttributeSupported(EFS.ATTRIBUTE_HIDDEN));
+		assumeTrue(isAttributeSupported(EFS.ATTRIBUTE_HIDDEN),
+				"only relevant for platforms supporting hidden attribute");
 
 		// Check that putInfo() applies the attribute to the symlink itself.
 		makeLinkStructure();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/URIUtilTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/URIUtilTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.tests.filesystem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import org.eclipse.core.filesystem.EFS;
@@ -23,7 +23,7 @@ import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.tests.internal.filesystem.wrapper.WrapperFileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests API methods of the class {@link org.eclipse.core.filesystem.URIUtil}.


### PR DESCRIPTION
- Replace `FileStoreCreationRule` with `FileStoreCreationExtension`
- Use JUnit 5 test annotations
- Migrate to JUnit 5 assertions

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903