### PR TITLE
Remove obsolete com.ibm.icu references and configurations

### DIFF
--- a/docs/Internationalization.md
+++ b/docs/Internationalization.md
@@ -9,7 +9,7 @@ This work involves translating strings into other languages (often called NLS fo
 Tools Used
 ----------
 
-Some Eclipse plug-ins use ICU4J APIs when working with locale-specific content.
+Eclipse plug-ins use standard Java APIs (such as `java.text` and `java.util`) when working with locale-specific content.
 
 Most Eclipse plug-ins use a special [Eclipse message bundle](http://www.eclipse.org/eclipse/platform-core/documents/3.1/message_bundles.html) mechanism for working with translated strings. This mechanism uses traditional Java message.properties files, but without using String-based keys. This has much better memory usage characteristics than traditional approaches.
 

--- a/resources/bundles/org.eclipse.core.resources/src_ant/org/eclipse/core/resources/ant/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src_ant/org/eclipse/core/resources/ant/Policy.java
@@ -17,7 +17,6 @@ import java.text.MessageFormat;
 import java.util.*;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-// can't use ICU, used by ant
 
 public class Policy {
 	private static final String bundleName = "org.eclipse.core.resources.ant.messages";//$NON-NLS-1$

--- a/ua/infocenter-web/infocenter-product/infocenter.product
+++ b/ua/infocenter-web/infocenter-product/infocenter.product
@@ -34,7 +34,6 @@ org.osgi.framework.bootdelegation=*
    </vm>
 
    <plugins>
-      <plugin id="com.ibm.icu"/>
       <plugin id="org.apache.felix.scr"/>
       <plugin id="org.apache.lucene.analysis-common"/>
       <plugin id="org.apache.lucene.analysis-smartcn"/>


### PR DESCRIPTION
This PR removes obsolete references and configurations related to `com.ibm.icu` from the Eclipse Platform repository.

Key changes:
- Removed `com.ibm.icu` plugin from `ua/infocenter-web/infocenter-product/infocenter.product`.
- Updated `docs/Internationalization.md` to reflect the migration to standard Java APIs.
- Removed an obsolete comment in `Policy.java` about ICU usage.

These changes follow recent efforts to phase out ICU usage in favor of standard Java APIs.