### PR TITLE
Remove unused functionality from launchview tests

### DIFF
--- a/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/AbstractLaunchViewTest.java
+++ b/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/AbstractLaunchViewTest.java
@@ -13,14 +13,10 @@
  *******************************************************************************/
 package org.eclipse.debug.ui.launchview.tests;
 
-import java.util.function.Function;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -37,16 +33,6 @@ public class AbstractLaunchViewTest {
 
 	private static boolean welcomeClosed;
 
-	/**
-	 * Default timeout in milliseconds to wait on some events
-	 */
-	protected long testTimeout = 30000;
-
-	/**
-	 * Preference helper to restore changed preference values after test run.
-	 */
-	private final PreferenceMemento prefMemento = new PreferenceMemento();
-
 	@Rule
 	public TestName name = new TestName();
 
@@ -61,7 +47,6 @@ public class AbstractLaunchViewTest {
 	public void tearDown() throws Exception {
 		TestUtil.log(IStatus.INFO, name.getMethodName(), "tearDown");
 		TestUtil.cleanUp(name.getMethodName());
-		prefMemento.resetPreferences();
 	}
 
 	/**
@@ -94,43 +79,6 @@ public class AbstractLaunchViewTest {
 		}
 	}
 
-	/**
-	 * Waits while given condition is {@code true} for a given amount of
-	 * milliseconds. If the actual wait time exceeds given timeout and condition
-	 * will be still {@code true}, throws
-	 * {@link junit.framework.AssertionFailedError} with given message.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param condition function which will be evaluated while waiting
-	 * @param timeout max wait time in milliseconds to wait on given condition
-	 * @param errorMessage message which will be used to construct the failure
-	 *            exception in case the condition will still return {@code true}
-	 *            after given timeout
-	 */
-	public void waitWhile(Function<AbstractLaunchViewTest, Boolean> condition, long timeout, Function<AbstractLaunchViewTest, String> errorMessage) throws Exception {
-		TestUtil.waitWhile(condition, this, timeout, errorMessage);
-	}
-
-	/**
-	 * Waits while given condition is {@code true} for some time. If the actual
-	 * wait time exceeds {@link #testTimeout} and condition will be still
-	 * {@code true}, throws {@link junit.framework.AssertionFailedError} with
-	 * given message.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param condition function which will be evaluated while waiting
-	 * @param errorMessage message which will be used to construct the failure
-	 *            exception in case the condition will still return {@code true}
-	 *            after given timeout
-	 */
-	public void waitWhile(Function<AbstractLaunchViewTest, Boolean> condition, Function<AbstractLaunchViewTest, String> errorMessage) throws Exception {
-		TestUtil.waitWhile(condition, this, testTimeout, errorMessage);
-	}
-
 	private static void closeIntro(final IWorkbench wb) {
 		IWorkbenchWindow window = wb.getActiveWorkbenchWindow();
 		if (window != null) {
@@ -140,29 +88,5 @@ public class AbstractLaunchViewTest {
 				welcomeClosed = im.closeIntro(intro);
 			}
 		}
-	}
-
-	/**
-	 * Change a preference value for this test run. The preference will be reset
-	 * to its value before test started automatically on {@link #tearDown()}.
-	 *
-	 * @param <T> preference value type. The type must have a corresponding
-	 *            {@link IPreferenceStore} setter.
-	 * @param store preference store to manipulate (must not be
-	 *            <code>null</code>)
-	 * @param name preference to change
-	 * @param value new preference value
-	 * @throws IllegalArgumentException when setting a type which is not
-	 *             supported by {@link IPreferenceStore}
-	 *
-	 * @see IPreferenceStore#setValue(String, double)
-	 * @see IPreferenceStore#setValue(String, float)
-	 * @see IPreferenceStore#setValue(String, int)
-	 * @see IPreferenceStore#setValue(String, long)
-	 * @see IPreferenceStore#setValue(String, boolean)
-	 * @see IPreferenceStore#setValue(String, String)
-	 */
-	protected <T> void setPreference(IPreferenceStore store, String name, T value) {
-		prefMemento.setValue(store, name, value);
 	}
 }

--- a/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/TestUtil.java
+++ b/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/TestUtil.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package org.eclipse.debug.ui.launchview.tests;
 
-import static org.junit.Assert.fail;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
@@ -23,8 +21,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
@@ -81,94 +77,6 @@ public class TestUtil {
 				// Keep pumping events until the queue is empty
 			}
 		}
-	}
-
-	/**
-	 * Process all queued UI events. If called from background thread, just
-	 * waits
-	 *
-	 * @param millis max wait time to process events
-	 */
-	public static void processUIEvents(final long millis) throws Exception {
-		long start = System.currentTimeMillis();
-		while (System.currentTimeMillis() - start < millis) {
-			Display display = Display.getCurrent();
-			if (display != null && !display.isDisposed()) {
-				while (display.readAndDispatch()) {
-					// loop until the queue is empty
-				}
-			} else {
-				Thread.sleep(10);
-			}
-		}
-	}
-
-	/**
-	 * Waits while given condition is {@code true} for a given amount of
-	 * milliseconds. If the actual wait time exceeds given timeout and condition
-	 * will be still {@code true}, throws
-	 * {@link junit.framework.AssertionFailedError} with given message.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param <T> type of the context
-	 * @param condition function which will be evaluated while waiting
-	 * @param context test context
-	 * @param timeout max wait time in milliseconds to wait on given condition
-	 * @param errorMessage message which will be used to construct the failure
-	 *            exception in case the condition will still return {@code true}
-	 *            after given timeout
-	 */
-	public static <T> void waitWhile(Function<T, Boolean> condition, T context, long timeout, Function<T, String> errorMessage) throws Exception {
-		long start = System.currentTimeMillis();
-		Display display = Display.getCurrent();
-		while (System.currentTimeMillis() - start < timeout && condition.apply(context)) {
-			if (display != null && !display.isDisposed()) {
-				if (!display.readAndDispatch()) {
-					Thread.sleep(0);
-				}
-			} else {
-				Thread.sleep(5);
-			}
-		}
-		Boolean stillTrue = condition.apply(context);
-		if (stillTrue) {
-			fail(errorMessage.apply(context));
-		}
-	}
-
-	/**
-	 * A simplified variant of
-	 * {@link #waitWhile(Function, Object, long, Function)}.
-	 * <p>
-	 * Waits while given condition is {@code true} for a given amount of
-	 * milliseconds.
-	 * <p>
-	 * Will process UI events while waiting in UI thread, if called from
-	 * background thread, just waits.
-	 *
-	 * @param condition function which will be evaluated while waiting
-	 * @param timeout max wait time in milliseconds to wait on given condition
-	 * @return value of condition when method returned
-	 */
-	public static boolean waitWhile(Supplier<Boolean> condition, long timeout) throws Exception {
-		if (condition == null) {
-			condition = () -> true;
-		}
-		long start = System.currentTimeMillis();
-		Display display = Display.getCurrent();
-		while (System.currentTimeMillis() - start < timeout && condition.get()) {
-			Thread.yield();
-			if (display != null && !display.isDisposed()) {
-				if (!display.readAndDispatch()) {
-					Thread.sleep(1);
-				}
-			} else {
-				Thread.sleep(5);
-			}
-		}
-		return condition.get();
 	}
 
 	/**


### PR DESCRIPTION
The utilities have been copied over while creating the test project without them ever being used.