### PR TITLE
Fix ClassCastException in WatchHandler

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/WatchHandler.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/WatchHandler.java
@@ -57,10 +57,13 @@ public class WatchHandler extends AbstractHandler {
 			if (structuredSelection instanceof TreeSelection treeSelection) {
 				for (TreePath path : treeSelection.getPaths()) {
 					List<IVariable> variables = new ArrayList<>();
-					if (path.getSegmentCount() > 1) {
-						for (int e = 0; e < path.getSegmentCount(); e++) {
-							IVariable variable = (IVariable) path.getSegment(e);
-							variables.add(variable);
+					int segments = path.getSegmentCount();
+					if (segments > 1) {
+						for (int e = 0; e < segments; e++) {
+							Object sel = path.getSegment(e);
+							if (sel instanceof IVariable variable) {
+								variables.add(variable);
+							}
 						}
 						IWatchExpressionFactoryAdapter2 factory = getFactory2(variables);
 						if (factory != null) {


### PR DESCRIPTION
This PR prevents ClassCastException when `Watch` creation is done from child of an expression in Expressions View.

Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2602