### PR TITLE
Eliminate includes of 3rd party bundles in features.

### DIFF
--- a/runtime/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/runtime/features/org.eclipse.core.runtime.feature/feature.xml
@@ -47,8 +47,4 @@
          id="org.eclipse.core.jobs"
          version="0.0.0"/>
 
-   <plugin
-         id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
 </feature>


### PR DESCRIPTION
- We don't need org.osgi.service.prefs because it's required by org.eclipse.equinox.preferences.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3585