### PR TITLE
Introduce Unified Diff display mode to Compare editor

### DIFF
--- a/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -64,7 +64,8 @@ Export-Package: org.eclipse.compare;
    org.eclipse.swt.widgets,
    org.eclipse.ui,
    org.eclipse.ui.services,
-   org.eclipse.ui.texteditor"
+   org.eclipse.ui.texteditor",
+ org.eclipse.compare.unifieddiff;x-internal:=true
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.8.0,4.0.0)",

--- a/team/bundles/org.eclipse.compare/build.properties
+++ b/team/bundles/org.eclipse.compare/build.properties
@@ -18,6 +18,7 @@ bin.includes = icons/,\
                .,\
                plugin.properties,\
                about.html,\
-               META-INF/
+               META-INF/,\
+               resources/
 src.includes = about.html,\
                schema/

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -2131,9 +2131,15 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		fBirdsEyeCanvas= null;
 		fSummaryHeader= null;
 
-		fAncestorContributor.unsetDocument(fAncestor);
-		fLeftContributor.unsetDocument(fLeft);
-		fRightContributor.unsetDocument(fRight);
+		if (fAncestorContributor != null) {
+			fAncestorContributor.unsetDocument(fAncestor);
+		}
+		if (fLeftContributor != null) {
+			fLeftContributor.unsetDocument(fLeft);
+		}
+		if (fRightContributor != null) {
+			fRightContributor.unsetDocument(fRight);
+		}
 
 		disconnect(fLeftContributor);
 		disconnect(fRightContributor);
@@ -5637,6 +5643,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 					return fMerger.changesCount();
 				}
 			};
+		}
+		if (adapter == IDocumentMergerInput.class) {
+			if (fMerger == null) {
+				return null;
+			}
+			return (T) fMerger.getInput();
 		}
 		if (adapter == OutlineViewerCreator.class) {
 			if (fOutlineViewerCreator == null) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -134,6 +134,21 @@ public final class CompareMessages extends NLS {
 	public static String ReaderCreator_fileIsNotAccessible;
 	public static String CompareWithClipboardTitle;
 
+	public static String UnifiedDiff_acceptAll;
+	public static String UnifiedDiff_hideAllDiffs;
+	public static String UnifiedDiff_keepAll;
+	public static String UnifiedDiff_undoAll;
+	public static String UnifiedDiff_next;
+	public static String UnifiedDiff_previous;
+	public static String UnifiedDiff_accept;
+	public static String UnifiedDiff_hideDiff;
+	public static String UnifiedDiff_keep;
+	public static String UnifiedDiff_undo;
+	public static String UnifiedDiff_revert;
+	public static String UnifiedDiff_openTwoWayCompare_tooltip;
+	public static String UnifiedDiff_cannotEditFile_title;
+	public static String UnifiedDiff_cannotEditFile_message;
+
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);
 	}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -148,3 +148,18 @@ CompareStructureViewerSwitchingPane_discoveredLabel={0} Structure Compare
 ReaderCreator_fileIsNotAccessible=Cannot create a reader because the file is inaccessible.
 
 CompareWithClipboardTitle=Compare {0} and Clipboard
+
+UnifiedDiff_acceptAll=Accept All
+UnifiedDiff_hideAllDiffs=Hide All Diffs
+UnifiedDiff_keepAll=Keep All
+UnifiedDiff_undoAll=Undo All
+UnifiedDiff_next=Next
+UnifiedDiff_previous=Previous
+UnifiedDiff_accept=Accept
+UnifiedDiff_hideDiff=Hide Diff
+UnifiedDiff_keep=Keep
+UnifiedDiff_undo=Undo
+UnifiedDiff_revert=Revert
+UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
+UnifiedDiff_cannotEditFile_title=Cannot edit file
+UnifiedDiff_cannotEditFile_message=Cannot edit file {0}: {1}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
@@ -123,6 +123,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 	public static final String ADDED_LINES_REGEX= PREFIX + "AddedLinesRegex"; //$NON-NLS-1$
 	public static final String REMOVED_LINES_REGEX= PREFIX + "RemovedLinesRegex"; //$NON-NLS-1$
 	public static final String SWAPPED = PREFIX + "Swapped"; //$NON-NLS-1$
+	public static final String UNIFIED_DIFF = PREFIX + "UnifiedDiff"; //$NON-NLS-1$
 
 
 	private IPropertyChangeListener fPreferenceChangeListener;
@@ -154,6 +155,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, ICompareUIConstants.PREF_NAVIGATION_END_ACTION),
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, ICompareUIConstants.PREF_NAVIGATION_END_ACTION_LOCAL),
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, SWAPPED),
+		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, UNIFIED_DIFF),
 	};
 	private final List<FieldEditor> editors = new ArrayList<>();
 	private CTabItem fTextCompareTab;
@@ -177,6 +179,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		store.setDefault(ICompareUIConstants.PREF_NAVIGATION_END_ACTION, ICompareUIConstants.PREF_VALUE_PROMPT);
 		store.setDefault(ICompareUIConstants.PREF_NAVIGATION_END_ACTION_LOCAL, ICompareUIConstants.PREF_VALUE_LOOP);
 		store.setDefault(SWAPPED, true);
