### PR TITLE
Fix AIOBE when calculating curve in TextMergeViewer

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -4593,12 +4593,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 	}
 
 	private int[] getCenterCurvePoints(int startx, int starty, int endx, int endy) {
-		if (fBasicCenterCurve == null) {
-			buildBaseCenterCurve(endx-startx);
+		int width = endx - startx;
+		if (fBasicCenterCurve == null || fBasicCenterCurve.length != width) {
+			fBasicCenterCurve = buildBaseCenterCurve(width);
 		}
 		double height= endy - starty;
 		height= height/2;
-		int width= endx-startx;
 		int[] points= new int[width];
 		for (int i= 0; i < width; i++) {
 			points[i]= (int) (-height * fBasicCenterCurve[i] + height + starty);
@@ -4606,13 +4606,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		return points;
 	}
 
-	private void buildBaseCenterCurve(int w) {
-		double width= w;
-		fBasicCenterCurve= new double[getCenterWidth()];
-		for (int i= 0; i < getCenterWidth(); i++) {
-			double r= i / width;
-			fBasicCenterCurve[i]= Math.cos(Math.PI * r);
+	private double[] buildBaseCenterCurve(int width) {
+		double[] curve = new double[width];
+		for (int x = 0; x < width; x++) {
+			curve[x] = Math.cos(Math.PI * x / width);
 		}
+		return curve;
 	}
 
 	private int calculateShift(MergeSourceViewer tp) {


### PR DESCRIPTION
The TextMergeViewer currently assumes that the center canvas between the two source code views always has a width of 34 points (exposed as getCenterWidth()). This width is also assumed when calculating the curve connecting regions between the two source viewers. Even though that size for the center canvas is set by the used layout, there is no guarantee that the size is an invariant that does always hold. In particular, during a zoom change on Windows, the shell and its controls are temporarily resized by the OS until the layout is applied again, so that temporarily the size does not equal 34 points and a paint operation can fail with an AIOBE.

This change adapts the curve calculation to adhere to the actual current width of the canvas instead of assuming the size to be invariant.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2584