### PR TITLE
Suppress warnings in resource tests explicitly testing deprecated API

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
@@ -147,7 +148,7 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		/* create file with flag false */
 		file.create(createInputStream(originalContent), false, null);
 		assertTrue(file.exists());
-		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(file, IResource.DEPTH_ZERO));
 		assertEquals(file.getStore().fetchInfo().getLastModified(), file.getResourceInfo(false, false).getLocalSyncInfo());
 		try (InputStream readFile = getLocalManager().read(file, true, null)) {
 			assertThat(readFile).hasContent(originalContent);
@@ -187,6 +188,8 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		assertNull(testFile);
 	}
 
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testIsLocal() throws CoreException {
 		// create resources

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.junit.Assert.assertEquals;
@@ -231,7 +232,7 @@ public class RefreshLocalTest implements ICoreConstants {
 		};
 		workspace.run(operation, null);
 		assertTrue(file.exists());
-		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(file, IResource.DEPTH_ZERO));
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		assertFalse(file.exists());
 		removeFromWorkspace(file);
@@ -252,15 +253,15 @@ public class RefreshLocalTest implements ICoreConstants {
 		file = folder.getFile("file");
 		createInFileSystem(file);
 		assertTrue(folder.exists());
-		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(folder, IResource.DEPTH_ZERO));
 		assertFalse(file.exists());
 		folder.refreshLocal(IResource.DEPTH_ZERO, null);
 		assertTrue(folder.exists());
-		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(folder, IResource.DEPTH_ZERO));
 		assertFalse(file.exists());
 		folder.refreshLocal(IResource.DEPTH_ONE, null);
 		assertTrue(folder.exists());
-		assertTrue(folder.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(folder, IResource.DEPTH_ZERO));
 		assertTrue(file.exists());
 		removeFromWorkspace(folder);
 		removeFromFileSystem(folder);
