### PR TITLE
Wrap different ways of IResource read-only property access in tests

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IFolderTest.java
@@ -23,9 +23,11 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStrea
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomContentsStream;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createRandomString;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnly;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,9 +44,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.tests.resources.ResourceTestUtil.ReadOnlyApi;
 import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @ExtendWith(WorkspaceResetExtension.class)
 public class IFolderTest {
@@ -316,8 +321,9 @@ public class IFolderTest {
 		assertDoesNotExistInWorkspace(source);
 	}
 
-	@Test
-	public void testReadOnlyFolderCopy() throws Exception {
+	@ParameterizedTest
+	@EnumSource(ReadOnlyApi.class)
+	public void testReadOnlyFolderCopy(ReadOnlyApi apiVersion) throws Exception {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
 		if (!isReadOnlySupported()) {
@@ -326,16 +332,16 @@ public class IFolderTest {
 		IProject project = getWorkspace().getRoot().getProject("Project");
 		IFolder source = project.getFolder("Folder1");
 		createInWorkspace(source);
-		source.setReadOnly(true);
+		setReadOnly(source, true, apiVersion);
 		IFolder dest = project.getFolder("Folder2");
 		source.copy(dest.getFullPath(), true, createTestMonitor());
 		assertExistsInWorkspace(dest);
 		assertExistsInWorkspace(source);
-		assertTrue(dest.isReadOnly());
+		assertTrue(isReadOnly(dest, apiVersion));
 
 		// cleanup - ensure that the files can be deleted.
-		source.setReadOnly(false);
-		dest.setReadOnly(false);
+		setReadOnly(source, false, apiVersion);
+		setReadOnly(dest, true, apiVersion);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceTest.java
@@ -43,6 +43,7 @@ import static org.eclipse.core.tests.resources.ResourceTestUtil.ensureOutOfSync;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.isReadOnlySupported;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.removeFromWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setReadOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -73,9 +74,12 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
+import org.eclipse.core.tests.resources.ResourceTestUtil.ReadOnlyApi;
 import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -762,8 +766,9 @@ public class IWorkspaceTest {
 				order -> assertThat(order).containsExactly(NATURE_SIMPLE, NATURE_WATER, NATURE_SNOW));
 	}
 
-	@Test
-	public void testValidateEdit() throws CoreException {
+	@ParameterizedTest
+	@EnumSource(ReadOnlyApi.class)
+	public void testValidateEdit(ReadOnlyApi apiVersion) throws CoreException {
 		// We need to know whether or not we can unset the read-only flag
 		// in order to perform this test.
 		if (!isReadOnlySupported()) {
@@ -774,12 +779,12 @@ public class IWorkspaceTest {
 		createInWorkspace(new IResource[] {project, file});
 		IStatus result = getWorkspace().validateEdit(new IFile[] {file}, null);
 		assertTrue(result.isOK());
-		file.setReadOnly(true);
+		setReadOnly(file, true, apiVersion);
 		result = getWorkspace().validateEdit(new IFile[] {file}, null);
 		assertEquals(IStatus.ERROR, result.getSeverity());
 		// assertEquals(IResourceStatus.READ_ONLY_LOCAL, result.getCode());
 		// remove the read-only status so test cleanup will work ok
-		file.setReadOnly(false);
+		setReadOnly(file, false, apiVersion);
 	}
 
 	@Test

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ResourceTestUtil.java
@@ -773,4 +773,28 @@ public final class ResourceTestUtil {
 		return resource.isLocal(depth);
 	}
 
+	public enum ReadOnlyApi {
+		CURRENT, DEPRECATED
+	}
+
+	@SuppressWarnings("deprecation")
+	public static void setReadOnly(IResource resource, boolean value, ReadOnlyApi api) throws CoreException {
+		if (api == ReadOnlyApi.CURRENT) {
+			ResourceAttributes attributes = new ResourceAttributes();
+			attributes.setReadOnly(value);
+			resource.setResourceAttributes(attributes);
+		} else {
+			resource.setReadOnly(value);
+		}
+	}
+
+	@SuppressWarnings("deprecation")
+	public static boolean isReadOnly(IResource resource, ReadOnlyApi api) {
+		if (api == ReadOnlyApi.CURRENT) {
+			ResourceAttributes attributes = resource.getResourceAttributes();
+			return attributes.isReadOnly();
+		}
+		return resource.isReadOnly();
+	}
+
 }


### PR DESCRIPTION
Some tests still access the deprecated IResource#isReadyOnly() and IResource#setReadOnly(). Some do that by intent to test the deprecated functionality, some have not been adapted to (also) test the new way of accessing that property. This leads to potentially missed test paths and also produces useless warnings.
This change parameterizes the existing callers in tests to test both the legacy API as well as the recommended one..