+		store.setDefault(UNIFIED_DIFF, false);
 	}
 
 	public ComparePreferencePage() {
@@ -286,6 +289,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		addCheckBox(composite, "ComparePreferencePage.structureCompare.label", OPEN_STRUCTURE_COMPARE, 0);	//$NON-NLS-1$
 		addCheckBox(composite, "ComparePreferencePage.structureOutline.label", USE_OUTLINE_VIEW, 0);	//$NON-NLS-1$
 		addCheckBox(composite, "ComparePreferencePage.ignoreWhitespace.label", IGNORE_WHITESPACE, 0);	//$NON-NLS-1$
+		addCheckBox(composite, "ComparePreferencePage.unifiedDiff.label", UNIFIED_DIFF, 0); //$NON-NLS-1$
 
 		// a spacer
 		new Label(composite, SWT.NONE);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -43,13 +45,19 @@ import java.util.stream.Stream;
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.CompareEditorInput;
 import org.eclipse.compare.IResourceProvider;
+import org.eclipse.compare.ISharedDocumentAdapter;
 import org.eclipse.compare.IStreamContentAccessor;
 import org.eclipse.compare.IStreamMerger;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.internal.core.CompareSettings;
+import org.eclipse.compare.internal.merge.DocumentMerger.IDocumentMergerInput;
 import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.compare.structuremergeviewer.IStructureCreator;
+import org.eclipse.compare.structuremergeviewer.SharedDocumentAdapterWrapper;
 import org.eclipse.compare.structuremergeviewer.StructureDiffViewer;
+import org.eclipse.compare.unifieddiff.UnifiedDiff;
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.HideAllDiffsRunnable;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.Adapters;
@@ -62,12 +70,14 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.jface.action.Action;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -84,6 +94,7 @@ import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorRegistry;
+import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IReusableEditor;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IWorkbench;
@@ -91,8 +102,11 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.model.IWorkbenchAdapter;
+import org.eclipse.ui.part.MultiPageEditorPart;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.ui.texteditor.ITextEditor;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
@@ -560,6 +574,10 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		CompareConfiguration configuration = input.getCompareConfiguration();
 		if (configuration != null) {
 			IPreferenceStore ps= configuration.getPreferenceStore();
+			boolean unifiedDiffEnabled = ps.getBoolean(ComparePreferencePage.UNIFIED_DIFF);
+			if (unifiedDiffEnabled && openUnifiedDiffInEditor(input, page, editor, activate)) {
+				return;
+			}
 			if (ps != null) {
 				configuration.setProperty(
 						CompareConfiguration.USE_OUTLINE_VIEW,
@@ -575,9 +593,205 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		}
 	}
 
-	private void openEditorInBackground(final CompareEditorInput input,
-			final IWorkbenchPage page, final IReusableEditor editor,
-			final boolean activate) {
+	private boolean openUnifiedDiffInEditor(final CompareEditorInput input, final IWorkbenchPage page,
+			IReusableEditor editor, boolean activate) {
+		var unifiedDiffInput = canShowInUnifiedDiff(input);
+		if (unifiedDiffInput!=null) {
+			try {
+				IWorkbenchPage wpage = page != null ? page : getActivePage();
+				if (wpage == null) {
+					// no active workbench page; fall back to the classic compare editor path
+					return false;
+				}
+				if (unifiedDiffInput.left instanceof IFileEditorInput) {
+					IEditorPart leftEditor = wpage.openEditor(unifiedDiffInput.left,
+							getEditorId(unifiedDiffInput.left, unifiedDiffInput.leftElement));
+					if (leftEditor instanceof MultiPageEditorPart mpe) {
+						Object p = mpe.getSelectedPage();
+						if (p instanceof IEditorPart) {
+							leftEditor = (IEditorPart) p;
+						}
+					}
+					if (leftEditor instanceof ITextEditor leftTextEditor) {
+						Action openTwoWayCompare = createOpenTwoWayCompareAction(input, page, editor, activate,
+								leftTextEditor);
+						IStatus status = UnifiedDiff
+								.create(leftTextEditor, getSourceOf(unifiedDiffInput.rightAcessor()),
+										UnifiedDiffMode.REVERT_MODE)
+								.additionalActions(Arrays.asList(openTwoWayCompare))
+								.ignoreWhitespaceContributorFactory(t -> unifiedDiffInput.documentMergerInput != null
+										? unifiedDiffInput.documentMergerInput.createIgnoreWhitespaceContributor(t)
+										: Optional.empty())
+								.tokenComparatorFactory(t -> unifiedDiffInput.documentMergerInput != null
+										? unifiedDiffInput.documentMergerInput.createTokenComparator(t)
+										: null)
+								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
+										CompareConfiguration.IGNORE_WHITESPACE, false))
+								.open();
+						return status.isOK();
+					}
+				} else {
+					IEditorPart rightEditor = wpage.openEditor(unifiedDiffInput.right,
+							getEditorId(unifiedDiffInput.right, unifiedDiffInput.rightElement));
+					if (rightEditor instanceof MultiPageEditorPart mpe) {
+						Object p = mpe.getSelectedPage();
+						if (p instanceof IEditorPart) {
+							rightEditor = (IEditorPart) p;
+						}
+					}
+					if (rightEditor instanceof ITextEditor rightTextEditor) {
+						Action openTwoWayCompare = createOpenTwoWayCompareAction(input, page, editor, activate,
+								rightTextEditor);
+						IStatus status = UnifiedDiff
+								.create(rightTextEditor, getSourceOf(unifiedDiffInput.leftAcessor()),
+										UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)
+								.additionalActions(Arrays.asList(openTwoWayCompare))
+								.ignoreWhitespaceContributorFactory(t -> unifiedDiffInput.documentMergerInput != null
+										? unifiedDiffInput.documentMergerInput.createIgnoreWhitespaceContributor(t)
+										: Optional.empty())
+								.tokenComparatorFactory(t -> unifiedDiffInput.documentMergerInput != null
+										? unifiedDiffInput.documentMergerInput.createTokenComparator(t)
+										: null)
+								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
+										CompareConfiguration.IGNORE_WHITESPACE, false))
+								.open();
+						return status.isOK();
+					}
+				}
+			} catch (PartInitException e) {
+				CompareUIPlugin.log(e);
+			}
+		}
+		return false;
+	}
+
+	private Action createOpenTwoWayCompareAction(final CompareEditorInput input, final IWorkbenchPage page,
+			IReusableEditor editor, boolean activate, ITextEditor textEditor) {
+		ImageDescriptor image = CompareUIPlugin.getImageDescriptor(ICompareUIConstants.TWO_WAY_COMPARE);
+		Action openTwoWayCompare = new Action(null, image) {
+			@Override
+			public void run() {
+				new HideAllDiffsRunnable(textEditor).run();
+				if (input.canRunAsJob()) {
+					openEditorInBackground(input, page, editor, activate);
+				} else {
+					if (compareResultOK(input, null)) {
+						internalOpenEditor(input, page, editor, activate);
+					}
+				}
+			}
+		};
+		openTwoWayCompare.setToolTipText(CompareMessages.UnifiedDiff_openTwoWayCompare_tooltip);
+		return openTwoWayCompare;
+	}
+
+	private String getSourceOf(IStreamContentAccessor right) {
+		try {
+			if (right == null) {
+				return ""; //$NON-NLS-1$
+			}
+			String result = toString(right.getContents());
+			return result;
+		} catch (CoreException | IOException e) {
+			CompareUIPlugin.log(e);
+		}
+		// UnifiedDiff.Builder requires a non-null source. Return an empty string so
+		// the unified diff path can still attempt to open and the fallback to the
+		// classic compare editor remains intact when an OK status is not returned.
+		return ""; //$NON-NLS-1$
+	}
+
+	private static String toString(InputStream inputStream) throws IOException {
+		if (inputStream == null) {
+			return ""; //$NON-NLS-1$
+		}
+		try (inputStream) {
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+	private static String getEditorId(IEditorInput editorInput, ITypedElement element) {
+		String fileName = editorInput.getName();
+		IEditorRegistry registry = PlatformUI.getWorkbench().getEditorRegistry();
+		IContentType type = getContentType(element);
+		IEditorDescriptor descriptor = registry.getDefaultEditor(fileName, type);
+		IDE.overrideDefaultEditorAssociation(editorInput, type, descriptor);
+		String id;
+		if (descriptor == null || descriptor.isOpenExternal()) {
+			id = "org.eclipse.ui.DefaultTextEditor"; //$NON-NLS-1$
+		} else {
+			id = descriptor.getId();
+		}
+		return id;
+	}
+
+	private static record LeftEditorInputAndRightStreamContentAccessor(IEditorInput left, ITypedElement leftElement,
+			IStreamContentAccessor leftAcessor, IEditorInput right, ITypedElement rightElement,
+			IStreamContentAccessor rightAcessor, IDocumentMergerInput documentMergerInput) {
+	}
+
+	private LeftEditorInputAndRightStreamContentAccessor canShowInUnifiedDiff(CompareEditorInput input) {
+		IDocumentMergerInput documentMergerInput = null;
+		try {
+			input.run(new NullProgressMonitor());
+			Object res = input.getCompareResult();
+			if (!(res instanceof ICompareInput compareInput)) {
+				return null;
+			}
+			ITypedElement ancestor = compareInput.getAncestor();
+			if (ancestor != null) {
+				return null;
+			}
+			ITypedElement left = compareInput.getLeft();
+			if (left == null) {
+				return null;
+			}
+			ISharedDocumentAdapter leftSda = SharedDocumentAdapterWrapper.getAdapter(left);
+			if (leftSda == null) {
+				return null;
+			}
+			IEditorInput leftEditorInput = leftSda.getDocumentKey(left);
+			if (leftEditorInput == null) {
+				return null;
+			}
+			if (!(left instanceof IStreamContentAccessor leftSa)) {
+				return null;
+			}
+			ITypedElement right = compareInput.getRight();
+			if (right == null) {
+				return null;
+			}
+			ISharedDocumentAdapter rightSda = SharedDocumentAdapterWrapper.getAdapter(right);
+			if (rightSda == null) {
+				return null;
+			}
+			IEditorInput rightEditorInput = rightSda.getDocumentKey(right);
+			if (rightEditorInput == null) {
+				return null;
+			}
+			if (!(right instanceof IStreamContentAccessor rightSa)) {
+				return null;
+			}
+			var invisibleParent = new Shell();
+			try {
+				invisibleParent.setVisible(false);
+				var viewer = input.findContentViewer(new NullViewer(invisibleParent), compareInput, invisibleParent);
+				if (viewer instanceof IAdaptable adaptable) {
+					documentMergerInput = adaptable.getAdapter(IDocumentMergerInput.class);
+				}
+			} finally {
+				invisibleParent.dispose();
+			}
+			return new LeftEditorInputAndRightStreamContentAccessor(leftEditorInput, left, leftSa, rightEditorInput,
+					right, rightSa, documentMergerInput);
+		} catch (InvocationTargetException | InterruptedException e) {
+			CompareUIPlugin.log(e);
+		}
+		return null;
+	}
+
+	private void openEditorInBackground(final CompareEditorInput input, final IWorkbenchPage page,
+			final IReusableEditor editor, final boolean activate) {
 		internalOpenEditor(input, page, editor, activate);
 	}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ICompareUIConstants.java
@@ -23,6 +23,8 @@ public interface ICompareUIConstants {
 	public static final String ETOOL_PREV = "elcl16/prev_nav.svg"; //$NON-NLS-1$
 	public static final String CTOOL_PREV= ETOOL_PREV;
 
+	public static final String TWO_WAY_COMPARE = "elcl16/twowaycompare_co.svg"; //$NON-NLS-1$
+
 	public static final String HUNK_OBJ = "obj16/hunk_obj.svg"; //$NON-NLS-1$
 
 	public static final String ERROR_OVERLAY = "ovr16/error_ov.svg"; //$NON-NLS-1$

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/DocumentMerger.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/merge/DocumentMerger.java
@@ -1403,4 +1403,7 @@ public class DocumentMerger {
 		return null;
 	}
 
+	public IDocumentMergerInput getInput() {
+		return fInput;
+	}
 }

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.compare.contentmergeviewer.IIgnoreWhitespaceContributor;
+import org.eclipse.compare.contentmergeviewer.ITokenComparator;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public final class UnifiedDiff {
+
+	private UnifiedDiff() {
+	}
+
+	@FunctionalInterface
+	public static interface TokenComparatorFactory extends Function<String, ITokenComparator> {
+	}
+
+	@FunctionalInterface
+	public static interface IgnoreWhitespaceContributorFactory
+			extends Function<IDocument, Optional<IIgnoreWhitespaceContributor>> {
+	}
+
+	/**
+	 * Shows the unified diff in the given editor.
+	 * @param editor the text editor where the diff will be shown
+	 * @param source the source content to compare
+	 * @param mode the mode in which the diff will be displayed
+	 * @return a builder to configure and open the unified diff
+	 */
+	public static Builder create(ITextEditor editor, String source, UnifiedDiffMode mode) {
+		return new Builder(editor, source, mode);
+	}
+
+	public static final class Builder {
+		// Required parameters
+		private final ITextEditor editor;
+		private final String source;
+		private final UnifiedDiffMode mode;
+		private boolean ignoreWhiteSpace = true;
+
+		// Optional parameters
+		private List<Action> additionalActions;
+		private TokenComparatorFactory tokenComparatorFactory;
+		private IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory;
+
+		private Builder(ITextEditor editor, String source, UnifiedDiffMode mode) {
+			this.editor = Objects.requireNonNull(editor, "Editor cannot be null"); //$NON-NLS-1$
+			this.source = Objects.requireNonNull(source, "Source cannot be null"); //$NON-NLS-1$
+			this.mode = Objects.requireNonNull(mode, "Mode cannot be null"); //$NON-NLS-1$
+		}
+
+		public Builder additionalActions(List<Action> actions) {
+			this.additionalActions = actions;
+			return this;
+		}
+
+		public Builder ignoreWhitespaceContributorFactory(IgnoreWhitespaceContributorFactory factory) {
+			this.ignoreWhitespaceContributorFactory = factory;
+			return this;
+		}
+
+		public Builder tokenComparatorFactory(TokenComparatorFactory factory) {
+			this.tokenComparatorFactory = factory;
+			return this;
+		}
+
+		public Builder ignoreWhiteSpace(boolean value) {
+			ignoreWhiteSpace = value;
+			return this;
+		}
+
+		public IStatus open() {
+			return UnifiedDiffManager.open(editor, source, mode, additionalActions, tokenComparatorFactory,
+					ignoreWhitespaceContributorFactory, ignoreWhiteSpace);
+		}
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiffMode.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiffMode.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff;
+
+public class UnifiedDiffMode {
+	/**
+	 * Diffs are directly applied in the editor. Users have the possibility to keep
+	 * or undo the applied diffs.
+	 */
+	public static final UnifiedDiffMode REPLACE_MODE = new UnifiedDiffMode("REPLACE_MODE"); //$NON-NLS-1$
+	/**
+	 * The source in the editor is not modified. Diffs are shown as code mining and
+	 * users have the possibility to apply or hide individual diffs.
+	 */
+	public static final UnifiedDiffMode OVERLAY_MODE = new UnifiedDiffMode("OVERLAY_MODE"); //$NON-NLS-1$
+	/**
+	 * The source in the editor is not modified. Diffs are shown as code mining and
+	 * users cannot apply or dismiss the diffs (read-only mode).
+	 */
+	public static final UnifiedDiffMode OVERLAY_READ_ONLY_MODE = new UnifiedDiffMode("OVERLAY_READ_ONLY_MODE"); //$NON-NLS-1$
+	/**
+	 * The current source in the editor represents the latest/newest version, which
+	 * is compared against an older version. Diffs are shown so that they can be
+	 * reverted to the old version. Unlike the other modes, the passed source is
+	 * treated as the base (old version) and the current source as the modified (new
+	 * version).
+	 */
+	public static final UnifiedDiffMode REVERT_MODE = new UnifiedDiffMode("REVERT_MODE"); //$NON-NLS-1$
+
+	private final String name;
+
+	private UnifiedDiffMode(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/AcceptAllRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/AcceptAllRunnable.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.disposeUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.runAfterRepaintFinished;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiffAnnotation;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+
+public class AcceptAllRunnable implements Runnable {
+	private IAnnotationModel model;
+	private ITextViewer tv;
+
+	public AcceptAllRunnable(ITextViewer tv, IAnnotationModel model) {
+		this.tv = tv;
+		this.model = model;
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_acceptAll;
+	}
+
+	public static ImageDescriptor getImageDescriptor() {
+		return PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_OBJ_ADD);
+	}
+
+	public static ImageDescriptor getUndoImageDescriptor() {
+		return CompareUIPlugin.getImageDescriptor("elcl16/undo.svg"); //$NON-NLS-1$
+	}
+
+	@Override
+	public void run() {
+		StyledText tw = tv.getTextWidget();
+		List<UnifiedDiff> diffs1 = get(tv);
+		List<Position> positions = new ArrayList<>();
+		List<String> replaceStrings = new ArrayList<>();
+		for (UnifiedDiff diff : diffs1) {
+			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+			int unifiedDiffAdditionCount = 0;
+			for (var lanno : annos) {
+				if (lanno instanceof UnifiedDiffAnnotation) {
+					unifiedDiffAdditionCount++;
+					if (unifiedDiffAdditionCount > 1) {
+						throw new IllegalStateException("Multiple UnifiedDiffAnnotation for one UnifiedDiff found"); //$NON-NLS-1$
+					}
+					Position pos = model.getPosition(lanno);
+					positions.add(pos);
+					replaceStrings.add(diff.rightStr);
+				}
+				model.removeAnnotation(lanno);
+			}
+		}
+		diffs1.clear();
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		disposeUnifiedDiff(tv, model, tv.getTextWidget());
+		// we have to insert with delay because otherwise the line header code minings
+		// cannot be deleted
+		runAfterRepaintFinished(tw, () -> {
+			for (int i = positions.size() - 1; i >= 0; i--) {
+				Position pos = positions.get(i);
+				String replaceStr = replaceStrings.get(i);
+				try {
+					tv.getDocument().replace(pos.offset, pos.length, replaceStr);
+				} catch (BadLocationException e) {
+					UnifiedDiffManager.error(e);
+				}
+			}
+		});
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/HideAllDiffsRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/HideAllDiffsRunnable.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.disposeUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.removeAnnotationModelListener;
+
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public class HideAllDiffsRunnable implements Runnable {
+
+	private IAnnotationModel model;
+	private ITextViewer tv;
+
+	public HideAllDiffsRunnable(ITextViewer tv, IAnnotationModel model) {
+		this.tv = tv;
+		this.model = model;
+	}
+
+	public HideAllDiffsRunnable(ITextEditor textEditor) {
+		this.tv = textEditor.getAdapter(ITextViewer.class);
+		this.model = textEditor.getDocumentProvider().getAnnotationModel(textEditor.getEditorInput());
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_hideAllDiffs;
+	}
+
+	public static ImageDescriptor getHideDiffImageDescriptor() {
+		return CompareUIPlugin.getImageDescriptor("elcl16/remove_highlighting.svg"); //$NON-NLS-1$
+	}
+
+	public ImageDescriptor getImageDescriptor() {
+		return getHideDiffImageDescriptor();
+	}
+
+	@Override
+	public void run() {
+		if (tv != null) {
+			removeAnnotationModelListener(model, tv.getTextWidget());
+		}
+		List<UnifiedDiff> diffs1 = get(tv);
+		for (UnifiedDiff diff : diffs1) {
+			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+			for (var lanno : annos) {
+				model.removeAnnotation(lanno);
+			}
+		}
+		diffs1.clear();
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		disposeUnifiedDiff(tv, model, tv.getTextWidget());
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/KeepAllRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/KeepAllRunnable.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.disposeUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+
+public class KeepAllRunnable implements Runnable {
+	private ITextViewer tv;
+	private IAnnotationModel model;
+
+	public KeepAllRunnable(ITextViewer tv, IAnnotationModel model) {
+		this.tv = tv;
+		this.model = model;
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_keepAll;
+	}
+
+	@Override
+	public void run() {
+		List<UnifiedDiff> diffs1 = get(tv);
+		for (UnifiedDiff diff : diffs1) {
+			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+			for (var lanno : annos) {
+				model.removeAnnotation(lanno);
+			}
+		}
+		diffs1.clear();
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		disposeUnifiedDiff(tv, model, tv.getTextWidget());
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/NextRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/NextRunnable.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getMinPositionAnno;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.selectAndRevealAnno;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.uncheckToolbarActionItems;
+
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.ICompareUIConstants;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+
+public class NextRunnable implements Runnable {
+
+	private ToolBarManager tm;
+	private IAnnotationModel model;
+	private ITextViewer tv;
+
+	public NextRunnable(ITextViewer tv, IAnnotationModel model, ToolBarManager tm) {
+		this.tv = tv;
+		this.model = model;
+		this.tm = tm;
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_next;
+	}
+
+	public ImageDescriptor getImageDescriptor() {
+		return CompareUIPlugin.getImageDescriptor(ICompareUIConstants.ETOOL_NEXT);
+	}
+
+	@Override
+	public void run() {
+		uncheckToolbarActionItems(tm);
+
+		if (!(tv.getSelectionProvider().getSelection() instanceof ITextSelection sel)) {
+			return;
+		}
+		int offset = sel.getOffset();
+		List<UnifiedDiff> diffs1 = get(tv);
+		// get next UnifiedDiff for given offset
+		UnifiedDiff nextDiff = null;
+		for (UnifiedDiff diff : diffs1) {
+			int diffStart = getStartOffset(diff, model);
+			if (diffStart > offset) {
+				nextDiff = diff;
+				break;
+			}
+			if (nextDiff != null) {
+				break;
+			}
+		}
+		if (nextDiff == null) {
+			nextDiff = diffs1.get(0);
+		}
+		List<Annotation> all = getAllAnnotationsForUnifiedDiff(model, nextDiff);
+		if (all.size() == 0) {
+			return;
+		}
+		Annotation nextAnno = getMinPositionAnno(model, all);
+		selectAndRevealAnno(tv, model, nextAnno);
+	}
+
+	static int getStartOffset(UnifiedDiff diff, IAnnotationModel model) {
+		int diffStart = diff.leftStart;
+		List<Annotation> all = getAllAnnotationsForUnifiedDiff(model, diff);
+		if (all.size() > 0) {
+			Annotation min = getMinPositionAnno(model, all);
+			if (min != null) {
+				Position pos = model.getPosition(min);
+				if (pos != null) {
+					diffStart = pos.getOffset();
+				}
+			}
+		}
+		return diffStart;
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/PreviousRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/PreviousRunnable.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.NextRunnable.getStartOffset;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getMinPositionAnno;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.selectAndRevealAnno;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.uncheckToolbarActionItems;
+
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.ICompareUIConstants;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+
+public class PreviousRunnable implements Runnable {
+
+	private ITextViewer tv;
+	private IAnnotationModel model;
+	private ToolBarManager tm;
+
+	public PreviousRunnable(ITextViewer tv, IAnnotationModel model, ToolBarManager tm) {
+		this.tv = tv;
+		this.model = model;
+		this.tm = tm;
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_previous;
+	}
+
+	public ImageDescriptor getImageDescriptor() {
+		return CompareUIPlugin.getImageDescriptor(ICompareUIConstants.ETOOL_PREV);
+	}
+
+	@Override
+	public void run() {
+		uncheckToolbarActionItems(tm);
+
+		if (!(tv.getSelectionProvider().getSelection() instanceof ITextSelection sel)) {
+			return;
+		}
+		int offset = sel.getOffset();
+		List<UnifiedDiff> diffs1 = get(tv);
+		// get next UnifiedDiff for given offset
+		UnifiedDiff nextDiff = null;
+		for (UnifiedDiff diff : diffs1) {
+			int diffStart = getStartOffset(diff, model);
+			if (diffStart < offset) {
+				nextDiff = diff;
+			}
+		}
+		if (nextDiff == null) {
+			nextDiff = diffs1.getLast();
+		}
+		List<Annotation> all = getAllAnnotationsForUnifiedDiff(model, nextDiff);
+		if (all.size() == 0) {
+			return;
+		}
+		Annotation nextAnno = getMinPositionAnno(model, all);
+		selectAndRevealAnno(tv, model, nextAnno);
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UndoAllRunnable.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UndoAllRunnable.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.disposeUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.error;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.get;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.getAllAnnotationsForUnifiedDiff;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.runAfterRepaintFinished;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiffAnnotation;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+
+public class UndoAllRunnable implements Runnable {
+	private ITextViewer tv;
+	private IAnnotationModel model;
+
+	public UndoAllRunnable(ITextViewer tv, IAnnotationModel model) {
+		this.tv = tv;
+		this.model = model;
+	}
+
+	public String getLabel() {
+		return CompareMessages.UnifiedDiff_undoAll;
+	}
+
+	@Override
+	public void run() {
+		var tw = tv.getTextWidget();
+		List<UnifiedDiff> diffs1 = get(tv);
+		List<Position> positions = new ArrayList<>();
+		List<String> replaceStrings = new ArrayList<>();
+		for (UnifiedDiff diff : diffs1) {
+			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+			int unifiedDiffAdditionCount = 0;
+			for (var lanno : annos) {
+				if (lanno instanceof UnifiedDiffAnnotation) {
+					unifiedDiffAdditionCount++;
+					if (unifiedDiffAdditionCount > 1) {
+						throw new IllegalStateException("Multiple UnifiedDiffAnnotation for one UnifiedDiff found"); //$NON-NLS-1$
+					}
+					Position pos = model.getPosition(lanno);
+					positions.add(pos);
+					replaceStrings.add(diff.leftStr);
+				}
+				model.removeAnnotation(lanno);
+			}
+		}
+		diffs1.clear();
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		disposeUnifiedDiff(tv, model, tv.getTextWidget());
+		// we have to insert with delay because otherwise the line header code minings
+		// cannot be deleted
+		runAfterRepaintFinished(tw, () -> {
+			for (int i = positions.size() - 1; i >= 0; i--) {
+				Position pos = positions.get(i);
+				String replaceStr = replaceStrings.get(i);
+				try {
+					tv.getDocument().replace(pos.offset, pos.length, replaceStr);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			}
+		});
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
@@ -1,0 +1,1069 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.error;
+import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.isOverlay;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
+import org.eclipse.jface.text.codemining.DocumentFooterCodeMining;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.text.source.inlined.LineFooterAnnotation;
+import org.eclipse.jface.text.source.inlined.LineHeaderAnnotation;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.editors.text.EditorsUI;
+import org.eclipse.ui.part.MultiPageEditorPart;
+import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
+
+public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
+
+	private Color deletionBackgroundColor;
+	private Color detailedDiffColor;
+	private boolean lastIsOverlay;
+
+	@Override
+	public void dispose() {
+		try {
+			if (deletionBackgroundColor != null && !deletionBackgroundColor.isDisposed()) {
+				deletionBackgroundColor.dispose();
+			}
+			deletionBackgroundColor = null;
+			if (detailedDiffColor != null && !detailedDiffColor.isDisposed()) {
+				detailedDiffColor.dispose();
+			}
+			detailedDiffColor = null;
+		} finally {
+			super.dispose();
+		}
+	}
+
+	@Override
+	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer,
+			IProgressMonitor monitor) {
+		List<UnifiedDiff> diffs = UnifiedDiffManager.get(viewer);
+		if (diffs == null || diffs.size() == 0) {
+			return CompletableFuture.completedFuture(new ArrayList<>());
+		}
+		boolean isOverlay = isOverlay(diffs);
+		if (Display.getCurrent() != null && (this.deletionBackgroundColor == null || isOverlay != lastIsOverlay)) {
+			// check class ColorPalette
+			RGB background = getBackground();
+			String colorName;
+			if (isOverlay) {
+				colorName = "ADDITION_COLOR"; //$NON-NLS-1$
+			} else {
+				colorName = "DELETION_COLOR"; //$NON-NLS-1$
+			}
+			RGB deletionColor = JFaceResources.getColorRegistry().getRGB(colorName);
+			// dispose any previously allocated colors before replacing them so the
+			// native handles are not leaked when the mode (isOverlay) changes
+			if (this.detailedDiffColor != null && !this.detailedDiffColor.isDisposed()) {
+				this.detailedDiffColor.dispose();
+			}
+			if (this.deletionBackgroundColor != null && !this.deletionBackgroundColor.isDisposed()) {
+				this.deletionBackgroundColor.dispose();
+			}
+			this.detailedDiffColor = new Color(interpolate(deletionColor, background, 0.9));
+			this.deletionBackgroundColor = new Color(interpolate(deletionColor, background, 0.8));
+			lastIsOverlay = isOverlay;
+		}
+		if (viewer instanceof ISourceViewer sv && UnifiedDiffManager.get(viewer) != null) {
+			List<ICodeMining> existingMinings = new ArrayList<>();
+			IAnnotationModel model = sv.getAnnotationModel();
+			Iterator<Annotation> it = model.getAnnotationIterator();
+			while (it.hasNext()) {
+				Annotation next = it.next();
+				if (next instanceof LineHeaderAnnotation n) {
+					try {
+						List<ICodeMining> m = n.getMinings();
+						if (m != null && m.size() == 1 && m.get(0) instanceof UnifiedDiffLineHeaderCodeMining idlhcm) {
+							Position p = n.getPosition();
+							IDocument doc = sv.getDocument();
+							int line = doc.getLineOfOffset(p.offset);
+							idlhcm.getPosition().offset = doc.getLineOffset(line); // we need to recalculate the line
+																					// offset for the scenario where
+																					// source is modified at the
+																					// beginning of the line
+							existingMinings.add(idlhcm);
+						}
+					} catch (BadLocationException e) {
+						error(e);
+					}
+				} else if (next instanceof LineFooterAnnotation footer) {
+					List<ICodeMining> m = footer.getMinings();
+					if (m != null && m.size() == 1 && m.get(0) instanceof UnifiedDiffFooterCodeMining idlhcm) {
+						IDocument doc = sv.getDocument();
+						idlhcm.getPosition().offset = doc.getLength();
+						existingMinings.add(idlhcm);
+					}
+				}
+			}
+			if (existingMinings.size() > 0) {
+				return CompletableFuture.completedFuture(existingMinings);
+			}
+		}
+
+		int tabWidth = getTabWidth(viewer);
+		// take an immutable snapshot so the async iteration cannot observe
+		// concurrent modifications when accept/hide actions mutate the live list
+		List<UnifiedDiff> diffsSnapshot = List.copyOf(diffs);
+		return CompletableFuture.supplyAsync(() -> {
+			List<ICodeMining> minings = new ArrayList<>();
+			createLineHeaderCodeMinings(diffsSnapshot, minings, viewer, tabWidth);
+			return minings;
+		});
+	}
+
+	public static RGB getBackground() {
+		RGB background = null;
+		IPreferenceStore store = EditorsUI.getPreferenceStore();
+		boolean isUsingSystemBackground = store
+				.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT);
+		if (!isUsingSystemBackground) {
+			background = createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND);
+		}
+		if (background != null) {
+			return background;
+		}
+		return Display.getDefault().getSystemColor(SWT.COLOR_LIST_BACKGROUND).getRGB();
+	}
+
+	private static RGB createColor(IPreferenceStore store, String key) {
+		if (!store.contains(key)) {
+			return null;
+		}
+		if (store.isDefault(key)) {
+			return PreferenceConverter.getDefaultColor(store, key);
+		}
+		return PreferenceConverter.getColor(store, key);
+	}
+
+	private int getTabWidth(ITextViewer viewer) {
+		int tabWidth = -1;
+		if (viewer != null && Display.getCurrent() != null) {
+			StyledText tw = viewer.getTextWidget();
+			tabWidth = tw.getTabs();
+			if (tabWidth > 0) {
+				return tabWidth;
+			}
+		}
+		if (tabWidth == -1) {
+			IPreferenceStore store = EditorsUI.getPreferenceStore();
+			tabWidth = store.getInt(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH);
+		}
+		return tabWidth;
+	}
+
+	private void createLineHeaderCodeMinings(List<UnifiedDiff> diffs, List<ICodeMining> minings, ITextViewer tv,
+			int tabWidth) {
+		if (diffs == null) {
+			return;
+		}
+		IDocument doc = tv.getDocument();
+		for (UnifiedDiff diff : diffs) {
+			if (diff.mode.equals(UnifiedDiffMode.REPLACE_MODE)) {
+				if (diff.leftStr.isEmpty()) {
+					continue;
+				}
+				try {
+					ICodeMining mining;
+					if (diff.leftStart == doc.getLength()) {
+						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
+								this.deletionBackgroundColor);
+					} else {
+						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart, 1), this, diff,
+								tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
+					}
+					minings.add(mining);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			} else if (diff.mode.equals(UnifiedDiffMode.OVERLAY_MODE)
+					|| diff.mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)) {
+				if (diff.rightStr.isEmpty()) {
+					continue;
+				}
+				try {
+					ICodeMining mining;
+					if (diff.leftStart == doc.getLength()) {
+						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
+								this.deletionBackgroundColor);
+					} else {
+						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart + diff.leftLength, 1),
+								this, diff, tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
+					}
+					minings.add(mining);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			} else if (diff.mode.equals(UnifiedDiffMode.REVERT_MODE)) {
+				if (diff.rightStr.isEmpty()) {
+					continue;
+				}
+				try {
+					ICodeMining mining;
+					if (diff.leftStart == doc.getLength()) {
+						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
+								this.deletionBackgroundColor);
+					} else {
+						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart, 1), this, diff,
+								tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
+					}
+					minings.add(mining);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			}
+		}
+	}
+
+	static class UnifiedDiffFooterCodeMining extends DocumentFooterCodeMining {
+		private final String unifiedDiffLabel;
+		private final Color deletionBackgroundColor;
+		private UnifiedDiff diff;
+
+		public UnifiedDiffFooterCodeMining(IDocument document, ICodeMiningProvider provider,
+				Consumer<MouseEvent> action, UnifiedDiff diff, int tabWidth, Color deletionBackgroundColor) {
+			super(document, provider, action);
+			this.deletionBackgroundColor = deletionBackgroundColor;
+			if (diff.mode.equals(UnifiedDiffMode.REPLACE_MODE)) {
+				this.unifiedDiffLabel = replaceTabWithSpaces(diff.leftStr, tabWidth);
+			} else {
+				this.unifiedDiffLabel = replaceTabWithSpaces(diff.rightStr, tabWidth);
+			}
+			this.diff = diff;
+		}
+
+		@Override
+		public String getLabel() {
+			return this.unifiedDiffLabel;
+		}
+
+		public UnifiedDiff getUnifiedDiff() {
+			return this.diff;
+		}
+
+		@Override
+		public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+			gc.setBackground(this.deletionBackgroundColor);
+			Color c = textWidget.getForeground();
+			gc.setForeground(c);
+			Font font = textWidget.getFont();
+			gc.setFont(font);
+			// first run to get width and height for label
+			// change from https://github.com/eclipse-platform/eclipse.platform.ui/pull/3651
+			// is required so that background correctly drawn with line spacing > 0
+			Point result = super.draw(gc, textWidget, color, x, y);
+			// draw background
+			// vs code is drawing the background to the top right of the editor - we do here
+			// the same!
+			gc.fillRectangle(0, y, textWidget.getBounds().width /* result.x */, result.y);
+			// draw foreground again
+			result = super.draw(gc, textWidget, color, x, y);
+			return result;
+		}
+	}
+
+	private static List<StyleRange> computeStyleRanges(ITextViewer v, int offset, String source) {
+		List<StyleRange> result = new ArrayList<>();
+		if (!(v instanceof SourceViewer sv)) {
+			return result;
+		}
+		try {
+			IDocument originalDocument = sv.getDocument();
+			String prefix = originalDocument.get(0, offset /* diff.leftStart */);
+			IDocument document = new Document(prefix + source);
+			IRegion damage = new Region(prefix.length(), source.length());
+			result = sv.computeStyleRanges(document, damage);
+			int startOffset = prefix.length();
+			for (StyleRange next : result) {
+				if (next.start < startOffset) {
+					throw new IllegalStateException(
+							"Invalid presentation with style range starting before source offset"); //$NON-NLS-1$
+				}
+				next.start -= startOffset;
+			}
+			return result;
+		} catch (BadLocationException e) {
+			return result;
+		}
+	}
+
+	public static class UnifiedDiffLineHeaderCodeMining extends LineHeaderCodeMining {
+		private final String unifiedDiffLabel;
+		private final Color deletionBackgroundColor;
+		private final Color detailedDiffColor;
+		private final UnifiedDiff diff;
+		private final int tabWidth;
+		private ITextViewer viewer;
+
+		private Rectangle lastRectangle;
+		private List<Rectangle> backgrounds;
+		private List<ForegroundInfo> foregrounds;
+		private Font cachedFont;
+		private final HashMap<Font, Map<Integer /* style */, Font>> styledFonts = new HashMap<>();
+
+		public UnifiedDiffLineHeaderCodeMining(Position position, ICodeMiningProvider provider, UnifiedDiff diff,
+				int tabWidth, Color deletionBackgroundColor, Color detailedDiffColor, ITextViewer viewer)
+				throws BadLocationException {
+			super(position, provider, new MouseClickConsumer(viewer));
+			if (diff.mode.equals(UnifiedDiffMode.REPLACE_MODE)) {
+				this.unifiedDiffLabel = removeTrailingNewLines(replaceTabWithSpaces(diff.leftStr, tabWidth));
+			} else {
+				this.unifiedDiffLabel = removeTrailingNewLines(replaceTabWithSpaces(diff.rightStr, tabWidth));
+			}
+			this.deletionBackgroundColor = deletionBackgroundColor;
+			this.detailedDiffColor = detailedDiffColor;
+			this.diff = diff;
+			this.tabWidth = tabWidth;
+			this.viewer = viewer;
+			((MouseClickConsumer) getAction()).setCodeMining(this);
+		}
+
+		private static String removeTrailingNewLines(String str) {
+			if (str == null) {
+				return str;
+			}
+			int end = str.length();
+			while (end > 0 && (str.charAt(end - 1) == '\n' || str.charAt(end - 1) == '\r')) {
+				end--;
+			}
+			return end == str.length() ? str : str.substring(0, end);
+		}
+
+		private static String removeLeadingNewLines(String str) {
+			if (str == null) {
+				return str;
+			}
+			int start = 0;
+			while (start < str.length() && (str.charAt(start) == '\n' || str.charAt(start) == '\r')) {
+				start++;
+			}
+			return start == 0 ? str : str.substring(start);
+		}
+
+		private static final class ForegroundInfo {
+
+			final int x;
+			final int y;
+			final String str;
+			final Font font;
+			final Color background;
+			final Color foreground;
+
+			public ForegroundInfo(int x, int y, String str, Font font, Color background, Color foreground) {
+				this.x = x;
+				this.y = y;
+				this.str = str;
+				this.font = font;
+				this.background = background;
+				this.foreground = foreground;
+			}
+
+		}
+
+		private static class MouseClickConsumer implements Consumer<MouseEvent> {
+
+			private final ITextViewer viewer;
+			private UnifiedDiffLineHeaderCodeMining mining;
+
+			public MouseClickConsumer(ITextViewer viewer) {
+				this.viewer = viewer;
+			}
+
+			public void setCodeMining(UnifiedDiffLineHeaderCodeMining mining) {
+				this.mining = mining;
+			}
+
+			@Override
+			public void accept(MouseEvent t) {
+				if (mining == null || viewer == null || mining.lastRectangle == null) {
+					return;
+				}
+				StyledText st = viewer.getTextWidget();
+				StyledText overlay = new StyledText(st, SWT.NONE);
+				overlay.setBounds(mining.lastRectangle);
+				overlay.setFont(st.getFont());
+				overlay.setBackground(mining.deletionBackgroundColor);
+				overlay.setLineSpacing(st.getLineSpacing());
+				String txt = mining.getLabel().stripTrailing();
+				overlay.setText(txt);
+				overlay.setFocus();
+				List<StyleRange> backgrounds = createDetailedDiffBackgroundRanges(mining, txt);
+				List<StyleRange> foregrounds = computeStyleRanges(viewer, mining.diff.leftStart, txt);
+				List<StyleRange> ranges = mergeStyleRanges(backgrounds, foregrounds);
+				overlay.setStyleRanges(ranges.toArray(new StyleRange[] {}));
+				overlay.addFocusListener(new FocusAdapter() {
+					@Override
+					public void focusLost(FocusEvent e) {
+						overlay.dispose();
+						setTextEditorActionsActivated(true);
+					}
+				});
+				overlay.addKeyListener(new KeyAdapter() {
+					@Override
+					public void keyPressed(KeyEvent e) {
+						if (e.keyCode == SWT.ESC) {
+							overlay.dispose();
+							setTextEditorActionsActivated(true);
+						}
+						e.doit = false;
+					}
+				});
+				setTextEditorActionsActivated(false);
+			}
+
+			private List<StyleRange> mergeStyleRanges(List<StyleRange> backgrounds, List<StyleRange> foregrounds) {
+				if (backgrounds.isEmpty()) {
+					return foregrounds;
+				}
+				if (foregrounds.isEmpty()) {
+					return backgrounds;
+				}
+				List<StyleRange> result = new ArrayList<>();
+				int bgIdx = 0;
+				for (StyleRange fg : foregrounds) {
+					int fgStart = fg.start;
+					int fgEnd = fg.start + fg.length;
+					int pos = fgStart;
+					while (pos < fgEnd && bgIdx < backgrounds.size()) {
+						StyleRange bg = backgrounds.get(bgIdx);
+						int bgStart = bg.start;
+						int bgEnd = bg.start + bg.length;
+						if (bgEnd <= pos) {
+							bgIdx++;
+							continue;
+						}
+						if (bgStart >= fgEnd) {
+							break;
+						}
+						if (bgStart > pos) {
+							result.add(createRange(fg, pos, bgStart - pos, null));
+							pos = bgStart;
+						}
+						int overlapEnd = Math.min(bgEnd, fgEnd);
+						result.add(createRange(fg, pos, overlapEnd - pos, bg.background));
+						pos = overlapEnd;
+						if (bgEnd <= fgEnd) {
+							bgIdx++;
+						}
+					}
+					if (pos < fgEnd) {
+						result.add(createRange(fg, pos, fgEnd - pos, null));
+					}
+				}
+				return result;
+			}
+
+			private StyleRange createRange(StyleRange base, int start, int length, Color background) {
+				StyleRange r = (StyleRange) base.clone();
+				r.start = start;
+				r.length = length;
+				if (background != null) {
+					r.background = background;
+				}
+				return r;
+			}
+
+			private List<StyleRange> createDetailedDiffBackgroundRanges(UnifiedDiffLineHeaderCodeMining miningParam,
+					String txt) {
+				List<StyleRange> ranges = new ArrayList<>();
+				String diffStr = miningParam.diff.mode.equals(UnifiedDiffMode.REPLACE_MODE) ? miningParam.diff.leftStr
+						: miningParam.diff.rightStr;
+				String trimmedDiffStr = removeTrailingNewLines(diffStr);
+				for (var detailedDiff : miningParam.diff.detailedDiffs) {
+					int detailedDiffStart;
+					int detailedDiffLength;
+					String detailedDiffStr;
+					if (miningParam.diff.mode.equals(UnifiedDiffMode.REPLACE_MODE)) {
+						detailedDiffStart = detailedDiff.leftStart;
+						detailedDiffLength = detailedDiff.leftLength;
+						detailedDiffStr = detailedDiff.leftStr;
+					} else {
+						detailedDiffStart = detailedDiff.rightStart;
+						detailedDiffLength = detailedDiff.rightLength;
+						detailedDiffStr = detailedDiff.rightStr;
+					}
+					if (detailedDiffStr.trim().length() == 0) {
+						continue;
+					}
+					if (detailedDiffStart + detailedDiffLength >= trimmedDiffStr.length()) {
+						int delta = diffStr.length() - trimmedDiffStr.length();
+						if (detailedDiffLength <= delta) {
+							continue;
+						}
+						detailedDiffLength -= delta;
+					}
+					int expandedStart = mapOffsetToTabExpanded(diffStr, detailedDiffStart, miningParam.tabWidth);
+					int expandedEnd = mapOffsetToTabExpanded(diffStr, detailedDiffStart + detailedDiffLength,
+							miningParam.tabWidth);
+					int expandedLength = expandedEnd - expandedStart;
+					if (expandedStart >= 0 && expandedLength > 0 && expandedStart + expandedLength <= txt.length()) {
+						StyleRange bgRange = new StyleRange();
+						bgRange.start = expandedStart;
+						bgRange.length = expandedLength;
+						bgRange.background = miningParam.detailedDiffColor;
+						ranges.add(bgRange);
+					}
+				}
+				return ranges;
+			}
+
+			private static int mapOffsetToTabExpanded(String originalStr, int offset, int tabWidth) {
+				int tabCount = 0;
+				int limit = Math.min(offset, originalStr.length());
+				for (int i = 0; i < limit; i++) {
+					if (originalStr.charAt(i) == '\t') {
+						tabCount++;
+					}
+				}
+				return offset + tabCount * (tabWidth - 1);
+			}
+
+			private void setTextEditorActionsActivated(boolean state) {
+				IEditorPart part = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+						.getActiveEditor();
+				if (part instanceof MultiPageEditorPart multiPageEditorPart) {
+					Object page = multiPageEditorPart.getSelectedPage();
+					if (page instanceof IEditorPart editorPart) {
+						part = editorPart;
+					}
+				}
+				if (!(part instanceof AbstractTextEditor) || part.getSite().getWorkbenchWindow().isClosing()) {
+					return;
+				}
+				if (UnifiedDiffManager.isViewerInPart(part, viewer)) {
+					try {
+						Method method = AbstractTextEditor.class.getDeclaredMethod("setActionActivation", //$NON-NLS-1$
+								boolean.class);
+						method.setAccessible(true);
+						method.invoke(part, Boolean.valueOf(state));
+					} catch (IllegalArgumentException | ReflectiveOperationException ex) {
+						error(ex);
+					}
+				}
+			}
+		}
+
+		@Override
+		public String getLabel() {
+			return this.unifiedDiffLabel;
+		}
+
+		public UnifiedDiff getUnifiedDiff() {
+			return this.diff;
+		}
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			clearStyledFonts();
+		}
+
+		private void clearStyledFonts() {
+			styledFonts.forEach((font1, styledFonts1) -> {
+				styledFonts1.forEach((style, styledFont) -> {
+					styledFont.dispose();
+				});
+				styledFonts1.clear();
+			});
+			styledFonts.clear();
+		}
+
+		@Override
+		public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+			gc.setBackground(this.deletionBackgroundColor);
+			Color c = textWidget.getForeground();
+			gc.setForeground(c);
+			Font font = textWidget.getFont();
+			gc.setFont(font);
+			if (cachedFont != null && !cachedFont.equals(font)) {
+				// font might have been changed in the meantime - remove cache
+				lastRectangle = null;
+				backgrounds = null;
+				foregrounds = null;
+				clearStyledFonts();
+			}
+			if (lastRectangle != null && backgrounds != null && foregrounds != null) {
+				// draw background
+				// vs code is drawing the background to the top right of the editor - we do here
+				// the same!
+				gc.fillRectangle(0, y, textWidget.getBounds().width, lastRectangle.height);
+
+				// backgrounds
+				gc.setBackground(this.detailedDiffColor);
+				for (var b : backgrounds) {
+					int rectY = y + b.y;
+					if (rectY < 0) {
+						continue;
+					}
+					gc.fillRectangle(x + b.x, rectY, b.width, b.height);
+				}
+				// foregrounds
+				for (var f : foregrounds) {
+					if (y + f.y < 0) {
+						continue;
+					}
+					if (f.font == null) {
+						gc.setFont(cachedFont);
+					} else {
+						gc.setFont(f.font);
+					}
+					gc.setBackground(f.background);
+					gc.setForeground(f.foreground);
+					gc.drawString(f.str, x + f.x, y + f.y, true);
+				}
+				lastRectangle = new Rectangle(x, y, lastRectangle.width, lastRectangle.height);
+				return new Point(lastRectangle.width, lastRectangle.height);
+			}
+			// first run to get width and height for label
+			Point result = super.draw(gc, textWidget, color, x, y);
+			lastRectangle = new Rectangle(x, y, result.x, result.y);
+			cachedFont = font;
+
+			// draw background
+			// vs code is drawing the background to the top right of the editor - we do here
+			// the same!
+			gc.fillRectangle(0, y, textWidget.getBounds().width /* result.x */, result.y);
+
+			String label = getLabel();
+			List<StyleRange> ranges = computeStyleRanges(viewer, diff.leftStart, label);
+
+			// draw darker background for detailed diff
+			gc.setBackground(this.detailedDiffColor);
+			backgrounds = new ArrayList<>();
+			for (var detailedDiff : this.diff.detailedDiffs) {
+				String diffStr = this.diff.leftStr;
+				String detailedDiffStr = detailedDiff.leftStr;
+				int detailedDiffStart = detailedDiff.leftStart;
+				int detailedDiffLength = detailedDiff.leftLength;
+				if (diff.mode.equals(UnifiedDiffMode.OVERLAY_MODE)
+						|| diff.mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)
+						|| diff.mode.equals(UnifiedDiffMode.REVERT_MODE)) {
+					diffStr = this.diff.rightStr;
+					detailedDiffStr = detailedDiff.rightStr;
+					detailedDiffStart = detailedDiff.rightStart;
+					detailedDiffLength = detailedDiff.rightLength;
+				}
+				if (detailedDiffStr.trim().length() == 0) {
+					continue;
+				}
+				int diffStrLength = diffStr.length();
+				diffStr = removeTrailingNewLines(diffStr);
+				if (detailedDiffStart + detailedDiffLength >= diffStr.length()) {
+					int diffStrDelta = diffStrLength - diffStr.length();
+					if (detailedDiffLength <= diffStrDelta) {
+						continue;
+					}
+					detailedDiffLength -= diffStrDelta;
+				}
+				try {
+					var rangeInfo = new RangeInfo(-1, -1, null);
+					String l = diffStr.substring(0, detailedDiffStart);
+					int fromLine = l.split("\n").length; //$NON-NLS-1$
+					int toLine = diffStr.substring(0, detailedDiffStart + detailedDiffLength).split("\n").length; //$NON-NLS-1$
+					if (fromLine == toLine) {
+						int starty = getYForLine(fromLine - 1, y, gc, textWidget);
+						Point start = getPositionForOffset(textWidget, gc, detailedDiffStart, diffStr, ranges,
+								rangeInfo);
+						Point curr = getPositionForOffset(textWidget, gc, detailedDiffStart + detailedDiffLength,
+								diffStr, ranges, rangeInfo);
+						if (start != null && curr != null && curr.x > start.x) {
+							int rectX = x + start.x;
+							int rectY = starty;
+							int rectWidth = curr.x - start.x;
+							int rectHeight = curr.y;
+							if (starty >= 0) {
+								gc.fillRectangle(rectX, rectY, rectWidth, rectHeight);
+							}
+							backgrounds.add(new Rectangle(rectX - x, rectY - y, rectWidth, rectHeight));
+						}
+					} else {
+						// mark first line until end
+						String[] lines = diffStr.split("\n"); //$NON-NLS-1$
+						String firstLine = lines[fromLine - 1];
+						int starty = getYForLine(fromLine - 1, y, gc, textWidget);
+						int idx = getOffsetAtLine(diffStr, detailedDiffStart);
+						var diffStrDoc = new Document(diffStr);
+						int fromLineOffset;
+						try {
+							fromLineOffset = diffStrDoc.getLineOffset(fromLine - 1);
+						} catch (BadLocationException e) {
+							error(e);
+							continue;
+						}
+						boolean ignoreFirstLine = false;
+						int remainingOnLine = firstLine.length() - idx;
+						if (remainingOnLine == 0) {
+							// detailed diff starts exactly at end-of-line; nothing visible to highlight
+							ignoreFirstLine = true;
+						} else if (remainingOnLine == 1 && diffStr.charAt(fromLineOffset + idx) == '\r') {
+							// detailed diff covers only the CR of a CRLF terminator
+							ignoreFirstLine = true;
+						}
+						if (!ignoreFirstLine) {
+							Point start = getPositionForOffset(textWidget, gc, fromLineOffset + idx, diffStr, ranges,
+									rangeInfo);
+							Point curr = getPositionForOffset(textWidget, gc, fromLineOffset + firstLine.length(),
+									diffStr, ranges, rangeInfo);
+							if (start != null && curr != null && curr.x > 0) {
+								int rectX = x + start.x;
+								int rectY = starty;
+								int rectWidth = curr.x - start.x;
+								int rectHeight = curr.y;
+								gc.fillRectangle(rectX, rectY, rectWidth, rectHeight);
+								backgrounds.add(new Rectangle(rectX - x, rectY - y, rectWidth, rectHeight));
+							}
+						}
+						// all the lines between first and last line
+						for (int middleLine = fromLine + 1; middleLine < toLine; middleLine++) {
+							starty = getYForLine(middleLine - 1, y, gc, textWidget);
+							try {
+								int currentLineEndOffset = diffStrDoc.getLineOffset(middleLine - 1)
+										+ diffStrDoc.getLineLength(middleLine - 1)
+										- getLineDelimiterLength(diffStrDoc, middleLine);
+								Point curr = getPositionForOffset(textWidget, gc, currentLineEndOffset, diffStr, ranges,
+										rangeInfo);
+								if (curr != null && curr.x > 0) {
+									int rectX = x;
+									int rectY = starty;
+									int rectWidth = curr.x;
+									int rectHeight = curr.y;
+									if (starty >= 0) {
+										gc.fillRectangle(rectX, rectY, rectWidth, rectHeight);
+									}
+									backgrounds.add(new Rectangle(rectX - x, rectY - y, rectWidth, rectHeight));
+								}
+							} catch (BadLocationException e) {
+								error(e);
+							}
+						}
+						// last line
+						starty = getYForLine(toLine - 1, y, gc, textWidget);
+						Point curr = getPositionForOffset(textWidget, gc, detailedDiffStart + detailedDiffLength,
+								diffStr, ranges, rangeInfo);
+						if (curr != null && curr.x > 0) {
+							int rectX = x;
+							int rectY = starty;
+							int rectWidth = curr.x;
+							int rectHeight = curr.y;
+							if (starty >= 0) {
+								gc.fillRectangle(rectX, rectY, rectWidth, rectHeight);
+							}
+							backgrounds.add(new Rectangle(rectX - x, rectY - y, rectWidth, rectHeight));
+						}
+					}
+				} catch (IllegalArgumentException e) {
+					error(e);
+				}
+			}
+			// draw foreground again
+			if (ranges.size() == 0) {
+				// no syntax coloring available (e.g. plain-text editor without a
+				// presentation reconciler); fall back to super.draw() so the label is
+				// still rendered. backgrounds/foregrounds are intentionally left unset
+				// so the next paint takes the full slow path again.
+				result = super.draw(gc, textWidget, color, x, y);
+				return result;
+			}
+			foregrounds = new ArrayList<>();
+			gc.setFont(cachedFont);
+			int textWidgetLineHeight = textWidget.getLineHeight();
+			int cx = x;
+			int cy = y;
+			for (StyleRange range : ranges) {
+				String sub = label.substring(range.start, range.start + range.length);
+				if (sub.trim().length() > 0) {
+					if (range.background != null) {
+						gc.setBackground(range.background);
+					}
+					if (range.foreground != null) {
+						gc.setForeground(range.foreground);
+					}
+					Font currentFont = gc.getFont();
+					var rangeWithFont = transformFontStyleToFont(currentFont, range);
+					if (rangeWithFont.font != null) {
+						gc.setFont(rangeWithFont.font);
+					}
+					String[] lines = sub.split("\n"); //$NON-NLS-1$
+					if (lines.length > 1) {
+						for (int i = 0; i < lines.length; i++) {
+							String line = lines[i].replace("\r", ""); //$NON-NLS-1$ //$NON-NLS-2$
+							gc.drawString(line, cx, cy, true);
+							foregrounds.add(new ForegroundInfo(cx - x, cy - y, line, gc.getFont(), gc.getBackground(),
+									gc.getForeground()));
+							Point p = gc.stringExtent(line);
+							if (i < lines.length - 1) {
+								cy += textWidgetLineHeight + textWidget.getLineSpacing();
+								cx = x;
+							} else {
+								if (sub.endsWith("\n")) { //$NON-NLS-1$
+									cy += textWidgetLineHeight + textWidget.getLineSpacing();
+									cx = x;
+								} else {
+									cx += p.x;
+								}
+							}
+						}
+					} else {
+						gc.drawString(sub, cx, cy, true);
+						foregrounds.add(new ForegroundInfo(cx - x, cy - y, sub, gc.getFont(), gc.getBackground(),
+								gc.getForeground()));
+						Point p = gc.stringExtent(sub);
+						if (sub.endsWith("\n")) { //$NON-NLS-1$
+							cy += textWidgetLineHeight + textWidget.getLineSpacing();
+							cx = x;
+						} else {
+							cx += p.x;
+						}
+					}
+					gc.setFont(currentFont);
+				} else {
+					int lfCount = 0;
+					if (sub.contains("\n")) { //$NON-NLS-1$
+						lfCount = sub.split("\n", -1).length - 1; //$NON-NLS-1$
+						sub = sub.substring(sub.lastIndexOf("\n") + 1); //$NON-NLS-1$
+					}
+					Point p = gc.stringExtent(sub);
+					if (lfCount > 0) {
+						cy += lfCount * (textWidgetLineHeight + textWidget.getLineSpacing());
+						cx = x;
+					}
+					cx += p.x;
+				}
+			}
+			return result;
+		}
+
+		private int getLineDelimiterLength(Document diffStrDoc, int middleLine) throws BadLocationException {
+			String delim = diffStrDoc.getLineDelimiter(middleLine - 1);
+			if (delim == null) {
+				return 0;
+			}
+			return delim.length();
+		}
+
+		private static class RangeInfo {
+			int rangeIndex;
+			int offset;
+			Point position;
+
+			RangeInfo(int rangeIndex, int offset, Point position) {
+				this.rangeIndex = rangeIndex;
+				this.offset = offset;
+				this.position = position;
+			}
+		}
+
+		private Point getPositionForOffset(StyledText tw, GC gc, int offset, String str, List<StyleRange> ranges,
+				RangeInfo rangeInfo) {
+			String sub = str.substring(0, offset);
+			Point result = null;
+			var before = gc.getFont();
+			int twLineHeight = tw.getLineHeight();
+			try {
+				int i = 0;
+				if (rangeInfo.rangeIndex != -1 && offset >= rangeInfo.offset) {
+					i = rangeInfo.rangeIndex + 1;
+					result = rangeInfo.position;
+				}
+				for (; i < ranges.size(); i++) {
+					var range = ranges.get(i);
+					if (range.start <= offset) {
+						boolean rangeEndBeforeOffset = true;
+						int rangeEnd = range.start + range.length;
+						if (rangeEnd > offset) {
+							rangeEnd = offset;
+							rangeEndBeforeOffset = false;
+						}
+						sub = str.substring(range.start, rangeEnd);
+						if (offset == rangeEnd && offset == str.length()) {
+							while (sub.endsWith("\n")) { //$NON-NLS-1$
+								sub = sub.substring(0, sub.length() - 1);
+							}
+						}
+						int lfIdx = sub.lastIndexOf("\n"); //$NON-NLS-1$
+						if (lfIdx > 0) {
+							if (lfIdx == sub.length() - 1 && isLastForCurrentOffset(ranges, i, offset)) {
+								sub = sub.substring(0, lfIdx);
+							} else {
+								sub = sub.substring(lfIdx + 1);
+								result = null;
+							}
+						}
+						var rangeWithFont = transformFontStyleToFont(before, range);
+						if (rangeWithFont.font != null) {
+							gc.setFont(rangeWithFont.font);
+						} else {
+							gc.setFont(before);
+						}
+						// gc.stringExtent does not consider tabs - we need to replace them with spaces
+						// to get correct width
+						Point extent = gc.stringExtent(removeLeadingNewLines(replaceTabWithSpaces(sub, tabWidth)));
+						if (result == null) {
+							result = extent;
+							result.y = twLineHeight;
+						} else {
+							result.x += extent.x;
+						}
+						if (rangeEndBeforeOffset) {
+							rangeInfo.offset = rangeEnd;
+							rangeInfo.rangeIndex = i;
+							rangeInfo.position = new Point(result.x, result.y);
+						}
+					} else {
+						break;
+					}
+				}
+			} finally {
+				gc.setFont(before);
+			}
+			return result;
+		}
+
+		private boolean isLastForCurrentOffset(List<StyleRange> ranges, int i, int offset) {
+			int nextIdx = i + 1;
+			if (nextIdx >= ranges.size()) {
+				return false;
+			}
+			StyleRange next = ranges.get(nextIdx);
+			if (next.start >= offset) {
+				return true;
+			}
+			return false;
+		}
+
+		private StyleRange transformFontStyleToFont(Font baseFont, StyleRange styleRange) {
+			// as per the StyleRange contract, only consider fontStyle if font is not
+			// already set
+			if (styleRange.font == null && styleRange.fontStyle > 0) {
+				StyleRange newRange = (StyleRange) styleRange.clone();
+				newRange.font = styledFonts.computeIfAbsent(baseFont, f -> new HashMap<>())
+						.computeIfAbsent(Integer.valueOf(styleRange.fontStyle), s -> {
+							FontData[] fontDatas = baseFont.getFontData();
+							for (FontData fontData : fontDatas) {
+								fontData.setStyle(styleRange.fontStyle);
+							}
+							return new Font(baseFont.getDevice(), fontDatas);
+						});
+				return newRange;
+			}
+			return styleRange;
+		}
+
+		private int getOffsetAtLine(String str, int off) {
+			Document doc;
+			if (off == str.length()) {
+				doc = new Document(str);
+			} else {
+				doc = new Document(str.stripTrailing());
+			}
+			try {
+				if (off > doc.getLength()) {
+					int line = doc.getLineOfOffset(doc.getLength());
+					int lineOffset = doc.getLineOffset(line);
+					int resultOff = doc.getLength() - lineOffset;
+					return resultOff;
+				}
+				int line = doc.getLineOfOffset(off);
+				int lineOffset = doc.getLineOffset(line);
+				int resultOff = off - lineOffset;
+				return resultOff;
+			} catch (BadLocationException e) {
+				error(e);
+			}
+			return -1;
+		}
+
+		private int getYForLine(int line, int y, GC gc, StyledText textWidget) {
+			int textWidgetLineHeight = textWidget.getLineHeight();
+			y += line * (textWidgetLineHeight + textWidget.getLineSpacing());
+			return y;
+		}
+	}
+
+	// from inner class ColorPalette in TextMergeViewer
+	static RGB interpolate(RGB fg, RGB bg, double scale) {
+		if (fg != null && bg != null) {
+			return new RGB((int) ((1.0 - scale) * fg.red + scale * bg.red),
+					(int) ((1.0 - scale) * fg.green + scale * bg.green),
+					(int) ((1.0 - scale) * fg.blue + scale * bg.blue));
+		}
+		if (fg != null) {
+			return fg;
+		}
+		if (bg != null) {
+			return bg;
+		}
+		return new RGB(128, 128, 128); // a gray
+	}
+
+	private static String replaceTabWithSpaces(String leftStr, int tabWidth) {
+		if (leftStr == null) {
+			return null;
+		}
+		StringBuilder sb = new StringBuilder();
+		for (int s = 0; s < tabWidth; s++) {
+			sb.append(' ');
+		}
+		String result = leftStr.replace("\t", sb); //$NON-NLS-1$
+		return result;
+	}
+}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -1,0 +1,1382 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.compare.unifieddiff.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import org.eclipse.compare.contentmergeviewer.IIgnoreWhitespaceContributor;
+import org.eclipse.compare.contentmergeviewer.ITokenComparator;
+import org.eclipse.compare.contentmergeviewer.TokenComparator;
+import org.eclipse.compare.internal.CompareMessages;
+import org.eclipse.compare.internal.DocLineComparator;
+import org.eclipse.compare.rangedifferencer.IRangeComparator;
+import org.eclipse.compare.rangedifferencer.RangeDifference;
+import org.eclipse.compare.rangedifferencer.RangeDifferencer;
+import org.eclipse.compare.unifieddiff.UnifiedDiff.IgnoreWhitespaceContributorFactory;
+import org.eclipse.compare.unifieddiff.UnifiedDiff.TokenComparatorFactory;
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider.UnifiedDiffLineHeaderCodeMining;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModelEvent;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.IAnnotationModelExtension;
+import org.eclipse.jface.text.source.IAnnotationModelListener;
+import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.ControlListener;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseMoveListener;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.events.PaintListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.ScrollBar;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.text.undo.DocumentUndoManagerRegistry;
+import org.eclipse.text.undo.IDocumentUndoListener;
+import org.eclipse.text.undo.IDocumentUndoManager;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public class UnifiedDiffManager {
+
+	private static final String CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY = "CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY"; //$NON-NLS-1$
+	private static final String UNDO_LISTENER_KEY = "UNIFIED_DIFF_UNDO_LISTENER_KEY"; //$NON-NLS-1$
+	private static final String UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY = "UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY"; //$NON-NLS-1$
+	private static final String ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.addition"; //$NON-NLS-1$
+	private static final String DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.deletion"; //$NON-NLS-1$
+	private static final String DETAILED_ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedAddition"; //$NON-NLS-1$
+	private static final String DETAILED_DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedDeletion"; //$NON-NLS-1$
+	private static final String TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY = "TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY"; //$NON-NLS-1$
+	private static final String TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY = "TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY"; //$NON-NLS-1$
+	private static final Map<ITextViewer, List<UnifiedDiff>> diffsByViewer = new HashMap<>();
+
+	public static void put(ITextViewer viewer, List<UnifiedDiff> diffs) {
+		diffsByViewer.put(viewer, diffs);
+	}
+
+	public static List<UnifiedDiff> get(ITextViewer viewer) {
+		return diffsByViewer.get(viewer);
+	}
+
+	public static IStatus open(ITextEditor editor, String source, UnifiedDiffMode mode, List<Action> additionalActions,
+			TokenComparatorFactory tokenComparatorFactory,
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace) {
+		ITextViewer viewer = editor.getAdapter(ITextViewer.class);
+		if (viewer instanceof ProjectionViewer pv) {
+			pv.doOperation(ProjectionViewer.EXPAND_ALL);
+		}
+		IAnnotationModel model = editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
+		if (model == null) {
+			return Status.CANCEL_STATUS;
+		}
+		clearAll(viewer, model);
+
+		IDocument leftDocument = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+		IDocument rightDocument = new Document(source);
+
+		DocLineComparator left = null, right = null;
+		Optional<IIgnoreWhitespaceContributor> lDocIgnonerWhitespaceContributor = Optional.empty();
+		Optional<IIgnoreWhitespaceContributor> rDocIgnonreWhitespaceContributor = Optional.empty();
+		if (ignoreWhitespaceContributorFactory != null) {
+			lDocIgnonerWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(leftDocument);
+			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace, null, '?',
+					lDocIgnonerWhitespaceContributor);
+			rDocIgnonreWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(rightDocument);
+			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace, null, '?',
+					rDocIgnonreWhitespaceContributor);
+		} else {
+			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace);
+			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace);
+		}
+		List<UnifiedDiff> unifiedDiffs = new ArrayList<>();
+		RangeDifference[] rangeDiffs = RangeDifferencer.findDifferences(left, right);
+		for (RangeDifference rangeDiff : rangeDiffs) {
+			try {
+				int leftStart = left.getTokenStart(rangeDiff.leftStart());
+				int leftEnd = getTokenEnd(left, rangeDiff.leftStart(), rangeDiff.leftLength());
+				String leftDiffSource = leftDocument.get(leftStart, leftEnd - leftStart);
+
+				int rightStart = right.getTokenStart(rangeDiff.rightStart());
+				int rightEnd = getTokenEnd(right, rangeDiff.rightStart(), rangeDiff.rightLength());
+				String rightDiffSource = rightDocument.get(rightStart, rightEnd - rightStart);
+
+				if (leftDiffSource.length() == 0 && rightDiffSource.length() == 0) {
+					continue;
+				}
+				boolean isWhitespace = false;
+				// Indicate whether all contributors are whitespace
+				if (ignoreWhiteSpace && leftDiffSource.trim().length() == 0 && rightDiffSource.trim().length() == 0) {
+					isWhitespace = true;
+
+					// Check if whitespace can be ignored by the contributor
+					if (leftDiffSource.length() > 0 && !lDocIgnonerWhitespaceContributor.isEmpty()) {
+						boolean isIgnored = lDocIgnonerWhitespaceContributor.get()
+								.isIgnoredWhitespace(rangeDiff.leftStart(), rangeDiff.leftLength());
+						isWhitespace = isIgnored;
+					}
+					if (isWhitespace && rightDiffSource.length() > 0 && !rDocIgnonreWhitespaceContributor.isEmpty()) {
+						boolean isIgnored = rDocIgnonreWhitespaceContributor.get()
+								.isIgnoredWhitespace(rangeDiff.rightStart(), rangeDiff.rightLength());
+						isWhitespace = isIgnored;
+					}
+				}
+				if (isWhitespace) {
+					continue;
+				}
+				int kind = rangeDiff.kind();
+				switch (kind) {
+				case RangeDifference.NOCHANGE:
+					break;
+				case RangeDifference.CHANGE:
+					var diff = new UnifiedDiff(leftDocument, leftStart, leftEnd, leftDiffSource, rightDocument,
+							rightStart, rightEnd, rightDiffSource, unifiedDiffs, mode);
+					unifiedDiffs.add(diff);
+
+					// line based fine granular diff via DocumentMerger#simpleTokenDiff
+					ITokenComparator l = createTokenComparator(leftDiffSource, tokenComparatorFactory);
+					ITokenComparator r = createTokenComparator(rightDiffSource, tokenComparatorFactory);
+					RangeDifference[] detailedDiffs = RangeDifferencer.findRanges((IRangeComparator) null, l, r);
+					for (RangeDifference detailedDiff : detailedDiffs) {
+						if (detailedDiff.kind() == RangeDifference.NOCHANGE) {
+							continue;
+						}
+						int detailedLeftStart = l.getTokenStart(detailedDiff.leftStart());
+						int detailedLeftEnd = getTokenEnd(l, detailedDiff.leftStart(), detailedDiff.leftLength());
+						String detailedLeftDiffSource = leftDiffSource.substring(detailedLeftStart, detailedLeftEnd);
+
+						int detailedRightStart = r.getTokenStart(detailedDiff.rightStart());
+						int detailedRightEnd = getTokenEnd(r, detailedDiff.rightStart(), detailedDiff.rightLength());
+						String detailedDiffRightDiffSource = rightDiffSource.substring(detailedRightStart,
+								detailedRightEnd);
+						if (detailedLeftDiffSource.trim().length() == 0
+								&& detailedDiffRightDiffSource.trim().length() == 0) {
+							continue;
+						}
+						diff.detailedDiffs.add(new UnifiedDiff(leftDocument, detailedLeftStart, detailedLeftEnd,
+								detailedLeftDiffSource, rightDocument, detailedRightStart, detailedRightEnd,
+								detailedDiffRightDiffSource, unifiedDiffs, mode));
+					}
+					break;
+				case RangeDifference.CONFLICT:
+					break;
+				case RangeDifference.LEFT:
+					break;
+				case RangeDifference.ERROR:
+					break;
+				case RangeDifference.ANCESTOR:
+					break;
+				default:
+					break;
+				}
+			} catch (BadLocationException e) {
+				error(e);
+			}
+		}
+		// call validateEdit before modifying the leftDocument; in read-only overlay
+		// mode the document is not modified, so skip the check to avoid prompting
+		// the user to make the file writable for a purely read-only diff
+		if (!UnifiedDiffMode.OVERLAY_READ_ONLY_MODE.equals(mode)) {
+			IFile file = editor.getEditorInput().getAdapter(IFile.class);
+			if (file != null && !validateEdit(file)) {
+				return Status.CANCEL_STATUS;
+			}
+		}
+		Map<Annotation, UnifiedDiff> diffByAnno = new HashMap<>();
+		// When the model supports batch updates, stage annotations into a map and flush
+		// them with a single replaceAnnotations() call so listeners receive one event
+		// instead of one per annotation. Otherwise fall back to per-annotation addAnnotation().
+		Map<Annotation, Position> annotationsToAdd = (model instanceof IAnnotationModelExtension) ? new HashMap<>()
+				: null;
+		BiConsumer<Annotation, Position> addOrStage = (anno, pos) -> {
+			if (annotationsToAdd != null) {
+				annotationsToAdd.put(anno, pos);
+			} else {
+				model.addAnnotation(anno, pos);
+			}
+		};
+		if (UnifiedDiffMode.REPLACE_MODE.equals(mode)) {
+			// modify document
+			int delta = 0;
+			for (UnifiedDiff unifiedDiff : unifiedDiffs) {
+				try {
+					unifiedDiff.leftStart += delta;
+					leftDocument.replace(unifiedDiff.leftStart, unifiedDiff.leftLength, unifiedDiff.rightStr);
+					delta += (unifiedDiff.rightLength - unifiedDiff.leftLength);
+					Annotation myAnnotation = new UnifiedDiffAnnotation(mode, unifiedDiff);
+					Position position = new Position(unifiedDiff.leftStart, unifiedDiff.rightLength);
+					addOrStage.accept(myAnnotation, position);
+					for (var detailedDiff : unifiedDiff.detailedDiffs) {
+						if (detailedDiff.rightStr.trim().length() == 0) {
+							continue;
+						}
+						Annotation detailedAnno = new DetailedDiffAnnotation(mode, unifiedDiff);
+						Position detailedPos = new Position(unifiedDiff.leftStart + detailedDiff.rightStart,
+								detailedDiff.rightLength);
+						addOrStage.accept(detailedAnno, detailedPos);
+					}
+					diffByAnno.put(myAnnotation, unifiedDiff);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			}
+		} else {
+			for (UnifiedDiff unifiedDiff : unifiedDiffs) {
+				Annotation myAnnotation = new UnifiedDiffAnnotation(mode, unifiedDiff);
+				Position position = new Position(unifiedDiff.leftStart, unifiedDiff.leftLength);
+				addOrStage.accept(myAnnotation, position);
+				for (var detailedDiff : unifiedDiff.detailedDiffs) {
+					if (detailedDiff.leftStr.trim().length() == 0) {
+						continue;
+					}
+					Annotation detailedAnno = new DetailedDiffAnnotation(mode, unifiedDiff);
+					Position detailedPos = new Position(unifiedDiff.leftStart + detailedDiff.leftStart,
+							detailedDiff.leftLength);
+					addOrStage.accept(detailedAnno, detailedPos);
+				}
+				diffByAnno.put(myAnnotation, unifiedDiff);
+			}
+		}
+		if (annotationsToAdd != null) {
+			((IAnnotationModelExtension) model).replaceAnnotations(new Annotation[] {}, annotationsToAdd);
+		}
+
+		UnifiedDiffManager.put(viewer, unifiedDiffs);
+		addPaintListener(viewer, model, mode);
+		addMouseMoveListener(viewer, model);
+		if (viewer instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		drawToolBarForAllDiffs(viewer, model, additionalActions, mode);
+		addUndoListener(viewer, leftDocument, model);
+		addAnnoModelChangeListener(viewer, model);
+
+		if (unifiedDiffs.size() > 0) {
+			runAfterRepaintFinished(viewer.getTextWidget(), () -> {
+				Annotation firstAnno = getFirstAnnotationForUnifiedDiff(model, unifiedDiffs.get(0));
+				selectAndRevealAnno(viewer, model, firstAnno);
+			});
+		}
+		return Status.OK_STATUS;
+	}
+
+	static boolean isViewerInPart(IWorkbenchPart part, ITextViewer viewer) {
+		if (part == null) {
+			return false;
+		}
+		Control partControl = part.getAdapter(Control.class);
+		if (partControl == null) {
+			return false;
+		}
+		StyledText textWidget = viewer.getTextWidget();
+		if (textWidget == null || textWidget.isDisposed()) {
+			return false;
+		}
+		// Check if the viewer's text widget is a descendant of the part's control
+		Control current = textWidget;
+		while (current != null) {
+			if (current == partControl) {
+				return true;
+			}
+			current = current.getParent();
+		}
+		return false;
+	}
+
+	static Composite getToolbarCompositeForOneDiff(StyledText tw) {
+		if (tw == null) {
+			return null;
+		}
+		var result = (Composite) tw.getData(TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY);
+		return result;
+	}
+
+	private static Composite getToolbarCompositeForAllDiffs(StyledText tw) {
+		if (tw == null) {
+			return null;
+		}
+		var result = (Composite) tw.getData(TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY);
+		return result;
+	}
+
+	private static void addAnnoModelChangeListener(ITextViewer tv, IAnnotationModel model) {
+		// ensure not registered multiple times
+		var listener = (UnifiedDiffAnnotationmodelListener) tv.getTextWidget()
+				.getData(UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY);
+		if (listener != null) {
+			return;
+		}
+		// we need to remove the UnifiedDiffs in the range when the user deletes the
+		// ranges manually via keyboard - listen to annotation model changes
+		listener = new UnifiedDiffAnnotationmodelListener(tv);
+		tv.getTextWidget().setData(UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY, listener);
+		model.addAnnotationModelListener(listener);
+	}
+
+	private static final class UnifiedDiffAnnotationmodelListener
+			implements IAnnotationModelListener, IAnnotationModelListenerExtension {
+
+		private final ITextViewer tv;
+
+		public UnifiedDiffAnnotationmodelListener(ITextViewer tv) {
+			this.tv = tv;
+		}
+
+		@Override
+		public void modelChanged(AnnotationModelEvent event) {
+			Annotation[] annos = event.getRemovedAnnotations();
+			if (annos == null) {
+				return;
+			}
+			List<UnifiedDiff> unifiedDiffsToDelete = new ArrayList<>();
+			for (var anno : annos) {
+				UnifiedDiff unifiedDiff = getUnifiedDiffForAnno(anno);
+				if (unifiedDiff != null) {
+					unifiedDiffsToDelete.add(unifiedDiff);
+				}
+			}
+			if (unifiedDiffsToDelete.size() > 0) {
+				Display.getDefault().asyncExec(() -> {
+					UnifiedDiff currentToolbarUnifiedDiff = null;
+					Composite toolbarCompositeForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+					if (toolbarCompositeForOneDiff != null) {
+						var currentToolbarUnifiedDiffAnno = (Annotation) toolbarCompositeForOneDiff
+								.getData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY);
+						currentToolbarUnifiedDiff = getUnifiedDiffForAnno(currentToolbarUnifiedDiffAnno);
+					}
+					List<UnifiedDiff> container = null;
+					IAnnotationModel model = event.getAnnotationModel();
+					for (var unifiedDiff : unifiedDiffsToDelete) {
+						List<Annotation> annos1 = getAllAnnotationsForUnifiedDiff(model, unifiedDiff);
+						for (var lanno : annos1) {
+							model.removeAnnotation(lanno);
+						}
+						if (currentToolbarUnifiedDiff != null && currentToolbarUnifiedDiff.equals(unifiedDiff)) {
+							disposeToolbarForOneDiff(toolbarCompositeForOneDiff,
+									UnifiedDiffAnnotationmodelListener.this.tv);
+						}
+						unifiedDiff.container.remove(unifiedDiff);
+						container = unifiedDiff.container;
+					}
+					if (UnifiedDiffAnnotationmodelListener.this.tv instanceof ISourceViewerExtension5 ext) {
+						ext.updateCodeMinings();
+					}
+					if (container != null && container.size() == 0) {
+						disposeUnifiedDiff(UnifiedDiffAnnotationmodelListener.this.tv, model, tv.getTextWidget());
+					}
+				});
+			}
+		}
+
+		@Override
+		public void modelChanged(IAnnotationModel model) {
+		}
+	}
+
+	public static void error(Exception e) {
+		Platform.getLog(UnifiedDiffManager.class).error(e.getMessage(), e);
+	}
+
+	static final class UnifiedDiffAnnotation extends Annotation {
+		private final UnifiedDiff unifiedDiff;
+
+		public UnifiedDiffAnnotation(UnifiedDiffMode mode, UnifiedDiff unifiedDiff) {
+			super(UnifiedDiffMode.REPLACE_MODE.equals(mode) || UnifiedDiffMode.REVERT_MODE.equals(mode)
+					? ADDITION_ANNO_TYPE
+					: DELETION_ANNO_TYPE, false, null);
+			this.unifiedDiff = unifiedDiff;
+		}
+
+		public UnifiedDiff getUnifiedDiff() {
+			return this.unifiedDiff;
+		}
+	}
+
+	private static final class DetailedDiffAnnotation extends Annotation {
+		private final UnifiedDiff unifiedDiff;
+
+		public DetailedDiffAnnotation(UnifiedDiffMode mode, UnifiedDiff unifiedDiff) {
+			super(UnifiedDiffMode.REPLACE_MODE.equals(mode) || UnifiedDiffMode.REVERT_MODE.equals(mode)
+					? DETAILED_ADDITION_ANNO_TYPE
+					: DETAILED_DELETION_ANNO_TYPE, false, null);
+			this.unifiedDiff = unifiedDiff;
+		}
+
+		public UnifiedDiff getUnifiedDiff() {
+			return this.unifiedDiff;
+		}
+	}
+
+	private static void drawToolBarForAllDiffs(ITextViewer tv, IAnnotationModel model, List<Action> additionalActions,
+			UnifiedDiffMode mode) {
+		StyledText tw = tv.getTextWidget();
+		var tm = new ToolBarManager(SWT.FLAT | SWT.HORIZONTAL | SWT.RIGHT);
+		List<UnifiedDiff> diffs = get(tv);
+		if (UnifiedDiffMode.OVERLAY_MODE.equals(mode) || UnifiedDiffMode.OVERLAY_READ_ONLY_MODE.equals(mode)) {
+			if (!isReadOnly(diffs)) {
+				var acceptAll = new AcceptAllRunnable(tv, model);
+				addToolbarAction(tm, acceptAll.getLabel(), AcceptAllRunnable.getImageDescriptor(), acceptAll);
+			}
+			var hideAll = new HideAllDiffsRunnable(tv, model);
+			addToolbarAction(tm, hideAll.getLabel(), hideAll.getImageDescriptor(), hideAll);
+		} else if (UnifiedDiffMode.REVERT_MODE.equals(mode)) {
+			var revertAll = new AcceptAllRunnable(tv, model);
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_revert, AcceptAllRunnable.getUndoImageDescriptor(), revertAll);
+			var hideAll = new HideAllDiffsRunnable(tv, model);
+			addToolbarAction(tm, hideAll.getLabel(), hideAll.getImageDescriptor(), hideAll);
+		} else {
+			var keepAll = new KeepAllRunnable(tv, model);
+			addToolbarAction(tm, keepAll.getLabel(), null, keepAll);
+			var undoAll = new UndoAllRunnable(tv, model);
+			addToolbarAction(tm, undoAll.getLabel(), null, undoAll);
+		}
+
+		var previous = new PreviousRunnable(tv, model, tm);
+		addToolbarAction(tm, previous.getLabel(), previous.getImageDescriptor(), previous);
+		var next = new NextRunnable(tv, model, tm);
+		addToolbarAction(tm, next.getLabel(), next.getImageDescriptor(), next);
+		if (additionalActions != null) {
+			for (var additionalAction : additionalActions) {
+				addToolbarAction(tm, additionalAction);
+			}
+		}
+		if (tm.isEmpty()) {
+			return;
+		}
+		var toolbarCompositeForAllDiffs = getToolbarCompositeForAllDiffs(tv.getTextWidget());
+		if (toolbarCompositeForAllDiffs != null && !toolbarCompositeForAllDiffs.isDisposed()) {
+			disposeToolbarForAllDiffs(toolbarCompositeForAllDiffs, tv);
+		}
+
+		Composite composite = new Composite(tw.getParent(), SWT.NONE);
+		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(composite);
+		GridLayoutFactory.fillDefaults().numColumns(2).equalWidth(false).margins(2, 2).spacing(2, 0).applyTo(composite);
+		ToolBar fToolBar = tm.createControl(composite);
+		composite.pack();
+
+		var setLocationRunnable = (Runnable) () -> {
+			Rectangle clientArea = tw.getClientArea();
+			Point toolbarSize = fToolBar.getSize();
+			// Center horizontally at the bottom of the text widget
+			int x = clientArea.x + (clientArea.width - toolbarSize.x) / 2;
+			int y = clientArea.y + clientArea.height - toolbarSize.y;
+			composite.setLocation(x, y);
+		};
+		composite.moveAbove(null);
+		setLocationRunnable.run();
+		composite.setVisible(true);
+		tw.setData(TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY, composite);
+
+		tw.addControlListener(new ControlListener() {
+
+			@Override
+			public void controlResized(ControlEvent e) {
+				if (fToolBar == null || fToolBar.isDisposed()) {
+					tw.removeControlListener(this);
+					return;
+				}
+				setLocationRunnable.run();
+			}
+
+			@Override
+			public void controlMoved(ControlEvent e) {
+			}
+		});
+
+		Stream<ToolbarDisposeListenerForOneAndAllDiffs> stream = tw.getTypedListeners(SWT.Dispose,
+				ToolbarDisposeListenerForOneAndAllDiffs.class);
+		if (stream == null || stream.count() == 0) {
+			tw.addDisposeListener(new ToolbarDisposeListenerForOneAndAllDiffs(tv, model));
+		}
+	}
+
+	private static void clearAll(ITextViewer tv, IAnnotationModel model) {
+		List<UnifiedDiff> diffs1 = get(tv);
+		if (diffs1 == null) {
+			return;
+		}
+		StyledText tw = tv.getTextWidget();
+		removeAnnotationModelListener(model, tw);
+		for (UnifiedDiff diff : diffs1) {
+			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+			for (var lanno : annos) {
+				model.removeAnnotation(lanno);
+			}
+		}
+		diffs1.clear();
+		// open unified diff a second time for the same viewer; the old code minings
+		// need to be removed before adding new ones
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+	}
+
+	static void uncheckToolbarActionItems(ToolBarManager tm) {
+		IContributionItem[] items = tm.getItems();
+		if (items == null) {
+			return;
+		}
+		for (IContributionItem item : items) {
+			if (item instanceof ActionContributionItem actionItem) {
+				IAction action = actionItem.getAction();
+				if (action == null) {
+					continue;
+				}
+				action.setChecked(false);
+			}
+		}
+	}
+
+	public static boolean isOverlay(List<UnifiedDiff> diffs) {
+		if (diffs != null && diffs.size() > 0) {
+			return diffs.get(0).mode.equals(UnifiedDiffMode.OVERLAY_MODE)
+					|| diffs.get(0).mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+		}
+		return false;
+	}
+
+	public static boolean isRevert(List<UnifiedDiff> diffs) {
+		if (diffs != null && diffs.size() > 0) {
+			return diffs.get(0).mode.equals(UnifiedDiffMode.REVERT_MODE);
+		}
+		return false;
+	}
+
+	public static boolean isReadOnly(List<UnifiedDiff> diffs) {
+		if (diffs != null && diffs.size() > 0) {
+			return diffs.get(0).mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+		}
+		return false;
+	}
+
+	private static void applyDiffRightStr(ITextViewer tv, IAnnotationModel model) {
+		StyledText tw = tv.getTextWidget();
+		Composite toolbarCompositeForOneDiff = getToolbarCompositeForOneDiff(tw);
+		if (toolbarCompositeForOneDiff == null) {
+			return;
+		}
+		var anno = (Annotation) toolbarCompositeForOneDiff.getData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY);
+		if (anno == null) {
+			return;
+		}
+		UnifiedDiff diff = getUnifiedDiffForAnno(anno);
+		if (diff == null) {
+			return;
+		}
+		List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+		List<Position> positions = new ArrayList<>();
+		List<String> replaceStrings = new ArrayList<>();
+		for (var lanno : annos) {
+			if (lanno instanceof UnifiedDiffAnnotation) {
+				Position pos = model.getPosition(lanno);
+				positions.add(pos);
+				replaceStrings.add(diff.rightStr);
+			}
+			model.removeAnnotation(lanno);
+		}
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+		// we have to insert with delay because otherwise the line header code minings
+		// cannot be deleted
+		runAfterRepaintFinished(tw, () -> {
+			for (int i = positions.size() - 1; i >= 0; i--) {
+				Position pos = positions.get(i);
+				String replaceStr = replaceStrings.get(i);
+				try {
+					tv.getDocument().replace(pos.offset, pos.length, replaceStr);
+				} catch (BadLocationException e) {
+					error(e);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Dismisses the current diff (navigates to the next one or disposes everything
+	 * when it is the last one). Used by the "Hide Diff" (overlay/revert) and "Keep"
+	 * (replace) toolbar actions.
+	 */
+	private static void dismissCurrentDiff(ITextViewer tv, IAnnotationModel model) {
+		StyledText tw = tv.getTextWidget();
+		Composite toolbarCompositeForOneDiff = getToolbarCompositeForOneDiff(tw);
+		if (toolbarCompositeForOneDiff == null) {
+			return;
+		}
+		var anno = (Annotation) toolbarCompositeForOneDiff.getData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY);
+		UnifiedDiff diff = getUnifiedDiffForAnno(anno);
+		int idx = diff.container.indexOf(diff);
+		if (idx < 0) {
+			throw new IllegalStateException("UnifiedDiff not found in container"); //$NON-NLS-1$
+		}
+		idx++;
+		if (idx >= diff.container.size()) {
+			idx = 0;
+		}
+		UnifiedDiff next = diff.container.get(idx);
+		if (next == diff) {
+			disposeUnifiedDiff(tv, model, tw);
+		} else {
+			List<Annotation> nextAnnos = getAllAnnotationsForUnifiedDiff(model, next);
+			if (nextAnnos.size() > 0) {
+				disposeToolbarForOneDiff(toolbarCompositeForOneDiff, tv);
+				Position pos = getMinPosition(model, nextAnnos);
+				tv.revealRange(pos.offset, pos.length);
+				tv.setSelectedRange(pos.offset, 0);
+				// we can update the toolbar location after the line header code minings are
+				// removed
+				runAfterRepaintFinished(tw, () -> setToolbarLocationForOneDiff(tv, model, nextAnnos.get(0)));
+			}
+		}
+		diff.container.remove(diff);
+		List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+		for (var lanno : annos) {
+			model.removeAnnotation(lanno);
+		}
+		if (tv instanceof ISourceViewerExtension5 ext) {
+			ext.updateCodeMinings();
+		}
+	}
+
+	private static void drawToolbarForOneDiff(ITextViewer tv, IAnnotationModel model) {
+		List<UnifiedDiff> diffs = get(tv);
+		StyledText tw = tv.getTextWidget();
+		var tm = new ToolBarManager(SWT.FLAT | SWT.HORIZONTAL | SWT.RIGHT);
+		if (isOverlay(diffs)) {
+			if (!isReadOnly(diffs)) {
+				addToolbarAction(tm, CompareMessages.UnifiedDiff_accept, AcceptAllRunnable.getImageDescriptor(),
+						() -> applyDiffRightStr(tv, model));
+			}
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_hideDiff, HideAllDiffsRunnable.getHideDiffImageDescriptor(),
+					() -> dismissCurrentDiff(tv, model));
+		} else if (isRevert(diffs)) {
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_revert, AcceptAllRunnable.getUndoImageDescriptor(),
+					() -> applyDiffRightStr(tv, model));
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_hideDiff, HideAllDiffsRunnable.getHideDiffImageDescriptor(),
+					() -> dismissCurrentDiff(tv, model));
+		} else {
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_keep, null, () -> dismissCurrentDiff(tv, model));
+			addToolbarAction(tm, CompareMessages.UnifiedDiff_undo, null, () -> {
+				var fToolbarShellForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+				if (fToolbarShellForOneDiff == null) {
+					return;
+				}
+				var anno = (Annotation) fToolbarShellForOneDiff.getData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY);
+				UnifiedDiff diff = getUnifiedDiffForAnno(anno);
+				int idx = diff.container.indexOf(diff);
+				if (idx < 0) {
+					return;
+				}
+				idx++;
+				if (idx >= diff.container.size()) {
+					idx = 0;
+				}
+				UnifiedDiff next = diff.container.get(idx);
+				final Annotation[] nextAnno = new Annotation[] { null };
+				if (next == diff) {
+					disposeUnifiedDiff(tv, model, tv.getTextWidget());
+				} else {
+					nextAnno[0] = getFirstAnnotationForUnifiedDiff(model, next);
+				}
+				diff.container.remove(diff);
+				List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
+				int unifiedDiffAdditionCount = 0;
+				for (var lanno : annos) {
+					if (lanno instanceof UnifiedDiffAnnotation) {
+						unifiedDiffAdditionCount++;
+						if (unifiedDiffAdditionCount > 1) {
+							throw new IllegalStateException(
+									"Multiple UnifiedDiffAdditionAnnotation for one UnifiedDiff found"); //$NON-NLS-1$
+						}
+						Position pos = model.getPosition(lanno);
+						// we have to insert with delay because otherwise the line header code minings
+						// cannot be deleted
+						runAfterRepaintFinished(tw, () -> {
+							try {
+								tv.getDocument().replace(pos.offset, pos.length, diff.leftStr);
+								if (nextAnno[0] != null) {
+									disposeToolbarForOneDiff(fToolbarShellForOneDiff, tv);
+									Position pos1 = model.getPosition(nextAnno[0]);
+									tv.revealRange(pos1.offset, pos1.length);
+									tv.setSelectedRange(pos1.offset, 0);
+									setToolbarLocationForOneDiff(tv, model, nextAnno[0]);
+								}
+							} catch (BadLocationException e) {
+								error(e);
+							}
+						});
+					}
+					model.removeAnnotation(lanno);
+				}
+				if (unifiedDiffAdditionCount == 0) {
+					throw new IllegalStateException("No UnifiedDiffAdditionAnnotation for UnifiedDiff found"); //$NON-NLS-1$
+				}
+				if (tv instanceof ISourceViewerExtension5 ext) {
+					ext.updateCodeMinings();
+				}
+			});
+		}
+		if (tm.isEmpty()) {
+			return;
+		}
+		var fToolbarShellForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+		if (fToolbarShellForOneDiff != null && !fToolbarShellForOneDiff.isDisposed()) {
+			disposeToolbarForOneDiff(fToolbarShellForOneDiff, tv);
+		}
+
+		Composite composite = new Composite(tw.getParent(), SWT.NONE);
+		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(composite);
+		GridLayoutFactory.fillDefaults().numColumns(2).equalWidth(false).margins(2, 2).spacing(2, 0).applyTo(composite);
+		tm.createControl(composite);
+		composite.pack();
+		composite.moveAbove(null);
+		tw.setData(TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY, composite);
+
+		ScrollBar verticalBar = tw.getVerticalBar();
+		if (verticalBar != null) {
+			Stream<VerticalBarSelectionAdapter> stream = verticalBar.getTypedListeners(SWT.Selection,
+					VerticalBarSelectionAdapter.class);
+			if (stream == null || stream.count() == 0) {
+				verticalBar.addSelectionListener(new VerticalBarSelectionAdapter(tv, model));
+			}
+		}
+		Stream<ToolbarDisposeListenerForOneAndAllDiffs> stream = tw.getTypedListeners(SWT.Dispose,
+				ToolbarDisposeListenerForOneAndAllDiffs.class);
+		if (stream == null || stream.count() == 0) {
+			tw.addDisposeListener(new ToolbarDisposeListenerForOneAndAllDiffs(tv, model));
+		}
+	}
+
+	private static final class VerticalBarSelectionAdapter extends SelectionAdapter {
+		private final IAnnotationModel model;
+		private final ITextViewer tv;
+
+		public VerticalBarSelectionAdapter(ITextViewer tv, IAnnotationModel model) {
+			this.tv = tv;
+			this.model = model;
+		}
+
+		@Override
+		public void widgetSelected(SelectionEvent e) {
+			var fToolbarShellForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+			if (fToolbarShellForOneDiff == null || fToolbarShellForOneDiff.isDisposed()) {
+				return;
+			}
+			var anno = (Annotation) fToolbarShellForOneDiff.getData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY);
+			if (anno != null) {
+				setToolbarLocationForOneDiff(this.tv, this.model, anno);
+			}
+		}
+	}
+
+	private static final class ToolbarDisposeListenerForOneAndAllDiffs implements DisposeListener {
+
+		private final ITextViewer tv;
+		private final IAnnotationModel model;
+
+		public ToolbarDisposeListenerForOneAndAllDiffs(ITextViewer tv, IAnnotationModel model) {
+			this.tv = tv;
+			this.model = model;
+		}
+
+		@Override
+		public void widgetDisposed(DisposeEvent e) {
+			disposeUnifiedDiff(this.tv, this.model, (StyledText) e.getSource());
+		}
+	}
+
+	private static UnifiedDiff getUnifiedDiffForAnno(Annotation anno) {
+		if (anno instanceof DetailedDiffAnnotation da) {
+			return da.getUnifiedDiff();
+		} else if (anno instanceof UnifiedDiffAnnotation a) {
+			return a.getUnifiedDiff();
+		} else if (anno instanceof AbstractInlinedAnnotation inlineAnno) {
+			List<ICodeMining> minings = inlineAnno.getMinings();
+			if (minings.size() == 1 && minings.get(0) instanceof UnifiedDiffLineHeaderCodeMining idlhcm) {
+				return idlhcm.getUnifiedDiff();
+			}
+		}
+		return null;
+	}
+
+	private static void disposeToolbarForOneDiff(Composite fToolbarCompositeForOneDiff, ITextViewer tv) {
+		if (fToolbarCompositeForOneDiff != null) {
+			fToolbarCompositeForOneDiff.dispose();
+		}
+		if (tv == null) {
+			return;
+		}
+		var tw = tv.getTextWidget();
+		if (tw == null) {
+			return;
+		}
+		tw.setData(TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY, null);
+	}
+
+	private static void disposeToolbarForAllDiffs(Composite toolbarShellForAllDiffs, ITextViewer tv) {
+		if (toolbarShellForAllDiffs != null) {
+			toolbarShellForAllDiffs.dispose();
+		}
+		if (tv == null) {
+			return;
+		}
+		var tw = tv.getTextWidget();
+		if (tw == null) {
+			return;
+		}
+		tw.setData(TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY, null);
+	}
+
+	private static void setToolbarLocationForOneDiff(ITextViewer tv, IAnnotationModel model, Annotation anno) {
+		var fToolbarShellForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+		if (fToolbarShellForOneDiff == null || fToolbarShellForOneDiff.isDisposed()) {
+			drawToolbarForOneDiff(tv, model);
+			fToolbarShellForOneDiff = getToolbarCompositeForOneDiff(tv.getTextWidget());
+			if (fToolbarShellForOneDiff == null) {
+				return;
+			}
+		}
+		UnifiedDiff unifiedDiff = getUnifiedDiffForAnno(anno);
+		if (unifiedDiff == null) {
+			return;
+		}
+		List<Annotation> all = getAllAnnotationsForUnifiedDiff(model, unifiedDiff);
+		if (all.size() == 0) {
+			return;
+		}
+		Position pos = getMinPosition(model, all);
+		fToolbarShellForOneDiff.setData(CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY, anno);
+		StyledText tw = tv.getTextWidget();
+		Rectangle clientArea = tw.getClientArea();
+
+		int startOffset = pos.offset;
+		if (tv instanceof ProjectionViewer pv) {
+			startOffset = pv.modelOffset2WidgetOffset(pos.offset);
+			if (startOffset < 0) {
+				return; // not visible
+			}
+		}
+		if (startOffset >= tw.getCharCount()) {
+			// ensure no out of bounds
+			startOffset = tw.getCharCount() - 1;
+		}
+		Rectangle startBounds = tw.getTextBounds(startOffset, startOffset);
+		if (!startBounds.intersects(clientArea)) {
+			fToolbarShellForOneDiff.setVisible(false);
+			return;
+		}
+		Rectangle twBounds = tw.getBounds();
+		Point verticalBarSize = tw.getVerticalBar().getSize();
+		fToolbarShellForOneDiff.setLocation(
+				twBounds.x + twBounds.width - fToolbarShellForOneDiff.getBounds().width - verticalBarSize.x,
+				startBounds.y);
+		fToolbarShellForOneDiff.setVisible(true);
+	}
+
+	private static Position getMinPosition(IAnnotationModel model, List<Annotation> all) {
+		Position min = null;
+		for (Annotation ann : all) {
+			Position position = model.getPosition(ann);
+			if (min == null) {
+				min = position;
+			} else if (position.offset < min.offset) {
+				min = position;
+			}
+		}
+		return min;
+	}
+
+	static Annotation getMinPositionAnno(IAnnotationModel model, List<Annotation> all) {
+		Position min = null;
+		Annotation result = null;
+		for (Annotation ann : all) {
+			Position position = model.getPosition(ann);
+			if (min == null) {
+				min = position;
+				result = ann;
+			} else if (position.offset < min.offset) {
+				min = position;
+				result = ann;
+			}
+		}
+		return result;
+	}
+
+	private static void addToolbarAction(ToolBarManager tm, String text, ImageDescriptor image, Runnable runnable) {
+		String tooltip = text;
+		Action action = null;
+		if (image != null) {
+			action = new Action(null, image) { // $NON-NLS-1$
+				@Override
+				public void run() {
+					setChecked(false);
+					runnable.run();
+				}
+			};
+		} else {
+			action = new Action(text, SWT.PUSH) { // $NON-NLS-1$
+				@Override
+				public void run() {
+					setChecked(false);
+					runnable.run();
+				}
+			};
+		}
+		action.setToolTipText(tooltip);
+		var actionItem = new ActionContributionItem(action);
+		actionItem.setMode(ActionContributionItem.MODE_FORCE_TEXT);
+		tm.add(actionItem);
+		tm.add(new Separator());
+	}
+
+	private static void addToolbarAction(ToolBarManager tm, Action action) {
+		Action a = null;
+		if (action.getImageDescriptor() != null) {
+			a = new Action(null, action.getImageDescriptor()) {
+				@Override
+				public void run() {
+					setChecked(false);
+					action.run();
+				}
+			};
+		} else {
+			a = new Action(action.getText(), SWT.PUSH) { // $NON-NLS-1$
+				@Override
+				public void run() {
+					setChecked(false);
+					action.run();
+				}
+			};
+		}
+		a.setToolTipText(action.getToolTipText());
+		var actionItem = new ActionContributionItem(a);
+		actionItem.setMode(ActionContributionItem.MODE_FORCE_TEXT);
+		tm.add(actionItem);
+		tm.add(new Separator());
+	}
+
+	private static void addMouseMoveListener(ITextViewer tv, IAnnotationModel model) {
+		StyledText textWidget = tv.getTextWidget();
+		Stream<UnifiedDiffMouseMoveListener> stream = textWidget.getTypedListeners(SWT.MouseMove,
+				UnifiedDiffMouseMoveListener.class);
+		if (stream != null && stream.count() > 0) {
+			return;
+		}
+		textWidget.addMouseMoveListener(new UnifiedDiffMouseMoveListener(model, tv));
+	}
+
+	private static final class UnifiedDiffMouseMoveListener implements MouseMoveListener {
+		private final IAnnotationModel model;
+		private final ITextViewer tv;
+		private final StyledText textWidget;
+
+		public UnifiedDiffMouseMoveListener(IAnnotationModel model, ITextViewer tv) {
+			this.model = model;
+			this.tv = tv;
+			this.textWidget = tv.getTextWidget();
+		}
+
+		@Override
+		public void mouseMove(MouseEvent e) {
+			Iterator<Annotation> it = this.model.getAnnotationIterator();
+			while (it.hasNext()) {
+				Annotation anno = getUnifiedDiffAnnotationFromIterator(it);
+				if (anno == null) {
+					continue;
+				}
+				Position pos = this.model.getPosition(anno);
+				int startOffset = pos.offset;
+				if (tv instanceof ProjectionViewer pv) {
+					startOffset = pv.modelOffset2WidgetOffset(pos.offset);
+				}
+				int endOffset = startOffset + pos.length;
+				try {
+					Rectangle startBounds = this.textWidget.getTextBounds(startOffset, startOffset);
+					Rectangle endBounds = this.textWidget.getTextBounds(endOffset, endOffset);
+					if (startBounds.y == endBounds.y) {
+						endBounds.y += endBounds.height;
+					}
+					if (e.y >= startBounds.y && e.y <= endBounds.y) {
+						setToolbarLocationForOneDiff(this.tv, this.model, anno);
+						return;
+					}
+				} catch (IllegalArgumentException ex) { // NOPMD silently ignored
+				}
+			}
+		}
+	}
+
+	private static Annotation getFirstAnnotationForUnifiedDiff(IAnnotationModel model, UnifiedDiff unifiedDiff) {
+		Iterator<Annotation> it = model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation anno = getUnifiedDiffAnnotationFromIterator(it);
+			if (anno == null) {
+				continue;
+			}
+			UnifiedDiff unifiedDiffForAnno = getUnifiedDiffForAnno(anno);
+			if (unifiedDiffForAnno == unifiedDiff) {
+				return anno;
+			}
+		}
+		return null;
+	}
+
+	static List<Annotation> getAllAnnotationsForUnifiedDiff(IAnnotationModel model, UnifiedDiff unifiedDiff) {
+		List<Annotation> result = new ArrayList<>();
+		Iterator<Annotation> it = model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation anno = getUnifiedDiffAnnotationFromIterator(it);
+			if (anno == null) {
+				continue;
+			}
+			UnifiedDiff unifiedDiffForAnno = getUnifiedDiffForAnno(anno);
+			if (unifiedDiffForAnno == unifiedDiff) {
+				result.add(anno);
+			}
+		}
+		return result;
+	}
+
+	private static Annotation getUnifiedDiffAnnotationFromIterator(Iterator<Annotation> it) {
+		boolean doit = false;
+		Annotation anno = it.next();
+		if (anno instanceof AbstractInlinedAnnotation inlineAnno) {
+			List<ICodeMining> minings = inlineAnno.getMinings();
+			if (minings.size() == 1 && minings.get(0) instanceof UnifiedDiffLineHeaderCodeMining) {
+				doit = true;
+			}
+		} else if (ADDITION_ANNO_TYPE.equals(anno.getType()) || DELETION_ANNO_TYPE.equals(anno.getType())
+				|| DETAILED_ADDITION_ANNO_TYPE.equals(anno.getType())
+				|| DETAILED_DELETION_ANNO_TYPE.equals(anno.getType())) {
+			doit = true;
+		}
+		if (!doit) {
+			return null;
+		}
+		return anno;
+	}
+
+	private static void addUndoListener(ITextViewer tv, IDocument document, IAnnotationModel model) {
+		IDocumentUndoManager documentUndoManager = DocumentUndoManagerRegistry.getDocumentUndoManager(document);
+		var undoListener = (IDocumentUndoListener) event -> {
+			UnifiedDiff toBeDeletedDiff = null;
+			Iterator<Annotation> it = model.getAnnotationIterator();
+			while (it.hasNext()) {
+				Annotation anno = getUnifiedDiffAnnotationFromIterator(it);
+				if (anno == null) {
+					continue;
+				}
+				Position pos = model.getPosition(anno);
+				if (pos.offset == event.getOffset()) {
+					UnifiedDiff diff = getUnifiedDiffForAnno(anno);
+					if (diff != null && diff.rightStr.equals(event.getPreservedText())) {
+						toBeDeletedDiff = diff;
+						break;
+					}
+				}
+			}
+			if (toBeDeletedDiff == null) {
+				return;
+			}
+			// delete the uni diff
+			List<Annotation> all = getAllAnnotationsForUnifiedDiff(model, toBeDeletedDiff);
+			for (var lanno : all) {
+				model.removeAnnotation(lanno);
+			}
+			toBeDeletedDiff.container.remove(toBeDeletedDiff);
+			if (tv instanceof ISourceViewerExtension5 ext) {
+				ext.updateCodeMinings();
+			}
+			if (toBeDeletedDiff.container.isEmpty()) {
+				disposeUnifiedDiff(tv, model, tv.getTextWidget());
+			}
+		};
+		tv.getTextWidget().setData(UNDO_LISTENER_KEY, undoListener);
+		documentUndoManager.addDocumentUndoListener(undoListener);
+	}
+
+	static void disposeUnifiedDiff(ITextViewer tv, IAnnotationModel model, StyledText tw) {
+		disposeToolbarForOneDiff(getToolbarCompositeForOneDiff(tw), tv);
+		disposeToolbarForAllDiffs(getToolbarCompositeForAllDiffs(tw), tv);
+		var undoListener = (IDocumentUndoListener) tw.getData(UNDO_LISTENER_KEY);
+		if (undoListener != null) {
+			tw.setData(UNDO_LISTENER_KEY, null);
+			IDocument document = tv.getDocument();
+			if (document != null) {
+				IDocumentUndoManager documentUndoManager = DocumentUndoManagerRegistry.getDocumentUndoManager(document);
+				documentUndoManager.removeDocumentUndoListener(undoListener);
+			}
+		}
+		removeAnnotationModelListener(model, tw);
+
+		diffsByViewer.remove(tv);
+
+		if (tw == null || tw.isDisposed()) {
+			// SWT removes listeners automatically when the widget is disposed
+			return;
+		}
+		tw.getTypedListeners(SWT.MouseMove, UnifiedDiffMouseMoveListener.class)
+				.forEach(tw::removeMouseMoveListener);
+		tw.getTypedListeners(SWT.Paint, UnifiedDiffPaintListener.class)
+				.forEach(listener -> {
+					tw.removePaintListener(listener);
+					listener.dispose();
+				});
+	}
+
+	static void removeAnnotationModelListener(IAnnotationModel model, StyledText tw) {
+		if (model == null || tw == null || tw.isDisposed()) {
+			return;
+		}
+		var listener = (UnifiedDiffAnnotationmodelListener) tw.getData(UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY);
+		if (listener != null) {
+			tw.setData(UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY, null);
+			model.removeAnnotationModelListener(listener);
+		}
+	}
+
+	private static void addPaintListener(ITextViewer viewer, IAnnotationModel model, UnifiedDiffMode mode) {
+		StyledText w = viewer.getTextWidget();
+		Stream<UnifiedDiffPaintListener> stream = w.getTypedListeners(SWT.Paint, UnifiedDiffPaintListener.class);
+		stream.forEach(e -> {
+			w.removePaintListener(e);
+			e.dispose();
+		});
+		w.addPaintListener(new UnifiedDiffPaintListener(viewer, model, mode));
+	}
+
+	private static class UnifiedDiffPaintListener implements PaintListener {
+
+		private final IAnnotationModel model;
+		private final ITextViewer viewer;
+		private final Color additionBackgroundColor;
+		private final StyledText w;
+
+		public UnifiedDiffPaintListener(ITextViewer viewer, IAnnotationModel model, UnifiedDiffMode mode) {
+			this.model = model;
+			this.viewer = viewer;
+			w = viewer.getTextWidget();
+			RGB color;
+			if (mode.equals(UnifiedDiffMode.OVERLAY_MODE) || mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)) {
+				color = JFaceResources.getColorRegistry().getRGB("DELETION_COLOR"); //$NON-NLS-1$
+			} else {
+				color = JFaceResources.getColorRegistry().getRGB("ADDITION_COLOR"); //$NON-NLS-1$
+			}
+			RGB background = UnifiedDiffCodeMiningProvider.getBackground();
+			RGB interpolated = UnifiedDiffCodeMiningProvider.interpolate(color, background, 0.9);
+			this.additionBackgroundColor = new Color(interpolated);
+		}
+
+		void dispose() {
+			if (additionBackgroundColor != null && !additionBackgroundColor.isDisposed()) {
+				additionBackgroundColor.dispose();
+			}
+		}
+
+		@Override
+		public void paintControl(PaintEvent e) {
+			Rectangle bounds = this.w.getBounds();
+			Iterator<Annotation> it = this.model.getAnnotationIterator();
+			while (it.hasNext()) {
+				Annotation anno = it.next();
+				if (!(ADDITION_ANNO_TYPE.equals(anno.getType()) || DELETION_ANNO_TYPE.equals(anno.getType()))) {
+					continue;
+				}
+				// Fill the area between the last character of the line and the widget boundary.
+				// This is not done via the Annotations.
+				int posOffset;
+				int posLength;
+				{
+					Position pos = this.model.getPosition(anno);
+					if (viewer instanceof ProjectionViewer pv) {
+						posOffset = pv.modelOffset2WidgetOffset(pos.offset);
+						if (posOffset < 0) {
+							continue; // not visible
+						}
+					} else {
+						posOffset = pos.offset;
+					}
+					posLength = pos.length;
+				}
+				int fromLine = this.w.getLineAtOffset(posOffset);
+				int toLine = this.w.getLineAtOffset(posOffset + posLength);
+				e.gc.setBackground(this.additionBackgroundColor);
+				for (int lineNr = fromLine; lineNr < toLine; lineNr++) {
+					String line = this.w.getLine(lineNr);
+					int endLineOffset = this.w.getOffsetAtLine(lineNr) + line.length();
+					Rectangle endLineBounds = this.w.getTextBounds(endLineOffset, endLineOffset);
+					endLineBounds.height += this.w.getLineSpacing();
+					if (line.length() == 0) {
+						// this.w.getTextBounds seems not to work for empty lines containing only \n in
+						// a document with \r\n as line delimeter
+						int nextLineOffset = this.w.getOffsetAtLine(lineNr + 1);
+						Rectangle nextLineBounds = this.w.getTextBounds(nextLineOffset, nextLineOffset);
+						if (endLineBounds.y + endLineBounds.height < nextLineBounds.y) {
+							endLineBounds.height = nextLineBounds.y - endLineBounds.y;
+						}
+					}
+					e.gc.fillRectangle(endLineBounds.x + endLineBounds.width, endLineBounds.y,
+							bounds.width - (endLineBounds.x + endLineBounds.width), endLineBounds.height);
+
+					// annotation painter is not taking line spacing into account - we therefore
+					// need to draw it by our own
+					e.gc.fillRectangle(2, endLineBounds.y + endLineBounds.height - this.w.getLineSpacing(),
+							endLineBounds.x + endLineBounds.width, this.w.getLineSpacing());
+				}
+			}
+		}
+	}
+
+	private static boolean validateEdit(IFile file) {
+		final boolean result[] = new boolean[] { false };
+		try {
+			final IFile fFile = file;
+			ResourcesPlugin.getWorkspace().run((IWorkspaceRunnable) monitor -> {
+				IStatus status = ResourcesPlugin.getWorkspace().validateEdit(new IFile[] { fFile }, null);
+				if (status != null) {
+					if (status.isOK()) {
+						result[0] = true;
+					} else {
+						MessageDialog.openError(Display.getDefault().getActiveShell(),
+								CompareMessages.UnifiedDiff_cannotEditFile_title,
+								NLS.bind(CompareMessages.UnifiedDiff_cannotEditFile_message, fFile.getFullPath(),
+										status.getMessage()));
+					}
+				}
+			}, new NullProgressMonitor());
+		} catch (CoreException e) {
+			error(e);
+		}
+		return result[0];
+	}
+
+	private static ITokenComparator createTokenComparator(String line, TokenComparatorFactory tokenComparatorFactory) {
+		ITokenComparator result = null;
+		if (tokenComparatorFactory != null) {
+			result = tokenComparatorFactory.apply(line);
+		}
+		if (result == null) {
+			result = new TokenComparator(line);
+		}
+		return result;
+	}
+
+	private static int getTokenEnd(ITokenComparator tc, int start, int length) {
+		return tc.getTokenStart(start + length);
+	}
+
+	static void selectAndRevealAnno(ITextViewer tv, IAnnotationModel model, Annotation nextAnno) {
+		disposeToolbarForOneDiff(getToolbarCompositeForOneDiff(tv.getTextWidget()), tv);
+		Position pos = model.getPosition(nextAnno);
+		tv.revealRange(pos.offset, pos.length);
+		tv.setSelectedRange(pos.offset, 0);
+		Display.getDefault().asyncExec(() -> setToolbarLocationForOneDiff(tv, model, nextAnno));
+	}
+
+	static void runAfterRepaintFinished(StyledText tw, Runnable runnable) {
+		tw.addPaintListener(new PaintListener() {
+			private final PaintListener me = this;
+			private final Runnable r = () -> {
+				if (tw.isDisposed()) {
+					return;
+				}
+				tw.removePaintListener(me);
+				runnable.run();
+			};
+
+			@Override
+			public void paintControl(PaintEvent e) {
+				Display.getDefault().timerExec(100, this.r);
+			}
+		});
+	}
+
+	public static class UnifiedDiff {
+		public IDocument left;
+		public int leftStart;
+		int leftLength;
+		public final String leftStr;
+
+		IDocument right;
+		int rightStart;
+		int rightLength;
+		String rightStr;
+		public final List<UnifiedDiff> detailedDiffs = new ArrayList<>();
+		final List<UnifiedDiff> container;
+		public final UnifiedDiffMode mode;
+
+		public UnifiedDiff(IDocument left, int leftStart, int leftEnd, String leftDiffSource, IDocument right,
+				int rightStart, int rightEnd, String rightDiffSource, List<UnifiedDiff> container,
+				UnifiedDiffMode mode) {
+			this.left = left;
+			this.leftStart = leftStart;
+			this.leftLength = leftEnd - leftStart;
+			this.leftStr = leftDiffSource;
+			this.right = right;
+			this.rightStart = rightStart;
+			this.rightLength = rightEnd - rightStart;
+			this.rightStr = rightDiffSource;
+			this.container = container;
+			this.mode = mode;
+		}
+	}
+}

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/remove_highlighting.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/remove_highlighting.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   sodipodi:docname="remove_highlighting.svg"
+   inkscape:export-filename="remove_highlighting.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4994">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#a19a7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#a29d80;stop-opacity:1"
+         offset="0.13130741"
+         id="stop5002" />
+      <stop
+         style="stop-color:#c5c3b5;stop-opacity:1"
+         offset="0.26261482"
+         id="stop4998" />
+      <stop
+         id="stop5004"
+         offset="0.63130742"
+         style="stop-color:#a29d80;stop-opacity:1" />
+      <stop
+         id="stop5000"
+         offset="1"
+         style="stop-color:#9e9070;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4976">
+      <stop
+         style="stop-color:#a8a38c;stop-opacity:1"
+         offset="0"
+         id="stop4978" />
+      <stop
+         id="stop4984"
+         offset="0.26261482"
+         style="stop-color:#c5c3b5;stop-opacity:1" />
+      <stop
+         style="stop-color:#a19a7c;stop-opacity:1"
+         offset="1"
+         id="stop4980" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4960">
+      <stop
+         style="stop-color:#eac826;stop-opacity:1"
+         offset="0"
+         id="stop4962" />
+      <stop
+         style="stop-color:#c5a334;stop-opacity:1"
+         offset="1"
+         id="stop4964" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4952">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4954" />
+      <stop
+         id="stop4970"
+         offset="0.25"
+         style="stop-color:#fdf39f;stop-opacity:1" />
+      <stop
+         id="stop4968"
+         offset="0.62763387"
+         style="stop-color:#fee745;stop-opacity:1" />
+      <stop
+         style="stop-color:#eac826;stop-opacity:1"
+         offset="1"
+         id="stop4956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4942">
+      <stop
+         style="stop-color:#f5d71e;stop-opacity:1"
+         offset="0"
+         id="stop4944" />
+      <stop
+         style="stop-color:#fdf39f;stop-opacity:1"
+         offset="1"
+         id="stop4946" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4942"
+       id="linearGradient4948"
+       x1="17.662846"
+       y1="1052.5724"
+       x2="19.885061"
+       y2="1052.5724"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2.1397741)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4952"
+       id="linearGradient4958"
+       x1="26.461384"
+       y1="1045.0045"
+       x2="29.825548"
+       y2="1048.598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1397741,4.8953347e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4960"
+       id="linearGradient4966"
+       x1="28.021715"
+       y1="1042.9713"
+       x2="32.686157"
+       y2="1046.8485"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1397741,4.8953347e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4976"
+       id="linearGradient4982"
+       x1="26.544964"
+       y1="1057.6731"
+       x2="30.345661"
+       y2="1061.172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-14.978419)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4992"
+       x1="29.5947"
+       y1="1053.5125"
+       x2="35.038246"
+       y2="1058.7136"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-14.978419)" />
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.5431537,0,0,0.54149605,24.278358,481.76145)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.5431537,0,0,0.54149605,24.278358,481.76145)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="17.096487"
+     inkscape:cx="6.9020027"
+     inkscape:cy="15.558752"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="false"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="50"
+     inkscape:window-y="344"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <rect
+         style="fill:url(#linearGradient4948);fill-opacity:1;stroke:none"
+         id="rect4172"
+         width="5.3480377"
+         height="1.0668679"
+         x="15.590192"
+         y="1049.8992" />
+      <g
+         transform="translate(15.600543,0)"
+         id="g8421" />
+      <path
+         style="fill:url(#linearGradient4958);fill-opacity:1;stroke:url(#linearGradient4966);stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 25.874196,1042.866 -5.532085,5.3903 c 0,0 -0.425545,1.3948 0.33098,1.9858 0.756524,0.5911 5.933987,0.2601 5.933987,0.2601 l 3.90083,-3.8299 z"
+         id="path4950"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4982);fill-opacity:1;stroke:#999072;stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 30.106004,1047.3342 -4.633711,-4.3499 3.889236,-3.8893 4.468222,4.3027 z"
+         id="path4972"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient4992);fill-opacity:1;stroke:#9c9170;stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 30.36606,1044.5919 c -0.532814,-0.6954 -1.460212,-1.6094 -2.245932,-2.1042 -0.785721,-0.4947 -1.820388,-0.6616 -1.820388,-0.6616 0,0 0.09457,-0.993 1.205712,-1.9859 l 8.700031,-8.854 0,12.542 -2.742401,2.3641 c -0.898374,0.5438 -2.316857,0.662 -2.316857,0.662 0.127896,-0.6188 -0.247352,-1.267 -0.780165,-1.9624 z"
+         id="path4974"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zzccccccz" />
+      <path
+         sodipodi:nodetypes="sccccccccssccsccsccss"
+         inkscape:connector-curvature="0"
+         id="rect4043-2"
+         d="m 31.510133,1045.1732 c -0.254296,-0.2535 -0.66372,-0.2535 -0.918003,0 l -1.690727,1.6856 -1.690714,-1.6856 c -0.254258,-0.2535 -0.66372,-0.2535 -0.918002,0 l -0.467143,0.4658 c -0.254271,0.2534 -0.254265,0.6616 2e-5,0.9152 l 1.690687,1.6855 -1.690689,1.6855 c -0.25431,0.2536 -0.254304,0.6617 -8e-6,0.9153 l 0.467168,0.4657 c 0.254269,0.2535 0.663692,0.2535 0.918002,0 l 1.690717,-1.6856 1.702464,1.6973 c 0.254269,0.2535 0.663693,0.2535 0.918003,0 l 0.467142,-0.4657 c 0.254282,-0.2535 0.251729,-0.6591 -2e-5,-0.9152 l -1.702465,-1.6973 1.690717,-1.6855 c 0.254294,-0.2536 0.254287,-0.6618 1.8e-5,-0.9152 z"
+         style="display:inline;fill:url(#linearGradient6120);fill-opacity:1;stroke:url(#linearGradient6122);stroke-width:1.06989;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/undo.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/undo.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="undo_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="arrow-stroke-6-7">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="arrow-stroke-stop0" />
+      <stop
+         style="stop-color:#996c22;stop-opacity:1"
+         offset="1"
+         id="arrow-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="arrow-bg-3-5">
+      <stop
+         id="arrow-bg-stop0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="arrow-bg-stop1"
+         offset="1"
+         style="stop-color:#ffd25d;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       r="4.6733794"
+       fy="1043.6658"
+       fx="23.61665"
+       cy="1043.6658"
+       cx="23.61665"
+       gradientTransform="matrix(3.7687879,0,0,-1.6007454,-79.994106,2712.7325)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-bg"
+       xlink:href="#arrow-bg-3-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1039.2389"
+       x2="22.668835"
+       y1="1043.5796"
+       x1="22.668835"
+       gradientTransform="matrix(1.604284,0,0,-1.6579203,-29.344853,2772.2612)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-stroke"
+       xlink:href="#arrow-stroke-6-7"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.803133"
+     inkscape:cx="9.3645769"
+     inkscape:cy="7.834905"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3020"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#arrow-bg);fill-opacity:1;stroke:url(#arrow-stroke);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1.4999698,1045.8207 7.0263049,-6.3724 c 0,0 -0.033867,2.2486 -0.033867,3.6226 2.3239983,0.1492 3.0002883,0.079 4.1376283,-1.0505 1.430689,-1.4212 1.215549,-3.9455 1.86729,-4.1528 0.651741,-0.2072 1.002677,3.6267 1.002677,4.352 0,0.7254 -0.280417,3.1527 -1.153079,4.3545 -0.470928,0.6484 -1.614825,1.584 -2.456559,1.8233 -0.841735,0.2394 -3.397957,0.7106 -3.397957,0.7106 l 0.020499,2.7542 c -1.2644448,-1.1042 -7.0129378,-6.0415 -7.0129372,-6.0415 z"
+       id="undo-arrow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssszccc">
+      <title
+         id="title3225">undo-arrow</title>
+    </path>
+  </g>
+</svg>

