### PR TITLE
Fix NPE when Find action is unavailable in Breakpoints view

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointsView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointsView.java
@@ -202,8 +202,10 @@ public class BreakpointsView extends VariablesView implements IBreakpointManager
 			menu.add(action);
 		}
 		action = getAction(FIND_ACTION);
-		action.setImageDescriptor(DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_FIND_ACTION));
-		menu.add(action);
+		if (action != null && action.isEnabled()) {
+			action.setImageDescriptor(DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_FIND_ACTION));
+			menu.add(action);
+		}
 		action = getAction(ACTION_REMOVE_FROM_GROUP);
 		if (action != null && action.isEnabled()) {
 			menu.add(action);


### PR DESCRIPTION
The Find action may be unavailable when the focus is outside the Breakpoints view, which leads to an NPE in fillContextMenu.

This adds a null and enablement check for the Find action to resolve the problem.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2558