### PR TITLE
Make eclipse.core.tools aboutText static to prevent comparator errors

### DIFF
--- a/runtime/bundles/org.eclipse.core.tools/about.mappings
+++ b/runtime/bundles/org.eclipse.core.tools/about.mappings
@@ -1,6 +1,0 @@
-# about.mappings
-# contains fill-ins for about.properties
-# java.io.Properties file (ISO 8859-1 with "\" escapes)
-# This file does not need to be translated.
-
-0=${buildId}

--- a/runtime/bundles/org.eclipse.core.tools/about.properties
+++ b/runtime/bundles/org.eclipse.core.tools/about.properties
@@ -19,9 +19,6 @@
 
 blurb=Eclipse Core Tools\n\
 \n\
-Version: 1.5.100\n\
-Build id: {0}\n\
-\n\
-(c) Copyright IBM Corp. and others 2000, 2013.  All rights reserved.\n\
+(c) Copyright IBM Corp. and others 2000, 2026. All rights reserved.\n\
 Visit http://eclipse.org/eclipse/development/performance
 

--- a/runtime/bundles/org.eclipse.core.tools/build.properties
+++ b/runtime/bundles/org.eclipse.core.tools/build.properties
@@ -22,7 +22,6 @@ bin.includes = plugin.xml,\
                .,\
                plugin.properties,\
                about.ini,\
-               about.mappings,\
                about.properties,\
                eclipse32.svg
 qualifier=context


### PR DESCRIPTION
This should prevent the current comparator error in I-builds, which are:
```
1.  eclipse.platform/runtime/bundles/org.eclipse.core.tools/.polyglot.META-INF
   no-classifier: different
      about.mappings: properties files differ
         0: baseline='I20260219-0810' != reactor='I20260219-1800'
    The main artifact has been replaced with the baseline version.
    The following attached artifacts have been replaced with the baseline version: [sources]
```

@iloveeclipse, @akurtakov WDYT?