### PR TITLE
Fix empty description for Prototype Label Decorator in preferences

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2025 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -418,6 +418,7 @@ debug.core.component.label = Platform Debug Core
 GroupLaunch.description=Launch several other configurations sequentially
 
 prototype.decorator.label = Prototype Decorator
+prototype.decorator.description = Decorates launch configurations that are marked as prototypes with an overlay icon.
 breakpointLabel.label= Label
 breakpointLabel.tooltip= Provide a custom label to quickly identify breakpoint
 breakpointLabelCommand = EditBreakpointLabel

--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-     Copyright (c) 2005, 2025 IBM Corporation and others.
+     Copyright (c) 2005, 2026 IBM Corporation and others.
 
      This program and the accompanying materials
      are made available under the terms of the Eclipse Public License 2.0
@@ -3385,6 +3385,9 @@ M4 = Platform-specific fourth key
             lightweight="true"
             location="TOP_RIGHT"
             state="true">
+         <description>
+            %prototype.decorator.description
+         </description>
          <enablement>
             <objectClass
                   name="org.eclipse.debug.internal.core.LaunchConfiguration">


### PR DESCRIPTION

The Prototype label decorator was missing a description, which resulted in an empty description area in the Label Decorations preference page when selection was made. 
This PR adds the description for the Prototype label decorator so that it is displayed correctly in the description box upon selection like the rest of the entries.