### PR TITLE
Improve the default layout of the debug perspective

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPerspectiveFactory.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPerspectiveFactory.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.debug.internal.ui;
 
-
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.ui.IFolderLayout;
 import org.eclipse.ui.IPageLayout;
@@ -32,26 +31,28 @@ public class DebugPerspectiveFactory implements IPerspectiveFactory {
 	 */
 	@Override
 	public void createInitialLayout(IPageLayout layout) {
-
 		String editorArea = layout.getEditorArea();
 
-		IFolderLayout navFolder = layout.createFolder(IInternalDebugUIConstants.ID_NAVIGATOR_FOLDER_VIEW, IPageLayout.LEFT, (float) 0.25, editorArea);
+		IFolderLayout navFolder = layout.createFolder(IInternalDebugUIConstants.ID_NAVIGATOR_FOLDER_VIEW,
+				IPageLayout.LEFT, (float) 0.25, editorArea);
 		navFolder.addView(IDebugUIConstants.ID_DEBUG_VIEW);
 		navFolder.addPlaceholder(IPageLayout.ID_PROJECT_EXPLORER);
 
-		IFolderLayout toolsFolder = layout.createFolder(IInternalDebugUIConstants.ID_TOOLS_FOLDER_VIEW, IPageLayout.BOTTOM, (float) 0.75, editorArea);
-		toolsFolder.addView(IConsoleConstants.ID_CONSOLE_VIEW);
-		toolsFolder.addView(IPageLayout.ID_PROBLEM_VIEW);
-		toolsFolder.addPlaceholder(IDebugUIConstants.ID_REGISTER_VIEW);
-		toolsFolder.addPlaceholder(IPageLayout.ID_BOOKMARKS);
-		toolsFolder.addPlaceholder(IProgressConstants.PROGRESS_VIEW_ID);
-
-		IFolderLayout outlineFolder = layout.createFolder(IInternalDebugUIConstants.ID_OUTLINE_FOLDER_VIEW, IPageLayout.RIGHT, (float) 0.65, editorArea);
+		IFolderLayout outlineFolder = layout.createFolder(IInternalDebugUIConstants.ID_OUTLINE_FOLDER_VIEW,
+				IPageLayout.RIGHT, (float) 0.65, editorArea);
 		outlineFolder.addView(IDebugUIConstants.ID_VARIABLE_VIEW);
 		outlineFolder.addView(IDebugUIConstants.ID_BREAKPOINT_VIEW);
 		outlineFolder.addView(IDebugUIConstants.ID_EXPRESSION_VIEW);
 		outlineFolder.addPlaceholder(IPageLayout.ID_OUTLINE);
 		outlineFolder.addPlaceholder(IPageLayout.ID_PROP_SHEET);
+
+		IFolderLayout toolsFolder = layout.createFolder(IInternalDebugUIConstants.ID_TOOLS_FOLDER_VIEW,
+				IPageLayout.BOTTOM, (float) 0.75, editorArea);
+		toolsFolder.addView(IConsoleConstants.ID_CONSOLE_VIEW);
+		toolsFolder.addView(IPageLayout.ID_PROBLEM_VIEW);
+		toolsFolder.addPlaceholder(IDebugUIConstants.ID_REGISTER_VIEW);
+		toolsFolder.addPlaceholder(IPageLayout.ID_BOOKMARKS);
+		toolsFolder.addPlaceholder(IProgressConstants.PROGRESS_VIEW_ID);
 
 		layout.addShowViewShortcut(IProgressConstants.PROGRESS_VIEW_ID);
 		layout.addShowViewShortcut(TemplatesView.ID);


### PR DESCRIPTION
- Configure the section with the Variables view so that it spans the full height of the window.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2570