### PR TITLE
Revert "Enable anti-aliasing for Terminal text"

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextLineRenderer.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextLineRenderer.java
@@ -18,7 +18,6 @@ package org.eclipse.terminal.internal.textcanvas;
 
 import java.util.Map;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
@@ -64,7 +63,6 @@ public class TextLineRenderer implements ILinelRenderer {
 		}
 		Image buffer = new Image(gc.getDevice(), width, height);
 		GC doubleBufferGC = new GC(buffer);
-		doubleBufferGC.setAntialias(SWT.ON);
 		if (line < 0 || line >= getTerminalText().getHeight() || colFirst >= getTerminalText().getWidth()
 				|| colFirst - colLast == 0) {
 			fillBackground(doubleBufferGC, 0, 0, width, height);


### PR DESCRIPTION
This reverts commit c02addcd130f15f314c092b4382bd3eb26f238d6 as it slows down Terminal functionality. See comments on https://github.com/eclipse-platform/eclipse.platform/pull/2463