--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -126,6 +126,7 @@ ComparePreferencePage.structureCompare.label= &Open structure compare automatica
 ComparePreferencePage.structureOutline.label= Show structure compare in Outline &view when possible
 ComparePreferencePage.ignoreWhitespace.label= Ignore &white space
 ComparePreferencePage.saveBeforePatching.label= A&utomatically save editors with unsaved changes before browsing patches
+ComparePreferencePage.unifiedDiff.label=EXPERIMENTAL: Use Unified Diff instead of 2-way compare when possible
 
 ComparePreferencePage.regex.description=Enter regular expressions used to identify added or removed lines in a patch\n(e.g. '^\\+\\s*\\S' for an added line with at least one word character).
 ComparePreferencePage.regexAdded.label=Added lines

--- a/team/bundles/org.eclipse.compare/plugin.xml
+++ b/team/bundles/org.eclipse.compare/plugin.xml
@@ -451,5 +451,140 @@
          </editorInputEnablement>
       </linkHelper>
    </extension>
-
+   <extension point="org.eclipse.ui.workbench.texteditor.codeMiningProviders">
+     <codeMiningProvider
+       class="org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider"
+       id="org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider"
+       label="Code mining provider rendering the additions/deletions via line header code minings of a diff">
+     </codeMiningProvider>
+   </extension>
+<extension point="org.eclipse.ui.editors.annotationTypes">
+<type
+  name="org.eclipse.compare.unifieddiff.internal.addition"
+  markerType="org.eclipse.core.resources.problemmarker"
+  markerSeverity="0">
+</type>
+<type
+  name="org.eclipse.compare.unifieddiff.internal.deletion"
+  markerType="org.eclipse.core.resources.problemmarker"
+  markerSeverity="0">
+</type>
+<type
+  name="org.eclipse.compare.unifieddiff.internal.detailedAddition"
+  markerType="org.eclipse.core.resources.problemmarker"
+  markerSeverity="0">
+</type>
+<type
+  name="org.eclipse.compare.unifieddiff.internal.detailedDeletion"
+  markerType="org.eclipse.core.resources.problemmarker"
+  markerSeverity="0">
+</type>
+</extension>
+<extension point="org.eclipse.ui.editors.markerAnnotationSpecification">
+<specification
+      annotationType="org.eclipse.compare.unifieddiff.internal.addition"
+      colorPreferenceKey="inlineDiffColor"
+      colorPreferenceValue="229,242,229"
+      contributesToHeader="false"
+      highlightPreferenceKey="inlineDiffIndicationHighlighting"
+      highlightPreferenceValue="true"
+      isGoToNextNavigationTarget="false"
+      isGoToNextNavigationTargetKey="inlineDiffGoToNextNavigationTarget"
+      isGoToPreviousNavigationTarget="false"
+      isGoToPreviousNavigationTargetKey="inlineDiffGoToPreviousNavigationTarget"
+      label="Inline Diff Addition"
+      overviewRulerPreferenceKey="inlineDiffIndicationInOverviewRuler"
+      overviewRulerPreferenceValue="false"
+      presentationLayer="1"
+      showInNextPrevDropdownToolbarAction="false"
+      showInNextPrevDropdownToolbarActionKey="showInlineDiffInNextPrevDropdownToolbarAction"
+      symbolicIcon="info"
+      textPreferenceKey="inlineDiffIndication"
+      textPreferenceValue="true"
+      textStylePreferenceKey="inlineDiffTextStyle"
+      textStylePreferenceValue="NONE"
+      verticalRulerPreferenceKey="inlineDiffIndicationInVerticalRuler"
+      verticalRulerPreferenceValue="false">
+</specification>
+<specification
+      annotationType="org.eclipse.compare.unifieddiff.internal.deletion"
+      colorPreferenceKey="deletionInlineDiffColor"
+      colorPreferenceValue="255,229,229"
+      contributesToHeader="false"
+      highlightPreferenceKey="deletionInlineDiffIndicationHighlighting"
+      highlightPreferenceValue="true"
+      isGoToNextNavigationTarget="false"
+      isGoToNextNavigationTargetKey="deletionInlineDiffGoToNextNavigationTarget"
+      isGoToPreviousNavigationTarget="false"
+      isGoToPreviousNavigationTargetKey="deletionInlineDiffGoToPreviousNavigationTarget"
+      label="Inline Diff Deletion"
+      overviewRulerPreferenceKey="deletionInlineDiffIndicationInOverviewRuler"
+      overviewRulerPreferenceValue="false"
+      presentationLayer="1"
+      showInNextPrevDropdownToolbarAction="false"
+      showInNextPrevDropdownToolbarActionKey="showDeletionInlineDiffInNextPrevDropdownToolbarAction"
+      symbolicIcon="info"
+      textPreferenceKey="deletionInlineDiffIndication"
+      textPreferenceValue="true"
+      textStylePreferenceKey="deletionInlineDiffTextStyle"
+      textStylePreferenceValue="NONE"
+      verticalRulerPreferenceKey="deletionInlineDiffIndicationInVerticalRuler"
+      verticalRulerPreferenceValue="false">
+</specification>
+<specification
+      annotationType="org.eclipse.compare.unifieddiff.internal.detailedAddition"
+      colorPreferenceKey="detailedInlineDiffColor"
+      colorPreferenceValue="204,229,204"
+      contributesToHeader="false"
+      highlightPreferenceKey="detailedInlineDiffIndicationHighlighting"
+      highlightPreferenceValue="true"
+      isGoToNextNavigationTarget="false"
+      isGoToNextNavigationTargetKey="detailedInlineDiffGoToNextNavigationTarget"
+      isGoToPreviousNavigationTarget="false"
+      isGoToPreviousNavigationTargetKey="detailedInlineDiffGoToPreviousNavigationTarget"
+      label="Inline Diff Detailed Addition"
+      overviewRulerPreferenceKey="detailedInlineDiffIndicationInOverviewRuler"
+      overviewRulerPreferenceValue="false"
+      presentationLayer="2"
+      showInNextPrevDropdownToolbarAction="false"
+      showInNextPrevDropdownToolbarActionKey="showDetailedInlineDiffInNextPrevDropdownToolbarAction"
+      symbolicIcon="info"
+      textPreferenceKey="detailedInlineDiffIndication"
+      textPreferenceValue="true"
+      textStylePreferenceKey="detailedInlineDiffTextStyle"
+      textStylePreferenceValue="NONE"
+      verticalRulerPreferenceKey="detailedInlineDiffIndicationInVerticalRuler"
+      verticalRulerPreferenceValue="false">
+</specification>
+<specification
+      annotationType="org.eclipse.compare.unifieddiff.internal.detailedDeletion"
+      colorPreferenceKey="detailedDeletionInlineDiffColor"
+      colorPreferenceValue="255,204,204"
+      contributesToHeader="false"
+      highlightPreferenceKey="detailedDeletionInlineDiffIndicationHighlighting"
+      highlightPreferenceValue="true"
+      isGoToNextNavigationTarget="false"
+      isGoToNextNavigationTargetKey="detailedDeletionInlineDiffGoToNextNavigationTarget"
+      isGoToPreviousNavigationTarget="false"
+      isGoToPreviousNavigationTargetKey="detailedDeletionInlineDiffGoToPreviousNavigationTarget"
+      label="Inline Diff Detailed Deletion"
+      overviewRulerPreferenceKey="detailedDeletionInlineDiffIndicationInOverviewRuler"
+      overviewRulerPreferenceValue="false"
+      presentationLayer="2"
+      showInNextPrevDropdownToolbarAction="false"
+      showInNextPrevDropdownToolbarActionKey="showDetailedDeletionInlineDiffInNextPrevDropdownToolbarAction"
+      symbolicIcon="info"
+      textPreferenceKey="detailedDeletionInlineDiffIndication"
+      textPreferenceValue="true"
+      textStylePreferenceKey="detailedDeletionInlineDiffTextStyle"
+      textStylePreferenceValue="NONE"
+      verticalRulerPreferenceKey="detailedDeletionInlineDiffIndicationInVerticalRuler"
+      verticalRulerPreferenceValue="false">
+</specification>
+</extension>
+<extension point="org.eclipse.e4.ui.css.swt.theme">
+  <stylesheet uri="resources/css/dark.css">
+     <themeid refid="org.eclipse.e4.ui.css.theme.e4_dark"></themeid>
+  </stylesheet>
+</extension>
 </plugin>

