### PR TITLE
Move Terminal launch action closer to Run/Debug toolbar actions

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/plugin.xml
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <!--
-    Copyright (c) 2018 Red Hat and others.
+    Copyright (c) 2018, 2026 Red Hat and others.
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -120,7 +120,7 @@
       </delegate>
    </extension>
    <extension point="org.eclipse.ui.menus">
-      <menuContribution locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+      <menuContribution locationURI="toolbar:org.eclipse.ui.main.toolbar?after=org.eclipse.debug.ui.launchActionSet">
          <toolbar
                id="org.eclipse.terminal.view.ui.toolbar"
                label="%toolbar.terminal.label">


### PR DESCRIPTION
Align Terminal launch toolbar action with Run/Debug launch workflow

Before : 
<img width="910" height="35" alt="Screenshot 2026-01-19 at 2 24 13 PM" src="https://github.com/user-attachments/assets/d31a99bf-13cf-4071-955d-2f9556d51c80" />

After : 
<img width="888" height="48" alt="Screenshot 2026-01-19 at 2 23 39 PM" src="https://github.com/user-attachments/assets/4d100700-eef2-4c00-b4f6-d0a9d3ee647a" />

