### PR TITLE
Add missing descriptions to Colours and Fonts theme entries in Preferences

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.properties
+++ b/debug/org.eclipse.debug.ui/plugin.properties
@@ -213,6 +213,8 @@ ActionDefinition.toggleStepFilters.description= Toggles enablement of debug step
 ActionDefinition.stepInto.name= Step Into
 ActionDefinition.stepInto.description= Step into
 
+org.eclipse.debug.ui.presentation.description = Colors and fonts used for debug sessions, breakpoints and variables.
+
 ActionDefinition.stepOver.name= Step Over
 ActionDefinition.stepOver.description= Step over
 

--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -2995,9 +2995,12 @@ M4 = Platform-specific fourth key
            perspectiveId="org.eclipse.debug.ui.DebugPerspective"/>
   </extension>
 
-   <extension
-         point="org.eclipse.ui.themes">
-		<themeElementCategory label="%debugPresentation.label" id="org.eclipse.debug.ui.presentation"/>
+	<extension point="org.eclipse.ui.themes">
+		<themeElementCategory id="org.eclipse.debug.ui.presentation" label="%debugPresentation.label">
+			<description>
+				%org.eclipse.debug.ui.presentation.description
+			</description>
+		</themeElementCategory>
       <fontDefinition
             label="%DetailPaneFontDefinition.label"
             defaultsTo="org.eclipse.jface.textfont"

--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2025 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -166,6 +166,8 @@ ComparePreferencePage.workingCopy= line 1\nline 2\nline 3\nadded words in line 4
 ComparePreferencePage.colorAndFontLink=See <a>''{0}''</a> preferences for text compare colors and fonts.
 
 textCompareAppearance.label=Text Compare
+
+org.eclipse.compare.contentmergeviewer.TextMergeViewer=Colors and fonts used in compare editors to indicate differences, conflicts, and changes.
 
 compareIncomingColor.label= Incoming change color
 compareIncomingColor.description= The color used to indicate an incoming change in compare and merge tools.

--- a/team/bundles/org.eclipse.compare/plugin.xml
+++ b/team/bundles/org.eclipse.compare/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-    Copyright (c) 2001, 2019 IBM Corporation and others.
+    Copyright (c) 2001, 2026 IBM Corporation and others.
 
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,9 @@
       <themeElementCategory
             label="%textCompareAppearance.label"
             id="org.eclipse.compare.contentmergeviewer.TextMergeViewer">
+         <description>
+            %org.eclipse.compare.contentmergeviewer.TextMergeViewer
+         </description>
       </themeElementCategory>
       <colorDefinition
             label="%compareIncomingColor.label"


### PR DESCRIPTION
**Consistent use of descriptions in Colours and Fonts preferences**

Some entries in the Colours and Fonts preference page already provide descriptions, while others leave the description area empty. This change makes use of the existing descriptions and applies them to theme entries so that the description box is consistently populated and available descriptions are properly utilised. This improves clarity and aligns the presentation with the approach used with the subtree elements in Eclipse preference pages and gives more clarity on what each entity is used for. The Colours and Fonts preference page shows a description panel which is empty now. There are already descriptions available for some and not available for rest and they are not being used so as to display in the box. This change adds the existing description usage to theme entries so that users always see meaningful information when navigating these settings.

The main change pertaining to this PR has been merged via https://github.com/eclipse-platform/eclipse.platform.ui/pull/3666 and some of the remaining changes are addressed here.