--- a/team/bundles/org.eclipse.compare/resources/css/dark.css
+++ b/team/bundles/org.eclipse.compare/resources/css/dark.css
@@ -1,0 +1,7 @@
+IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-compare {
+	preferences:
+		'inlineDiffColor=27,40,30'
+		'detailedInlineDiffColor=24,50,27'
+		'deletionInlineDiffColor=52,27,30'
+		'detailedDeletionInlineDiffColor=74,24,27'
+}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
@@ -15,6 +15,7 @@ package org.eclipse.team.tests.core;
 
 import org.eclipse.team.tests.core.mapping.AllTeamMappingTests;
 import org.eclipse.team.tests.ui.SaveableCompareEditorInputTest;
+import org.eclipse.team.tests.ui.UnifiedDiffManagerTest;
 import org.eclipse.team.tests.ui.synchronize.AllTeamSynchronizeTests;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -24,6 +25,7 @@ import org.junit.platform.suite.api.Suite;
 		AllTeamMappingTests.class, //
 		AllTeamSynchronizeTests.class, //
 		SaveableCompareEditorInputTest.class, //
+		UnifiedDiffManagerTest.class, //
 })
 public class AllTeamUITests {
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffManagerTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffManagerTest.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP - initial implementation
+ *******************************************************************************/
+package org.eclipse.team.tests.ui;
+
+import static java.util.Collections.synchronizedList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInputStream;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.compare.unifieddiff.UnifiedDiff;
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@SuppressWarnings("restriction")
+@ExtendWith(WorkspaceResetExtension.class)
+public class UnifiedDiffManagerTest {
+
+	// Annotation type constants from
+	// org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager
+	private static final String ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.addition";
+	private static final String DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.deletion";
+	private static final String DETAILED_ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedAddition";
+	private static final String DETAILED_DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedDeletion";
+
+	private static final String LEFT = """
+			line one
+			line two
+			line three
+			""";
+	private static final String RIGHT = """
+			line one
+			line TWO modified
+			line three
+			""";
+
+	private IFile file;
+	private ITextEditor editor;
+	private final List<IStatus> loggedErrors = synchronizedList(new ArrayList<>());
+	private final ILogListener logListener = (status, plugin) -> {
+		if (status.getSeverity() == IStatus.ERROR) {
+			loggedErrors.add(status);
+		}
+	};
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		// Tests force a paint cycle, which requires a real Display. Fail loudly if
+		// the test is launched in a headless environment instead of silently passing.
+		assertNotNull(Display.getCurrent(), "tests require a UI thread / Display");
+
+		IProject project = getWorkspace().getRoot().getProject("UnifiedDiffProject");
+		createInWorkspace(project);
+		file = project.getFile("Sample.txt");
+		createInWorkspace(file);
+		file.setContents(createInputStream(LEFT), true, true, null);
+
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		// Opens the default text editor (.txt has no presentation reconciler), which
+		// exercises the empty-StyleRange fallback path in
+		// UnifiedDiffCodeMiningProvider.UnifiedDiffLineHeaderCodeMining.draw.
+		editor = (ITextEditor) IDE.openEditor(page, file);
+		processEvents();
+
+		Platform.addLogListener(logListener);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		Platform.removeLogListener(logListener);
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		if (editor != null) {
+			page.closeEditor(editor, false);
+		}
+		assertThat(loggedErrors).as("errors logged during open + paint").isEmpty();
+	}
+
+	@Test
+	public void testOverlayReadOnlyModeProducesAnnotationsAndPaints() {
+		IStatus status = UnifiedDiff.create(editor, RIGHT, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE).open();
+		assertTrue(status.isOK(), "open() should return OK status: " + status);
+
+		ITextViewer viewer = editor.getAdapter(ITextViewer.class);
+		assertNotNull(viewer, "editor must adapt to ITextViewer");
+
+		IAnnotationModel model = editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
+		assertNotNull(model, "annotation model must not be null");
+
+		// In OVERLAY_READ_ONLY_MODE the document is not modified; the diff is shown as
+		// a deletion annotation on the original line plus detailed-deletion annotations
+		// on the changed tokens.
+		int deletionCount = countAnnotations(model, DELETION_ANNO_TYPE);
+		int detailedDeletionCount = countAnnotations(model, DETAILED_DELETION_ANNO_TYPE);
+		assertTrue(deletionCount >= 1,
+				"expected at least one deletion annotation, got " + deletionCount);
+		assertTrue(detailedDeletionCount >= 1,
+				"expected at least one detailed-deletion annotation, got " + detailedDeletionCount);
+
+		forcePaintCycle(viewer.getTextWidget());
+	}
+
+	@Test
+	public void testRevertModeProducesAnnotationsAndPaints() {
+		IStatus status = UnifiedDiff.create(editor, RIGHT, UnifiedDiffMode.REVERT_MODE).open();
+		assertTrue(status.isOK(), "open() should return OK status: " + status);
+
+		ITextViewer viewer = editor.getAdapter(ITextViewer.class);
+		assertNotNull(viewer, "editor must adapt to ITextViewer");
+
+		IAnnotationModel model = editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
+		assertNotNull(model, "annotation model must not be null");
+
+		// REVERT_MODE uses ADDITION_ANNO_TYPE for the main annotation and
+		// DETAILED_ADDITION_ANNO_TYPE for the fine-grained ones (see
+		// UnifiedDiffAnnotation / DetailedDiffAnnotation constructors).
+		int additionCount = countAnnotations(model, ADDITION_ANNO_TYPE);
+		int detailedAdditionCount = countAnnotations(model, DETAILED_ADDITION_ANNO_TYPE);
+		assertTrue(additionCount >= 1,
+				"expected at least one addition annotation, got " + additionCount);
+		assertTrue(detailedAdditionCount >= 1,
+				"expected at least one detailed-addition annotation, got " + detailedAdditionCount);
+
+		forcePaintCycle(viewer.getTextWidget());
+	}
+
+	private static int countAnnotations(IAnnotationModel model, String type) {
+		int count = 0;
+		Iterator<Annotation> it = model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation anno = it.next();
+			if (type.equals(anno.getType())) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private static void forcePaintCycle(StyledText tw) {
+		if (tw == null || tw.isDisposed()) {
+			return;
+		}
+		tw.redraw();
+		tw.update();
+		processEvents();
+	}
+
+	private static void processEvents() {
+		Display display = Display.getCurrent();
+		if (display == null) {
+			return;
+		}
+		while (display.readAndDispatch()) {
+			// drain the event queue
+		}
+	}
+}


### PR DESCRIPTION
# Add Unified Diff Display in Text Editor as Alternative to Classic 2-Way Compare

Implements https://github.com/eclipse-platform/eclipse.platform.ui/issues/3771

## Summary

This contribution introduces a new **Unified Diff** viewing mode for `org.eclipse.compare` that displays differences in a single editor pane, similar to `git diff` or GitHub's pull request view. When enabled, it replaces the traditional side-by-side 2-way compare editor for read-only comparisons, providing a more compact and familiar diff experience.

This is a **draft** implementation to gather early feedback from the Eclipse community on:
- API design and public interface shape
- Integration approach with existing compare infrastructure
- User experience and workflow expectations
- Performance and edge case handling

---

## What's Included

### 1. New Public API (`org.eclipse.compare.unifieddiff`)

Added a new public package with the `UnifiedDiff` class as the main entry point for programmatically opening unified diffs in text editors.

**Supported Modes:**
- **REPLACE_MODE**: Diffs are directly applied to the editor content. Users can keep or undo individual changes.
- **OVERLAY_MODE**: Source content remains unmodified. Diffs are shown via code mining annotations, and users can selectively apply or cancel individual changes.
- **OVERLAY_READ_ONLY_MODE**: Source content remains unmodified and read-only. Diffs are shown via code mining annotations for viewing only.

**API Example:**
```java
UnifiedDiff.create(editor, sourceContent, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)
    .ignoreWhiteSpace(true)
    .open();
```

### 2. Preference Page Integration

Added a new checkbox in **Preferences > General > Compare/Patch**:
- **"Use Unified Diff instead of 2-way compare when possible"**

When enabled, eligible compare operations automatically use the unified diff viewer instead of the traditional side-by-side editor.

### 3. Automatic Compare Editor Integration

Modified `CompareUIPlugin#openCompareEditor()` to detect when unified diff should be used:
- Only applies to **2-way comparisons** (left vs. right, no ancestor)
- Only applies to **read-only comparisons** (no editing capabilities needed)
- Automatically extracts content and opens in unified diff mode when preference is enabled

---

## How to Test

### Prerequisites
- Eclipse workspace with a Java project tracked in a Git repository

### Steps
1. Open **Window > Preferences > General > Compare/Patch**
2. Enable the checkbox: **"Use Unified Diff instead of 2-way compare when possible"**
3. In the **Package Explorer**, right-click a Java file
4. Select **Team > Show in History**
5. In the **History** view, select two different commits
6. Right-click and choose **Compare with Each Other**

**Expected Result:**
- Instead of the traditional side-by-side compare editor, a single editor opens showing the unified diff
- Added lines appear with green background highlighting
- Deleted lines appear as code mining annotations with red background
- Character-level changes within modified lines are highlighted with darker shades


## Next Steps

- **Remove reflection calls** - Enhance the code mining APIs so that the current reflection calls can be removed
- **Code cleanup** - Polish implementation
- **Bug fixes** - Address issues reported by the Eclipse community
- **UI/UX improvements** - Enhance user experience based on the community feedback
