### PR TITLE
Simplify intro framework: deprecate StandbyPart and IntroLaunchBar

### DIFF
--- a/ua/org.eclipse.ui.intro.universal/plugin.xml
+++ b/ua/org.eclipse.ui.intro.universal/plugin.xml
@@ -54,12 +54,7 @@
             <implementation
                   kind="swt">
             </implementation>
-            <launchBar
-               	location="fastview"
-            	bg="$launchbarBackground$"
-            	computed="true">
-            </launchBar>
-         </presentation>
+            </presentation>
       </config>
    </extension>
    <extension

--- a/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin_name
 Bundle-SymbolicName: org.eclipse.ui.intro; singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.9.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.intro.impl.IntroPlugin
 Bundle-Vendor: %provider_name
 Bundle-Localization: plugin

--- a/ua/org.eclipse.ui.intro/pom.xml
+++ b/ua/org.eclipse.ui.intro/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.ui.intro</artifactId>
-  <version>3.8.100-SNAPSHOT</version>
+  <version>3.9.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/IntroPlugin.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/IntroPlugin.java
@@ -42,6 +42,7 @@ public class IntroPlugin extends AbstractUIPlugin {
 
 	// We must keep track of the launch bar so that we can
 	// close it if intro is opened from the menu.
+	@SuppressWarnings("removal")
 	private IntroLaunchBar launchBar;
 
 	// used for performance logging. Time when the constructor of
@@ -88,6 +89,12 @@ public class IntroPlugin extends AbstractUIPlugin {
 	}
 
 
+	/**
+	 * @deprecated The launch bar is no longer used. This method will be removed
+	 *             in a future release.
+	 */
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
 	public void closeLaunchBar() {
 		if (launchBar != null) {
 			launchBar.close();
@@ -96,6 +103,12 @@ public class IntroPlugin extends AbstractUIPlugin {
 		IntroLaunchBar.destroyAll(PlatformUI.getWorkbench());
 	}
 
+	/**
+	 * @deprecated The launch bar is no longer used. This method will be removed
+	 *             in a future release.
+	 */
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
 	public void setLaunchBar(IntroLaunchBar launchBar) {
 		this.launchBar = launchBar;
 	}

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/url/IntroURL.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/url/IntroURL.java
@@ -28,26 +28,21 @@ import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.IWorkbenchWindowActionDelegate;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
-import org.eclipse.ui.internal.intro.impl.IIntroConstants;
 import org.eclipse.ui.internal.intro.impl.IntroPlugin;
 import org.eclipse.ui.internal.intro.impl.Messages;
 import org.eclipse.ui.internal.intro.impl.model.AbstractIntroElement;
 import org.eclipse.ui.internal.intro.impl.model.AbstractIntroPage;
-import org.eclipse.ui.internal.intro.impl.model.IntroLaunchBarElement;
 import org.eclipse.ui.internal.intro.impl.model.IntroModelRoot;
 import org.eclipse.ui.internal.intro.impl.model.IntroPartPresentation;
 import org.eclipse.ui.internal.intro.impl.model.IntroURLAction;
 import org.eclipse.ui.internal.intro.impl.model.loader.ExtensionPointManager;
 import org.eclipse.ui.internal.intro.impl.model.loader.ModelLoaderUtil;
 import org.eclipse.ui.internal.intro.impl.model.util.ModelUtil;
-import org.eclipse.ui.internal.intro.impl.parts.StandbyPart;
 import org.eclipse.ui.internal.intro.impl.presentations.BrowserIntroPartImplementation;
-import org.eclipse.ui.internal.intro.impl.presentations.IntroLaunchBar;
 import org.eclipse.ui.internal.intro.impl.util.DialogUtil;
 import org.eclipse.ui.internal.intro.impl.util.Log;
 import org.eclipse.ui.internal.intro.impl.util.StringUtil;
@@ -76,7 +71,15 @@ public class IntroURL implements IIntroURL {
 	/**
 	 * Constants that represent Intro URL actions.
 	 */
+	/**
+	 * @deprecated Standby mode is no longer used.
+	 */
+	@Deprecated(forRemoval = true)
 	public static final String SET_STANDBY_MODE = "setStandbyMode"; //$NON-NLS-1$
+	/**
+	 * @deprecated Standby mode is no longer used.
+	 */
+	@Deprecated(forRemoval = true)
 	public static final String SHOW_STANDBY = "showStandby"; //$NON-NLS-1$
 	public static final String CLOSE = "close"; //$NON-NLS-1$
 	public static final String SHOW_HELP_TOPIC = "showHelpTopic"; //$NON-NLS-1$
@@ -87,6 +90,10 @@ public class IntroURL implements IIntroURL {
 	public static final String SHOW_PAGE = "showPage"; //$NON-NLS-1$
 	public static final String SHOW_MESSAGE = "showMessage"; //$NON-NLS-1$
 	public static final String NAVIGATE = "navigate"; //$NON-NLS-1$
+	/**
+	 * @deprecated The launch bar is no longer used.
+	 */
+	@Deprecated(forRemoval = true)
 	public static final String SWITCH_TO_LAUNCH_BAR = "switchToLaunchBar"; //$NON-NLS-1$
 	public static final String EXECUTE = "execute"; //$NON-NLS-1$
 
@@ -114,7 +121,15 @@ public class IntroURL implements IIntroURL {
 	public static final String VALUE_TRUE = "true"; //$NON-NLS-1$
 	public static final String VALUE_FALSE = "false"; //$NON-NLS-1$
 	public static final String VALUE_CLOSE = "close"; //$NON-NLS-1$
+	/**
+	 * @deprecated Standby mode is no longer used.
+	 */
+	@Deprecated(forRemoval = true)
 	public static final String VALUE_STANDBY = "standby"; //$NON-NLS-1$
+	/**
+	 * @deprecated The launch bar is no longer used.
+	 */
+	@Deprecated(forRemoval = true)
 	public static final String VALUE_LAUNCHBAR = "launchbar"; //$NON-NLS-1$
 
 
@@ -155,12 +170,12 @@ public class IntroURL implements IIntroURL {
 		case CLOSE:
 			return closeIntro();
 		case SET_STANDBY_MODE:
-			// Sets the state of the intro part. Does not care about passing
-			// input to the part.
+			// Standby mode is deprecated - treat as simple show/close
 			return setStandbyState(getParameter(KEY_STANDBY));
 		case SHOW_STANDBY:
-			return handleStandbyState(getParameter(KEY_PART_ID),
-					getParameter(KEY_INPUT));
+			// Standby mode is deprecated - just show the intro
+			Log.warning("showStandby action is deprecated; showing intro instead"); //$NON-NLS-1$
+			return IntroPlugin.showIntro(false) != null;
 		case SHOW_HELP:
 			// display the full Help System.
 			return showHelp();
@@ -197,7 +212,9 @@ public class IntroURL implements IIntroURL {
 		case NAVIGATE:
 			return navigate(getParameter(KEY_DIRECTION));
 		case SWITCH_TO_LAUNCH_BAR:
-			return switchToLaunchBar();
+			// Launch bar is deprecated - just close the intro
+			Log.warning("switchToLaunchBar action is deprecated; closing intro instead"); //$NON-NLS-1$
+			return closeIntro();
 		default:
 			return handleCustomAction();
 		}
@@ -207,29 +224,6 @@ public class IntroURL implements IIntroURL {
 	private boolean closeIntro() {
 		// Relies on Workbench.
 		return IntroPlugin.closeIntro();
-	}
-
-	/**
-	 * Sets the into part to standby, and shows the passed standby part, with
-	 * the given input. Forces the Intro view to open, if not yet created.
-	 */
-	private boolean handleStandbyState(String partId, String input) {
-		// set intro to standby mode. we know we have a customizable part.
-		CustomizableIntroPart introPart = (CustomizableIntroPart) IntroPlugin
-			.getIntro();
-		if (introPart == null) {
-			introPart = (CustomizableIntroPart) IntroPlugin.showIntro(true);
-		}
-		// store the flag to indicate that standbypart is needed.
-		introPart.getControl().setData(IIntroConstants.SHOW_STANDBY_PART,
-			VALUE_TRUE);
-		IntroPlugin.setIntroStandby(true);
-		StandbyPart standbyPart = introPart
-			.getAdapter(StandbyPart.class);
-
-		// We may not have a valid partId or we might fail to instantiate part or
-		// create the part content. An empty part will be shown. Signal failure.
-		return standbyPart != null && standbyPart.showContentPart(partId, input);
 	}
 
 	/**
@@ -247,7 +241,9 @@ public class IntroURL implements IIntroURL {
 		if (state.equals(VALUE_CLOSE)) {
 			return IntroPlugin.closeIntro();
 		} else if (state.equals(VALUE_LAUNCHBAR)) {
-			return switchToLaunchBar();
+			// Launch bar is deprecated - just close the intro instead
+			Log.warning("launchbar standby state is deprecated; closing intro instead"); //$NON-NLS-1$
+			return IntroPlugin.closeIntro();
 		}
 		boolean standby = state.equals(VALUE_TRUE) || state.equals(VALUE_STANDBY);
 
@@ -635,26 +631,4 @@ public class IntroURL implements IIntroURL {
 		return query.toString();
 	}
 
-
-	private boolean switchToLaunchBar() {
-		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
-		if (intro == null) {
-			return false;
-		}
-
-		IntroModelRoot modelRoot = IntroPlugin.getDefault().getIntroModelRoot();
-
-		IntroLaunchBarElement launchBarElement = modelRoot.getPresentation().getLaunchBarElement();
-		if (launchBarElement == null) {
-			return true;
-		}
-		IWorkbenchWindow window = intro.getIntroSite().getWorkbenchWindow();
-		IntroLaunchBar.create(window, modelRoot, launchBarElement);
-
-		PlatformUI.getWorkbench().getIntroManager().setIntroStandby(intro, true);
-
-		closeIntro();
-
-		return true;
-	}
 }

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/parts/StandbyPart.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/parts/StandbyPart.java
@@ -47,17 +47,13 @@ import org.eclipse.ui.intro.config.IStandbyContentPart;
 /**
  * Standby part is responsible for managing and creating IStandbycontent parts.
  * It knows how to create and cache content parts. It also handles saving and
- * restoring its own state. It does that by caching the id of the last content
- * part viewed and recreating that part on startup. It also manages the life
- * cycle of content parts by creating and initializing them at the right
- * moments. It also passes the momento at appropriate times to these content
- * parts to enable storing and retrieving of state by content parts. Content
- * parts are responsible for recreating there own state, including input, from
- * the passed momemnto. When the Return to Introduction link is clicked, the
- * Intro goes out of standby content mode, and the standby content parts are not
- * shown anymore until the user explicitly asks for a part again. This is
- * accomplished through a data flag on the CustomizableIntroPart control.
+ * restoring its own state.
+ *
+ * @deprecated The standby part is no longer used. The welcome screen is now
+ *             treated as a regular editor without standby mode. This class will
+ *             be removed in a future release.
  */
+@Deprecated(forRemoval = true)
 public class StandbyPart implements IIntroConstants {
 
 	private FormToolkit toolkit;

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/IntroLaunchBar.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/IntroLaunchBar.java
@@ -73,7 +73,11 @@ import jakarta.inject.Inject;
  * available from the application IEclipseContext.
  *
  * @since 3.1
+ * @deprecated The intro launch bar is no longer used. The welcome screen is now treated as a
+ *             regular editor. This class will be removed in a future release.
  */
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public class IntroLaunchBar {
 
 	private static final String LAUNCHBAR_ID = "org.eclipse.ui.internal.intro.impl.presentations.IntroLaunchBar"; //$NON-NLS-1$

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/intro/config/CustomizableIntroPart.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/intro/config/CustomizableIntroPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2016 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.IRegistryChangeListener;
 import org.eclipse.core.runtime.PerformanceStats;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -36,7 +36,6 @@ import org.eclipse.ui.internal.intro.impl.model.IntroPartPresentation;
 import org.eclipse.ui.internal.intro.impl.model.loader.ContentProviderManager;
 import org.eclipse.ui.internal.intro.impl.model.loader.ExtensionPointManager;
 import org.eclipse.ui.internal.intro.impl.model.loader.ModelLoaderUtil;
-import org.eclipse.ui.internal.intro.impl.parts.StandbyPart;
 import org.eclipse.ui.internal.intro.impl.presentations.BrowserIntroPartImplementation;
 import org.eclipse.ui.internal.intro.impl.util.DialogUtil;
 import org.eclipse.ui.internal.intro.impl.util.Log;
@@ -58,14 +57,10 @@ import org.eclipse.ui.part.IntroPart;
  * files. Again, both of which can be specified using the above extension point.
  * <p>
  * Memento Support: This intro part tries to restore its previous state when
- * possible. The state of the intro page is remembered, along with which standby
- * content content part was opened. IStandbyContent parts are passed the Intro's
- * memento shortly after construction, and are expected to restore there own
- * state based on the memento. The customizable intro part handles there initial
- * creation on load, and leaves restoring state to content part. Same with
- * saving state. The memento is passed shortly before shutdown to enable storing
- * of part specific data.
- *
+ * possible. The state of the intro page is remembered. The memento is passed
+ * shortly before shutdown to enable storing of part specific data.
+ * </p>
+ * <p>
  * Note: This class was made public for re-use, as-is, as a valid class for the
  * <code>org.eclipse.ui.intro</code> extension point. It is not intended to be
  * subclassed or used otherwise.
@@ -73,34 +68,19 @@ import org.eclipse.ui.part.IntroPart;
  *
  * @since 3.0
  */
-
-/*
- * Internal docs: This class wraps a presentation part and a standby part. The
- * standby part is only shown when an IntroURL asks to show standby or when we
- * are restarting an Intro with an old memento. An internal data object
- * "showStandbyPart" is set on the control by the intro URL to signal standby
- * part needed. This data is nulled when the close button on the standby part is
- * clicked, signaling that the standby part is no longer needed.
- */
 public final class CustomizableIntroPart extends IntroPart implements
 		 IRegistryChangeListener {
 
 	private IntroPartPresentation presentation;
-	private StandbyPart standbyPart;
 	private Composite container;
-	private IMemento memento;
 	IntroModelRoot model;
-	// this flag is used to recreate a cached standby part. It is used once and
-	// the set to false when the standby part is first created.
-	private boolean restoreStandby;
 
-
-	// Adapter factory to abstract out the StandbyPart implementation from APIs.
+	// Adapter factory to expose IntroPartPresentation.
 	IAdapterFactory factory = new IAdapterFactory() {
 
 		@Override
 		public Class<?>[] getAdapterList() {
-			return new Class[] { StandbyPart.class, IntroPartPresentation.class };
+			return new Class[] { IntroPartPresentation.class };
 		}
 
 		@Override
@@ -109,18 +89,14 @@ public final class CustomizableIntroPart extends IntroPart implements
 				return null;
 			}
 
-			if (adapterType.equals(StandbyPart.class)) {
-				return adapterType.cast(getStandbyPart());
-			} else if (adapterType.equals(IntroPartPresentation.class)) {
+			if (adapterType.equals(IntroPartPresentation.class)) {
 				return adapterType.cast(getPresentation());
-			} else {
-				return null;
 			}
+			return null;
 		}
 	};
 
 	public CustomizableIntroPart() {
-		// register adapter to hide standbypart.
 		Platform.getAdapterManager().registerAdapters(factory,
 			CustomizableIntroPart.class);
 		// model can not be loaded here because the configElement of this part
@@ -134,15 +110,13 @@ public final class CustomizableIntroPart extends IntroPart implements
 					IIntroConstants.PERF_VIEW_CREATION_TIME,
 					IIntroConstants.INTRO).startRun();
 			} else {
-				// capture start time to be used when only Intro performance
-				// trace
-				// is turned on.
 				IntroPlugin.getDefault().setUICreationStartTime(
 					System.currentTimeMillis());
 			}
 		}
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	public void init(IIntroSite site, IMemento memento)
 			throws PartInitException {
@@ -172,13 +146,7 @@ public final class CustomizableIntroPart extends IntroPart implements
 					IIntroConstants.MEMENTO_PRESENTATION_TAG));
 			}
 
-			// standby part is not created here for performance.
-
-			// cache memento, and detemine if we have a cached standby part.
-			this.memento = memento;
-			restoreStandby = needToRestoreStandby(memento);
-
-			// add the registry listerner for dynamic awarness.
+			// add the registry listener for dynamic awareness.
 			Platform.getExtensionRegistry().addRegistryChangeListener(this,
 				IIntroConstants.PLUGIN_ID);
 		}
@@ -193,21 +161,20 @@ public final class CustomizableIntroPart extends IntroPart implements
 	}
 
 	/**
-	 * Creates the UI based on how the InroPart has been configured.
+	 * Creates the UI based on how the IntroPart has been configured.
 	 *
 	 * @see org.eclipse.ui.IWorkbenchPart#createPartControl(org.eclipse.swt.widgets.Composite)
 	 */
 	@Override
 	public void createPartControl(Composite parent) {
 		container = new Composite(parent, SWT.NULL);
-		StackLayout layout = new StackLayout();
+		FillLayout layout = new FillLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		container.setLayout(layout);
 
 		if (model != null && model.hasValidConfig()) {
 			presentation.createPartControl(container);
-			// do not create the standby part here for performance.
 		}
 
 		if (Log.logPerformance) {
@@ -218,138 +185,26 @@ public final class CustomizableIntroPart extends IntroPart implements
 
 	}
 
-
-
-
-	/**
-	 * Determine if we need to recreate a standby part. Return true if we have a
-	 * standby part memento that is not for the empty part AND stangby memento
-	 * has been tagged for restore, ie: it was open when workbench closed.
-	 *
-	 * @return <code>true</code> if we need to recreate a standby part
-	 */
-	private boolean needToRestoreStandby(IMemento memento) {
-		// If we have a standby memento, it means we closed with standby open,
-		// and so recreate it.
-		IMemento standbyMemento = getMemento(memento, IIntroConstants.MEMENTO_STANDBY_PART_TAG);
-		if (standbyMemento == null) {
-			return false;
-		}
-		String restore = standbyMemento.getString(IIntroConstants.MEMENTO_RESTORE_ATT);
-		if (restore == null) {
-			return false;
-		}
-		String cachedStandbyPart = standbyMemento
-			.getString(IIntroConstants.MEMENTO_STANDBY_CONTENT_PART_ID_ATT);
-		if (cachedStandbyPart != null
-				&& cachedStandbyPart.equals(IIntroConstants.EMPTY_STANDBY_CONTENT_PART)) {
-			return false;
-		}
-
-		return cachedStandbyPart != null ? true : false;
-	}
-
-	/*
-	 * Handled state changes. Recreates the standby part if workbench was shut
-	 * down with one.
-	 *
-	 * @see org.eclipse.ui.IIntroPart#standbyStateChanged(boolean)
-	 */
 	@Override
 	public void standbyStateChanged(boolean standby) {
-
 		// do this only if there is a valid config.
 		if (model == null || !model.hasValidConfig()) {
 			return;
 		}
 
-		if (!standby) {
-			// we started of not in standby, no need to restore standby.
-			restoreStandby = false;
-		}
-
-		boolean isStandbyPartNeeded = isStandbyPartNeeded();
-		isStandbyPartNeeded = isStandbyPartNeeded || restoreStandby;
-
 		try {
-			if (standbyPart == null && standby && isStandbyPartNeeded) {
-				// if standby part is not created yet, create it only if in
-				// standby, and we need to.
-				createStandbyPart();
-			}
-
-			handleSetFocus(isStandbyPartNeeded);
-			setTopControl(isStandbyPartNeeded ? getStandbyControl()
-					: getPresentationControl());
-			// triger state change in presentation to enable/disable toobar
-			// actions. For this, we need to disable actions as long as we are in
-			// standby, or we need to show standby part.
-			presentation.standbyStateChanged(standby, isStandbyPartNeeded);
+			presentation.setFocus();
+			presentation.standbyStateChanged(standby, false);
 		} catch (RuntimeException e) {
 			Log.error("Exception thrown in intro", e); //$NON-NLS-1$
 		}
 	}
 
-	/**
-	 * Returns true if we need to show the standby part. False in all other
-	 * cases. This basically overrides the workbench behavior of Standby/normal
-	 * states. The design here is that if the showStandbyPart flag is set, then
-	 * we always need to show the standby part.
-	 *
-	 * @return <code>true</code> if we need to show the standby part
-	 */
-	private boolean isStandbyPartNeeded() {
-		return container.getData(IIntroConstants.SHOW_STANDBY_PART) == null ? false : true;
-	}
-
-	/*
-	 * Create standby part. Called only when really needed. We reset the restore
-	 * falg, but we need to tag the intro part as needing standby.
-	 */
-	private void createStandbyPart() {
-		standbyPart = new StandbyPart(model);
-		standbyPart.init(this, getMemento(memento, IIntroConstants.MEMENTO_STANDBY_PART_TAG));
-		standbyPart.createPartControl((Composite) getControl());
-		restoreStandby = false;
-		container.setData(IIntroConstants.SHOW_STANDBY_PART, "true"); //$NON-NLS-1$
-	}
-
-	private void handleSetFocus(boolean standby) {
-		if (standby) {
-			// standby part is null when Intro has not gone into standby state
-			// yet.
-			if (standbyPart != null) {
-				standbyPart.setFocus();
-			}
-		} else {
-			presentation.setFocus();
-		}
-	}
-
 	@Override
 	public void setFocus() {
-		handleSetFocus(IntroPlugin.isIntroStandby());
-	}
-
-	private void setTopControl(Control c) {
-		// container has stack layout. safe to cast.
-		StackLayout layout = (StackLayout) container.getLayout();
-		layout.topControl = c;
-		container.layout();
-	}
-
-	private Control getPresentationControl() {
-		return container.getChildren()[0];
-	}
-
-	private Control getStandbyControl() {
-		// the Container top control may have only one child if the standby
-		// part is not created yet. This happens if the intro never goes into
-		// standby. Doing this for performance.
-		if (standbyPart != null) {
-			return container.getChildren()[1];
+		if (presentation != null) {
+			presentation.setFocus();
 		}
-		return null;
 	}
 
 	IntroPartPresentation getPresentation() {
@@ -359,12 +214,8 @@ public final class CustomizableIntroPart extends IntroPart implements
 	@Override
 	public void dispose() {
 		super.dispose();
-		// call dispose on both parts.
 		if (presentation != null) {
 			presentation.dispose();
-		}
-		if (standbyPart != null) {
-			standbyPart.dispose();
 		}
 		// clear all loaded models since we are disposing of the Intro Part.
 		IntroPlugin.getDefault().getExtensionPointManager().clear();
@@ -379,18 +230,11 @@ public final class CustomizableIntroPart extends IntroPart implements
 	}
 
 	/**
-	 * @return Returns the standbyPart.
-	 */
-	StandbyPart getStandbyPart() {
-		return standbyPart;
-	}
-
-	/**
 	 * Returns the primary control associated with this Intro part.
 	 *
 	 * @return the SWT control which displays this Intro part's content, or
-	 *         <code>null</code> if this standby part's controls have not yet
-	 *         been created.
+	 *         <code>null</code> if this part's controls have not yet been
+	 *         created.
 	 */
 	public Control getControl() {
 		return container;
@@ -398,33 +242,11 @@ public final class CustomizableIntroPart extends IntroPart implements
 
 	@Override
 	public void saveState(IMemento memento) {
-		// give presentation and standby part there own children to create a
-		// name space for each. But save either the presentation or the standby
-		// part as needing to be restored. This way if we close with a standby
-		// mode, we dont get the cached standby part.
-
-		// Find out if presentation or standby is at the top and restore
-		// them. Container has stack layout. safe to cast.
-		boolean restorePresentation = false;
-		StackLayout layout = (StackLayout) container.getLayout();
-		if (getPresentationControl().equals(layout.topControl)) {
-			restorePresentation = true;
-		}
-
 		IMemento presentationMemento = memento
 			.createChild(IIntroConstants.MEMENTO_PRESENTATION_TAG);
-		IMemento standbyPartMemento = memento
-			.createChild(IIntroConstants.MEMENTO_STANDBY_PART_TAG);
-		if (restorePresentation) {
-			presentationMemento.putString(IIntroConstants.MEMENTO_RESTORE_ATT, "true"); //$NON-NLS-1$
-		} else {
-			standbyPartMemento.putString(IIntroConstants.MEMENTO_RESTORE_ATT, "true"); //$NON-NLS-1$
-		}
+		presentationMemento.putString(IIntroConstants.MEMENTO_RESTORE_ATT, "true"); //$NON-NLS-1$
 		if (presentation != null) {
 			presentation.saveState(presentationMemento);
-		}
-		if (standbyPart != null) {
-			standbyPart.saveState(standbyPartMemento);
 		}
 	}
 
@@ -436,17 +258,12 @@ public final class CustomizableIntroPart extends IntroPart implements
 	}
 
 	/**
-	 * Support dynamic awarness.
+	 * Support dynamic awareness.
 	 *
 	 * @see org.eclipse.core.runtime.IRegistryChangeListener#registryChanged(org.eclipse.core.runtime.IRegistryChangeEvent)
 	 */
 	@Override
 	public void registryChanged(final IRegistryChangeEvent event) {
-		// Clear cached models first, then update UI by delegating to
-		// implementation. wrap in synchExec because notification is
-		// asynchronous. The design here is that the notification is centralized
-		// here, then this event propagates and each receiving class reacts
-		// accordingly.
 		Display.getDefault().syncExec(() -> {
 			String currentPageId = model.getCurrentPageId();
 			// clear model, including content providers.


### PR DESCRIPTION
## Summary

Treat the welcome screen like a regular editor by removing the special standby mode and launch bar handling from `CustomizableIntroPart`.

## Changes

- **Simplify `CustomizableIntroPart`**: Remove `StackLayout`, `StandbyPart` handling, and standby memento logic. Use `FillLayout` to show the presentation directly.
- **Deprecate `IntroLaunchBar`** (`forRemoval=true`): The toolbar launch bar is no longer created when the intro is minimized.
- **Deprecate `StandbyPart`** (`forRemoval=true`): Standby content parts are no longer used by the intro framework.
- **Clean up `IntroURL`**: Deprecate `SET_STANDBY_MODE`, `SHOW_STANDBY`, and `SWITCH_TO_LAUNCH_BAR` actions. Remove `switchToLaunchBar()` and `handleStandbyState()` methods; deprecated actions now log warnings and fall back to showing/closing the intro.
- **Deprecate `closeLaunchBar()` and `setLaunchBar()`** in `IntroPlugin`.
- **Remove `<launchBar>` element** from universal intro `plugin.xml`.
- **Bump `org.eclipse.ui.intro` version** to 3.9.0.

## Testing

- `org.eclipse.ui.intro` compiles with 0 errors and no new warnings.

Fixes #2598