### PR TITLE
Prevent NPE in LaunchConfigurationTabGroupViewer.handleApplyPressed

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1513,7 +1513,10 @@ public class LaunchConfigurationTabGroupViewer {
 			// trim name
 			String trimmed = fNameWidget.getText().trim();
 			fNameWidget.setText(trimmed);
-			if(fWorkingCopy == null) {
+			if (fWorkingCopy == null) {
+				if (fOriginal == null) {
+					return null;
+				}
 				fWorkingCopy = fOriginal.getWorkingCopy();
 			}
 			fWorkingCopy.rename(trimmed);


### PR DESCRIPTION
Add a null check for `fOriginal` in
`LaunchConfigurationTabGroupViewer.handleApplyPressed` to prevent a NullPointerException when switching between launch configurations.

Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2571