### PR TITLE
Mark test methods for deprecated API as deprecated

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/localstore/FileSystemResourceManagerTest.java
@@ -186,9 +186,8 @@ public class FileSystemResourceManagerTest implements ICoreConstants {
 		assertNull(testFile);
 	}
 
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testIsLocal() throws CoreException {
 		// create resources
 		IResource[] resources = buildResources(project, new String[] { "/Folder1/", "/Folder1/File1",

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/FilteredResourceTest.java
@@ -1303,9 +1303,8 @@ public class FilteredResourceTest {
 	/**
 	 * Regression test for bug 343914
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void test343914() throws CoreException {
 		String subProjectName = "subProject";
 		IPath subProjectLocation = existingProject.getLocation().append(subProjectName);

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IPathVariableTest.java
@@ -228,6 +228,7 @@ public class IPathVariableTest {
 	 * Test IPathVariableManager#getValue and IPathVariableManager#setValue
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testGetSetValue() throws CoreException {
 		boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("C:\\testGetSetValue") : IPath.fromOSString("/testGetSetValue");
@@ -296,6 +297,7 @@ public class IPathVariableTest {
 	 * Test IPathVariableManager#resolvePath
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testResolvePathWithMacro() throws CoreException {
 		final boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("c:/testGetSetValue/foo") : IPath.fromOSString("/testGetSetValue/foo");
@@ -378,6 +380,7 @@ public class IPathVariableTest {
 	 * Test IPathVariableManager#resolvePath
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testResolvePath() throws CoreException {
 		final boolean WINDOWS = java.io.File.separatorChar == '\\';
 		IPath pathOne = WINDOWS ? IPath.fromOSString("C:/testGetSetValue/foo") : IPath.fromOSString("/testGetSetValue/foo");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectDescriptionTest.java
@@ -157,9 +157,8 @@ public class IProjectDescriptionTest {
 		assertTrue(modificationStamp != projectDescription.getModificationStamp());
 	}
 
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testDynamicProjectReferences() throws CoreException {
 		IProject target1 = getWorkspace().getRoot().getProject("target1");
 		IProject target2 = getWorkspace().getRoot().getProject("target2");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IProjectTest.java
@@ -1994,9 +1994,8 @@ public class IProjectTest  {
 	/**
 	 * Tests API on IProjectDescription
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testProjectDescriptionDynamic() {
 		IProjectDescription desc = getWorkspace().newProjectDescription("foo");
 		IProject project1 = getWorkspace().getRoot().getProject("P1");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceChangeListenerTest.java
@@ -1426,9 +1426,8 @@ public class IResourceChangeListenerTest {
 		assertDelta();
 	}
 
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testProjectDescriptionDynamicRefs() throws CoreException {
 		/* change file1's contents */
 		verifier.addExpectedChange(project1, IResourceDelta.CHANGED, IResourceDelta.DESCRIPTION);
@@ -1521,9 +1520,8 @@ public class IResourceChangeListenerTest {
 		assertDelta();
 	}
 
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testSetLocal() throws CoreException {
 		verifier.reset();
 		// set local on a file that is already local -- should be no change

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IResourceTest.java
@@ -1343,9 +1343,8 @@ public class IResourceTest {
 	 * Performs black box testing of the following methods: isDerived() and
 	 * setDerived(boolean)
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testDeprecatedDerived() throws CoreException {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("Project");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/IWorkspaceRootTest.java
@@ -62,9 +62,8 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests findFilesForLocation when non-canonical paths are used (bug 155101).
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindFilesNonCanonicalPath() throws Exception {
 		assumeTrue(OS.isWindows(), "only relevant on Windows");
 
@@ -90,6 +89,7 @@ public class IWorkspaceRootTest {
 	 * Tests the API method findContainersForLocation.
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindContainersForLocation() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject("p1");
@@ -104,6 +104,7 @@ public class IWorkspaceRootTest {
 	}
 
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindContainersForLocationOnWrappedFileSystem() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject p1 = root.getProject("p1");
@@ -117,8 +118,7 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests the API method findContainersForLocation.
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
+	@Deprecated // Explicitly tests deprecated API
 	private void testFindContainersForLocation(IProject p1, IProject p2) throws Exception {
 		//should find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -171,6 +171,7 @@ public class IWorkspaceRootTest {
 	 * Tests the API method findFilesForLocation.
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindFilesForLocationOnWrappedFileSystem() throws CoreException {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -184,6 +185,7 @@ public class IWorkspaceRootTest {
 	 * Tests the API method findFilesForLocation on non-default file system.
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindFilesForLocation() throws CoreException {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();
@@ -193,8 +195,7 @@ public class IWorkspaceRootTest {
 	/**
 	 * Tests the API method findFilesForLocation.
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
+	@Deprecated // Explicitly tests deprecated API
 	private void testFindFilesForLocation(IProject project) throws CoreException {
 		//should not find the workspace root
 		IWorkspaceRoot root = getWorkspace().getRoot();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/LinkedResourceTest.java
@@ -894,6 +894,7 @@ public class LinkedResourceTest {
 	 * in presence of a linked resource that does not match the case in the file system
 	 */
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testFindFilesForLocationCaseVariant() throws CoreException {
 		assumeTrue(OS.isWindows(), "only relevant on Windows");
 

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/AllRegressionTests.java
@@ -20,6 +20,7 @@ import org.junit.platform.suite.api.Suite;
 /**
  * A suite that runs all regression tests.
  */
+@SuppressWarnings("deprecation")
 @Suite
 @SelectClasses({ //
 		Bug_006708.class, //

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/Bug_027271.java
@@ -33,18 +33,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Tests how changes in the underlying preference store may affect the path
  * variable manager.
  */
-// Explicitly tests deprecated API
-@SuppressWarnings("deprecation")
+@Deprecated // Explicitly tests deprecated API
 @ExtendWith(WorkspaceResetExtension.class)
 public class Bug_027271 {
 
+	@Deprecated
 	static final String VARIABLE_PREFIX = "pathvariable."; //$NON-NLS-1$
 
+	@Deprecated
 	@BeforeEach
 	public void setUp() {
 		clearPathVariablesProperties();
 	}
 
+	@Deprecated
 	@AfterEach
 	public void tearDown() {
 		clearPathVariablesProperties();
@@ -61,6 +63,7 @@ public class Bug_027271 {
 		}
 	}
 
+	@Deprecated
 	@Test
 	public void testBug() {
 		assumeTrue(OS.isWindows(), "only relevant on Windows");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IFolderTest.java
@@ -75,9 +75,8 @@ public class IFolderTest {
 	/**
 	 * Bug 11510 [resources] Non-local folders do not become local when directory is created.
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testBug11510() throws Exception {
 		IWorkspaceRoot root = getWorkspace().getRoot();
 		IProject project = root.getProject("TestProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IProjectTest.java
@@ -70,9 +70,8 @@ public class IProjectTest {
 		project.delete(true, createTestMonitor());
 	}
 
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void test_1G5I6PV() throws CoreException {
 		/* common objects */
 		IProject project = getWorkspace().getRoot().getProject("MyProject");

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/regression/IResourceTest.java
@@ -205,9 +205,8 @@ public class IResourceTest {
 	/**
 	 * Calling isSynchronized on a non-local resource caused an internal error.
 	 */
-	// Explicitly tests deprecated API
-	@SuppressWarnings("deprecation")
 	@Test
+	@Deprecated // Explicitly tests deprecated API
 	public void testBug83777() throws CoreException {
 		IProject project = getWorkspace().getRoot().getProject("testBug83777");
 		IFolder folder = project.getFolder("f");


### PR DESCRIPTION
For methods testing deprecated API, the according warnings have been suppressed. However, it seems more reasonable to mark those methods as deprecated themselves.
This adapts the annotations of those methods and applies deprecations to further test methods that explicitly test deprecated API.