### PR TITLE
Use assertThrows in terminal tests

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/model/TerminalTextDataStore.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/model/TerminalTextDataStore.java
@@ -140,9 +140,13 @@ public class TerminalTextDataStore implements ITerminalTextData {
 
 	@Override
 	public char getChar(int line, int column) {
-		if (column >= fWidth) {
+		if (column < 0 || column >= fWidth) {
 			throw new IllegalArgumentException(
 					"Parameter 'column' must be >= 0 and less than 'width' (current value '" + fWidth + "')"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		if (line < 0 || line >= fHeight) {
+			throw new IllegalArgumentException(
+					"Parameter 'line' must be >= 0 and less than 'height' (current value '" + fHeight + "')"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (fChars[line] == null || column >= fChars[line].length) {
 			return 0;
@@ -162,19 +166,24 @@ public class TerminalTextDataStore implements ITerminalTextData {
 		return fStyle[line][column];
 	}
 
-	void ensureLineLength(int iLine, int length) {
+	void ensureLineLength(int line, int length) {
+		if (line < 0 || line >= fHeight) {
+			throw new IllegalArgumentException(
+					"Parameter 'line' must be >= 0 and less than 'height' (current value '" + fHeight + "')"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		if (length > fWidth) {
-			throw new RuntimeException();
+			throw new IllegalArgumentException(
+					"Parameter 'length'(value='" + length + "') exceeds 'width'(value='" + fWidth + "')"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
-		if (fChars[iLine] == null) {
-			fChars[iLine] = new char[length];
-		} else if (fChars[iLine].length < length) {
-			fChars[iLine] = (char[]) resizeArray(fChars[iLine], length);
+		if (fChars[line] == null) {
+			fChars[line] = new char[length];
+		} else if (fChars[line].length < length) {
+			fChars[line] = (char[]) resizeArray(fChars[line], length);
 		}
-		if (fStyle[iLine] == null) {
-			fStyle[iLine] = new TerminalStyle[length];
-		} else if (fStyle[iLine].length < length) {
-			fStyle[iLine] = (TerminalStyle[]) resizeArray(fStyle[iLine], length);
+		if (fStyle[line] == null) {
+			fStyle[line] = new TerminalStyle[length];
+		} else if (fStyle[line].length < length) {
+			fStyle[line] = (TerminalStyle[]) resizeArray(fStyle[line], length);
 		}
 	}
 
@@ -192,6 +201,10 @@ public class TerminalTextDataStore implements ITerminalTextData {
 
 	@Override
 	public void setChars(int line, int column, char[] chars, int start, int len, TerminalStyle style) {
+		if (column < 0 || column >= fWidth) {
+			throw new IllegalArgumentException(
+					"Parameter 'column' must be >= 0 and less than 'width' (current value '" + fWidth + "')"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		ensureLineLength(line, column + len);
 		for (int i = 0; i < len; i++) {
 			fChars[line][column + i] = chars[i + start];
@@ -287,6 +300,20 @@ public class TerminalTextDataStore implements ITerminalTextData {
 
 	@Override
 	public void copyRange(ITerminalTextData source, int sourceStartLine, int destStartLine, int length) {
+		if (destStartLine < 0 || destStartLine + length > fHeight) {
+			throw new IllegalArgumentException(
+					"Value of 'destStartLine'+'length' parameters must be valid line (range [0-" //$NON-NLS-1$
+							+ fHeight + "). Parameter values: 'destStartLine'=" + destStartLine //$NON-NLS-1$
+							+ ", 'size'=" //$NON-NLS-1$
+							+ length);
+		}
+		if (sourceStartLine < 0 || sourceStartLine + length > source.getHeight()) {
+			throw new IllegalArgumentException(
+					"Value of 'sourceStartLine'+'length' parameters must be valid line (range [0-" //$NON-NLS-1$
+							+ source.getHeight() + "). Parameter values: 'sourceStartLine'=" + sourceStartLine //$NON-NLS-1$
+							+ ", 'size'=" //$NON-NLS-1$
+							+ length);
+		}
 		for (int i = 0; i < length; i++) {
 			copyLine(source, i + sourceStartLine, i + destStartLine);
 		}

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalToRemoteInjectionOutputStreamTest.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/connector/TerminalToRemoteInjectionOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Wind River Systems, Inc. and others.
+ * Copyright (c) 2008, 2026 Wind River Systems, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
 package org.eclipse.terminal.internal.connector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -72,20 +72,12 @@ public class TerminalToRemoteInjectionOutputStreamTest {
 			s.write('-');
 			OutputStream os = s.grabOutput();
 			// make sure the closed output does not inject anything
-			try {
-				os1.write('k');
-				fail("...");
-			} catch (Exception e) {
-			}
+			assertThrows(IOException.class, () -> os1.write('k'));
 			os.write('X');
 			s.write('a');
 			os.write('Y');
 			// make sure the closed output does not inject anything
-			try {
-				os1.write('l');
-				fail("...");
-			} catch (Exception e) {
-			}
+			assertThrows(IOException.class, () -> os1.write('l'));
 			s.write('b');
 			os.close();
 			assertEquals("begin:xyAB-XYab", new String(bs.toByteArray(), ENCODING));
@@ -127,14 +119,9 @@ public class TerminalToRemoteInjectionOutputStreamTest {
 			s.write("begin:".getBytes(ENCODING));
 			assertEquals("begin:", new String(bs.toByteArray(), ENCODING));
 			OutputStream os1 = s.grabOutput();
-			OutputStream os2;
-			try {
-				os2 = s.grabOutput();
-				fail("should fail until the foirst output is closed");
-			} catch (IOException e) {
-			}
+			assertThrows(IOException.class, () -> s.grabOutput(), "should fail until the first output is closed");
 			os1.close();
-			os2 = s.grabOutput();
+			OutputStream os2 = s.grabOutput();
 			assertEquals("begin:", new String(bs.toByteArray(), ENCODING));
 			os2.write("Test".getBytes(ENCODING));
 			assertEquals("begin:Test", new String(bs.toByteArray(), ENCODING));
@@ -147,6 +134,7 @@ public class TerminalToRemoteInjectionOutputStreamTest {
 			s.write('!');
 			assertEquals("begin:Test the west!", new String(bs.toByteArray(), ENCODING));
 		}
+
 	}
 
 	@Test

--- a/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/model/AbstractITerminalTextDataTest.java
+++ b/terminal/tests/org.eclipse.terminal.test/src/org/eclipse/terminal/internal/model/AbstractITerminalTextDataTest.java
@@ -14,8 +14,8 @@ package org.eclipse.terminal.internal.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.terminal.model.ITerminalTextData;
 import org.eclipse.terminal.model.ITerminalTextDataReadOnly;
@@ -188,12 +188,7 @@ abstract public class AbstractITerminalTextDataTest {
 		String s = "12345\n" + "abcde\n" + "ABCDE";
 		fill(term, 0, 0, s);
 		assertEqualsTerm(s, toMultiLineText(term));
-		try {
-			term.setDimensions(-3, 4);
-			fail();
-		} catch (RuntimeException e) {
-			// OK
-		}
+		assertThrows(IllegalArgumentException.class, () -> term.setDimensions(-3, 4));
 		//		assertEquals(5, term.getWidth());
 		//		assertEquals(3, term.getHeight());
 		//		assertEquals(s, toSimpleText(term));
@@ -303,36 +298,12 @@ abstract public class AbstractITerminalTextDataTest {
 		assertEquals('C', term.getChar(2, 2));
 		assertEquals('D', term.getChar(2, 3));
 		assertEquals('E', term.getChar(2, 4));
-		try {
-			term.getChar(0, -1);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.getChar(-1, -1);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.getChar(-1, 0);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.getChar(0, 5);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.getChar(3, 5);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.getChar(3, 0);
-			fail();
-		} catch (RuntimeException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(0, -1));
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(-1, -1));
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(-1, 0));
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(0, 5));
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(3, 5));
+		assertThrows(IllegalArgumentException.class, () -> term.getChar(3, 0));
 	}
 
 	@Test
@@ -398,12 +369,9 @@ abstract public class AbstractITerminalTextDataTest {
 
 		term.setChars(3, 1, new char[] { '1', '2' }, null);
 		assertEqualsTerm("abc\n" + "bcd\n" + "cde\n" + "d12\n" + "efg\n" + "fgh", toMultiLineText(term));
-		try {
-			// check if we cannot exceed the range
-			term.setChars(4, 1, new char[] { '1', '2', '3', '4', '5' }, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
+		// check if we cannot exceed the range
+		assertThrows(IllegalArgumentException.class,
+				() -> term.setChars(4, 1, new char[] { '1', '2', '3', '4', '5' }, null));
 
 	}
 
@@ -433,33 +401,12 @@ abstract public class AbstractITerminalTextDataTest {
 		assertEqualsTerm("ZYXWVU\n" + "ab4567\n" + "ABCDEF", toMultiLineText(term));
 
 		fill(term, s);
-		try {
-			term.setChars(1, 0, chars, 7, 10, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> term.setChars(1, 0, chars, 7, 10, null));
 		fill(term, s);
-		try {
-			term.setChars(1, -1, chars, 0, 2, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.setChars(-1, 1, chars, 0, 2, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.setChars(1, 10, chars, 0, 2, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			term.setChars(10, 1, chars, 0, 2, null);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		//		assertEquals(s, toSimpleText(term));
+		assertThrows(IllegalArgumentException.class, () -> term.setChars(1, -1, chars, 0, 2, null));
+		assertThrows(IllegalArgumentException.class, () -> term.setChars(-1, 1, chars, 0, 2, null));
+		assertThrows(IllegalArgumentException.class, () -> term.setChars(1, 10, chars, 0, 2, null));
+		assertThrows(IllegalArgumentException.class, () -> term.setChars(10, 1, chars, 0, 2, null));
 	}
 
 	@Test
@@ -527,30 +474,14 @@ abstract public class AbstractITerminalTextDataTest {
 		assertEqualsSimple(s, toSimple(term));
 		assertEqualsSimple("a2345", toSimple(termCopy));
 
-		try {
-			fillSimple(termCopy, sCopy);
-			termCopy.copyRange(term, 1, 1, 5);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			fillSimple(termCopy, sCopy);
-			termCopy.copyRange(term, 0, 0, 6);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			fillSimple(termCopy, sCopy);
-			termCopy.copyRange(term, 7, 0, 1);
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			fillSimple(termCopy, sCopy);
-			termCopy.copyRange(term, 0, 7, 1);
-			fail();
-		} catch (RuntimeException e) {
-		}
+		fillSimple(termCopy, sCopy);
+		assertThrows(IllegalArgumentException.class, () -> termCopy.copyRange(term, 1, 1, 5));
+		fillSimple(termCopy, sCopy);
+		assertThrows(IllegalArgumentException.class, () -> termCopy.copyRange(term, 0, 0, 6));
+		fillSimple(termCopy, sCopy);
+		assertThrows(IllegalArgumentException.class, () -> termCopy.copyRange(term, 7, 0, 1));
+		fillSimple(termCopy, sCopy);
+		assertThrows(IllegalArgumentException.class, () -> termCopy.copyRange(term, 0, 7, 1));
 	}
 
 	@Test
@@ -690,16 +621,8 @@ abstract public class AbstractITerminalTextDataTest {
 
 	@Test
 	public void testScrollFail() {
-		try {
-			scrollTest(5, 2, -1, "012345", "012345");
-			fail();
-		} catch (RuntimeException e) {
-		}
-		try {
-			scrollTest(0, 7, 1, "012345", "      ");
-			fail();
-		} catch (RuntimeException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> scrollTest(5, 2, -1, "012345", "012345"));
+		assertThrows(IllegalArgumentException.class, () -> scrollTest(0, 7, 1, "012345", "      "));
 	}
 
 	/**


### PR DESCRIPTION
Improves the tests and also the model to consistently throw IllegalArgumentException rather than a mixture of
IllegalArgumentException and ArrayIndexOutOfBoundsException depending on which exact store is used.

Final bits for https://github.com/eclipse-platform/eclipse.platform/issues/2412