### PR TITLE
Show 'time notation' format as default for elapsed time

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -33,7 +33,7 @@ ConsolePreferencePage_Interpret_control_characters=Interpret ASCII &control char
 ConsolePreferencePage_Interpret_cr_as_control_character=Interpret Carriage &Return (\\r) as control character 
 ConsolePreferencePage_Enable_Word_Wrap_text=E&nable word wrap
 ConsoleElapsedTimeLabel=Elapsed Time Format (Choose 'None' to disable)
-ConsoleDefaultElapsedTimeFormat=%d:%02d:%02d
+ConsoleDefaultElapsedTimeFormat=H:MM:SS
 ConsoleElapsedTimeToolTip=Supports formats like: 'H:MM:SS.mmm', 'MMm SSs', 'H:MM:SS' \nYou can also use positional parameters \n%1$ = (H)hours\n%2$ = (M)minutes\n%3$ = (S)seconds\n%4$ = (mmm)milliseconds
 ConsoleDisableElapsedTime=None
 ConsolePreferencePage_ConsoleIconUpdate=Update Console icon based on currently active page


### PR DESCRIPTION
This commit will update existing default printf style time format to modern time notation. - Making selection values consistent with initial selection

Before : 
<img width="483" height="51" alt="image" src="https://github.com/user-attachments/assets/77431f00-9463-4a1b-9bbd-2050bf5ca189" />

After : 
<img width="491" height="55" alt="image" src="https://github.com/user-attachments/assets/cb8be6ae-49d2-4b51-a065-4824658826b3" />
