### PR TITLE
Test the validity of configuration element before accessing attributes

### DIFF
--- a/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.expressions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.expressions; singleton:=true
-Bundle-Version: 3.9.500.qualifier
+Bundle-Version: 3.9.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.expressions,

--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/ExpressionMessages.java
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/ExpressionMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,6 +45,7 @@ public final class ExpressionMessages extends NLS {
 
 	public static String ResolveExpression_variable_not_defined;
 
+	public static String PropertyTesterDescriptor_invalid;
 	public static String PropertyTesterDescriptor_no_namespace;
 	public static String PropertyTesterDescritpri_no_properties;
 

--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/ExpressionMessages.properties
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/ExpressionMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2009 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,7 @@ WithExpression_variable_not_defined= The variable {0} is not defined
 
 ResolveExpression_variable_not_defined= The variable {0} is not defined
 
+PropertyTesterDescriptor_invalid= The configuration element is invalid. Tester has been disabled.
 PropertyTesterDescriptor_no_namespace= The mandatory attribute namespace is missing. Tester has been disabled.
 PropertyTesterDescritpri_no_properties= The mandatory attribute properties is missing. Tester has been disabled.
 

--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/PropertyTesterDescriptor.java
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/PropertyTesterDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,24 +32,24 @@ public class PropertyTesterDescriptor implements IPropertyTester {
 
 	private static final String PROPERTIES= "properties"; //$NON-NLS-1$
 	private static final String NAMESPACE= "namespace"; //$NON-NLS-1$
-	private static final String CLASS= "class";  //$NON-NLS-1$
+	private static final String CLASS= "class"; //$NON-NLS-1$
 
 	public PropertyTesterDescriptor(IConfigurationElement element) throws CoreException {
 		fConfigElement= element;
-		fNamespace= fConfigElement.getAttribute(NAMESPACE);
+		if (!element.isValid()) {
+			throw new CoreException(new Status(IStatus.ERROR, PropertyTesterDescriptor.class,
+					IStatus.ERROR, ExpressionMessages.PropertyTesterDescriptor_invalid, null));
+		}
+		fNamespace= element.getAttribute(NAMESPACE);
 		if (fNamespace == null) {
 			throw new CoreException(new Status(IStatus.ERROR, PropertyTesterDescriptor.class,
-				IStatus.ERROR,
-				ExpressionMessages.PropertyTesterDescriptor_no_namespace,
-				null));
+					IStatus.ERROR, ExpressionMessages.PropertyTesterDescriptor_no_namespace, null));
 		}
 		StringBuilder buffer= new StringBuilder(","); //$NON-NLS-1$
 		String properties= element.getAttribute(PROPERTIES);
 		if (properties == null) {
 			throw new CoreException(new Status(IStatus.ERROR, PropertyTesterDescriptor.class,
-				IStatus.ERROR,
-				ExpressionMessages.PropertyTesterDescritpri_no_properties,
-				null));
+					IStatus.ERROR, ExpressionMessages.PropertyTesterDescritpri_no_properties, null));
 		}
 		for (int i= 0; i < properties.length(); i++) {
 			char ch= properties.charAt(i);
@@ -62,6 +62,8 @@ public class PropertyTesterDescriptor implements IPropertyTester {
 	}
 
 	public PropertyTesterDescriptor(IConfigurationElement element, String namespace, String properties) {
+		if (!element.isValid())
+			throw new IllegalStateException(ExpressionMessages.PropertyTesterDescriptor_invalid);
 		fConfigElement= element;
 		fNamespace= namespace;
 		fProperties= properties;

--- a/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.eclipse.core.expressions.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Import-Package: org.assertj.core.api,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
- org.mockito
+ org.mockito,
+ org.mockito.stubbing
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/PropertyTesterTests.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/PropertyTesterTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 
@@ -26,30 +27,25 @@ import org.eclipse.core.expressions.EvaluationContext;
 import org.eclipse.core.expressions.EvaluationResult;
 import org.eclipse.core.expressions.TestExpression;
 import org.eclipse.core.internal.expressions.Property;
+import org.eclipse.core.internal.expressions.PropertyTesterDescriptor;
 import org.eclipse.core.internal.expressions.TypeExtensionManager;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.core.runtime.Platform;
 
 @SuppressWarnings("restriction")
 public class PropertyTesterTests {
 
-	private A a;
-	private B b;
-	private I i;
-
 	private static final TypeExtensionManager fgManager= new TypeExtensionManager("propertyTesters"); //$NON-NLS-1$
 
 	// Needs additional local test plug-ins
 	private static final boolean TEST_DYNAMIC_AND_ACTIVATION= false;
 
-	@BeforeEach
-	public void setUp() throws Exception {
-		a= new A();
-		b= new B();
-		i= b;
-	}
+	private final A a= new A();
+	private final B b= new B();
+	private final I i= b;
 
 	@Test
 	public void testSimple() throws Exception {
@@ -68,13 +64,17 @@ public class PropertyTesterTests {
 	}
 
 	@Test
+	public void testInvalid() throws Exception {
+		IConfigurationElement element=
+			mock(IConfigurationElement.class);
+		when(element.isValid()).thenReturn(false);
+		var ce = assertThrows(CoreException.class, () -> new PropertyTesterDescriptor(element));
+		assertEquals("The configuration element is invalid. Tester has been disabled.", ce.getMessage());
+	}
+
+	@Test
 	public void testUnknown() throws Exception {
-		try {
-			test(a, "unknown", null, null); //$NON-NLS-1$
-		} catch (CoreException e) {
-			return;
-		}
-		assertTrue(false);
+		assertThrows(CoreException.class, () -> test(a, "unknown", null, null)); //$NON-NLS-1$
 	}
 
 	@Test


### PR DESCRIPTION
The `IConfigurationElement.getAttribute` method throws `InvalidRegistryObjectException`.  Check `isValid()` before accessing attributes to prevent uncaught exception.

see #2593