### PR TITLE
Properly register ConsoleManager listeners on workbench windows

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/ConsoleManager.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/ConsoleManager.java
@@ -47,6 +47,7 @@ import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PerspectiveAdapter;
 import org.eclipse.ui.PlatformUI;
@@ -156,13 +157,21 @@ public final class ConsoleManager implements ITerminalConsoleViewManager {
 	public ConsoleManager() {
 		perspectiveListener = new ConsoleManagerPerspectiveListener();
 		partListener = new ConsoleManagerPartListener();
+	}
 
-		if (PlatformUI.isWorkbenchRunning() && PlatformUI.getWorkbench() != null
-				&& PlatformUI.getWorkbench().getActiveWorkbenchWindow() != null) {
-			PlatformUI.getWorkbench().getActiveWorkbenchWindow().addPerspectiveListener(perspectiveListener);
-
-			IPartService service = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getPartService();
+	public void addWindowAndPerspectiveListeners(IWorkbenchWindow window) {
+		if (PlatformUI.isWorkbenchRunning() && window != null) {
+			window.addPerspectiveListener(perspectiveListener);
+			IPartService service = window.getPartService();
 			service.addPartListener(partListener);
+		}
+	}
+
+	public void removeWindowAndPerspectiveListeners(IWorkbenchWindow window) {
+		if (PlatformUI.isWorkbenchRunning() && window != null) {
+			window.removePerspectiveListener(perspectiveListener);
+			IPartService service = window.getPartService();
+			service.removePartListener(partListener);
 		}
 	}
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/listeners/AbstractWindowListener.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/listeners/AbstractWindowListener.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.internal.listeners;
 
+import org.eclipse.terminal.view.ui.internal.ConsoleManager;
+import org.eclipse.terminal.view.ui.launcher.ITerminalConsoleViewManager;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IPartService;
 import org.eclipse.ui.IPerspectiveListener;
@@ -85,6 +87,8 @@ public abstract class AbstractWindowListener implements IWindowListener {
 			if (perspectiveListener != null) {
 				window.removePerspectiveListener(perspectiveListener);
 			}
+			ConsoleManager consoleViewManager = (ConsoleManager) window.getService(ITerminalConsoleViewManager.class);
+			consoleViewManager.removeWindowAndPerspectiveListeners(window);
 		}
 	}
 
@@ -119,6 +123,8 @@ public abstract class AbstractWindowListener implements IWindowListener {
 				}
 			}
 
+			ConsoleManager consoleViewManager = (ConsoleManager) window.getService(ITerminalConsoleViewManager.class);
+			consoleViewManager.addWindowAndPerspectiveListeners(window);
 			initialized = true;
 		}
 	}


### PR DESCRIPTION
`ConsoleManager` service is activated on
`org.eclipse.terminal.view.ui.internal.UIPlugin.start(BundleContext)` **before** workbench creates any window. This prevents that it can register his window & perspective listeners to any window and so it can't properly manage terminals if they are opened from multiple different terminal view instances existing in parallel.

This happens because terminal ui bundle contributes `ExternalExecutablesState` service that is activated very early at workbench startup, **before** window creation.

Beside this, `ConsoleManager` service, if ever connected to a window, would only listen to that single window events and would never support other windows.

Fixed both issues by moving window & perspective listener registration (and de-registration) of `ConsoleManager` service to already existing `org.eclipse.terminal.view.ui.internal.listeners.AbstractWindowListener`.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2455