### PR TITLE
Migrate internal resource tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug544975Test.java
@@ -15,8 +15,8 @@ package org.eclipse.core.tests.internal.resources;
 
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,14 +31,12 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class Bug544975Test {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testBug544975ProjectOpenBackgroundRefresh() throws Exception {
@@ -58,7 +56,7 @@ public class Bug544975Test {
 			project.close(new NullProgressMonitor());
 
 			Path projectPath = Paths.get(project.getLocationURI());
-			assertTrue("Test project must exist on file system", Files.exists(projectPath));
+			assertTrue(Files.exists(projectPath), "Test project must exist on file system");
 
 			Path filePath = projectPath.resolve("someFile.txt");
 			Files.delete(filePath);
@@ -70,11 +68,11 @@ public class Bug544975Test {
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, new NullProgressMonitor());
 
 			file1 = project.getFile("someFile.txt");
-			assertFalse("Expected deleted project resource not exist after opening with BACKGROUND_REFRESH",
-					file1.exists());
+			assertFalse(file1.exists(),
+					"Expected deleted project resource not exist after opening with BACKGROUND_REFRESH");
 			file2 = project.getFile("someOtherFile.txt");
-			assertTrue("Expected new project resource to be found after opening with BACKGROUND_REFRESH",
-					file2.exists());
+			assertTrue(file2.exists(),
+					"Expected new project resource to be found after opening with BACKGROUND_REFRESH");
 		} finally {
 			prefs.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
 		}
@@ -93,7 +91,7 @@ public class Bug544975Test {
 		project.close(new NullProgressMonitor());
 
 		Path projectPath = Paths.get(project.getLocationURI());
-		assertTrue("Test project must exist on file system", Files.exists(projectPath));
+		assertTrue(Files.exists(projectPath), "Test project must exist on file system");
 
 		Path filePath = projectPath.resolve("someFile.txt");
 		Files.delete(filePath);
@@ -105,11 +103,11 @@ public class Bug544975Test {
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, new NullProgressMonitor());
 
 		file1 = project.getFile("someFile.txt");
-		assertTrue("Expected deleted project resource still exist after opening without BACKGROUND_REFRESH",
-				file1.exists());
+		assertTrue(file1.exists(),
+				"Expected deleted project resource still exist after opening without BACKGROUND_REFRESH");
 		file2 = project.getFile("someOtherFile.txt");
-		assertFalse("Expected new project resource not to be found after opening without BACKGROUND_REFRESH",
-				file2.exists());
+		assertFalse(file2.exists(),
+				"Expected new project resource not to be found after opening without BACKGROUND_REFRESH");
 	}
 
 	private IFile createFile(IProject project, String fileName, String initialContents) throws CoreException {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug552185PerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/Bug552185PerformanceTest.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.junit.jupiter.api.Test;
 
 /**
  * A benchmark for bug 552185.
@@ -35,6 +36,7 @@ import org.eclipse.core.runtime.SubMonitor;
  */
 public class Bug552185PerformanceTest {
 
+	@Test
 	public void testBug552185Performance() throws Exception {
 		// run inside a WorkspaceJob, in case there are listeners on workspace changes
 		WorkspaceJob testJob = new WorkspaceJob(Bug552185PerformanceTest.class.getName()) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectBuildConfigsTest.java
@@ -23,18 +23,16 @@ import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests configuration project build configuration on the project description
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectBuildConfigsTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 	private static final String variantId0 = "Variant0";
@@ -45,7 +43,7 @@ public class ProjectBuildConfigsTest {
 	private IBuildConfiguration variant2;
 	private IBuildConfiguration defaultVariant;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project = getWorkspace().getRoot().getProject("ProjectBuildConfigsTest_Project");
 		createInWorkspace(new IProject[] {project});

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectDynamicReferencesTest.java
@@ -33,21 +33,19 @@ import org.eclipse.core.resources.IWorkspace.ProjectOrder;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test project dynamic references provided by extension point
  * <code>org.eclipse.core.resources.builders</code> and dynamicReference
  * {@link IDynamicReferenceProvider}
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectDynamicReferencesTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String PROJECT_0_NAME = "ProjectDynamicReferencesTest_p0";
 
@@ -55,7 +53,7 @@ public class ProjectDynamicReferencesTest {
 	private IProject project1;
 	private IProject project2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project0 = getWorkspace().getRoot().getProject(PROJECT_0_NAME);
 		project1 = getWorkspace().getRoot().getProject("ProjectDynamicReferencesTest_p1");
@@ -66,7 +64,7 @@ public class ProjectDynamicReferencesTest {
 		updateProjectDescription(project2).addingCommand(Builder.NAME).apply();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		DynamicReferenceProvider.clear();
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectPreferencesTest.java
@@ -23,13 +23,13 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.getLineSeparator
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.touchInFilesystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -70,19 +70,17 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChange
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 /**
  * @since 3.0
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectPreferencesTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private static final String DIR_NAME = ".settings";
 	private static final String FILE_EXTENSION = "prefs";
@@ -163,13 +161,13 @@ public class ProjectPreferencesTest {
 		// get the value through service searching
 		for (int i = 0; i < contextsWithoutScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithoutScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, instanceValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(instanceValue, actual, "Not Equal Index:" + i);
 		}
 		for (int i = 0; i < contextsWithScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, instanceValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(instanceValue, actual, "Not Equal Index:" + i);
 		}
 
 		// set a preference value in the project scope
@@ -182,13 +180,13 @@ public class ProjectPreferencesTest {
 		// get the value through service searching
 		for (int i = 0; i < contextsWithoutScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithoutScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, instanceValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(instanceValue, actual, "Not Equal Index:" + i);
 		}
 		for (int i = 0; i < contextsWithScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, projectValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(projectValue, actual, "Not Equal Index:" + i);
 		}
 
 		// remove the project scope value
@@ -200,13 +198,13 @@ public class ProjectPreferencesTest {
 		// get the value through service searching
 		for (int i = 0; i < contextsWithoutScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithoutScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, instanceValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(instanceValue, actual, "Not Equal Index:" + i);
 		}
 		for (int i = 0; i < contextsWithScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithScope[i]);
-			assertNotNull("Null Index:" + i, actual);
-			assertEquals("Not Equal Index:" + i, instanceValue, actual);
+			assertNotNull(actual, "Null Index:" + i);
+			assertEquals(instanceValue, actual, "Not Equal Index:" + i);
 		}
 
 		// remove the instance value so there is nothing
@@ -215,11 +213,11 @@ public class ProjectPreferencesTest {
 		actual = node.get(key, null);
 		for (int i = 0; i < contextsWithoutScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithoutScope[i]);
-			assertNull("Not Null Index:" + i, actual);
+			assertNull(actual, "Not Null Index:" + i);
 		}
 		for (int i = 0; i < contextsWithScope.length; i++) {
 			actual = service.getString(qualifier, key, null, contextsWithScope[i]);
-			assertNull("Not Null Index:" + i, actual);
+			assertNull(actual, "Not Null Index:" + i);
 		}
 	}
 
@@ -617,7 +615,7 @@ public class ProjectPreferencesTest {
 		node.node("child").node("node").put("key", "childValue2");
 		node.flush();
 		IFile prefFile = getFileInWorkspace(project, ResourcesPlugin.PI_RESOURCES);
-		assertTrue("Preferences missing", prefFile.exists());
+		assertTrue(prefFile.exists(), "Preferences missing");
 		Properties properties = new Properties();
 		try (InputStream contents = prefFile.getContents()) {
 			properties.load(contents);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ProjectReferencesTest.java
@@ -17,25 +17,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.internal.resources.BuildConfiguration;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test project variant references
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class ProjectReferencesTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project0;
 	private IProject project1;
@@ -52,7 +50,7 @@ public class ProjectReferencesTest {
 	private static final String bc1 = "Variant1";
 	private static final String nonExistentBC = "foo";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project0 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p0");
 		project1 = getWorkspace().getRoot().getProject("ProjectReferencesTest_p1");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/ResourceInfoTest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.resources;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,22 +23,18 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import org.eclipse.core.internal.resources.ResourceInfo;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class ResourceInfoTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	static public void assertEquals(ResourceInfo expected, ResourceInfo actual) {
 		if (expected == null && actual == null) {
 			return;
 		}
-		if (expected == null || actual == null) {
-			assertTrue(false);
-		}
+		assertFalse(expected == null || actual == null);
 		boolean different = false;
 		different &= expected.getFlags() == actual.getFlags();
 		different &= expected.getContentId() == actual.getContentId();
@@ -48,9 +44,7 @@ public class ResourceInfoTest {
 		// TODO sync info isn't serialized by this class so don't expect it to be loaded
 		//	assertEquals(message, expected.getSyncInfo(false), actual.getSyncInfo(false));
 		different &= expected.getMarkerGenerationCount() == actual.getMarkerGenerationCount();
-		if (different) {
-			assertTrue(false);
-		}
+		assertFalse(different);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/resources/WorkspaceConcurrencyTest.java
@@ -16,8 +16,8 @@ package org.eclipse.core.tests.internal.resources;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -40,17 +40,15 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.tests.harness.CancelingProgressMonitor;
 import org.eclipse.core.tests.harness.TestBarrier2;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests concurrency issues when dealing with operations on the workspace
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class WorkspaceConcurrencyTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private void sleep(long duration) {
 		try {
@@ -119,7 +117,7 @@ public class WorkspaceConcurrencyTest {
 			t2.start();
 			t2.join();
 			//should have canceled
-			assertTrue("thread was not canceled", canceled.get());
+			assertTrue(canceled.get(), "thread was not canceled");
 
 			//finally release the listener and ensure the first thread completes
 			barrier.set(0, TestBarrier2.STATUS_DONE);
@@ -291,7 +289,7 @@ public class WorkspaceConcurrencyTest {
 		while (job.getState() != Job.NONE) {
 			sleep(100);
 			//sanity test to avoid hanging tests
-			assertTrue("Timeout waiting for job to complete", i++ < 1000);
+			assertTrue(i++ < 1000, "Timeout waiting for job to complete");
 		}
 	}
 }


### PR DESCRIPTION
- Switch to JUnit 5 test annotations and assertions
- Use test extensions replacing JUnit 4 test rules

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903