### PR TITLE
Set Creation Time as Default Sorting Order in Breakpoints View

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2004, 2025 IBM Corporation and others.
+ *  Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -69,7 +69,8 @@ public class DebugUIPreferenceInitializer extends AbstractPreferenceInitializer 
 		prefs.setDefault(IInternalDebugUIConstants.PREF_LAUNCH_LAST_IF_NOT_LAUNCHABLE, true);
 
 		prefs.setDefault(IInternalDebugUIConstants.PREF_TERMINATE_AND_RELAUNCH_LAUNCH_ACTION, false);
-		prefs.setDefault(IInternalDebugUIConstants.PREF_BREAKPOINT_SORTING_ORDER, IInternalDebugUIConstants.BREAKPOINT_SORTING_ORDER_NAME);
+		prefs.setDefault(IInternalDebugUIConstants.PREF_BREAKPOINT_SORTING_ORDER,
+				IInternalDebugUIConstants.BREAKPOINT_SORTING_ORDER_CREATION_TIME);
 
 		//View Management preference page
 		prefs.setDefault(IDebugUIConstants.PREF_MANAGE_VIEW_PERSPECTIVES, IDebugUIConstants.PREF_MANAGE_VIEW_PERSPECTIVES_DEFAULT);


### PR DESCRIPTION
This change updates the default ordering of breakpoints in the Breakpoints view to sort them based on their creation time. At present, the default ordering does not emphasize when a breakpoint was added, which can make it less intuitive for users to locate the most recently created breakpoints during an active debugging session. By setting creation time as the default sorting criteria, the view better aligns with common debugging workflows where recently added breakpoints are typically the most relevant and frequently accessed.

<img width="431" height="326" alt="Screenshot 2026-03-23 at 3 45 41 PM" src="https://github.com/user-attachments/assets/88f089c4-11aa-4a3e-ac72-0232e58a4b6d" />
