### PR TITLE
Remove general preference memento handling in debug tests

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
@@ -20,8 +20,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -43,11 +41,6 @@ public class AbstractDebugTest {
 	 */
 	protected long testTimeout = 30000;
 
-	/**
-	 * Preference helper to restore changed preference values after test run.
-	 */
-	private final PreferenceMemento prefMemento = new PreferenceMemento();
-
 	@Rule
 	public TestName name = new TestName();
 
@@ -62,7 +55,6 @@ public class AbstractDebugTest {
 	public void tearDown() throws Exception {
 		TestUtil.log(IStatus.INFO, name.getMethodName(), "tearDown");
 		TestUtil.cleanUp(name.getMethodName());
-		prefMemento.resetPreferences();
 	}
 
 	/**
@@ -143,27 +135,4 @@ public class AbstractDebugTest {
 		}
 	}
 
-	/**
-	 * Change a preference value for this test run. The preference will be reset
-	 * to its value before test started automatically on {@link #tearDown()}.
-	 *
-	 * @param <T> preference value type. The type must have a corresponding
-	 *            {@link IPreferenceStore} setter.
-	 * @param store preference store to manipulate (must not be
-	 *            <code>null</code>)
-	 * @param name preference to change
-	 * @param value new preference value
-	 * @throws IllegalArgumentException when setting a type which is not
-	 *             supported by {@link IPreferenceStore}
-	 *
-	 * @see IPreferenceStore#setValue(String, double)
-	 * @see IPreferenceStore#setValue(String, float)
-	 * @see IPreferenceStore#setValue(String, int)
-	 * @see IPreferenceStore#setValue(String, long)
-	 * @see IPreferenceStore#setValue(String, boolean)
-	 * @see IPreferenceStore#setValue(String, String)
-	 */
-	protected <T> void setPreference(IPreferenceStore store, String name, T value) {
-		prefMemento.setValue(store, name, value);
-	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
@@ -37,15 +37,24 @@ import org.eclipse.debug.internal.ui.views.console.ProcessConsoleManager;
 import org.eclipse.debug.tests.AbstractDebugTest;
 import org.eclipse.debug.tests.TestUtil;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
+import org.junit.After;
 import org.junit.Test;
 
 /**
  * Tests the ProcessConsoleManager.
  */
 public class ProcessConsoleManagerTests extends AbstractDebugTest {
+
+	private final PreferenceMemento prefMemento = new PreferenceMemento();
+
+	@After
+	public void restorePreferences() {
+		prefMemento.resetPreferences();
+	}
 
 	/**
 	 * Test addition and removal of a ProcessConsole. It also kind of tests
@@ -102,7 +111,7 @@ public class ProcessConsoleManagerTests extends AbstractDebugTest {
 		final MockProcess mockProcess2 = new MockProcess(0);
 		final IProcess process2 = mockProcess2.toRuntimeProcess("SecondMockProcess");
 		try {
-			setPreference(DebugUIPlugin.getDefault().getPreferenceStore(), IDebugUIConstants.PREF_AUTO_REMOVE_OLD_LAUNCHES, true);
+			prefMemento.setValue(DebugUIPlugin.getDefault().getPreferenceStore(), IDebugUIConstants.PREF_AUTO_REMOVE_OLD_LAUNCHES, true);
 			// Stop the JobManager to reliable trigger the tested race
 			// condition.
 			TestUtil.waitForJobs(name.getMethodName(), ProcessConsoleManager.class, 0, 10000);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchHistoryTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchHistoryTests.java
@@ -26,6 +26,8 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.launchConfigurations.LaunchHistory;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.preference.PreferenceMemento;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -39,6 +41,13 @@ import org.junit.Test;
  * @since 3.3
  */
 public class LaunchHistoryTests extends AbstractLaunchTest {
+
+	private final PreferenceMemento prefMemento = new PreferenceMemento();
+
+	@After
+	public void restorePreferences() {
+		prefMemento.resetPreferences();
+	}
 
 	/**
 	 * Returns the run launch history
@@ -60,7 +69,7 @@ public class LaunchHistoryTests extends AbstractLaunchTest {
 	 * @param value the new maximum size for launch histories
 	 */
 	private void setMaxHistorySize(int value) {
-		setPreference(DebugUIPlugin.getDefault().getPreferenceStore(), IDebugUIConstants.PREF_MAX_HISTORY_SIZE, value);
+		prefMemento.setValue(DebugUIPlugin.getDefault().getPreferenceStore(), IDebugUIConstants.PREF_MAX_HISTORY_SIZE, value);
 	}
 
 	/**


### PR DESCRIPTION
The superclass of all debug tests manages a preference memento to restore initial preferences after a test case execution. This is, however, only used by two actual tests, such that providing it for every debug test is not necessary and leads to unnecessary complexity in the hierarchy of test classes.
This change moves the preference memento to exactly those two test classes in which it is required, as a prerequisite for simplifying the inheritance hierarchy and moving to JUnit 5.