### PR TITLE
Streamline debug tests timeout handling

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
@@ -36,11 +36,6 @@ public class AbstractDebugTest {
 
 	private static boolean welcomeClosed;
 
-	/**
-	 * Default timeout in milliseconds to wait on some events
-	 */
-	protected long testTimeout = 30000;
-
 	@Rule
 	public TestName name = new TestName();
 
@@ -88,27 +83,8 @@ public class AbstractDebugTest {
 	}
 
 	/**
-	 * Waits while given condition is {@code true} for a given amount of
-	 * milliseconds. If the actual wait time exceeds given timeout and condition
-	 * will be still {@code true}, throws
-	 * {@link junit.framework.AssertionFailedError} with given message.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param condition function which will be evaluated while waiting
-	 * @param timeout max wait time in milliseconds to wait on given condition
-	 * @param errorMessage message which will be used to construct the failure
-	 *            exception in case the condition will still return {@code true}
-	 *            after given timeout
-	 */
-	public void waitWhile(Predicate<AbstractDebugTest> condition, long timeout, Function<AbstractDebugTest, String> errorMessage) throws Exception {
-		TestUtil.waitWhile(condition, this, timeout, errorMessage);
-	}
-
-	/**
 	 * Waits while given condition is {@code true} for some time. If the actual
-	 * wait time exceeds {@link #testTimeout} and condition will be still
+	 * wait time exceeds {@link TestUtil#DEFAULT_TIMEOUT} and condition will be still
 	 * {@code true}, throws {@link junit.framework.AssertionFailedError} with
 	 * given message.
 	 * <p>
@@ -121,7 +97,7 @@ public class AbstractDebugTest {
 	 *            after given timeout
 	 */
 	public void waitWhile(Predicate<AbstractDebugTest> condition, Function<AbstractDebugTest, String> errorMessage) throws Exception {
-		TestUtil.waitWhile(condition, this, testTimeout, errorMessage);
+		TestUtil.waitWhile(condition, this, errorMessage);
 	}
 
 	private static void closeIntro(final IWorkbench wb) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
@@ -37,7 +37,15 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 
-public class TestUtil {
+public final class TestUtil {
+
+	/**
+	 * The default test timeout in milliseconds
+	 */
+	public static long DEFAULT_TIMEOUT = 30_000;
+
+	private TestUtil() {
+	}
 
 	/**
 	 * Call this in the tearDown method of every test to clean up state that can
@@ -137,6 +145,26 @@ public class TestUtil {
 		if (stillTrue) {
 			fail(errorMessage.apply(context));
 		}
+	}
+
+	/**
+	 * Waits while given condition is {@code true} for the time defined as
+	 * {@code #TEST_TIMEOUT}. If the actual wait time exceeds that timeout and
+	 * condition will be still {@code true}, throws {@link AssertionError} with
+	 * given message.
+	 * <p>
+	 * Will process UI events while waiting in UI thread, if called from
+	 * background thread, just waits.
+	 *
+	 * @param <T> type of the context
+	 * @param condition function which will be evaluated while waiting
+	 * @param context test context
+	 * @param errorMessage message which will be used to construct the failure
+	 *            exception in case the condition will still return {@code true}
+	 *            after given timeout
+	 */
+	public static <T> void waitWhile(Predicate<T> condition, T context, Function<T, String> errorMessage) throws Exception {
+		waitWhile(condition, context, DEFAULT_TIMEOUT, errorMessage);
 	}
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/BreakpointTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/BreakpointTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,20 +86,20 @@ public class BreakpointTests extends AbstractDebugTest {
 			IUndoContext context = DebugUITools.getBreakpointsUndoContext();
 
 			bpm.addBreakpoint(bp);
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, testTimeout, c -> "Breakpoint is not created");
+			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not created");
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
 			assertTrue("Breakpoint not registered", bp.isRegistered());
 
 			DebugUITools.deleteBreakpoints(new IBreakpoint[] {
 					bp }, null, null);
 			assertTrue(operationHistory.canUndo(context));
-			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, testTimeout, c -> "Breakpoint is not deleted");
+			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not deleted");
 			assertFalse("Breakpoint marker not removed", bp.getMarker().exists());
 			assertFalse("Breakpoint still registered", bp.isRegistered());
 
 			operationHistory.undo(context, null, null);
 			assertTrue(operationHistory.canRedo(context));
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, testTimeout, c -> "Breakpoint is not recreated");
+			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not recreated");
 			bp = getTestBreakpoints().get(0);
 			assertEquals("Breakpoint attributes not correctly restored", content, bp.getText());
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
@@ -106,13 +107,13 @@ public class BreakpointTests extends AbstractDebugTest {
 
 			operationHistory.redo(context, null, null);
 			assertTrue(operationHistory.canUndo(context));
-			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, testTimeout, c -> "Breakpoint is not deleted");
+			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not deleted");
 			assertFalse("Breakpoint marker not removed", bp.getMarker().exists());
 			assertFalse("Breakpoint still registered", bp.isRegistered());
 
 			operationHistory.undo(context, null, null);
 			assertTrue(operationHistory.canRedo(context));
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, testTimeout, c -> "Breakpoint is not recreated");
+			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not recreated");
 			bp = getTestBreakpoints().get(0);
 			assertEquals("Breakpoint attributes not correctly restored", content, bp.getText());
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
@@ -123,7 +124,7 @@ public class BreakpointTests extends AbstractDebugTest {
 			TestUtil.waitWhile(c -> {
 				TreeItem item = (TreeItem) finalView.getTreeModelViewer().testFindItem(finalBp);
 				return item == null || item.getText() == null || !item.getText().contains(content);
-			}, this, testTimeout, c -> "Breakpoint not restored in view");
+			}, this, c -> "Breakpoint not restored in view");
 		} finally {
 			if (!viewVisible) {
 				DebugUIPlugin.getActiveWorkbenchWindow().getActivePage().hideView(view);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
@@ -902,7 +902,7 @@ public class IOConsoleTests extends AbstractDebugTest {
 		};
 		Thread watchdog = new Thread(() -> {
 			try {
-				Thread.sleep(testTimeout);
+				Thread.sleep(TestUtil.DEFAULT_TIMEOUT);
 				synchronized (c) {
 					c.notifyAll();
 				}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -187,7 +187,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 	 */
 	public void processConsoleUTF8Input(String prefix, int numTwoByteCharacters) throws Exception {
 		final String input = prefix + String.join("", Collections.nCopies(numTwoByteCharacters, "\u00F8"));
-		final MockProcess mockProcess = new MockProcess(input.getBytes(StandardCharsets.UTF_8).length, testTimeout);
+		final MockProcess mockProcess = new MockProcess(input.getBytes(StandardCharsets.UTF_8).length, TestUtil.DEFAULT_TIMEOUT);
 		try {
 			final ILaunch launch = new Launch(null, ILaunchManager.RUN_MODE, null);
 			launch.setAttribute(DebugPlugin.ATTR_CONSOLE_ENCODING, StandardCharsets.UTF_8.toString());
@@ -198,7 +198,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				@SuppressWarnings("resource")
 				IOConsoleInputStream consoleIn = console.getInputStream();
 				consoleIn.appendData(input);
-				mockProcess.waitFor(testTimeout, TimeUnit.MILLISECONDS);
+				mockProcess.waitFor(TestUtil.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
 			} finally {
 				console.destroy();
 			}
@@ -296,7 +296,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			if (mockProcess.isAlive()) {
 				mockProcess.destroy();
 			}
-			waitWhile(__ -> !terminationSignaled.get(), 10_000, __ -> "No console complete notification received.");
+			waitWhile(__ -> !terminationSignaled.get(), __ -> "No console complete notification received.");
 		} finally {
 			consoleManager.removeConsoles(new IConsole[] { console });
 			TestUtil.waitForJobs(name.getMethodName(), ConsoleManager.CONSOLE_JOB_FAMILY, 0, 10000);
@@ -395,7 +395,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		try {
 			consoleManager.addConsoles(new IConsole[] { console });
 			mockProcess.destroy();
-			waitWhile(c -> !consoleFinished.get(), testTimeout, c -> "Console did not finished.");
+			waitWhile(c -> !consoleFinished.get(), c -> "Console did not finished.");
 
 			Object value = launchConfigAttributes != null ? launchConfigAttributes.get(IDebugUIConstants.ATTR_CAPTURE_IN_FILE) : null;
 			final File outFile = value != null ? new File((String) value) : null;
@@ -465,7 +465,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 						String actual = console.getDocument().get();
 						return "Not all lines have been written, expected: " + expected + ", was: " + actual;
 					};
-					waitWhile(waitForLastLineWritten, testTimeout, errorMessageProvider);
+					waitWhile(waitForLastLineWritten, errorMessageProvider);
 
 					for (int i = 0; i < lines.length; i++) {
 						IRegion lineInfo = console.getDocument().getLineInformation(i);
@@ -521,7 +521,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 					}
 					return "File has not been written, expected: " + Arrays.toString(output) + ", was: " + Arrays.toString(actualOutput);
 				};
-				waitWhile(waitForFileWritten, testTimeout, errorMessageProvider);
+				waitWhile(waitForFileWritten, errorMessageProvider);
 				mockProcess.destroy();
 			} finally {
 				console.destroy();
@@ -546,7 +546,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 
 		final File inFile = createTmpFile("testinput.bin");
 		Files.write(inFile.toPath(), input);
-		final MockProcess mockProcess = new MockProcess(input.length, testTimeout);
+		final MockProcess mockProcess = new MockProcess(input.length, TestUtil.DEFAULT_TIMEOUT);
 		try {
 			Map<String, Object> launchConfigAttributes = new HashMap<>();
 			launchConfigAttributes.put(DebugPlugin.ATTR_CONSOLE_ENCODING, consoleEncoding);
@@ -556,7 +556,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), consoleEncoding);
 			try {
 				console.initialize();
-				mockProcess.waitFor(testTimeout, TimeUnit.MILLISECONDS);
+				mockProcess.waitFor(TestUtil.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
 			} finally {
 				console.destroy();
 			}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/RuntimeProcessTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/RuntimeProcessTests.java
@@ -64,8 +64,8 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		mockProcess.setExitValue(1);
 		mockProcess.destroy();
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, testTimeout, p -> "RuntimeProcess not terminated.");
-		TestUtil.waitForJobs(name.getMethodName(), 25, testTimeout);
+		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitForJobs(name.getMethodName(), 25, TestUtil.DEFAULT_TIMEOUT);
 		assertEquals("Wrong number of terminate events.", 1, processTerminateEvents.get());
 		assertEquals("RuntimeProcess reported wrong exit code.", 1, runtimeProcess.getExitValue());
 	}
@@ -92,8 +92,8 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		runtimeProcess.terminate();
 		assertFalse("RuntimeProcess failed to terminate wrapped process.", mockProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, testTimeout, p -> "RuntimeProcess not terminated.");
-		TestUtil.waitForJobs(name.getMethodName(), 25, testTimeout);
+		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitForJobs(name.getMethodName(), 25, TestUtil.DEFAULT_TIMEOUT);
 		assertEquals("Wrong number of terminate events.", 1, processTerminateEvents.get());
 		assertEquals("RuntimeProcess reported wrong exit code.", 1, runtimeProcess.getExitValue());
 	}
@@ -129,7 +129,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		assertFalse("RuntimeProcess failed to terminate child of wrapped process.", childProcess2.isAlive());
 		assertFalse("RuntimeProcess failed to terminate descendant of wrapped process.", grandChildProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, testTimeout, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
 	}
 
 	/**
@@ -154,7 +154,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		assertFalse("RuntimeProcess failed to terminate wrapped process.", mockProcess.isAlive());
 		assertTrue("RuntimeProcess terminated child of wrapped process, unlike configured.", childProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, testTimeout, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		RuntimeProcess runtimeProcess = mockProcess.toRuntimeProcess();
 		runtimeProcess.terminate(); // must not throw, even toHandle() does
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, testTimeout, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
 	}
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -1306,7 +1306,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		IProcess process = null;
 		try {
 			process = DebugPlugin.newProcess(launch, new MockProcess(0), "test-terminate-timestamp");
-			waitWhile(__ -> !terminatedLaunches.contains(launch), testTimeout,
+			waitWhile(__ -> !terminatedLaunches.contains(launch),
 					__ -> "Launch termination event did not occur: "+
 							"launch termination state is \"" + launch.isTerminated() + "\" " +
 							"and " + terminatedLaunches.size() + " launches have terminated");
@@ -1454,7 +1454,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		IProcess runtimeProcess = null;
 		try {
 			runtimeProcess = DebugPlugin.newProcess(launch, mockProcess, "test-terminate-launch-listener");
-			waitWhile(__ -> !launchTerminated.get(), testTimeout, __ -> "Launch termination event did not occur");
+			waitWhile(__ -> !launchTerminated.get(), __ -> "Launch termination event did not occur");
 		} finally {
 			DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(listener);
 			if (launch != null) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
@@ -468,7 +468,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			long start = System.currentTimeMillis();
 			// Wait for the delta to be processed.
 			while (!fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILDREN_UPDATES_STARTED)
-					&& System.currentTimeMillis() - start < testTimeout) {
+					&& System.currentTimeMillis() - start < TestUtil.DEFAULT_TIMEOUT) {
 				completeQueuedUpdatesOfType(model, IChildrenCountUpdate.class);
 				completeQueuedUpdatesOfType(model, IHasChildrenUpdate.class);
 				TestUtil.processUIEvents();
@@ -511,7 +511,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			long start = System.currentTimeMillis();
 			// Wait for the delta to be processed.
 			while (!fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILDREN_UPDATES_STARTED)
-					&& System.currentTimeMillis() - start < testTimeout) {
+					&& System.currentTimeMillis() - start < TestUtil.DEFAULT_TIMEOUT) {
 				completeQueuedUpdatesOfType(model, IChildrenCountUpdate.class);
 				completeQueuedUpdatesOfType(model, IHasChildrenUpdate.class);
 				TestUtil.processUIEvents();


### PR DESCRIPTION
The debug tests use a centrally defined timeout when waiting for some condition. This value is defined in a non-final way in a superclass instead of the central TestUtil to where it is passed by most consumers.

This moves the default timeout value to the TestUtil class and adds a convenience version of the the waitWhile() method that uses this timeout value, as it is passed by most consumers anyway.