### PR TITLE
Improve assertions and avoid race condition in MarkerTest

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/MarkerTest.java
@@ -690,6 +690,7 @@ public class MarkerTest {
 		listener.reset();
 		resource.delete(true, createTestMonitor());
 		assertMarkerDoesNotExist(marker);
+		listener.assertNumberOfAffectedResources(1);
 		listener.assertChanges(resource, null, new IMarker[] { marker }, null);
 	}
 
@@ -929,14 +930,18 @@ public class MarkerTest {
 		folder.move(destFolder.getFullPath(), IResource.FORCE, createTestMonitor());
 
 		// verify marker deltas
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(folder, null, new IMarker[] { folderMarker }, null);
 		IMarker[] folderMarkers = destFolder.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertSingleMarkerWithId(folderMarkers, folderMarker.getId());
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(destFolder, new IMarker[] { folderMarkers[0] }, null, null);
 
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(subFile, null, new IMarker[] { subFileMarker }, null);
 		IMarker[] subFolderMarkers = destSubFile.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertSingleMarkerWithId(subFolderMarkers, subFileMarker.getId());
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(destSubFile, new IMarker[] { subFolderMarkers[0] }, null, null);
 	}
 
@@ -969,14 +974,18 @@ public class MarkerTest {
 		subFile.move(destSubFile.getFullPath(), IResource.FORCE, createTestMonitor());
 
 		// verify marker deltas
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(file, null, new IMarker[] { fileMarker }, null);
 		IMarker[] markers = destFile.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertSingleMarkerWithId(markers, fileMarker.getId());
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(destFile, new IMarker[] { markers[0] }, null, null);
 
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(subFile, null, new IMarker[] { subFileMarker }, null);
 		markers = destSubFile.findMarkers(null, true, IResource.DEPTH_ZERO);
 		assertSingleMarkerWithId(markers, subFileMarker.getId());
+		listener.assertNumberOfAffectedResources(4);
 		listener.assertChanges(destSubFile, new IMarker[] { markers[0] }, null, null);
 	}
 


### PR DESCRIPTION
- add further assertions for the number of affected resources
- make MarkersChangeListener.assertChange() wait for asynchronously processed change events to avoid race conditions

Addresses race condition seen as test failure `testMarkerDeltasMoveFile(TestInfo) (AutomatedResourceTests AllResourcesTests MarkerTest)` in this test run: https://github.com/eclipse-platform/eclipse.platform/pull/2396/checks?check_run_id=59405642125

```
[number of markers for resource /MyProject/folder/subFile.txt] 
expected: 2
 but was: 1
org.opentest4j.AssertionFailedError: 
[number of markers for resource /MyProject/folder/subFile.txt] 
expected: 2
 but was: 1
	at org.eclipse.core.tests.resources.MarkersChangeListener.assertChanges(MarkersChangeListener.java:54)
	at org.eclipse.core.tests.resources.MarkerTest.testMarkerDeltasMoveFile(MarkerTest.java:977)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

```