### PR TITLE
Remove org.junit dependency from org.eclipse.terminal.test

### DIFF
--- a/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
+++ b/terminal/tests/org.eclipse.terminal.test/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.eclipse.terminal.test;singleton:=true
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Require-Bundle: org.junit;bundle-version="[4.13.2,5)",
- org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.33.0,4)",
  org.eclipse.ui;bundle-version="[3.208.0,4)",
  org.opentest4j;bundle-version="[1.3.0,2)",
  org.eclipse.terminal.control;bundle-version="1.0.0"


### PR DESCRIPTION
All tests have been migrated to JUnit 5, so the dependency it not necessary anymore.