### PR TITLE
Remove mention of JUnit 4 in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Key profiles:
 **Test Organization:**
 - Tests are in `<module>/tests/` subdirectories (e.g., `runtime/tests/`, `resources/tests/`)
 - Test bundles follow naming: `org.eclipse.<area>.tests.<component>`
-- Tests use JUnit 4/5 with Tycho Surefire
+- Tests use JUnit 5 with Tycho Surefire
 
 **Running Tests:**
 ```bash


### PR DESCRIPTION
All tests in the repository have been migrated to JUnit 5. This change adapts the AGENTS.md by removing the mention of JUnit 4 accordingly.

Only remaining reference to `org.junit` in Platform is in `org.eclipse.core.tests.harness`:
https://github.com/eclipse-platform/eclipse.platform/blob/b08b2403ef17e0190f791b0a77e0adfdb0a0f653/runtime/tests/org.eclipse.core.tests.harness/META-INF/MANIFEST.MF#L9

This is because of the tooling dependencies (specifically `org.eclipse.pde.junit.runtime`) pulling in JUnit 4 support and the session test framework defined in this bundle requiring all dependencies to be explicitly mentioned to start the test sessions.