@@ -270,7 +271,7 @@ public class RefreshLocalTest implements ICoreConstants {
 		IFileStore fileStore = ((Resource) file).getStore();
 		createInWorkspace(file);
 		assertTrue(file.exists());
-		assertTrue(file.isLocal(IResource.DEPTH_ZERO));
+		assertTrue(isLocal(file, IResource.DEPTH_ZERO));
 		assertEquals(fileStore.fetchInfo().getLastModified(),
 				((Resource) file).getResourceInfo(false, false).getLocalSyncInfo());
 		ensureOutOfSync(file);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -157,7 +157,7 @@ public class ProjectReferencesTest {
 	public void testMixedProjectAndBuildConfigRefs() throws CoreException {
 		// Set project variant references
 		IProjectDescription desc = project0.getDescription();
-		desc.setDynamicReferences(new IProject[] {project1, project3});
+		setDynamicReferences(desc, new IProject[] { project1, project3 });
 		project0.setDescription(desc, createTestMonitor());
 
 		// Check getters
@@ -192,22 +192,22 @@ public class ProjectReferencesTest {
 		// Set project references
 		IProjectDescription desc = project0.getDescription();
 		desc.setReferencedProjects(new IProject[] {project3, project1});
-		desc.setDynamicReferences(new IProject[] {project1, project2});
+		setDynamicReferences(desc, new IProject[] { project1, project2 });
 		project0.setDescription(desc, createTestMonitor());
 
 		desc = project1.getDescription();
 		desc.setReferencedProjects(new IProject[] {project0});
-		desc.setDynamicReferences(new IProject[] {});
+		setDynamicReferences(desc, new IProject[] {});
 		project1.setDescription(desc, createTestMonitor());
 
 		desc = project2.getDescription();
 		desc.setReferencedProjects(new IProject[] {});
-		desc.setDynamicReferences(new IProject[] {});
+		setDynamicReferences(desc, new IProject[] {});
 		project2.setDescription(desc, createTestMonitor());
 
 		desc = project3.getDescription();
 		desc.setReferencedProjects(new IProject[] {});
-		desc.setDynamicReferences(new IProject[] {project0});
+		setDynamicReferences(desc, new IProject[] { project0 });
 		project3.setDescription(desc, createTestMonitor());
 
 		// Test getters
@@ -222,6 +222,12 @@ public class ProjectReferencesTest {
 				project1v0, project2v0);
 	}
 
+	// Suppress warning as we explicitly test deprecated API
+	@SuppressWarnings("deprecation")
+	private void setDynamicReferences(IProjectDescription description, IProject[] projects) {
+		description.setDynamicReferences(projects);
+	}
+
 	@Test
 	public void testSetAndGetProjectConfigReferences() throws CoreException {
 		// Set project variant references
@@ -229,7 +235,7 @@ public class ProjectReferencesTest {
 		// 1 static reference
 		desc.setReferencedProjects(new IProject[] {project1});
 		// 1 dynamic project-level reference
-		desc.setDynamicReferences(new IProject[] {project3});
+		setDynamicReferences(desc, new IProject[] { project3 });
 		// config level references
 		desc.setBuildConfigReferences(bc0, new IBuildConfiguration[] {project2v0, project1v0});
 		desc.setBuildConfigReferences(bc1, new IBuildConfiguration[] {project2v0});

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -1298,6 +1298,8 @@ public class FilteredResourceTest {
 	/**
 	 * Regression test for bug 343914
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void test343914() throws CoreException {
 		String subProjectName = "subProject";

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -157,6 +157,8 @@ public class IProjectDescriptionTest {
 		assertTrue(modificationStamp != projectDescription.getModificationStamp());
 	}
 
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testDynamicProjectReferences() throws CoreException {
 		IProject target1 = getWorkspace().getRoot().getProject("target1");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -1990,6 +1990,8 @@ public class IProjectTest  {
 	/**
 	 * Tests API on IProjectDescription
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testProjectDescriptionDynamic() {
 		IProjectDescription desc = getWorkspace().newProjectDescription("foo");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -1430,6 +1430,8 @@ public class IResourceChangeListenerTest {
 		assertDelta();
 	}
 
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testProjectDescriptionDynamicRefs() throws CoreException {
 		/* change file1's contents */
@@ -1523,6 +1525,8 @@ public class IResourceChangeListenerTest {
 		assertDelta();
 	}
 
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSetLocal() throws CoreException {
 		verifier.reset();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -1338,6 +1338,8 @@ public class IResourceTest {
 	 * Performs black box testing of the following methods: isDerived() and
 	 * setDerived(boolean)
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testDeprecatedDerived() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -58,6 +58,8 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testFindFilesNonCanonicalPath() throws Exception {
 		assumeTrue("only relevant on Windows", OS.isWindows());
@@ -111,6 +113,8 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests the API method findContainersForLocation.
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	private void testFindContainersForLocation(IProject p1, IProject p2) throws Exception {
 		//should find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -185,6 +189,8 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests the API method findFilesForLocation.
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	private void testFindFilesForLocation(IProject project) throws CoreException {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.readStringInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
@@ -710,7 +711,7 @@ public class LinkedResourceTest {
 		project.open(IResource.BACKGROUND_REFRESH, createTestMonitor());
 		assertTrue(folder.exists());
 		assertTrue(parent.exists());
-		assertTrue(parent.isLocal(IResource.DEPTH_INFINITE));
+		assertTrue(isLocal(parent, IResource.DEPTH_INFINITE));
 	}
 
 	/**

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -767,5 +767,10 @@ public final class ResourceTestUtil {
 		IPath canonicalIPath = wrapInCanonicalIPath(path);
 		return EFS.getLocalFileSystem().getStore(canonicalIPath);
 	}
+	
+	@SuppressWarnings("deprecation")
+	public static boolean isLocal(IResource resource, int depth) {
+		return resource.isLocal(depth);
+	}
 
 }

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Tests how changes in the underlying preference store may affect the path
  * variable manager.
  */
+// Explicitly tests deprecated API
+@SuppressWarnings("deprecation")
 @ExtendWith(WorkspaceResetExtension.class)
 public class Bug_027271 {
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -75,6 +75,8 @@ public class IFolderTest {
 	/**
 	 * Bug 11510 [resources] Non-local folders do not become local when directory is created.
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBug11510() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -70,6 +70,8 @@ public class IProjectTest {
 		project.delete(true, createTestMonitor());
 	}
 
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void test_1G5I6PV() throws CoreException {
 		/* common objects */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -205,6 +205,8 @@ public class IResourceTest {
 	/**
 	 * Calling isSynchronized on a non-local resource caused an internal error.
 	 */
+	// Explicitly tests deprecated API
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBug83777() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("testBug83777");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFileTest.java
@@ -17,13 +17,13 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FILE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FOLDER;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
-import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IFolderTest.java
@@ -16,12 +16,12 @@ package org.eclipse.core.tests.resources.usecase;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.FOLDER;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
-import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.resources.IContainer;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IProjectTest.java
@@ -17,11 +17,11 @@ package org.eclipse.core.tests.resources.usecase;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.PROJECT;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.Q_NAME_SESSION;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.STRING_VALUE;
 import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.commonFailureTestsForResource;
-import static org.eclipse.core.tests.resources.usecase.IResourceTestUtil.isLocal;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Hashtable;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/usecase/IResourceTestUtil.java
@@ -47,12 +47,4 @@ final class IResourceTestUtil {
 		assertThrows(CoreException.class, () -> resource.getSessionProperty(Q_NAME_SESSION));
 		assertThrows(CoreException.class, () -> resource.setSessionProperty(Q_NAME_SESSION, STRING_VALUE));
 	}
-
-	/**
-	 * Wrapper for deprecated method {@link IResource#isLocal(int)} to reduce
-	 * warnings.
-	 */
-	public static boolean isLocal(IResource resource, int depth) {
-		return resource.isLocal(depth);
-	}
 }


### PR DESCRIPTION
Several resource tests explicitly test API that is deprecated. Since those tests are expected to access deprecated methods, there should be no warnings that mess up the workspace. This change suppresses the according warnings for several methods that by intent call deprecated methods.