### PR TITLE
Synchronize Console view icon with selected console

### DIFF
--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
@@ -279,18 +279,19 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 	protected void updateIcon() {
 		IConsole console = getConsole();
 		if (console == null) {
+			// Check and restore default console icon if last page is closed
+			if (currentIcon != defaultIcon) {
+				currentIcon = defaultIcon;
+				setTitleImage(currentIcon);
+			}
 			return;
 		}
-		Image newImage = null;
+		Image newImage;
 
-		if (console != null) {
-			ImageDescriptor desc = console.getImageDescriptor();
-			if (desc != null) {
-				newImage = localResManager.create(desc);
-			}
-		}
-
-		if (newImage == null) {
+		ImageDescriptor desc = console.getImageDescriptor();
+		if (desc != null) {
+			newImage = localResManager.create(desc);
+		} else {
 			newImage = defaultIcon;
 		}
 


### PR DESCRIPTION
The Console view icon now reflects the currently selected console. This helps users quickly identify different consoles when multiple consoles are present, without having to inspect each one.

Before : 

<img width="360" height="125" alt="image" src="https://github.com/user-attachments/assets/54c65a37-87f4-479f-b085-f31c71b16fdb" />


After : 

<img width="343" height="152" alt="image" src="https://github.com/user-attachments/assets/946dd4ef-4a4d-4750-9da0-c9c6c896370e" />
