### PR TITLE
Add preference page for console icon update

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/ConsolePreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -181,6 +181,10 @@ public class ConsolePreferencePage extends FieldEditorPreferencePage implements 
 				DebugPreferencesMessages.ConsolePreferencePage_ConsoleAutoPinEnable, SWT.NONE, getFieldEditorParent());
 		autoPinEditor.setPreferenceStore(ConsolePlugin.getDefault().getPreferenceStore());
 		addField(autoPinEditor);
+		BooleanFieldEditor consoleIconUpdate = new BooleanFieldEditor(IConsoleConstants.UPDATE_CONSOLE_ICON,
+				DebugPreferencesMessages.ConsolePreferencePage_ConsoleIconUpdate, SWT.NONE, getFieldEditorParent());
+		consoleIconUpdate.setPreferenceStore(ConsolePlugin.getDefault().getPreferenceStore());
+		addField(consoleIconUpdate);
 		Label comboLabel = new Label(getFieldEditorParent(), SWT.NONE);
 		comboLabel.setText(DebugPreferencesMessages.ConsoleElapsedTimeLabel);
 		fElapsedFormat = new ComboViewer(getFieldEditorParent(), SWT.DROP_DOWN | SWT.BORDER);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2025 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -229,5 +229,7 @@ public class DebugPreferencesMessages extends NLS {
 	public static String ConsoleElapsedTimeToolTip;
 
 	public static Object ConsoleDisableElapsedTime;
+
+	public static String ConsolePreferencePage_ConsoleIconUpdate;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2025 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,7 @@ ConsoleElapsedTimeLabel=Elapsed Time Format (Choose 'None' to disable)
 ConsoleDefaultElapsedTimeFormat=%d:%02d:%02d
 ConsoleElapsedTimeToolTip=Supports formats like: 'H:MM:SS.mmm', 'MMm SSs', 'H:MM:SS' \nYou can also use positional parameters \n%1$ = (H)hours\n%2$ = (M)minutes\n%3$ = (S)seconds\n%4$ = (mmm)milliseconds
 ConsoleDisableElapsedTime=None
+ConsolePreferencePage_ConsoleIconUpdate=Update Console icon based on currently active page
 
 DebugPreferencePage_1=General Settings for Running and Debugging.
 DebugPreferencePage_2=Re&use editor when displaying source code

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IConsoleConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -196,5 +196,12 @@ public interface IConsoleConstants {
 	 * @since 3.13
 	 */
 	String COMMAND_ID_CLEAR_CONSOLE = "org.eclipse.debug.ui.commands.console.clear"; //$NON-NLS-1$
+
+	/**
+	 * The preference for updating console icon based on active console page
+	 *
+	 * @since 3.16
+	 */
+	String UPDATE_CONSOLE_ICON = ConsolePlugin.getUniqueIdentifier() + ".PREF_DYNAMIC_CONSOLE_ICON"; //$NON-NLS-1$
 
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleUIPreferenceInitializer.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleUIPreferenceInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Andrey Loskutov <loskutov@gmx.de> and others.
+ * Copyright (c) 2018, 2026 Andrey Loskutov <loskutov@gmx.de> and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ public class ConsoleUIPreferenceInitializer extends AbstractPreferenceInitialize
 		prefs.setDefault(IConsoleConstants.P_CONSOLE_WORD_WRAP, false);
 		prefs.setDefault(IConsoleConstants.AUTO_PIN_ENABLED_PREF_NAME, true);
 		prefs.setDefault(IConsoleConstants.REMEMBER_AUTO_PIN_DECISION_PREF_NAME, false);
+		prefs.setDefault(IConsoleConstants.UPDATE_CONSOLE_ICON, true);
 	}
 
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleView.java
@@ -129,6 +129,8 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 	private Image currentIcon, defaultIcon;
 	private LocalResourceManager localResManager;
 
+	private boolean updateConsoleIcon;
+
 	private boolean isAvailable() {
 		return getPageBook() != null && !getPageBook().isDisposed();
 	}
@@ -141,7 +143,15 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 				updateTitle();
 			}
 		}
+		if (IConsoleConstants.UPDATE_CONSOLE_ICON.equals(event.getProperty())) {
+			updateConsoleIcon = shouldUpdateConsoleIcon();
+			updateIcon();
+		}
 
+	}
+
+	private boolean shouldUpdateConsoleIcon() {
+		return ConsolePlugin.getDefault().getPreferenceStore().getBoolean(IConsoleConstants.UPDATE_CONSOLE_ICON);
 	}
 
 	@Override
@@ -277,6 +287,13 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 	}
 
 	protected void updateIcon() {
+		if (!updateConsoleIcon) {
+			if (currentIcon != defaultIcon) {
+				currentIcon = defaultIcon;
+				setTitleImage(currentIcon);
+			}
+			return;
+		}
 		IConsole console = getConsole();
 		if (console == null) {
 			// Check and restore default console icon if last page is closed
@@ -412,6 +429,7 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 			localResManager.dispose();
 			localResManager = null;
 		}
+		ConsolePlugin.getDefault().getPreferenceStore().removePropertyChangeListener(this);
 	}
 
 	/**
@@ -612,8 +630,10 @@ public class ConsoleView extends PageBookView implements IConsoleView, IConsoleL
 		getViewSite().getPage().addPartListener((IPartListener2)this);
 		initPageSwitcher();
 		localResManager = new LocalResourceManager(JFaceResources.getResources(), parent);
+		updateConsoleIcon = shouldUpdateConsoleIcon();
 		defaultIcon = ConsolePluginImages.getImage(IConsoleConstants.IMG_VIEW_CONSOLE);
 		currentIcon = defaultIcon;
+		ConsolePlugin.getDefault().getPreferenceStore().addPropertyChangeListener(this);
 	}
 
 	/**


### PR DESCRIPTION
This commit adds a preference option in console preference for enable/disable dynamic console update based on active console page

<img width="868" height="686" alt="image" src="https://github.com/user-attachments/assets/5aa90a16-f674-494c-b524-671b857c3d3c" />


Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2434
