### PR TITLE
Fix NPE when Find action is unavailable in Expressions view

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/expression/ExpressionView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/expression/ExpressionView.java
@@ -84,8 +84,10 @@ public class ExpressionView extends VariablesView {
 		IAction action;
 		if (DebugPlugin.getDefault().getExpressionManager().getExpressions().length > 0) {
 			action = getAction(FIND_ACTION);
-			action.setImageDescriptor(DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_FIND_ACTION));
-			menu.add(action);
+			if (action != null && action.isEnabled()) {
+				action.setImageDescriptor(DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_FIND_ACTION));
+				menu.add(action);
+			}
 		}
 		ChangeVariableValueAction changeValueAction = (ChangeVariableValueAction)getAction("ChangeVariableValue"); //$NON-NLS-1$
 		if (changeValueAction.isApplicable()) {


### PR DESCRIPTION
The Find action may be unavailable when the focus is outside the Expressions view, which leads to an NPE in fillContextMenu.

This adds a null and enablement check for the Find action to resolve the problem.

This relates to #2558 and https://github.com/eclipse-platform/eclipse.platform/pull/2559#issuecomment-4047441563.