### PR TITLE
Show mouse move control even when not showing single line

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -2532,7 +2532,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		}
 		@Override
 		public void mouseMove(MouseEvent e) {
-			if (!fIsDown && fUseSingleLine && isAnySideEditable() && handleMouseMoveOverCenter(fCanvas, e.x, e.y)) {
+			if (!fIsDown && isAnySideEditable() && handleMouseMoveOverCenter(fCanvas, e.x, e.y)) {
 				return;
 			}
 			super.mouseMove(e);


### PR DESCRIPTION
With this simple change, the controls to do the merging still appear when you hover over the area that's connecting the changes on the two sides:

<img width="627" height="394" alt="image" src="https://github.com/user-attachments/assets/9602929e-e685-443f-a784-af8d285eaa19" />

@HannesWell @akurtakov 

I think this addresses your concerns about lost of functionality.

@iloveeclipse 

Given there is no visual appearance until you hover, I assume this is not a controversial addition.