### PR TITLE
Migrate localstore resource tests to JUnit 5 #903

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BlobStoreTest.java
@@ -16,9 +16,9 @@ package org.eclipse.core.tests.internal.localstore;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,14 +30,17 @@ import org.eclipse.core.internal.localstore.BlobStore;
 import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class BlobStoreTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	@Test
 	public void testConstructor() throws CoreException {
@@ -63,11 +66,11 @@ public class BlobStoreTest {
 	}
 
 	private IFileStore createStore() throws CoreException {
-		IFileStore root = workspaceRule.getTempStore();
+		IFileStore root = fileStoreExtension.getTempStore();
 		root.mkdir(EFS.NONE, null);
 		IFileInfo info = root.fetchInfo();
-		assertTrue("createStore.1", info.exists());
-		assertTrue("createStore.2", info.isDirectory());
+		assertTrue(info.exists());
+		assertTrue(info.isDirectory());
 		return root;
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/BucketTreeTests.java
@@ -18,8 +18,8 @@ package org.eclipse.core.tests.internal.localstore;
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -39,14 +39,17 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class BucketTreeTests {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	static class SimpleBucket extends Bucket {
 
@@ -147,7 +150,7 @@ public class BucketTreeTests {
 	@Test
 	public void testVisitor() throws CoreException {
 		IPath baseLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(baseLocation);
+		fileStoreExtension.deleteOnTearDown(baseLocation);
 
 		// keep the reference around - it is the same returned by tree.getCurrent()
 		SimpleBucket bucket = new SimpleBucket();
@@ -166,44 +169,44 @@ public class BucketTreeTests {
 			bucket.set(path, "segments", Integer.toString(path.segmentCount()));
 		}
 		bucket.save();
-		verify(tree, "1.1", IPath.ROOT, BucketTree.DEPTH_ZERO, Set.of(IPath.ROOT));
-		verify(tree, "1.2", IPath.ROOT, BucketTree.DEPTH_ONE,
+		verify(tree, IPath.ROOT, BucketTree.DEPTH_ZERO, Set.of(IPath.ROOT));
+		verify(tree, IPath.ROOT, BucketTree.DEPTH_ONE,
 				Set.of(IPath.ROOT, proj1.getFullPath(), proj2.getFullPath()));
-		verify(tree, "1.3", IPath.ROOT, BucketTree.DEPTH_INFINITE, Set.of(IPath.ROOT, proj1.getFullPath(),
+		verify(tree, IPath.ROOT, BucketTree.DEPTH_INFINITE, Set.of(IPath.ROOT, proj1.getFullPath(),
 				file1.getFullPath(), folder1.getFullPath(), file2.getFullPath(), proj2.getFullPath()));
-		verify(tree, "2.1", proj1.getFullPath(), BucketTree.DEPTH_ZERO,
+		verify(tree, proj1.getFullPath(), BucketTree.DEPTH_ZERO,
 				Arrays.asList(new IPath[] { proj1.getFullPath() }));
-		verify(tree, "2.2", proj1.getFullPath(), BucketTree.DEPTH_ONE,
+		verify(tree, proj1.getFullPath(), BucketTree.DEPTH_ONE,
 				Arrays.asList(new IPath[] { proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath() }));
-		verify(tree, "2.3", proj1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(
+		verify(tree, proj1.getFullPath(), BucketTree.DEPTH_INFINITE, Arrays.asList(
 				new IPath[] { proj1.getFullPath(), file1.getFullPath(), folder1.getFullPath(), file2.getFullPath() }));
-		verify(tree, "3.1", file1.getFullPath(), BucketTree.DEPTH_ZERO,
+		verify(tree, file1.getFullPath(), BucketTree.DEPTH_ZERO,
 				Arrays.asList(new IPath[] { file1.getFullPath() }));
-		verify(tree, "3.2", file1.getFullPath(), BucketTree.DEPTH_ONE,
+		verify(tree, file1.getFullPath(), BucketTree.DEPTH_ONE,
 				Arrays.asList(new IPath[] { file1.getFullPath() }));
-		verify(tree, "3.3", file1.getFullPath(), BucketTree.DEPTH_INFINITE,
+		verify(tree, file1.getFullPath(), BucketTree.DEPTH_INFINITE,
 				Arrays.asList(new IPath[] { file1.getFullPath() }));
-		verify(tree, "4.1", folder1.getFullPath(), BucketTree.DEPTH_ZERO,
+		verify(tree, folder1.getFullPath(), BucketTree.DEPTH_ZERO,
 				Arrays.asList(new IPath[] { folder1.getFullPath() }));
-		verify(tree, "4.2", folder1.getFullPath(), BucketTree.DEPTH_ONE,
+		verify(tree, folder1.getFullPath(), BucketTree.DEPTH_ONE,
 				Arrays.asList(new IPath[] { folder1.getFullPath(), file2.getFullPath() }));
-		verify(tree, "4.3", folder1.getFullPath(), BucketTree.DEPTH_INFINITE,
+		verify(tree, folder1.getFullPath(), BucketTree.DEPTH_INFINITE,
 				Arrays.asList(new IPath[] { folder1.getFullPath(), file2.getFullPath() }));
-		verify(tree, "5.1", file2.getFullPath(), BucketTree.DEPTH_ZERO,
+		verify(tree, file2.getFullPath(), BucketTree.DEPTH_ZERO,
 				Arrays.asList(new IPath[] { file2.getFullPath() }));
-		verify(tree, "5.2", file2.getFullPath(), BucketTree.DEPTH_ONE,
+		verify(tree, file2.getFullPath(), BucketTree.DEPTH_ONE,
 				Arrays.asList(new IPath[] { file2.getFullPath() }));
-		verify(tree, "5.3", file2.getFullPath(), BucketTree.DEPTH_INFINITE,
+		verify(tree, file2.getFullPath(), BucketTree.DEPTH_INFINITE,
 				Arrays.asList(new IPath[] { file2.getFullPath() }));
-		verify(tree, "6.1", proj2.getFullPath(), BucketTree.DEPTH_ZERO,
+		verify(tree, proj2.getFullPath(), BucketTree.DEPTH_ZERO,
 				Arrays.asList(new IPath[] { proj2.getFullPath() }));
-		verify(tree, "6.2", proj2.getFullPath(), BucketTree.DEPTH_ONE,
+		verify(tree, proj2.getFullPath(), BucketTree.DEPTH_ONE,
 				Arrays.asList(new IPath[] { proj2.getFullPath() }));
-		verify(tree, "6.3", proj2.getFullPath(), BucketTree.DEPTH_INFINITE,
+		verify(tree, proj2.getFullPath(), BucketTree.DEPTH_INFINITE,
 				Arrays.asList(new IPath[] { proj2.getFullPath() }));
 	}
 
-	public void verify(BucketTree tree, final String tag, IPath root, int depth, final Collection<IPath> expected)
+	public void verify(BucketTree tree, IPath root, int depth, final Collection<IPath> expected)
 			throws CoreException {
 		final Set<IPath> visited = new HashSet<>();
 		SimpleBucket.Visitor verifier = new SimpleBucket.Visitor() {
@@ -211,17 +214,17 @@ public class BucketTreeTests {
 			public int visit(org.eclipse.core.internal.localstore.Bucket.Entry entry) {
 				SimpleBucket.SimpleEntry simple = (SimpleBucket.SimpleEntry) entry;
 				IPath path = simple.getPath();
-				assertTrue(tag + ".0 " + path, expected.contains(path));
+				assertTrue(expected.contains(path), path.toString());
 				visited.add(path);
-				assertEquals(tag + ".1 " + path, path.toString(), simple.getProperty("path"));
-				assertEquals(tag + ".2 " + path, Integer.toString(path.segmentCount()), simple.getProperty("segments"));
+				assertEquals(path.toString(), simple.getProperty("path"), path.toString());
+				assertEquals(Integer.toString(path.segmentCount()), simple.getProperty("segments"), path.toString());
 				return CONTINUE;
 			}
 		};
 		tree.accept(verifier, root, depth);
-		assertEquals(tag + ".4", expected.size(), visited.size());
+		assertEquals(expected.size(), visited.size());
 		for (IPath path : expected) {
-			assertTrue(tag + ".5 " + path, visited.contains(path));
+			assertTrue(visited.contains(path), path.toString());
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CaseSensitivityTest.java
@@ -18,9 +18,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.eclipse.core.internal.resources.Workspace;
@@ -30,15 +30,13 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class CaseSensitivityTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private final boolean isCaseSensitive = Workspace.caseSensitive;
 
@@ -53,12 +51,12 @@ public class CaseSensitivityTest {
 
 		// create a second project; should fail because has same name with different casing
 		IProject project2 = getWorkspace().getRoot().getProject(projectName.toUpperCase());
-		ThrowingRunnable projectCreation = () -> {
+		Executable projectCreation = () -> {
 			project2.create(null);
 			project2.open(null);
 		};
 		if (isCaseSensitive) {
-			projectCreation.run();
+			projectCreation.execute();
 		} else {
 			assertThrows(CoreException.class, projectCreation);
 		}
@@ -76,9 +74,9 @@ public class CaseSensitivityTest {
 
 		// create a second folder; should fail because has same name with different casing
 		IFolder folder2 = project.getFolder(folderName.toUpperCase());
-		ThrowingRunnable folderCreation = () -> folder2.create(true, true, null);
+		Executable folderCreation = () -> folder2.create(true, true, null);
 		if (isCaseSensitive) {
-			folderCreation.run();
+			folderCreation.execute();
 		} else {
 			assertThrows(CoreException.class, folderCreation);
 		}
@@ -100,9 +98,9 @@ public class CaseSensitivityTest {
 
 		// create a second file; should fail because has same name with different casing
 		IFile file2 = project.getFile(fileName.toUpperCase());
-		ThrowingRunnable fileCreation = () -> file2.create(createRandomContentsStream(), true, null);
+		Executable fileCreation = () -> file2.create(createRandomContentsStream(), true, null);
 		if (isCaseSensitive) {
-			fileCreation.run();
+			fileCreation.execute();
 		} else {
 			assertThrows(CoreException.class, fileCreation);
 		}
@@ -127,10 +125,10 @@ public class CaseSensitivityTest {
 		project2.open(null);
 
 		// try to rename project 1 to the uppercase name of project 2, should fail
-		ThrowingRunnable projectMovement = () -> project1.move(IPath.ROOT.append(project2.getName().toUpperCase()),
+		Executable projectMovement = () -> project1.move(IPath.ROOT.append(project2.getName().toUpperCase()),
 				true, null);
 		if (isCaseSensitive) {
-			projectMovement.run();
+			projectMovement.execute();
 		} else {
 			assertThrows(CoreException.class, projectMovement);
 		}
@@ -153,9 +151,9 @@ public class CaseSensitivityTest {
 
 		// try to rename folder 1 to the uppercase name of folder 2, should fail
 		IFolder folder3 = project.getFolder(folder2name.toUpperCase());
-		ThrowingRunnable folderMovement = () -> folder1.move(folder3.getFullPath(), true, null);
+		Executable folderMovement = () -> folder1.move(folder3.getFullPath(), true, null);
 		if (isCaseSensitive) {
-			folderMovement.run();
+			folderMovement.execute();
 		} else {
 			assertThrows(CoreException.class, folderMovement);
 		}
@@ -178,9 +176,9 @@ public class CaseSensitivityTest {
 
 		// try to rename folder 1 to the uppercase name of folder 2, should fail
 		IFile file3 = project.getFile(file2name.toUpperCase());
-		ThrowingRunnable fileMovement = () -> file1.move(file3.getFullPath(), true, null);
+		Executable fileMovement = () -> file1.move(file3.getFullPath(), true, null);
 		if (isCaseSensitive) {
-			fileMovement.run();
+			fileMovement.execute();
 		} else {
 			assertThrows(CoreException.class, fileMovement);
 		}
@@ -203,10 +201,10 @@ public class CaseSensitivityTest {
 
 		// try to copy the folder from source project to destination project.
 		// should fail due to conflict
-		ThrowingRunnable folderCopy = () -> folder1.copy(destinationProject.getFullPath().append(folder1.getName()),
+		Executable folderCopy = () -> folder1.copy(destinationProject.getFullPath().append(folder1.getName()),
 				true, null);
 		if (isCaseSensitive) {
-			folderCopy.run();
+			folderCopy.execute();
 		} else {
 			assertThrows(CoreException.class, folderCopy);
 		}
@@ -234,10 +232,10 @@ public class CaseSensitivityTest {
 
 		// try to copy the file from source project to destination project.
 		// should fail due to conflict
-		ThrowingRunnable fileCopy = () -> file1.copy(destinationProject.getFullPath().append(file1.getName()), true,
+		Executable fileCopy = () -> file1.copy(destinationProject.getFullPath().append(file1.getName()), true,
 				null);
 		if (isCaseSensitive) {
-			fileCopy.run();
+			fileCopy.execute();
 		} else {
 			assertThrows(CoreException.class, fileCopy);
 		}
@@ -265,10 +263,10 @@ public class CaseSensitivityTest {
 
 		// try to copy the folder from source project to destination project.
 		// should fail due to conflict with existing file with case-different name
-		ThrowingRunnable folderCopy = () -> folder.copy(destinationProject.getFullPath().append(folder.getName()), true,
+		Executable folderCopy = () -> folder.copy(destinationProject.getFullPath().append(folder.getName()), true,
 				null);
 		if (isCaseSensitive) {
-			folderCopy.run();
+			folderCopy.execute();
 		} else {
 			assertThrows(CoreException.class, folderCopy);
 		}
@@ -296,10 +294,10 @@ public class CaseSensitivityTest {
 
 		// try to copy the file from source project to destination project.
 		// should fail due to conflict with existing folder with case-different name
-		ThrowingRunnable fileCopy = () -> file.copy(destinationProject.getFullPath().append(file.getName()), true,
+		Executable fileCopy = () -> file.copy(destinationProject.getFullPath().append(file.getName()), true,
 				null);
 		if (isCaseSensitive) {
-			fileCopy.run();
+			fileCopy.execute();
 		} else {
 			assertThrows(CoreException.class, fileCopy);
 		}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/CopyTest.java
@@ -19,9 +19,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSyst
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -30,19 +30,17 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test the copy operation.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class CopyTest {
 
 	private static final int NUMBER_OF_PROPERTIES = 5;
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	@Test
 	public void testCopyResource() throws Throwable {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/DeleteTest.java
@@ -19,10 +19,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspac
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -32,19 +32,17 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class DeleteTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 
-	@Before
+	@BeforeEach
 	public void createTestProject() throws CoreException {
 		project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -25,12 +25,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForRefresh;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -57,19 +57,17 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.internal.filesystem.bug440110.Bug440110FileSystem;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class FileSystemResourceManagerTest implements ICoreConstants {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 
-	@Before
+	@BeforeEach
 	public void createTestProject() throws CoreException {
 		project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
@@ -308,11 +306,11 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		/* test the overwrite parameter (false) */
 		ensureOutOfSync(file);
 		InputStream another2 = createInputStream(anotherContent);
-		assertThrows("Should fail writing out of sync file #1", CoreException.class,
-				() -> write(file, another2, false, null));
+		assertThrows(CoreException.class, () -> write(file, another2, false, null),
+				"Should fail writing out of sync file #1");
 		ensureOutOfSync(file);
-		assertThrows("Should fail writing out of sync file #2", CoreException.class,
-				() -> file.setContents(another2, false, false, null));
+		assertThrows(CoreException.class, () -> file.setContents(another2, false, false, null),
+				"Should fail writing out of sync file #2");
 		try (InputStream another = createInputStream(anotherContent)) {
 			file.setContents(another, true, false, null);
 		}
@@ -321,8 +319,8 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		removeFromFileSystem(file); // FIXME Race Condition with asynchronous workplace refresh see Bug 571133
 		InputStream another3 = createInputStream(anotherContent);
 		waitForRefresh(); // wait for refresh to ensure that file is not present in workspace
-		assertThrows("Should fail writing non existing file", CoreException.class,
-				() -> write(file, another3, false, null));
+		assertThrows(CoreException.class, () -> write(file, another3, false, null),
+				"Should fail writing non existing file");
 
 		/* remove trash */
 		removeFromWorkspace(project);
@@ -339,8 +337,8 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		write(file, createInputStream(content), true, null);
 
 		file.delete(true, null);
-		assertThrows("Should fail writing file that is already deleted", CoreException.class,
-				() -> write(file, createInputStream(content), false, null));
+		assertThrows(CoreException.class, () -> write(file, createInputStream(content), false, null),
+				"Should fail writing file that is already deleted");
 	}
 
 	@Test
@@ -405,7 +403,7 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		// wrap in runnable to prevent snapshot from occurring in the middle.
 		getWorkspace().run((IWorkspaceRunnable) monitor -> {
 			removeFromFileSystem(project);
-			assertFalse("2.1", fileStore.fetchInfo().isDirectory());
+			assertFalse(fileStore.fetchInfo().isDirectory());
 			//write project in a runnable, otherwise tree will be locked
 			((Project) project).writeDescription(IResource.FORCE);
 		}, null);
@@ -428,10 +426,10 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		project.open(null);
 		FileSystemResourceManager manager = ((Workspace) getWorkspace()).getFileSystemManager();
 		URI location = manager.locationURIFor(project);
-		assertNotNull("Expected location for accessible project to not be null", location);
+		assertNotNull(location, "Expected location for accessible project to not be null");
 		project.delete(true, null);
 		URI locationAfterDelete = manager.locationURIFor(project);
-		assertEquals("Expected location of project to not change after delete", location, locationAfterDelete);
+		assertEquals(location, locationAfterDelete, "Expected location of project to not change after delete");
 	}
 
 	@Test
@@ -449,7 +447,7 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 			throws CoreException {
 		try {
 			IWorkspace workspace = getWorkspace();
-			assertNotNull("workspace cannot be null", workspace);
+			assertNotNull(workspace, "workspace cannot be null");
 			workspace.run(new WriteFileContents(file, contents, force, getLocalManager()), monitor);
 		} catch (Throwable t) {
 			// Bug 541493: we see unlikely stack traces reported by JUnit here, log the
@@ -474,21 +472,21 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 
 		WriteFileContents(IFile file, InputStream contents, boolean force, FileSystemResourceManager localManager) {
 			this.file = file;
-			assertNotNull("file cannot be null", file);
+			assertNotNull(file, "file cannot be null");
 			this.contents = contents;
-			assertNotNull("contents cannot be null", contents);
+			assertNotNull(contents, "contents cannot be null");
 			this.force = force;
 			this.localManager = localManager;
-			assertNotNull("file system resource manager cannot be null", localManager);
+			assertNotNull(localManager, "file system resource manager cannot be null");
 		}
 
 		@Override
 		public void run(IProgressMonitor jobMonitor) throws CoreException {
 			int flags = force ? IResource.FORCE : IResource.NONE;
 			IFileStore store = ((Resource) file).getStore();
-			assertNotNull("file store cannot be null", store);
+			assertNotNull(store, "file store cannot be null");
 			IFileInfo info = store.fetchInfo();
-			assertNotNull("file info cannot be null for file " + file, info);
+			assertNotNull(info, "file info cannot be null for file " + file);
 			localManager.write(file, contents, info, flags, false, jobMonitor);
 		}
 	}

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryBucketTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/HistoryBucketTest.java
@@ -14,23 +14,23 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.core.internal.localstore.Bucket.Entry;
 import org.eclipse.core.internal.localstore.HistoryBucket;
 import org.eclipse.core.internal.utils.UniversalUniqueIdentifier;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class HistoryBucketTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	/**
 	 * Ensures that if another entry having exactly the same UUID is added,
@@ -39,7 +39,7 @@ public class HistoryBucketTest {
 	@Test
 	public void testDuplicates() throws CoreException {
 		IPath baseLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(baseLocation);
+		fileStoreExtension.deleteOnTearDown(baseLocation);
 		HistoryBucket index1 = new HistoryBucket();
 		IPath location1 = baseLocation.append("location1");
 		index1.load("foo", location1.toFile());
@@ -61,7 +61,7 @@ public class HistoryBucketTest {
 	@Test
 	public void testPersistence() throws CoreException {
 		IPath baseLocation = getRandomLocation();
-		workspaceRule.deleteOnTearDown(baseLocation);
+		fileStoreExtension.deleteOnTearDown(baseLocation);
 		HistoryBucket index1 = new HistoryBucket();
 		IPath location = baseLocation.append("location");
 		index1.load("foo", location.toFile());

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/LocalSyncTest.java
@@ -22,9 +22,9 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.buildResources;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.resources.ICoreConstants;
 import org.eclipse.core.internal.resources.TestingSupport;
@@ -34,19 +34,17 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class LocalSyncTest implements ICoreConstants {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private IProject project;
 
-	@Before
+	@BeforeEach
 	public void createTestProject() throws CoreException {
 		project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
@@ -83,7 +81,7 @@ public class LocalSyncTest implements ICoreConstants {
 
 		/* resources should not exist anymore */
 		for (int i = 1; i < resources.length; i++) {
-			assertFalse("Resource does unexpectedly exist: " + resources[i], resources[i].exists());
+			assertFalse(resources[i].exists(), "Resource does unexpectedly exist: " + resources[i]);
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/MoveTest.java
@@ -25,12 +25,12 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomCont
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.findAvailableDevices;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.core.internal.resources.File;
 import org.eclipse.core.internal.resources.Resource;
@@ -47,30 +47,28 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the move operation.
  */
+@ExtendWith(WorkspaceResetExtension.class)
 public class MoveTest {
 
 	private static final int NUMBER_OF_PROPERTIES = 5;
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * This test has Windows as the target OS. Drives C: and D: should be available.
 	 */
 	@Test
 	public void testMoveFileAcrossVolumes() throws CoreException {
-		assumeTrue("only relevant on Windows", OS.isWindows());
+		assumeTrue(OS.isWindows(), "only relevant on Windows");
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		assumeFalse("only executable if at least two volumes are present", devices[0] == null || devices[1] == null);
+		assumeFalse(devices[0] == null || devices[1] == null, "only executable if at least two volumes are present");
 
 		// create common objects
 		String location = createUniqueString();
@@ -113,8 +111,8 @@ public class MoveTest {
 		for (int j = 0; j < NUMBER_OF_PROPERTIES; j++) {
 			String persistentValue = newFile.getPersistentProperty(propNames[j]);
 			Object sessionValue = newFile.getSessionProperty(propNames[j]);
-			assertEquals("5.1", persistentValue, propValues[j]);
-			assertEquals("5.2", sessionValue, propValues[j]);
+			assertEquals(persistentValue, propValues[j]);
+			assertEquals(sessionValue, propValues[j]);
 		}
 	}
 
@@ -160,8 +158,8 @@ public class MoveTest {
 		for (int j = 0; j < NUMBER_OF_PROPERTIES; j++) {
 			String persistentValue = newFile.getPersistentProperty(propNames[j]);
 			Object sessionValue = newFile.getSessionProperty(propNames[j]);
-			assertEquals("persistent property value is not the same", propValues[j], persistentValue);
-			assertEquals("session property value is not the same", propValues[j], sessionValue);
+			assertEquals(propValues[j], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[j], sessionValue, "session property value is not the same");
 		}
 	}
 
@@ -170,11 +168,11 @@ public class MoveTest {
 	 */
 	@Test
 	public void testMoveFolderAcrossVolumes() throws CoreException {
-		assumeTrue("only relevant on Windows", OS.isWindows());
+		assumeTrue(OS.isWindows(), "only relevant on Windows");
 
 		/* look for the adequate environment */
 		String[] devices = findAvailableDevices();
-		assumeFalse("only executable if at least two volumes are present", devices[0] == null || devices[1] == null);
+		assumeFalse(devices[0] == null || devices[1] == null, "only executable if at least two volumes are present");
 
 		// create common objects
 		String location = createUniqueString();
@@ -265,8 +263,8 @@ public class MoveTest {
 		for (int j = 0; j < NUMBER_OF_PROPERTIES; j++) {
 			String persistentValue = newFolder.getPersistentProperty(propNames[j]);
 			Object sessionValue = newFolder.getSessionProperty(propNames[j]);
-			assertEquals("persistent property value is not the same", propValues[j], persistentValue);
-			assertEquals("session property value is not the same", propValues[j], sessionValue);
+			assertEquals(propValues[j], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[j], sessionValue, "session property value is not the same");
 		}
 	}
 
@@ -338,8 +336,8 @@ public class MoveTest {
 				String propValue = sourceResource.getName() + propValues[j];
 				String persistentValue = destResource.getPersistentProperty(propName);
 				Object sessionValue = destResource.getSessionProperty(propName);
-				assertEquals("persistent property value is not the same", propValue, persistentValue);
-				assertEquals("session property value is not the same", propValue, sessionValue);
+				assertEquals(propValue, persistentValue, "persistent property value is not the same");
+				assertEquals(propValue, sessionValue, "session property value is not the same");
 			}
 		}
 	}
@@ -411,8 +409,8 @@ public class MoveTest {
 				String propValue = sourceResource.getName() + propValues[j];
 				String persistentValue = destResource.getPersistentProperty(propName);
 				Object sessionValue = destResource.getSessionProperty(propName);
-				assertEquals("persistent property value is not the same", propValue, persistentValue);
-				assertEquals("session property value is not the same", propValue, sessionValue);
+				assertEquals(propValue, persistentValue, "persistent property value is not the same");
+				assertEquals(propValue, sessionValue, "session property value is not the same");
 			}
 		}
 	}
@@ -541,8 +539,8 @@ public class MoveTest {
 		for (int j = 0; j < NUMBER_OF_PROPERTIES; j++) {
 			String persistentValue = newFile.getPersistentProperty(propNames[j]);
 			Object sessionValue = newFile.getSessionProperty(propNames[j]);
-			assertEquals("persistent property value is not the same", propValues[j], persistentValue);
-			assertEquals("session property value is not the same", propValues[j], sessionValue);
+			assertEquals(propValues[j], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[j], sessionValue, "session property value is not the same");
 		}
 	}
 
@@ -593,8 +591,8 @@ public class MoveTest {
 		for (int j = 0; j < NUMBER_OF_PROPERTIES; j++) {
 			String persistentValue = newFolder.getPersistentProperty(propNames[j]);
 			Object sessionValue = newFolder.getSessionProperty(propNames[j]);
-			assertEquals("persistent property value is not the same", propValues[j], persistentValue);
-			assertEquals("session property value is not the same", propValues[j], sessionValue);
+			assertEquals(propValues[j], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[j], sessionValue, "session property value is not the same");
 		}
 	}
 
@@ -628,8 +626,8 @@ public class MoveTest {
 		for (int i = 0; i < NUMBER_OF_PROPERTIES; i++) {
 			String persistentValue = projects[i].getPersistentProperty(propNames[i]);
 			Object sessionValue = projects[i].getSessionProperty(propNames[i]);
-			assertEquals("persistent property value is not the same", propValues[i], persistentValue);
-			assertEquals("session property value is not the same", propValues[i], sessionValue);
+			assertEquals(propValues[i], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[i], sessionValue, "session property value is not the same");
 		}
 
 		// move (rename) projects
@@ -649,8 +647,8 @@ public class MoveTest {
 		for (int i = 0; i < NUMBER_OF_PROPERTIES; i++) {
 			String persistentValue = projects[i].getPersistentProperty(propNames[i]);
 			Object sessionValue = projects[i].getSessionProperty(propNames[i]);
-			assertEquals("persistent property value is not the same", propValues[i], persistentValue);
-			assertEquals("session property value is not the same", propValues[i], sessionValue);
+			assertEquals(propValues[i], persistentValue, "persistent property value is not the same");
+			assertEquals(propValues[i], sessionValue, "session property value is not the same");
 		}
 	}
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/PrefixPoolTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/PrefixPoolTest.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.tests.internal.localstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.localstore.PrefixPool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PrefixPoolTest {
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalPerformanceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalPerformanceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.tests.internal.localstore;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.util.Date;
@@ -22,15 +23,12 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class RefreshLocalPerformanceTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/** big site default volume (windows) */
 	public static final String bigSiteDevice = "d:";
@@ -76,7 +74,7 @@ public class RefreshLocalPerformanceTest {
 	@Test
 	public void testLocalRefreshPerformance() throws Exception {
 		// test if the test can be done in this machine
-		Assume.assumeTrue(bigSiteLocation.toFile().isDirectory());
+		assumeTrue(bigSiteLocation.toFile().isDirectory());
 
 		// create common objects
 		int n = 10;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/RefreshLocalTest.java
@@ -24,10 +24,10 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isLocal;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.eclipse.core.filesystem.IFileStore;
@@ -40,19 +40,22 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class RefreshLocalTest implements ICoreConstants {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	private IProject project;
 
-	@Before
+	@BeforeEach
 	public void createTestProject() throws CoreException {
 		project = getWorkspace().getRoot().getProject("Project");
 		createInWorkspace(project);
@@ -86,65 +89,12 @@ public class RefreshLocalTest implements ICoreConstants {
 	}
 
 	/**
-	 * Test discovery of a linked resource on refresh.
-	 */
-	@Test
-	public void testDiscoverLinkedResource() {
-		//create a linked resource with local contents missing
-		//	IProject project = projects[0];
-		//	ensureExistsInWorkspace(project);
-		//	IPath location = getRandomLocation();
-		//	IFile link = project.getFile("Link");
-		//	try {
-		//		link.createLink(location, IResource.ALLOW_MISSING_LOCAL, getMonitor());
-		//	} catch (CoreException e) {
-		//		fail("0.99", e);
-		//	}
-		//
-		//	//should not be synchronized (exists in ws, but not in fs)
-		//	assertTrue("1.0", !project.isSynchronized(IResource.DEPTH_INFINITE));
-		//	assertTrue("1.1", !link.isSynchronized(IResource.DEPTH_ZERO));
-		//
-		//	//should exist in workspace
-		//	assertTrue("1.3", link.exists());
-		//
-		//	//refreshing shouldn't get rid of the link
-		//	try {
-		//		link.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		//	} catch (CoreException e) {
-		//		fail("1.99", e);
-		//	}
-		//	assertTrue("1.4", link.exists());
-		//
-		//	//create the contents in the file system
-		//	try {
-		//		createFileInFileSystem(location);
-		//	} catch (CoreException e) {
-		//		fail("2.99", e);
-		//	}
-		//
-		//	//should now be synchronized
-		//	assertTrue("2.1", project.isSynchronized(IResource.DEPTH_INFINITE));
-		//	assertTrue("2.2", link.isSynchronized(IResource.DEPTH_ZERO));
-		//
-		//	//refresh
-		//	try {
-		//		link.refreshLocal(IResource.DEPTH_INFINITE, getMonitor());
-		//	} catch (CoreException e) {
-		//		fail("3.99", e);
-		//	}
-		//
-		//	//assert should exist in workspace
-		//	assertTrue("2.3", link.exists());
-	}
-
-	/**
 	 * Tests discovering a file via refresh local when neither the file
 	 * nor its parent exists in the workspace.
 	 */
 	@Test
 	public void testFileDiscovery() throws Throwable {
-		workspaceRule.deleteOnTearDown(project.getLocation());
+		fileStoreExtension.deleteOnTearDown(project.getLocation());
 		IFolder folder = project.getFolder("Folder");
 		IFile file = folder.getFile("File");
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeChunkyInputOutputStreamTest.java
@@ -17,9 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -30,16 +30,14 @@ import org.eclipse.core.internal.localstore.ILocalStoreConstants;
 import org.eclipse.core.internal.localstore.SafeChunkyInputStream;
 import org.eclipse.core.internal.localstore.SafeChunkyOutputStream;
 import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class SafeChunkyInputOutputStreamTest {
-
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	private File temp;
 
@@ -54,16 +52,16 @@ public class SafeChunkyInputOutputStreamTest {
 		return result;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		streams = new ArrayList<>();
 		temp = getRandomLocation().append("temp").toFile();
 		temp.mkdirs();
-		assertTrue("could not create temp directory", temp.isDirectory());
+		assertTrue(temp.isDirectory(), "could not create temp directory");
 		target = new File(temp, "target");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		for (SafeChunkyOutputStream stream : streams) {
 			try {
@@ -78,7 +76,7 @@ public class SafeChunkyInputOutputStreamTest {
 	@Test
 	public void testBufferLimit() throws Exception {
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue(!target.exists());
+		assertFalse(target.exists());
 
 		// use only one chunk but bigger than the buffer
 		int bufferSize = 10024;
@@ -192,7 +190,7 @@ public class SafeChunkyInputOutputStreamTest {
 	@Test
 	public void testAlmostEmpty() throws Exception {
 		Workspace.clear(target); // make sure there was nothing here before
-		assertTrue(!target.exists());
+		assertFalse(target.exists());
 
 		// open the file but don't write anything.
 		try (SafeChunkyOutputStream output = new SafeChunkyOutputStream(target)) {

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/SafeFileInputOutputStreamTest.java
@@ -17,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.tests.harness.FileSystemHelper.getRandomLocation;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,15 +27,18 @@ import org.eclipse.core.internal.localstore.SafeFileInputStream;
 import org.eclipse.core.internal.localstore.SafeFileOutputStream;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class SafeFileInputOutputStreamTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	private IPath temp;
 
@@ -52,12 +55,12 @@ public class SafeFileInputOutputStreamTest {
 		return new SafeFileInputStream(target);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		temp = getRandomLocation().append("temp");
 		temp.toFile().mkdirs();
-		workspaceRule.deleteOnTearDown(temp);
-		assertTrue("could not create temp directory", temp.toFile().isDirectory());
+		fileStoreExtension.deleteOnTearDown(temp);
+		assertTrue(temp.toFile().isDirectory(), "could not create temp directory");
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/UnifiedTreeTest.java
@@ -18,9 +18,9 @@ import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -44,16 +44,19 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.resources.WorkspaceTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.core.tests.resources.util.FileStoreAutoDeleteExtension;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(WorkspaceResetExtension.class)
 public class UnifiedTreeTest {
 
-	@Rule
-	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
-
 	private static final int LIMIT = 10;
+
+	@RegisterExtension
+	private final FileStoreAutoDeleteExtension fileStoreExtension = new FileStoreAutoDeleteExtension();
 
 	protected void createFiles(IFileStore folder, Hashtable<String, String> set) throws Exception {
 		for (int i = 0; i < LIMIT; i++) {
@@ -276,7 +279,7 @@ public class UnifiedTreeTest {
 
 		IFileStore fileStore = EFS.getLocalFileSystem().fromLocalFile(file);
 		link.createLink(fileStore.toURI(), IResource.NONE, null);
-		workspaceRule.deleteOnTearDown(fileStore);
+		fileStoreExtension.deleteOnTearDown(fileStore);
 
 		IFile rf = link.getFile("fileTest342968.txt");
 		rf.create(new ByteArrayInputStream("test342968".getBytes()), false, null);


### PR DESCRIPTION
- Switch to JUnit 5 test annotations and assertions
- Use test extensions replacing JUnit 4 test rules

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/903