### PR TITLE
Make FileSystemResourceManager.storeHistory() not static

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/DeleteVisitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/DeleteVisitor.java
@@ -21,6 +21,7 @@ import org.eclipse.core.filesystem.*;
 import org.eclipse.core.filesystem.provider.FileInfo;
 import org.eclipse.core.internal.resources.ICoreConstants;
 import org.eclipse.core.internal.resources.Resource;
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.internal.utils.Policy;
 import org.eclipse.core.resources.*;
@@ -126,7 +127,7 @@ public class DeleteVisitor implements IUnifiedTreeVisitor, ICoreConstants {
 			if (info == null) {
 				info = new FileInfo(node.getLocalName());
 			}
-			if (FileSystemResourceManager.storeHistory(node.getResource())) {
+			if (((Workspace) target.getWorkspace()).getFileSystemManager().storeHistory(target)) {
 				store.addState(target.getFullPath(), node.getStore(), info, true);
 			}
 		}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -1357,7 +1357,7 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 		}
 		// add entry to History Store.
 		if (BitMask.isSet(updateFlags, IResource.KEEP_HISTORY) && fileInfo.exists()
-				&& FileSystemResourceManager.storeHistory(target)) {
+				&& storeHistory(target)) {
 			// never move to the history store, because then the file is missing if write
 			// fails
 			getHistoryStore().addState(target.getFullPath(), store, fileInfo, false);
@@ -1495,8 +1495,8 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 		getWorkspace().getMetaArea().clearOldDescription(target);
 	}
 
-	public static boolean storeHistory(IResource file) {
-		WorkspaceDescription description = ((Workspace) file.getWorkspace()).internalGetDescription();
+	public boolean storeHistory(IResource file) {
+		WorkspaceDescription description = workspace.internalGetDescription();
 		return description.isKeepDerivedState() || !file.isDerived();
 	}
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ResourceTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ResourceTree.java
@@ -61,7 +61,7 @@ class ResourceTree implements IResourceTree {
 	 */
 	@Override
 	public void addToLocalHistory(IFile file) {
-		if (!FileSystemResourceManager.storeHistory(file)) {
+		if (!localManager.storeHistory(file)) {
 			return;
 		}
 		Assert.isLegal(isValid);


### PR DESCRIPTION
This change adjusts `FileSystemResourceManager.storeHistory()` to not be `static`, enabling the method to use preferences stored in `FileSystemResourceManager`.

Fixes: https://github.com/eclipse-platform/eclipse.platform/issues/2591