### PR TITLE
Adjust buildId rectangle for 2026 Splash Screen

### DIFF
--- a/platform/org.eclipse.platform/plugin.xml
+++ b/platform/org.eclipse.platform/plugin.xml
@@ -46,17 +46,17 @@
 				value="ffffff"/>
           <property
                 name="startupMessageRect"
-                value="7,265,320,25"/>
+                value="7,265,250,25"/>
           <property
                 name="startupProgressRect"
                 value="2,290,450,10"/>
           <property
                 name="buildIdLocation"
-                value="108,222">
+                value="257,265">
           </property>
           <property
                 name="buildIdSize"
-                value="293,40">
+                value="188,25">
           </property>
 
       </product> 

--- a/platform/org.eclipse.sdk/plugin.xml
+++ b/platform/org.eclipse.sdk/plugin.xml
@@ -45,17 +45,17 @@
 				value="ffffff"/>
           <property
                 name="startupMessageRect"
-                value="7,265,320,25"/>
+                value="7,265,250,25"/>
           <property
                 name="startupProgressRect"
                 value="2,290,450,10"/>
           <property
                 name="buildIdLocation"
-                value="108,222">
+                value="257,265">
           </property>
           <property
                 name="buildIdSize"
-                value="293,40">
+                value="188,25">
           </property>
 
        </product>


### PR DESCRIPTION
The new splash-screens have their logo text in the center so the injected buildId text has to be moved to the bottom above the progress-bar, next to the product name.

Has to be submitted in the next development cycle and after
- https://github.com/eclipse-platform/eclipse.platform/pull/2469

The final splashes look as shown in
- https://github.com/eclipse-platform/eclipse.platform/pull/2470#issuecomment-3964790641

With the earlier proposal the splash-screen looked like
- For the `Eclipse Platform` Product
<img width="400" alt="grafik" src="https://github.com/user-attachments/assets/15256146-a8f2-48a8-93f0-ff5e8ece928a" />

- For the `Eclipse SDK` Product
<img width="400" alt="grafik" src="https://github.com/user-attachments/assets/e64d2b49-a8e7-4e1c-bebd-a128a800f54a" />

To clarify the borders of the `startupMessage` and `buildId` rectangle I temporarily set their background colors with the new sizes in
- https://github.com/eclipse-platform/eclipse.platform.ui/blob/89a19bf9c20a55490d281e0a97cd0a43bf505085/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/splash/EclipseSplashHandler.java#L93-L97
- https://github.com/eclipse-platform/eclipse.platform.ui/blob/89a19bf9c20a55490d281e0a97cd0a43bf505085/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/ProgressMonitorPart.java#L244-L245

 <img width="400" alt="grafik" src="https://github.com/user-attachments/assets/d3fb405d-7a18-4075-9fc2-9c8c295ccdc6" />

In case the final new splash-screens have the logo text moved up a bit and there is sufficient space, the buildId can also be moved to the very right.


Also note that only the Eclipse Platform and SDK product seem show the `buildID` and only for I-builds, not for milestones or RC or releases. So IMO it's not a big problem if the `buildID` isn't displayed optimally.
