### PR TITLE
Make waitWhile() utility method in debug tests static

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/AbstractDebugTest.java
@@ -13,9 +13,6 @@
  *******************************************************************************/
 package org.eclipse.debug.tests;
 
-import java.util.function.Function;
-import java.util.function.Predicate;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -80,24 +77,6 @@ public class AbstractDebugTest {
 			job.setSystem(true);
 			job.schedule();
 		}
-	}
-
-	/**
-	 * Waits while given condition is {@code true} for some time. If the actual
-	 * wait time exceeds {@link TestUtil#DEFAULT_TIMEOUT} and condition will be still
-	 * {@code true}, throws {@link junit.framework.AssertionFailedError} with
-	 * given message.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param condition function which will be evaluated while waiting
-	 * @param errorMessage message which will be used to construct the failure
-	 *            exception in case the condition will still return {@code true}
-	 *            after given timeout
-	 */
-	public void waitWhile(Predicate<AbstractDebugTest> condition, Function<AbstractDebugTest, String> errorMessage) throws Exception {
-		TestUtil.waitWhile(condition, this, errorMessage);
 	}
 
 	private static void closeIntro(final IWorkbench wb) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -121,18 +122,16 @@ public final class TestUtil {
 	 * Will process UI events while waiting in UI thread, if called from
 	 * background thread, just waits.
 	 *
-	 * @param <T> type of the context
 	 * @param condition function which will be evaluated while waiting
-	 * @param context test context
 	 * @param timeout max wait time in milliseconds to wait on given condition
 	 * @param errorMessage message which will be used to construct the failure
 	 *            exception in case the condition will still return {@code true}
 	 *            after given timeout
 	 */
-	public static <T> void waitWhile(Predicate<T> condition, T context, long timeout, Function<T, String> errorMessage) throws Exception {
+	public static void waitWhile(BooleanSupplier condition, long timeout, Supplier<String> errorMessage) throws Exception {
 		long start = System.currentTimeMillis();
 		Display display = Display.getCurrent();
-		while (System.currentTimeMillis() - start < timeout && condition.test(context)) {
+		while (System.currentTimeMillis() - start < timeout && condition.getAsBoolean()) {
 			if (display != null && !display.isDisposed()) {
 				if (!display.readAndDispatch()) {
 					Thread.sleep(0);
@@ -141,9 +140,9 @@ public final class TestUtil {
 				Thread.sleep(5);
 			}
 		}
-		Boolean stillTrue = condition.test(context);
+		Boolean stillTrue = condition.getAsBoolean();
 		if (stillTrue) {
-			fail(errorMessage.apply(context));
+			fail(errorMessage.get());
 		}
 	}
 
@@ -156,15 +155,13 @@ public final class TestUtil {
 	 * Will process UI events while waiting in UI thread, if called from
 	 * background thread, just waits.
 	 *
-	 * @param <T> type of the context
 	 * @param condition function which will be evaluated while waiting
-	 * @param context test context
 	 * @param errorMessage message which will be used to construct the failure
 	 *            exception in case the condition will still return {@code true}
 	 *            after given timeout
 	 */
-	public static <T> void waitWhile(Predicate<T> condition, T context, Function<T, String> errorMessage) throws Exception {
-		waitWhile(condition, context, DEFAULT_TIMEOUT, errorMessage);
+	public static void waitWhile(BooleanSupplier condition, Supplier<String> errorMessage) throws Exception {
+		waitWhile(condition, DEFAULT_TIMEOUT, errorMessage);
 	}
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/BreakpointTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/BreakpointTests.java
@@ -86,20 +86,20 @@ public class BreakpointTests extends AbstractDebugTest {
 			IUndoContext context = DebugUITools.getBreakpointsUndoContext();
 
 			bpm.addBreakpoint(bp);
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not created");
+			TestUtil.waitWhile(() -> getTestBreakpoints().isEmpty(), () -> "Breakpoint is not created");
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
 			assertTrue("Breakpoint not registered", bp.isRegistered());
 
 			DebugUITools.deleteBreakpoints(new IBreakpoint[] {
 					bp }, null, null);
 			assertTrue(operationHistory.canUndo(context));
-			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not deleted");
+			TestUtil.waitWhile(() -> !getTestBreakpoints().isEmpty(), () -> "Breakpoint is not deleted");
 			assertFalse("Breakpoint marker not removed", bp.getMarker().exists());
 			assertFalse("Breakpoint still registered", bp.isRegistered());
 
 			operationHistory.undo(context, null, null);
 			assertTrue(operationHistory.canRedo(context));
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not recreated");
+			TestUtil.waitWhile(() -> getTestBreakpoints().isEmpty(), () -> "Breakpoint is not recreated");
 			bp = getTestBreakpoints().get(0);
 			assertEquals("Breakpoint attributes not correctly restored", content, bp.getText());
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
@@ -107,13 +107,13 @@ public class BreakpointTests extends AbstractDebugTest {
 
 			operationHistory.redo(context, null, null);
 			assertTrue(operationHistory.canUndo(context));
-			TestUtil.waitWhile(c -> !c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not deleted");
+			TestUtil.waitWhile(() -> !getTestBreakpoints().isEmpty(), () -> "Breakpoint is not deleted");
 			assertFalse("Breakpoint marker not removed", bp.getMarker().exists());
 			assertFalse("Breakpoint still registered", bp.isRegistered());
 
 			operationHistory.undo(context, null, null);
 			assertTrue(operationHistory.canRedo(context));
-			TestUtil.waitWhile(c -> c.getTestBreakpoints().isEmpty(), this, c -> "Breakpoint is not recreated");
+			TestUtil.waitWhile(() -> getTestBreakpoints().isEmpty(), () -> "Breakpoint is not recreated");
 			bp = getTestBreakpoints().get(0);
 			assertEquals("Breakpoint attributes not correctly restored", content, bp.getText());
 			assertTrue("Breakpoint marker missing", bp.getMarker().exists());
@@ -121,10 +121,10 @@ public class BreakpointTests extends AbstractDebugTest {
 
 			final BreakpointsView finalView = view;
 			final TestBreakpoint finalBp = bp;
-			TestUtil.waitWhile(c -> {
+			TestUtil.waitWhile(() -> {
 				TreeItem item = (TreeItem) finalView.getTreeModelViewer().testFindItem(finalBp);
 				return item == null || item.getText() == null || !item.getText().contains(content);
-			}, this, c -> "Breakpoint not restored in view");
+			}, () -> "Breakpoint not restored in view");
 		} finally {
 			if (!viewVisible) {
 				DebugUIPlugin.getActiveWorkbenchWindow().getActivePage().hideView(view);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/RuntimeProcessTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/RuntimeProcessTests.java
@@ -64,7 +64,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		mockProcess.setExitValue(1);
 		mockProcess.destroy();
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(() -> !runtimeProcess.isTerminated(), () -> "RuntimeProcess not terminated.");
 		TestUtil.waitForJobs(name.getMethodName(), 25, TestUtil.DEFAULT_TIMEOUT);
 		assertEquals("Wrong number of terminate events.", 1, processTerminateEvents.get());
 		assertEquals("RuntimeProcess reported wrong exit code.", 1, runtimeProcess.getExitValue());
@@ -92,7 +92,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		runtimeProcess.terminate();
 		assertFalse("RuntimeProcess failed to terminate wrapped process.", mockProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(() -> !runtimeProcess.isTerminated(), () -> "RuntimeProcess not terminated.");
 		TestUtil.waitForJobs(name.getMethodName(), 25, TestUtil.DEFAULT_TIMEOUT);
 		assertEquals("Wrong number of terminate events.", 1, processTerminateEvents.get());
 		assertEquals("RuntimeProcess reported wrong exit code.", 1, runtimeProcess.getExitValue());
@@ -129,7 +129,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		assertFalse("RuntimeProcess failed to terminate child of wrapped process.", childProcess2.isAlive());
 		assertFalse("RuntimeProcess failed to terminate descendant of wrapped process.", grandChildProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(() -> !runtimeProcess.isTerminated(), () -> "RuntimeProcess not terminated.");
 	}
 
 	/**
@@ -154,7 +154,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		assertFalse("RuntimeProcess failed to terminate wrapped process.", mockProcess.isAlive());
 		assertTrue("RuntimeProcess terminated child of wrapped process, unlike configured.", childProcess.isAlive());
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(() -> !runtimeProcess.isTerminated(), () -> "RuntimeProcess not terminated.");
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class RuntimeProcessTests extends AbstractDebugTest {
 		RuntimeProcess runtimeProcess = mockProcess.toRuntimeProcess();
 		runtimeProcess.terminate(); // must not throw, even toHandle() does
 
-		TestUtil.waitWhile(p -> !p.isTerminated(), runtimeProcess, p -> "RuntimeProcess not terminated.");
+		TestUtil.waitWhile(() -> !runtimeProcess.isTerminated(), () -> "RuntimeProcess not terminated.");
 	}
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.debug.tests.launching;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1306,8 +1307,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		IProcess process = null;
 		try {
 			process = DebugPlugin.newProcess(launch, new MockProcess(0), "test-terminate-timestamp");
-			waitWhile(__ -> !terminatedLaunches.contains(launch),
-					__ -> "Launch termination event did not occur: "+
+			waitWhile(() -> !terminatedLaunches.contains(launch), () -> "Launch termination event did not occur: " +
 							"launch termination state is \"" + launch.isTerminated() + "\" " +
 							"and " + terminatedLaunches.size() + " launches have terminated");
 			String launchTerminateTimestampUntyped = launch.getAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP);
@@ -1454,7 +1454,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		IProcess runtimeProcess = null;
 		try {
 			runtimeProcess = DebugPlugin.newProcess(launch, mockProcess, "test-terminate-launch-listener");
-			waitWhile(__ -> !launchTerminated.get(), __ -> "Launch termination event did not occur");
+			waitWhile(() -> !launchTerminated.get(), () -> "Launch termination event did not occur");
 		} finally {
 			DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(listener);
 			if (launch != null) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/AbstractViewerModelTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/AbstractViewerModelTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
 import org.eclipse.debug.tests.AbstractDebugTest;
@@ -62,8 +62,8 @@ public abstract class AbstractViewerModelTest extends AbstractDebugTest {
 
 	abstract protected TestModelUpdatesListener createListener(IInternalTreeModelViewer viewer);
 
-	protected Function<AbstractDebugTest, String> createListenerErrorMessage() {
-		return t -> "Listener not finished: " + fListener;
+	protected Supplier<String> createListenerErrorMessage() {
+		return () -> "Listener not finished: " + fListener;
 	}
 
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/CheckTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/CheckTests.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
+
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ModelDelta;
 import org.eclipse.debug.tests.viewer.model.TestModel.TestElement;
@@ -54,7 +56,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 		fViewer.setInput(model.getRootElement());
 
 		// Wait for the updates to complete.
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
@@ -70,7 +72,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
@@ -85,7 +87,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, true, false);
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		TestElement element = model.getRootElement().getChildren()[0];
@@ -96,7 +98,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 		fListener.reset(elementPath, element, -1, true, false);
 		model.postDelta(delta);
 
-		waitWhile(t -> !fListener.isFinished(ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		Assert.assertTrue(element.getChecked() != initialCheckState);
 	}
@@ -113,7 +115,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -124,7 +126,7 @@ abstract public class CheckTests extends AbstractViewerModelTest {
 
 		fListener.reset(elementPath, element, -1, true, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(ITestModelUpdatesListenerConstants.LABEL_COMPLETE | ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ITestModelUpdatesListenerConstants.LABEL_COMPLETE | ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ColumnPresentationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/ColumnPresentationTests.java
@@ -14,10 +14,11 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IColumnPresentation;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IColumnPresentation2;
@@ -251,7 +252,7 @@ public class ColumnPresentationTests extends AbstractDebugTest implements ITestM
 		new TestElement(model, "6", new TestElement[0]) })); //$NON-NLS-1$
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, true, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 		return model;
 	}
@@ -350,10 +351,10 @@ public class ColumnPresentationTests extends AbstractDebugTest implements ITestM
 		// get InternalTreeModelViewer to rebuild columns due to hide and show columns
 		fViewer.setShowColumns(false);
 		TestUtil.processUIEvents();
-		waitWhile(t -> fViewer.getTree().getColumns().length > 0, createColumnsErrorMessage());
+		waitWhile(() -> fViewer.getTree().getColumns().length > 0, createColumnsErrorMessage());
 		fViewer.setShowColumns(true);
 		TestUtil.processUIEvents();
-		waitWhile(t -> fViewer.getTree().getColumns().length != newWidths.length, createColumnsErrorMessage());
+		waitWhile(() -> fViewer.getTree().getColumns().length != newWidths.length, createColumnsErrorMessage());
 		// verify user resized widths are used instead of the initial widths from IColumnPresentation2
 		columns = fViewer.getTree().getColumns();
 		for (int i = 0; i < columns.length; i++) {
@@ -411,7 +412,7 @@ public class ColumnPresentationTests extends AbstractDebugTest implements ITestM
 		// Select visible columns
 		fViewer.setVisibleColumns(new String[] { colPre.columnIds[0] });
 		TestUtil.processUIEvents();
-		waitWhile(t -> fViewer.getTree().getColumns().length != 1, createColumnsErrorMessage());
+		waitWhile(() -> fViewer.getTree().getColumns().length != 1, createColumnsErrorMessage());
 
 		// get InternalTreeModelViewer to rebuild columns due to change of
 		// model and presentation - first set to another model and column
@@ -431,11 +432,11 @@ public class ColumnPresentationTests extends AbstractDebugTest implements ITestM
 		}
 	}
 
-	private Function<AbstractDebugTest, String> createColumnsErrorMessage() {
-		return t -> "Unexpected columns number: " + fViewer.getTree().getColumns().length;
+	private Supplier<String> createColumnsErrorMessage() {
+		return () -> "Unexpected columns number: " + fViewer.getTree().getColumns().length;
 	}
 
-	private Function<AbstractDebugTest, String> createListenerErrorMessage() {
-		return t -> "Listener not finished: " + fListener;
+	private Supplier<String> createListenerErrorMessage() {
+		return () -> "Listener not finished: " + fListener;
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/DeltaTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/DeltaTests.java
@@ -14,12 +14,14 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IModelDelta;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ModelDelta;
@@ -53,7 +55,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -63,7 +65,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		fListener.reset(elementPath, element, -1, true, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(LABEL_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(LABEL_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -79,7 +81,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -94,7 +96,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		fListener.reset(elementPath, element, -1, true, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -110,7 +112,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		String prefix = "new - "; //$NON-NLS-1$
@@ -144,7 +146,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.reset(TreePath.EMPTY, element, -1, false, false);
 
 		model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -168,12 +170,12 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, false, false);
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 		assertTrue( fListener.checkCoalesced(TreePath.EMPTY, 0, 6) );
@@ -192,7 +194,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -210,7 +212,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// TODO: redundant label updates on insert!
 		fListener.setFailOnRedundantUpdates(false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -231,7 +233,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 
@@ -258,7 +260,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.setFailOnRedundantUpdates(false);
 
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
@@ -276,7 +278,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, true, false);
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 
@@ -303,7 +305,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.setFailOnRedundantUpdates(false);
 
 		model.postDelta(combinedDelta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
@@ -320,7 +322,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -334,7 +336,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// TODO: redundant updates on add!
 		fListener.setFailOnRedundantUpdates(false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -352,7 +354,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Update the model
 		TreePath parentPath = model.findElement("1"); //$NON-NLS-1$
@@ -365,7 +367,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.reset();
 		fListener.setFailOnRedundantUpdates(false);
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Update the elements that were added.
 		fListener.reset();
@@ -377,12 +379,12 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		model.getElementDelta(rootDelta, model.findElement("1.4"), true).setFlags(IModelDelta.CONTENT); //$NON-NLS-1$
 
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		fListener.reset(parentPath, model.getElement(parentPath), 1, false, true);
 		fViewer.expandToLevel(parentPath, 1);
 
-		waitWhile(t -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, parentPath);
 	}
@@ -400,14 +402,14 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Expand elment "2"
 		TreePath parentPath = model.findElement("2"); //$NON-NLS-1$
 		fListener.reset(parentPath, model.getElement(parentPath), 1, false, true);
 		fViewer.expandToLevel(parentPath, 1);
 
-		waitWhile(t -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Collapse back element "2"
 		fViewer.setExpandedState(parentPath, false);
@@ -421,13 +423,13 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		model.getElementDelta(rootDelta, model.findElement("2.3"), true).setFlags(IModelDelta.CONTENT); //$NON-NLS-1$
 
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Expand back element "2"
 		fListener.reset(parentPath, model.getElement(parentPath), 1, false, true);
 		fViewer.expandToLevel(parentPath, 1);
 
-		waitWhile(t -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, parentPath, true);
 	}
@@ -444,7 +446,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -454,7 +456,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// be processed.
 		fListener.reset();
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -467,7 +469,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Create the delta
@@ -520,7 +522,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		assertFalse(contentProviderViewer.getExpandedState(path_root_3_2_2));
 
 		model.postDelta(deltaRoot);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Validate the expansion state AFTER posting the delta.
@@ -550,7 +552,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Create the delta
@@ -574,7 +576,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		model.postDelta(deltaRoot);
 		TestUtil.processUIEvents();
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Validate the expansion state AFTER posting the delta.
@@ -603,7 +605,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Update the model
@@ -620,7 +622,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		fListener.reset(m4_2_1Path, m4_2_1, -1, true, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -635,7 +637,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		TreePath m3_1Path = model.findElement("m3.1"); //$NON-NLS-1$
@@ -650,7 +652,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.setFailOnRedundantUpdates(false);
 
 		m3.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
@@ -663,7 +665,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Update the model: remove one child of an un-expanded element, then
@@ -676,7 +678,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		fListener.reset(parentPath, parentElement, 0, false, false);
 		//fListener.addChildreCountUpdate(parentPath);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
 
 		// Validate the viewer data.
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -688,7 +690,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// Update the viewer
 		fListener.reset(parentPath, parentElement, 0, false, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
 
 		// Validate the viewer data.
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -700,7 +702,7 @@ abstract public class DeltaTests extends AbstractViewerModelTest implements ITes
 		// Update the viewer
 		fListener.reset(parentPath, parentElement, 0, false, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_COMPLETE), createListenerErrorMessage());
 
 		// Validate the viewer data.
 		model.validateData(fViewer, TreePath.EMPTY, true);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.debug.tests.viewer.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;
@@ -146,7 +147,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		fViewer.setInput(model.getRootElement());
 
 		// Wait for the updates to complete.
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY, false, filters);
 	}
@@ -175,7 +176,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 	}
 
 
@@ -214,7 +215,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
 
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Switch out element "201" which is filtered out, with a "replaced element" which should NOT be
 		// filtered out.
@@ -222,12 +223,12 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		IModelDelta replaceDelta = model.replaceElementChild(TreePath.EMPTY, 200, replacedElement);
 		fListener.reset();
 		model.postDelta(replaceDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Reposition the viewer to make element 100 the top element, making the replaced element visible.
 		fListener.reset();
 		fViewer.reveal(TreePath.EMPTY, 150);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Verify that the replaced element is in viewer now (i.e. it's not filtered out.
 		TreePath[] replacedElementPaths = fViewer.getElementPaths(replacedElement);
@@ -263,7 +264,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
 
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Switch out element "201" which is filtered out, with a "replaced element" which should NOT be
 		// filtered out.
@@ -271,12 +272,12 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		model.replaceElementChild(TreePath.EMPTY, 200, replacedElement);
 		fListener.reset();
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Reposition the viewer to make element 100 the top element, making the replaced element visible.
 		fListener.reset();
 		fViewer.reveal(TreePath.EMPTY, 150);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Verify that the replaced element is in viewer now (i.e. it's not filtered out.
 		TreePath[] replacedElementPaths = fViewer.getElementPaths(replacedElement);
@@ -319,7 +320,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
 
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Turn off filters and refresh.
 		filters1 = new ViewerFilter[0];
@@ -327,7 +328,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		fListener.reset();
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		model.validateData(fViewer, TreePath.EMPTY, false, filters1);
 	}
@@ -344,7 +345,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		StateTests.expandAlternateElements(fListener, model, true);
@@ -366,7 +367,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Post the refresh delta
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true, filters);
@@ -391,7 +392,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset();
 		fListener.addUpdates(getInternalViewer(), TreePath.EMPTY, model.getRootElement(), filters, -1, ALL_UPDATES_COMPLETE);
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true, filters);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/JFaceViewerTopIndexTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/JFaceViewerTopIndexTests.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -82,7 +83,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Stop forcing view updates.
@@ -106,12 +107,12 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		fListener.addStateUpdates(getCTargetViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Set the viewer input back to the model to trigger RESTORE operation.
 		fListener.reset(false, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		TestUtil.processUIEvents();
 		// check if REVEAL was restored OK
@@ -157,7 +158,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Expand first element
@@ -175,7 +176,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		model.postDelta(rootDelta);
 
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Validate that the first node is expanded
 		assertTrue(getCTargetViewer().getExpandedState(firstElemPath));
@@ -199,12 +200,12 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		fListener.reset(true, false);
 		fListener.addStateUpdates(getCTargetViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
 
 		// Set the viewer input back to the model
 		fListener.reset(false, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		TestUtil.processUIEvents();
 		// check if REVEAL was restored OK
@@ -252,7 +253,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		int indexLastElem = elements.length-1;
@@ -281,12 +282,12 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		fListener.addStateUpdates(getCTargetViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Set the viewer input back to the model.
 		fListener.reset(false, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		TestUtil.processUIEvents();
 		// check if REVEAL was restored OK
@@ -313,7 +314,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Stop autopopulating the view.
@@ -336,7 +337,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		TreePath elementPath = model.findElement("3"); //$NON-NLS-1$
 		fListener.addUpdates(fViewer, elementPath, model.getElement(elementPath), 1, STATE_UPDATES);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Update the viewer with new selection delta to something new in the view
 		ModelDelta revealDelta = model.makeElementDelta(model.findElement("2.1"), IModelDelta.REVEAL); //$NON-NLS-1$
@@ -344,7 +345,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		// Wait for the second model delta to process
 		fListener.reset();
 		model.postDelta(revealDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Clear view then reset it again.
 		fListener.reset();
@@ -355,7 +356,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		autopopulateAgent = new TreeModelViewerAutopopulateAgent(getCTargetViewer());
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 		autopopulateAgent.dispose();
 	}
 
@@ -381,7 +382,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Stop auto-populating and auto-expanding the view.
@@ -407,7 +408,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		elementPath = model.findElement("3"); //$NON-NLS-1$
 		fListener.addUpdates(fViewer, elementPath, model.getElement(elementPath), 0, STATE_UPDATES);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_UPDATES), createListenerErrorMessage());
 
 		// Update the viewer with new selection delta to something new in the view
 		TreePath pathToBeRevealed = model.findElement("2.1"); //$NON-NLS-1$
@@ -419,7 +420,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		// Wait for the second model delta to process
 		model.postDelta(revealDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILDREN_UPDATES | LABEL_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILDREN_UPDATES | LABEL_UPDATES), createListenerErrorMessage());
 
 		// check if REVEAL was triggered by the delta and not by the
 		// state restore operation
@@ -450,7 +451,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Stop forcing view updates.
@@ -470,13 +471,13 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 		fListener.reset(true, false);
 		fListener.addStateUpdates(getCTargetViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
 
 		// Set the viewer input back to the model
 		fListener.reset(false, false);
 		fListener.addUpdates(getCTargetViewer(), originalTopPath, (TestElement)originalTopPath.getLastSegment(), 0, STATE_UPDATES);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(STATE_UPDATES | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_UPDATES | CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		TestUtil.processUIEvents();
 		// check if REVEAL was restored OK
@@ -504,7 +505,7 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Set top index of view to element "2" and wait for view to repaint.
@@ -535,11 +536,11 @@ public class JFaceViewerTopIndexTests extends AbstractViewerModelTest implements
 
 		// Wait for the model delta to process
 		model.postDelta(revealDelta);
-		waitWhile(t -> !fListener.isFinished(CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
 
 		model.setQeueueingUpdate(false);
 
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// check if REVEAL actually revealed the desired element
 		topPath = getCTargetViewer().getTopElementPath();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/LazyTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/LazyTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
@@ -75,7 +76,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		// Populate initial view content
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, true, true);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Create delta to expand the "1" element.
 		TestElement rootElement = model.getRootElement();
@@ -98,7 +99,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		}
 		model.postDelta(rootDelta);
 
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 	}
 
 	/**
@@ -123,7 +124,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		fListener.setFailOnRedundantUpdates(false);
 		fViewer.setInput(model.getRootElement());
 		fListener.addLabelUpdate(model.findElement("1.0")); //$NON-NLS-1$
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_COMPLETE), createListenerErrorMessage());
 
 		// Set selection so that the initial selection is not empty
 		fViewer.setSelection(new TreeSelection(new TreePath[] { model.findElement("1.0") })); //$NON-NLS-1$
@@ -148,7 +149,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		fListener.addLabelUpdate(_1_0_newElementPath);
 		model.postDelta(rootDelta);
 
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | LABEL_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | LABEL_COMPLETE), createListenerErrorMessage());
 
 
 		assertEquals(((IStructuredSelection)fViewer.getSelection()).getFirstElement(), _1_0_newElement);
@@ -165,7 +166,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		// Populate initial view content
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, true, true);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Turn off autoexpand
 		fViewer.setAutoExpandLevel(0);
@@ -174,7 +175,7 @@ abstract public class LazyTests extends AbstractViewerModelTest implements ITest
 		fListener.reset();
 		fListener.setFailOnRedundantUpdates(false);
 		fViewer.reveal(model.findElement("1"), 500); //$NON-NLS-1$
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Create delta to refresh the "1" element.
 		TestElement rootElement = model.getRootElement();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PerformanceTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PerformanceTests.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
+
 import org.eclipse.debug.internal.ui.viewers.model.IInternalTreeModelViewer;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.IModelDelta;
 import org.eclipse.debug.internal.ui.viewers.model.provisional.ModelDelta;
@@ -70,7 +72,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		Performance perf = Performance.getDefault();
@@ -85,7 +87,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}
@@ -110,7 +112,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		fVirtualItemValidator.setVisibleRange(0, 50);
 
@@ -127,9 +129,9 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}
@@ -154,7 +156,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		Performance perf = Performance.getDefault();
@@ -169,7 +171,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}
@@ -195,7 +197,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		Performance perf = Performance.getDefault();
@@ -210,7 +212,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}
@@ -235,7 +237,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Set a selection in view
@@ -256,7 +258,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				fViewer.setInput(null);
-				waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
 
 				// Set the viewer input back to the model.  When view updates are complete
 				// the viewer
@@ -264,7 +266,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 				fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, false, false);
 				// TODO: add state updates somehow?
 				fViewer.setInput(model.getRootElement());
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}
@@ -307,7 +309,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		Performance perf = Performance.getDefault();
@@ -322,7 +324,7 @@ abstract public class PerformanceTests extends AbstractViewerModelTest implement
 
 				meter.start();
 				model.postDelta(new ModelDelta(element, IModelDelta.CONTENT));
-				waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+				waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 				meter.stop();
 				System.gc();
 			}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PopupTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/PopupTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -76,7 +77,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -91,7 +92,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		fListener.reset(elementPath, element, -1, true, false);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -107,7 +108,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Create the delta
@@ -131,7 +132,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		model.postDelta(deltaRoot);
 		TestUtil.processUIEvents();
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE)
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE)
 				&& (fListener.isFinished(CONTENT_SEQUENCE_STARTED)
 						|| !fListener.isFinished(CONTENT_SEQUENCE_STARTED) && !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE)),
 				createListenerErrorMessage());
@@ -163,7 +164,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Turn off auto-expansion
@@ -188,7 +189,7 @@ abstract public class PopupTests extends AbstractViewerModelTest implements ITes
 
 		// Post the sub-tree update
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/SelectionTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/SelectionTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -56,7 +57,7 @@ abstract public class SelectionTests extends AbstractViewerModelTest implements 
 		fViewer.setAutoExpandLevel(-1);
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), -1, true, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 		return model;
 	}
@@ -138,14 +139,14 @@ abstract public class SelectionTests extends AbstractViewerModelTest implements 
 		ModelDelta delta_3_3_3 = model.getElementDelta(baseDelta, path_3_3_3, false);
 		delta_3_3_3.setFlags(IModelDelta.SELECT);
 		fViewer.updateViewer(baseDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		assertEquals(selection_3_3_1, fViewer.getSelection());
 
 		// Add the *force* flag to the selection delta and update viewer again.
 		// Verify that selection did change.
 		delta_3_3_3.setFlags(IModelDelta.SELECT | IModelDelta.FORCE);
 		fViewer.updateViewer(baseDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		assertEquals(selection_3_3_3, fViewer.getSelection());
 	}
 
@@ -183,7 +184,7 @@ abstract public class SelectionTests extends AbstractViewerModelTest implements 
 		// delta only wait for the delta to be processed.
 		fListener.reset();
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ITestModelUpdatesListenerConstants.MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure the selection was made
 		//assertTrue(listener.fEvents.size() == 1);
@@ -228,7 +229,7 @@ abstract public class SelectionTests extends AbstractViewerModelTest implements 
 
 		// Refresh the viewer
 		model.postDelta( new ModelDelta(model.getRootElement(), IModelDelta.CONTENT) );
-		waitWhile(t -> !fListener.isFinished(ITestModelUpdatesListenerConstants.ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ITestModelUpdatesListenerConstants.ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure the selection was made
 		// Commented out until JFace bug 219887 is fixed.

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/StateTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/StateTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +66,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Create the update delta
@@ -100,7 +101,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 		fListener.addLabelUpdate(path3);
 
 		fViewer.updateViewer(updateDelta);
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | LABEL_UPDATES), createListenerErrorMessage());
 
 		// Extract the new state from viewer
 		ModelDelta savedDelta = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -270,7 +271,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 		}
 		model.postDelta(rootDelta);
 
-		TestUtil.waitWhile(t -> !listener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE), null, 30000, t -> "Listener not finished: " + listener);
+		TestUtil.waitWhile(() -> !listener.isFinished(CONTENT_SEQUENCE_COMPLETE | MODEL_CHANGED_COMPLETE), 30000, () -> "Listener not finished: " + listener);
 	}
 
 	@Test
@@ -285,7 +286,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		expandAlternateElements(fListener, model, true);
@@ -300,7 +301,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 		// Remove delta should not generate any new updates
 		fListener.reset();
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -326,7 +327,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		expandAlternateElements(fListener, model, true);
@@ -344,7 +345,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 		fListener.reset(path, (TestElement)path.getLastSegment(), 0, false, false);
 		fListener.addChildreUpdate(TreePath.EMPTY, 0);
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -372,7 +373,7 @@ abstract public class StateTests extends AbstractViewerModelTest implements ITes
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		expandAlternateElements(fListener, model, true);
@@ -398,7 +399,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Post the multi-content update delta
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -429,7 +430,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		/*
@@ -458,7 +459,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			model.postDelta(rootDelta);
 
-			TestUtil.waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), null, 300000, t -> "Listener not finished: " + fListener);
+			TestUtil.waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), 300000, () -> "Listener not finished: " + fListener);
 		}
 
 		/*
@@ -479,7 +480,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			model.postDelta(rootDelta);
 
-			TestUtil.waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), null, 60000, t -> "Listener not finished: " + fListener);
+			TestUtil.waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), 60000, () -> "Listener not finished: " + fListener);
 		}
 
 		/*
@@ -509,7 +510,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			model.postDelta(rootDelta);
 
-			TestUtil.waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), null, 60000, t -> "Listener not finished: " + fListener);
+			TestUtil.waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), 60000, () -> "Listener not finished: " + fListener);
 		}
 
 		/*
@@ -531,7 +532,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 			model.postDelta(rootDelta);
 
-			TestUtil.waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), null, 6000000, t -> "Listener not finished: " + fListener);
+			TestUtil.waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | MODEL_CHANGED_COMPLETE), 6000000, () -> "Listener not finished: " + fListener);
 		}
 
 		/*
@@ -555,7 +556,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Turn off auto-expansion
@@ -580,7 +581,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Post the sub-tree update
 		model.postDelta(rootDelta);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		model.validateData(fViewer, TreePath.EMPTY, true);
@@ -605,7 +606,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		expandAlternateElements(fListener, model, true);
@@ -627,7 +628,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 			fListener.reset(false, false);
 			fListener.addUpdates(getInternalViewer(), TreePath.EMPTY, model.getRootElement(), -1, ALL_UPDATES_COMPLETE);
 			model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-			waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 			// Validate data
 			model.validateData(fViewer, TreePath.EMPTY, true);
@@ -647,7 +648,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 			fListener.reset(false, false);
 			fListener.addUpdates(getInternalViewer(), TreePath.EMPTY, model.getRootElement(), -1, ALL_UPDATES_COMPLETE);
 			model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-			waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 			// Validate data
 			model.validateData(fViewer, TreePath.EMPTY, true);
@@ -675,7 +676,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		expandAlternateElements(fListener, model, false);
 
@@ -690,7 +691,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Note: Re-expanding nodes causes redundant updates.
 		fListener.reset(false, false);
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
@@ -708,7 +709,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Note: Re-expanding nodes causes redundant updates.
 		fListener.reset(false, false);
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
@@ -739,7 +740,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Set a selection in view
@@ -751,7 +752,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Refresh content.
 		// Note: Wait only for the processing of the delta, not for all updates
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Update the viewer with new selection delta to something new in the view
 		ModelDelta selectDelta = model.makeElementDelta(model.findElement("2.1"), IModelDelta.SELECT); //$NON-NLS-1$
@@ -759,11 +760,11 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Wait for the second model delta to process
 		fListener.resetModelChanged();
 		model.postDelta(selectDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Wait for all the updates to complete (note: we're not resetting the listener.
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
 		assertEquals(new TreeSelection(model.findElement("2.1")), fViewer.getSelection()); //$NON-NLS-1$
@@ -782,7 +783,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Turn off auto-expand
@@ -794,7 +795,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Refresh content.
 		// Note: Wait only for the processing of the delta, not for all updates
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Update the viewer to collapse an element
 		ModelDelta collapseDelta = model.makeElementDelta(model.findElement("3.1"), IModelDelta.COLLAPSE); //$NON-NLS-1$
@@ -815,11 +816,11 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Wait for the second model delta to process
 		model.postDelta(collapseDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Wait for all the updates to complete (note: we're not resetting the listener.
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
 		assertFalse(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
@@ -837,7 +838,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Reset the listener (ignore redundant updates)
@@ -846,7 +847,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Refresh content.
 		// Note: Wait only for the processing of the delta, not for all updates
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Update the viewer to expand an element
 		ModelDelta expandDelta = model.makeElementDelta(model.findElement("3.1"), IModelDelta.EXPAND); //$NON-NLS-1$
@@ -854,11 +855,11 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Wait for the second model delta to process
 		fListener.resetModelChanged();
 		model.postDelta(expandDelta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Wait for all the updates to complete (note: we're not resetting the listener.
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
 		assertTrue(getInternalViewer().getExpandedState(model.findElement("3.1"))); //$NON-NLS-1$
@@ -876,7 +877,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Expand some, but not all elements
@@ -893,7 +894,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset(false, false);
 		fListener.addStateUpdates(getInternalViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Set the viewer input back to the model.  When view updates are complete
 		// the viewer
@@ -901,7 +902,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, false, false);
 		// TODO: add state updates somehow?
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Extract the restored state from viewer
 		ModelDelta restoredState = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -925,7 +926,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Set a selection in view
@@ -944,7 +945,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.addStateUpdates(getInternalViewer(), originalState, IModelDelta.EXPAND | IModelDelta.SELECT | IModelDelta.REVEAL);
 
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Set the viewer input back to the model.  When view updates are complete
 		// the viewer
@@ -952,7 +953,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, false, false);
 		// TODO: add state updates somehow?
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Extract the restored state from viewer
 		ModelDelta restoredState = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -975,7 +976,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Expand some, but not all elements
@@ -995,7 +996,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Note: disable redundant updates because the reveal delta triggers one.
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, false, false);
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Extract the restored state from viewer
 		ModelDelta restoredState = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -1018,7 +1019,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// Expand some, but not all elements
@@ -1041,7 +1042,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset(TreePath.EMPTY, model.getRootElement(), 1, false, false);
 
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 
 		// Extract the restored state from viewer
 		ModelDelta restoredState = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -1065,7 +1066,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		expandAlternateElements(fListener, model, false);
 
@@ -1084,7 +1085,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		fViewer.setInput(null);
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 		// Set the viewer input back to the model.  When view updates are complete
 		// the viewer
@@ -1092,7 +1093,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset();
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data (only select visible elements).
 		assertTrue(getInternalViewer().getExpandedState(model.findElement("1"))); //$NON-NLS-1$
@@ -1125,7 +1126,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE), createListenerErrorMessage());
 
 		expandAlternateElements(fListener, model, false);
 
@@ -1144,7 +1145,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		fViewer.setInput(null);
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE | STATE_UPDATES), createListenerErrorMessage());
 
 
 		TestElement[] elements = model.getRootElement().getChildren();
@@ -1160,7 +1161,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		TestUtil.waitForJobs(name.getMethodName(), 300, 5000);
 
 		// MONITOR FOR THE STATE RESTORE TO COMPLETE
-		waitWhile(t -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_SEQUENCE_COMPLETE | STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Validate data
 		assertTrue(getInternalViewer().getExpandedState(model.findElement("1"))); //$NON-NLS-1$
@@ -1188,7 +1189,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		fViewer.setSelection(new TreeSelection(model.findElement("3"))); //$NON-NLS-1$
@@ -1199,7 +1200,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Set the viewer input to null.  This will trigger the view to save the viewer state.
 		fListener.reset(false, false);
 		fViewer.setInput(null);
-		waitWhile(t -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_SAVE_COMPLETE), createListenerErrorMessage());
 
 		// Set the viewer input back to the model.  When view updates are complete
 		// the viewer
@@ -1214,24 +1215,24 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		// Wait till we restore state of elements we want to collapse and select
 		// Bug 372619 - Need to wait until proxy installed delta is processed before
 		// posting the next delta.
-		waitWhile(t -> !fListener.isFinished(STATE_RESTORE_STARTED | STATE_UPDATES | CHILDREN_UPDATES | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_RESTORE_STARTED | STATE_UPDATES | CHILDREN_UPDATES | MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Post first collapse delta
 		fListener.resetModelChanged();
 		model.postDelta(model.makeElementDelta(model.findElement("2"), IModelDelta.COLLAPSE)); //$NON-NLS-1$
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Post second collapse delta
 		fListener.resetModelChanged();
 		model.postDelta(model.makeElementDelta(model.findElement("3"), IModelDelta.COLLAPSE)); //$NON-NLS-1$
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Post select delta
 		model.postDelta(model.makeElementDelta(model.findElement("1"), IModelDelta.SELECT)); //$NON-NLS-1$
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		// Wait for all the updates to complete (note: we're not resetting the listener).
-		waitWhile(t -> !fListener.isFinished(STATE_RESTORE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_RESTORE_COMPLETE), createListenerErrorMessage());
 
 		// Check to make sure that the state restore didn't change the selection.
 		assertFalse(getInternalViewer().getExpandedState(model.findElement("2"))); //$NON-NLS-1$
@@ -1258,7 +1259,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY, true);
 
 		// a new similar model
@@ -1268,7 +1269,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		fListener.reset();
 		fListener.expectRestoreAfterSaveComplete();
 		fViewer.setInput(copyModel.getRootElement());
-		waitWhile(t -> !fListener.isFinished(STATE_RESTORE_STARTED), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(STATE_RESTORE_STARTED), createListenerErrorMessage());
 		assertTrue("RESTORE started before SAVE to complete", fListener.isFinished(STATE_SAVE_COMPLETE)); //$NON-NLS-1$
 	}
 
@@ -1286,7 +1287,7 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		ModelDelta expandedState = new ModelDelta(model.getRootElement(), IModelDelta.NO_CHANGE);
@@ -1298,12 +1299,12 @@ new TreePath[] { model.findElement("5"), model.findElement("5.1"), model.findEle
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 		// Wait for the delta to be processed.
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
 
 		fViewer.setInput(null);
 		fViewer.updateViewer(expandedState);
 
-		waitWhile(t -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
 
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/UpdateTests.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.debug.tests.viewer.model;
 
+import static org.eclipse.debug.tests.TestUtil.waitWhile;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -58,7 +60,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -78,7 +80,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		fListener.reset(rootPath, root, -1, false, false);
 
 		model.postDelta(new ModelDelta(root, IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -96,7 +98,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -118,7 +120,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Refresh the viewer
 		model.postDelta(new ModelDelta(rootElement, IModelDelta.CONTENT));
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -130,7 +132,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		// be processed.
 		fListener.reset();
 		model.postDelta(delta);
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		if (validate) {
 			model.validateData(fViewer, TreePath.EMPTY);
@@ -146,10 +148,10 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(delta);
 
 		if (validate) {
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 			model.validateData(fViewer, TreePath.EMPTY);
 		} else {
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		}
 	}
 
@@ -162,10 +164,10 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(delta);
 
 		if (validate) {
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 			model.validateData(fViewer, TreePath.EMPTY);
 		} else {
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 		}
 	}
 
@@ -181,7 +183,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Update the model
@@ -210,7 +212,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Refresh the viewer so that updates are generated.
@@ -218,7 +220,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 		// Wait for the delta to be processed.
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 		Assert.assertTrue( fListener.isFinished(CONTENT_SEQUENCE_STARTED) );
 	}
@@ -240,7 +242,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Create a listener to listen only to a children count update for the root.
@@ -254,7 +256,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			childrenCountUpdateListener.addChildreCountUpdate(TreePath.EMPTY);
 			model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 			// Wait until the delta is processed
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 
 			removeElement(model, 5, false);
 			removeElement(model, 4, false);
@@ -265,7 +267,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 			// Wait until the children count update is completed using the count from
 			// before elements were removed.
-			waitWhile(t -> !childrenCountUpdateListener.isFinished(CHILD_COUNT_UPDATES), createListenerErrorMessage());
+			waitWhile(() -> !childrenCountUpdateListener.isFinished(CHILD_COUNT_UPDATES), createListenerErrorMessage());
 
 			insertElement(model, "1 - " + pass, 0, false); //$NON-NLS-1$
 			insertElement(model, "2 - " + pass, 1, false); //$NON-NLS-1$
@@ -274,7 +276,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			insertElement(model, "5 - " + pass, 4, false); //$NON-NLS-1$
 			insertElement(model, "6 - " + pass, 5, false); //$NON-NLS-1$
 
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE), createListenerErrorMessage());
 			model.validateData(fViewer, TreePath.EMPTY);
 
 		}
@@ -299,7 +301,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Insert element at the end of the list.
@@ -319,7 +321,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		fListener.reset();
 		model.postDelta(delta);
 
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CONTENT_SEQUENCE_COMPLETE | LABEL_SEQUENCE_COMPLETE), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 	}
 
@@ -337,7 +339,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		for (int i = 0; i < 5; i++) {
@@ -348,7 +350,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			model.postDelta(new ModelDelta(rootElement, IModelDelta.CONTENT));
 
 			// Wait for the delta to be processed.
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES | CHILDREN_UPDATES_STARTED), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES | CHILDREN_UPDATES_STARTED), createListenerErrorMessage());
 
 			// Update the model
 			removeElement(model, 0, true);
@@ -373,7 +375,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 
@@ -385,12 +387,12 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 			// Wait for the delta to be processed.
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
 
 		}
 
 		model.setQeueueingUpdate(false);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 	}
 
@@ -411,7 +413,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 
@@ -423,7 +425,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 			model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 			// Wait for the delta to be processed.
-			waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
+			waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES_STARTED), createListenerErrorMessage());
 
 		}
 
@@ -434,7 +436,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		}
 
 		model.setQeueueingUpdate(false);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 	}
 
 	/**
@@ -454,7 +456,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 
@@ -476,7 +478,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		}
 
 		model.setQeueueingUpdate(false);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 
 	}
 
@@ -497,7 +499,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 
@@ -526,7 +528,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		}
 
 		model.setQeueueingUpdate(false);
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 	}
 
 	/**
@@ -546,7 +548,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		// Refresh the viewer so that updates are generated.
@@ -557,13 +559,13 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 		// Wait for the delta to be processed and child updates for "2" to get started.
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES | CHILDREN_UPDATES_RUNNING), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES | CHILDREN_UPDATES_RUNNING), createListenerErrorMessage());
 
 		// Remove element "2"
 		removeElement(model, 1, true);
 
 		// Wait for all updates to finish.
-		waitWhile(t -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(ALL_UPDATES_COMPLETE), createListenerErrorMessage());
 	}
 
 	/**
@@ -583,7 +585,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		model.setQeueueingUpdate(false);
@@ -594,13 +596,13 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 		// Wait for the delta to be processed.
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
 
 		TestModel model2 = new TestModel();
 		model2.setRoot(new TestElement(model2, "root", new TestElement[0])); //$NON-NLS-1$
 		fViewer.setInput(model2.getRootElement());
 
-		waitWhile(t -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
 
 	}
 
@@ -621,7 +623,7 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 
 		// Set the input into the view and update the view.
 		fViewer.setInput(model.getRootElement());
-		waitWhile(t -> !fListener.isFinished(), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(), createListenerErrorMessage());
 		model.validateData(fViewer, TreePath.EMPTY);
 
 		model.setQeueueingUpdate(false);
@@ -632,11 +634,11 @@ abstract public class UpdateTests extends AbstractViewerModelTest implements ITe
 		model.postDelta(new ModelDelta(model.getRootElement(), IModelDelta.CONTENT));
 
 		// Wait for the delta to be processed.
-		waitWhile(t -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(MODEL_CHANGED_COMPLETE | CHILD_COUNT_UPDATES), createListenerErrorMessage());
 
 		fViewer.setInput(null);
 
-		waitWhile(t -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
+		waitWhile(() -> !fListener.isFinished(CONTENT_COMPLETE | VIEWER_UPDATES_RUNNING), createListenerErrorMessage());
 
 	}
 


### PR DESCRIPTION
The waitWhile() method for waiting until a condition is fulfilled is implemented as an instance method of AbstractDebugTest. The reason is that the test class instance itself is passed as a context to that method. This context, however, is not used by any of the method's consumers.

This change removes the unnecessary context from the waitWhile() method and simplifies all consumers accordingly. With that, the method in AbstractDebugTests degrades to a pure delegation to the same method in TestUtil, which is why the method is removed from the test superclass and consumers are adapted to directly call the method in TestUtil.