### PR TITLE
Make MarkerTest properly handle asynchronous change listener #106

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -345,6 +345,7 @@ public class MarkerTest {
 			IMarker marker = resource.createMarker(TEST_PROBLEM_MARKER);
 			marker.setAttribute(IMarker.MESSAGE, createRandomString());
 			marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			TestUtil.waitForCondition(() -> listener.numberOfChanges() == 3, 5000);
 			assertThat(listener.numberOfChanges()).isEqualTo(3);
 		}
 	}
@@ -362,6 +363,7 @@ public class MarkerTest {
 			// each setAttributes triggers one resource change event
 			resource.createMarker(TEST_PROBLEM_MARKER,
 					Map.of(IMarker.MESSAGE, createRandomString(), IMarker.PRIORITY, IMarker.PRIORITY_HIGH));
+			TestUtil.waitForCondition(() -> listener.numberOfChanges() == 1, 5000);
 			assertThat(listener.numberOfChanges()).isEqualTo(1);
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkersNumberOfDeltasChangeListener.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkersNumberOfDeltasChangeListener.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.resources;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 
@@ -21,25 +22,25 @@ import org.eclipse.core.resources.IResourceChangeListener;
  */
 public class MarkersNumberOfDeltasChangeListener implements IResourceChangeListener {
 
-	private int number = 0;
+	private AtomicInteger number = new AtomicInteger();
 
 	/**
 	 * Returns the number of resource changed calls.
 	 */
 	public int numberOfChanges() {
-		return number;
+		return number.get();
 	}
 
 
 	public void reset() {
-		number = 0;
+		number.set(0);
 	}
 	/**
 	 * Notification from the workspace.  Extract the marker changes.
 	 */
 	@Override
 	public void resourceChanged(IResourceChangeEvent event) {
-		number++;
+		number.incrementAndGet();
 	}
 
 }


### PR DESCRIPTION
The MarkerTest implementations currently assume that resource change listeners are notifies synchronously about changes due to modified markers. This assumption is not correct and leads to several race conditions in the tests which can make them fail sporadically.

This change adapts the MarkerTests to properly handle asynchronous execution of resource change listeners:
- Wait until a timeout for the number of expected resource changes being processed by the used resource change listener
- Make the data structures inside the resource listeners thread safe

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/106