### PR TITLE
Make double buffering of Terminal adopt to higher monitor zooms

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextCanvas.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextCanvas.java
@@ -101,7 +101,7 @@ public class TextCanvas extends GridCanvas {
 	 * (SWT.H_SCROLL and SWT.V_SCROLL are automatically added).
 	 */
 	public TextCanvas(Composite parent, ITextCanvasModel model, int style, ILinelRenderer cellRenderer) {
-		super(parent, style | SWT.H_SCROLL | SWT.V_SCROLL);
+		super(parent, style | SWT.H_SCROLL | SWT.V_SCROLL | SWT.DOUBLE_BUFFERED);
 		fCellRenderer = cellRenderer;
 		setCellWidth(fCellRenderer.getCellWidth());
 		setCellHeight(fCellRenderer.getCellHeight());


### PR DESCRIPTION
The terminal implementation uses a custom double buffering implementation for rendering the current line. On most Platforms (Linux and MacOS) the current implementation will always render the double-buffered image at 100% zoom, even if the target zoom is higher.

This change adapts the implementation to directly render into the actual control and enable native double buffering for the control instead. This ensures that the contents are rendered at the actual target zoom, producing sharper results on HiDPI monitors when using MacOS or Linux.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2295

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2191

## How to reproduce

### MacOS

On MacOS, have a two monitor setup with one high-resolution and one low-resolution monitor. Start the application on the low-resolution monitor and move the window over to the high-resolution monitor.

Without this change:
<img width="668" height="329" alt="image" src="https://github.com/user-attachments/assets/d85303ed-69ab-4fe1-8b60-e91ebb70c01f" />

With this change:
<img width="665" height="336" alt="image" src="https://github.com/user-attachments/assets/7cfc9886-62d2-46b4-8ee8-d52c85f7e46c" />

### Linux

On Linux, a single monitor setup with a monitor zoom > 100% is sufficient. It also happens with fractional scales. In the following, you see the appearance with 125% monitor zoom.

Without this change:
<img width="1798" height="155" alt="image" src="https://github.com/user-attachments/assets/c758abd4-8c98-467b-94a3-4c86ad6bacea" />

With this change:
<img width="1798" height="155" alt="image" src="https://github.com/user-attachments/assets/d9407f7c-348a-4048-90bf-95064717043b" />
