### PR TITLE
Improve No Recent Launch Dialog

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2012 IBM Corporation and others.
+ *  Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ public class ContextMessages extends NLS {
 	public static String ContextRunner_7;
 	public static String LaunchingResourceManager_0;
 	public static String LaunchingResourceManager_1;
+	public static String OpenLaunchConfigButton;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, ContextMessages.class);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2007, 2012 IBM Corporation and others.
+#  Copyright (c) 2007, 2026 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ ContextRunner_13=The resource ''{0}'' is not accessible for launching
 ContextRunner_14=As...
 ContextRunner_15=...
 ContextRunner_1={0} Not Supported
+OpenLaunchConfigButton=Open {0} Configuration
 
 #The possible values for {0} are the names of the launch configurations in the current workspace
 LaunchingResourceManager_0={0} (already running)

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextRunner.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/ContextRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2025 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -38,6 +38,9 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.window.Window;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
 
 /**
@@ -153,7 +156,9 @@ public final class ContextRunner {
 				else if(esize < 1) {
 					if(DebugUIPlugin.getDefault().getPreferenceStore().getBoolean(IInternalDebugUIConstants.PREF_LAUNCH_LAST_IF_NOT_LAUNCHABLE)) {
 						if (!launchLast(group, isShift)) {
-							MessageDialog.openInformation(DebugUIPlugin.getShell(), ContextMessages.ContextRunner_0, ContextMessages.ContextRunner_7);
+							openNoRecentLaunchDialog(DebugUIPlugin.getShell(), ContextMessages.ContextRunner_7, mode,
+									group.getIdentifier());
+
 						}
 					} else {
 						if(resource != null) {
@@ -166,12 +171,13 @@ public final class ContextRunner {
 								if(!resource.isAccessible()) {
 									msg = MessageFormat.format(ContextMessages.ContextRunner_13, resource.getName());
 								}
-								MessageDialog.openInformation(DebugUIPlugin.getShell(), ContextMessages.ContextRunner_0, msg);
+								openNoRecentLaunchDialog(DebugUIPlugin.getShell(), msg, mode, group.getIdentifier());
 							}
 						}
 						else {
 							if (!launchLast(group, isShift)) {
-								MessageDialog.openInformation(DebugUIPlugin.getShell(), ContextMessages.ContextRunner_0, ContextMessages.ContextRunner_7);
+								openNoRecentLaunchDialog(DebugUIPlugin.getShell(), ContextMessages.ContextRunner_7,
+										mode, group.getIdentifier());
 							}
 						}
 					}
@@ -185,6 +191,64 @@ public final class ContextRunner {
 					showConfigurationSelectionDialog(configs, mode, isShift);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Returns the label for the launch configuration button based on the given
+	 * launch mode.
+	 *
+	 * @param launchMode launch mode identifier (e.g., run or debug)
+	 * @return the corresponding button label for opening the launch configuration
+	 *         dialog
+	 */
+	private String launchButtonName(String launchMode) {
+		String config = launchMode.substring(0, 1).toUpperCase() + launchMode.substring(1);
+		return NLS.bind(ContextMessages.OpenLaunchConfigButton, config);
+	}
+
+	/**
+	 * Opens a dialog informing the user that no recent launch configuration is
+	 * available. The dialog provides an option to proceed with opening launch
+	 * configuration using the given mode.
+	 *
+	 * @param shell            the parent {@link Shell} for the dialog
+	 * @param message          the message to be displayed in the dialog
+	 * @param mode             the launch mode (e.g., run or debug) used to
+	 *                         determine the button label
+	 * @param launchIdentifier an identifier associated with the launch, used for
+	 *                         handling the action
+	 */
+	private void openNoRecentLaunchDialog(Shell shell, String message, String mode, String launchIdentifier) {
+		LaunchFailedDialog launchDialog = new LaunchFailedDialog(shell,
+				ContextMessages.ContextRunner_0, null, message, MessageDialog.INFORMATION,
+				new String[] { launchButtonName(mode), IDialogConstants.OK_LABEL }, launchIdentifier);
+		launchDialog.open();
+	}
+	/**
+	 * Custom dialog shown when a launch fails with no recent configurations.
+	 * Provides an option to directly open the corresponding launch configuration
+	 * group.
+	 */
+	private static class LaunchFailedDialog extends MessageDialog {
+
+		private final String launchGroup;
+
+		LaunchFailedDialog(Shell parentShell, String dialogTitle, Image dialogTitleImage, String dialogMessage,
+				int dialogImageType, String[] dialogButtonLabels, String launchGroup) {
+			super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, dialogButtonLabels, 1);
+			this.launchGroup = launchGroup;
+		}
+
+		@Override
+		protected void buttonPressed(int buttonId) {
+			if (buttonId == 0) {
+				DebugUITools.openLaunchConfigurationDialogOnGroup(getShell(), null, launchGroup);
+				setReturnCode(buttonId);
+				close();
+				return;
+			}
+			super.buttonPressed(buttonId);
 		}
 	}
 


### PR DESCRIPTION
Adds a new button in the Run/Debug/etc Launch Configuration dialog for the “No Recent Launches” state. This allows users who accidentally click Run or Debug or Any launches without any recent configurations to quickly jump to the corresponding launch configuration group directly from the dialog, without closing it and navigating through the dropdown again.

This improves usability by providing a faster and more convenient recovery path when no recent launches are available.

Before : 

<img width="674" height="170" alt="image" src="https://github.com/user-attachments/assets/e246bcf3-c043-4695-b5dd-7e2c81d386d7" />

After : 
<img width="714" height="189" alt="Screenshot 2026-04-06 at 10 55 05 AM" src="https://github.com/user-attachments/assets/78b608b5-6b4f-4fe1-8b4b-f5618fa2d8d6" />

<img width="718" height="206" alt="Screenshot 2026-04-06 at 10 54 54 AM" src="https://github.com/user-attachments/assets/6c68483e-57de-4ebd-a24b-fe66f0dcab45" />

