### PR TITLE
Fix change highlight placement in TextMergeViewer after zoom change

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -2737,7 +2737,8 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				createSourceViewer(parent, getDirection()),
 				getResourceBundle(), getCompareConfiguration().getContainer());
 		final StyledText te= viewer.getSourceViewer().getTextWidget();
-
+		// Clear cached line heights upon zoom changes, as they are no longer valid
+		te.addListener(SWT.ZoomChanged, e -> resetCachedLineHeights(viewer));
 		if (!fConfirmSave) {
 			viewer.hideSaveAction();
 		}
@@ -4398,13 +4399,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 			lineHeights = new ArrayList<>();
 			lineHeights.addAll(Collections.nCopies(w.getLineCount(), null));
 			this.lineHeightsByViewer.put(tp, lineHeights);
-			tp.getSourceViewer().addTextListener(event -> {
-				List<Integer> lineHeightsList = lineHeightsByViewer.get(tp);
-				if (lineHeightsList != null) {
-					lineHeightsList.clear();
-					lineHeightsList.addAll(Collections.nCopies(w.getLineCount(), null));
-				}
-			});
+			tp.getSourceViewer().addTextListener(event -> resetCachedLineHeights(tp));
 		}
 
 		int lineSpacing = w.getLineSpacing();
@@ -4427,6 +4422,15 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 			height += heightAtLine;
 		}
 		return height;
+	}
+
+	private void resetCachedLineHeights(MergeSourceViewer mergeViewer) {
+		StyledText styledText = mergeViewer.getSourceViewer().getTextWidget();
+		List<Integer> lineHeightsList = lineHeightsByViewer.get(mergeViewer);
+		if (lineHeightsList != null) {
+			lineHeightsList.clear();
+			lineHeightsList.addAll(Collections.nCopies(styledText.getLineCount(), null));
+		}
 	}
 
 	private void invalidateLines() {


### PR DESCRIPTION
The TextMergeViewer caches line heights for painting the change region highlights. That cache is not invalidated upon a zoom change even though the cached line heights are only valid for one specific zoom. In consequence, the highlights are not properly placed after a zoom change anymore.

This change clears the line height cached upon zoom change of the according canvas, which fixes the placement of change highlight regions after zoom changes.

## How to test
Just open a text compare viewer and move it between monitors of different zooms on Windows.
For example when moving from 125% to 100%, it looks like this:

### Before
<img width="854" height="264" alt="image" src="https://github.com/user-attachments/assets/2f4920d7-6cfa-439a-a68f-962606e99366" />

### After
<img width="858" height="260" alt="image" src="https://github.com/user-attachments/assets/e8308862-7c37-41fc-a4e7-38e30f905955" />