### PR TITLE
Add test.xml to org.eclipse.terminal.test for execution in I-Build

### DIFF
--- a/terminal/tests/org.eclipse.terminal.test/build.properties
+++ b/terminal/tests/org.eclipse.terminal.test/build.properties
@@ -16,7 +16,8 @@ bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                plugin.xml,\
-               about.html
+               about.html,\
+               test.xml
 src.includes = teamConfig/,\
                about.html
 pom.model.property.testClass = org.eclipse.terminal.test.AutomatedIntegrationSuite

--- a/terminal/tests/org.eclipse.terminal.test/test.xml
+++ b/terminal/tests/org.eclipse.terminal.test/test.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<project name="Terminal Tests" default="run" basedir=".">
+
+	<!-- The property ${eclipse-home} should be passed into this script -->
+	<!-- sets the properties eclipse-home, and library-file -->
+	<property name="eclipse-home" value="${basedir}/../../"/>
+	<property name="library-file" value="${eclipse-home}/plugins/org.eclipse.test/library.xml"/>
+	<property name="plugin-name" value="org.eclipse.terminal.test"/>
+
+	<!-- This target holds all initialization code that needs to be done for -->
+	<!-- all tests that are to be run. Initialization for individual tests -->
+	<!-- should be done within the body of the suite target. -->
+	<target name="init">
+		<tstamp/>
+	</target>
+
+	<!-- This target holds code to cleanup the testing environment after the tests -->
+	<!-- have been run. You can use this to delete temporary files that are created. -->
+	<target name="cleanup">
+	</target>
+
+	<!-- This target runs the test suite. Any actions that need to happen after all -->
+	<!-- the tests have been run should go here. -->
+	<target name="run" depends="init,suite,cleanup">
+		<ant target="collect" antfile="${library-file}" dir="${eclipse-home}">
+			<property name="includes" value="org*.xml"/>
+			<property name="output-file" value="${plugin-name}.xml"/>
+		</ant>
+	</target>
+
+	<!-- This target defines the tests that need to be run. -->
+	<target name="suite">
+		<property name="sniff-folder" value="${eclipse-home}/terminal_sniff_folder" />
+		<delete dir="${sniff-folder}" quiet="true" />
+		<ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
+			<property name="data-dir" value="${sniff-folder}"/>
+			<property name="plugin-name" value="${plugin-name}"/>
+			<property name="classname" value="org.eclipse.terminal.test.AutomatedIntegrationSuite"/>
+		</ant>
+	</target>
+
+</project>


### PR DESCRIPTION
The terminal tests currently lack a `test.xml` required for their nightly execution in the I-Build tests. This change adds them. A follow up change that integrates the test in the aggregation is required (see https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3590).