### PR TITLE
Update Color constructors to use Device-less versions

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ColorManager.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ColorManager.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import org.eclipse.jface.text.source.ISharedTextColors;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
 /**
@@ -48,7 +47,7 @@ public class ColorManager implements ISharedTextColors {
 			synchronized (fColorTable) {
 				color = fColorTable.get(rgb);
 				if (color == null) {
-					PlatformUI.getWorkbench().getDisplay().syncExec(() -> fColorTable.put(rgb, new Color(Display.getCurrent(), rgb)));
+					PlatformUI.getWorkbench().getDisplay().syncExec(() -> fColorTable.put(rgb, new Color(rgb)));
 					color = fColorTable.get(rgb);
 				}
 			}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 
 /**
@@ -114,22 +113,22 @@ class AntPreviewerUpdater {
 
 		// ----------- foreground color --------------------
 		Color color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT) ? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND, styledText.getDisplay());
+				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND);
 		styledText.setForeground(color);
 
 		// ---------- background color ----------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT) ? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND, styledText.getDisplay());
+				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND);
 		styledText.setBackground(color);
 
 		// ----------- selection foreground color --------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_SELECTION_FOREGROUND_SYSTEM_DEFAULT) ? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_FOREGROUND, styledText.getDisplay());
+				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_FOREGROUND);
 		styledText.setSelectionForeground(color);
 
 		// ---------- selection background color ----------------------
 		color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_SELECTION_BACKGROUND_SYSTEM_DEFAULT) ? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_BACKGROUND, styledText.getDisplay());
+				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_SELECTION_BACKGROUND);
 		styledText.setSelectionBackground(color);
 	}
 
@@ -140,12 +139,10 @@ class AntPreviewerUpdater {
 	 *            the store to read from
 	 * @param key
 	 *            the key used for the lookup in the preference store
-	 * @param display
-	 *            the display used create the color
 	 * @return the created color according to the specification in the preference store
 	 * @since 2.0
 	 */
-	private Color createColor(IPreferenceStore store, String key, Display display) {
+	private Color createColor(IPreferenceStore store, String key) {
 
 		RGB rgb = null;
 
@@ -158,7 +155,7 @@ class AntPreviewerUpdater {
 			}
 
 			if (rgb != null) {
-				return new Color(display, rgb);
+				return new Color(rgb);
 			}
 		}
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/MessageLine.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/MessageLine.java
@@ -73,7 +73,7 @@ public class MessageLine extends CLabel {
 				setText(message);
 				setImage(findImage(status));
 				if (fErrorMsgAreaBackground == null) {
-					fErrorMsgAreaBackground = new Color(getDisplay(), ERROR_BACKGROUND_RGB);
+					fErrorMsgAreaBackground = new Color(ERROR_BACKGROUND_RGB);
 				}
 				setBackground(fErrorMsgAreaBackground);
 				return;

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -194,7 +193,7 @@ public class DebugUIPlugin extends AbstractUIPlugin {
 	public Color getColor(RGB rgb) {
 		Color color = fColors.get(rgb);
 		if (color == null) {
-			color= new Color(Display.getCurrent(), rgb);
+			color= new Color(rgb);
 			fColors.put(rgb, color);
 		}
 		return color;

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
@@ -53,11 +53,11 @@ public class TextConsoleViewerTest {
 			assertTrue(Modifier.isStatic(method.getModifiers()), "Required method <\" + method + \"> is not static.\"");
 
 			final List<StyleRange> styles = new ArrayList<>();
-			colorR = new Color(null, 255, 0, 0);
-			colorG = new Color(null, 0, 255, 0);
-			colorB = new Color(null, 0, 0, 255);
-			colorK = new Color(null, 0, 0, 0);
-			colorW = new Color(null, 255, 255, 255);
+			colorR = new Color(255, 0, 0);
+			colorG = new Color(0, 255, 0);
+			colorB = new Color(0, 0, 255);
+			colorK = new Color(0, 0, 0);
+			colorW = new Color(255, 255, 255);
 
 			// overwrite in empty list
 			method.invoke(null, styles, new StyleRange(5, 5, colorR, null));

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/ColorManager.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/ColorManager.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * Generic color manager.
@@ -43,7 +42,7 @@ public class ColorManager {
 	public Color getColor(RGB rgb) {
 		Color color= fColorTable.get(rgb);
 		if (color == null) {
-			color= new Color(Display.getCurrent(), rgb);
+			color= new Color(rgb);
 			fColorTable.put(rgb, color);
 		}
 		return color;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/AsynchronousViewer.java
@@ -365,7 +365,7 @@ public abstract class AsynchronousViewer extends StructuredViewer implements Lis
 		}
 		Color color = fColorCache.get(rgb);
 		if (color == null) {
-			color = new Color(getControl().getDisplay(), rgb);
+			color = new Color(rgb);
 			fColorCache.put(rgb, color);
 		}
 		return color;

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/breadcrumb/BreadcrumbItemDropDown.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/breadcrumb/BreadcrumbItemDropDown.java
@@ -140,7 +140,7 @@ class BreadcrumbItemDropDown implements IBreadcrumbDropDownSite {
 
 			RGB blend= BreadcrumbViewer.blend(rgb2, rgb1, ratio);
 
-			return new Color(display, blend);
+			return new Color(blend);
 		}
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/viewers/model/TreeModelLabelProvider.java
@@ -198,7 +198,7 @@ public class TreeModelLabelProvider extends ColumnLabelProvider
 		}
 		Color color = fColorCache.get(rgb);
 		if (color == null) {
-			color = new Color(getDisplay(), rgb);
+			color = new Color(rgb);
 			fColorCache.put(rgb, color);
 		}
 		return color;

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/utils/ColorCache.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/utils/ColorCache.java
@@ -23,6 +23,6 @@ public class ColorCache {
 	}
 
 	public static Color get(RGB rgb) {
-		return CACHE.computeIfAbsent(rgb, color -> new Color(null, color));
+		return CACHE.computeIfAbsent(rgb, color -> new Color(color));
 	}
 }

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/UnitTestProgressBar.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/UnitTestProgressBar.java
@@ -57,10 +57,9 @@ public class UnitTestProgressBar extends Canvas {
 			}
 		});
 		addPaintListener(this::paint);
-		Display display = parent.getDisplay();
-		fFailureColor = new Color(display, 159, 63, 63);
-		fOKColor = new Color(display, 95, 191, 95);
-		fStoppedColor = new Color(display, 120, 120, 120);
+		fFailureColor = new Color(159, 63, 63);
+		fOKColor = new Color(95, 191, 95);
+		fStoppedColor = new Color(120, 120, 120);
 	}
 
 	/**

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -1274,7 +1274,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 			if (fIndicatorColor != null) {
 				Display d= fSummaryHeader.getDisplay();
-				e.gc.setBackground(getColor(d, fIndicatorColor));
+				e.gc.setBackground(getColor(fIndicatorColor));
 				int min= Math.min(s.x, s.y)-2*INSET;
 				Rectangle r= new Rectangle((s.x-min)/2, (s.y-min)/2, min, min);
 				e.gc.fillRectangle(r);
@@ -1366,8 +1366,8 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		}
 
 		private StyleRange getStyleRange(Diff diff, IRegion region, boolean showAdditionRemoval) {
-			//Color cText = getColor(null, getTextColor());
-			Color cTextFill = getColor(null, getTextFillColor(diff, showAdditionRemoval));
+			//Color cText = getColor(getTextColor());
+			Color cTextFill = getColor(getTextFillColor(diff, showAdditionRemoval));
 			if (cTextFill == null) {
 				return null;
 			}
@@ -1842,7 +1842,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 		Color bgColor = null;
 		if (fBackground != null) {
-			bgColor = getColor(display, fBackground);
+			bgColor = getColor(fBackground);
 		}
 
 		if (fAncestor != null) {
@@ -1857,7 +1857,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 		Color fgColor = null;
 		if (fForeground != null) {
-			fgColor = getColor(display, fForeground);
+			fgColor = getColor(fForeground);
 		}
 
 		if (fAncestor != null) {
@@ -2435,7 +2435,6 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 			return;
 		}
 
-		Display display= canvas.getDisplay();
 		int y= 0;
 		boolean allOutgoing = allOutgoing();
 		for (Iterator<Diff> iterator = fMerger.rangesIterator(); iterator.hasNext();) {
@@ -2451,12 +2450,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 					hh= 3;
 				}
 
-				c = getColor(display, getFillColor(diff, allOutgoing));
+				c = getColor(getFillColor(diff, allOutgoing));
 				if (c != null) {
 					gc.setBackground(c);
 					gc.fillRectangle(BIRDS_EYE_VIEW_INSET, yy, size.x-(2*BIRDS_EYE_VIEW_INSET),hh);
 				}
-				c = getColor(display, getStrokeColor(diff, allOutgoing));
+				c = getColor(getStrokeColor(diff, allOutgoing));
 				if (c != null) {
 					gc.setForeground(c);
 					r.x= BIRDS_EYE_VIEW_INSET;
@@ -2785,7 +2784,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		}
 
 		if (fBackground != null) { // not default
-			te.setBackground(getColor(parent.getDisplay(), fBackground));
+			te.setBackground(getColor(fBackground));
 		}
 
 		// Add the find action to the popup menu of the viewer
@@ -2863,8 +2862,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 							if (diff != null && updateDiffBackground(diff)) {
 								// highlights only the event line, not the
 								// whole diff
-								event.lineBackground = getColor(fComposite
-										.getDisplay(), getFillColor(diff, allOutgoing()));
+								event.lineBackground = getColor(getFillColor(diff, allOutgoing()));
 							}
 						}
 					}
@@ -4542,8 +4540,8 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				fPts[0]= x;	fPts[1]= ly;	fPts[2]= w;	fPts[3]= ry;
 				fPts[6]= x;	fPts[7]= ly+lh;	fPts[4]= w;	fPts[5]= ry+rh;
 
-				Color fillColor = getColor(display, getFillColor(diff, allOutgoing));
-				Color strokeColor = getColor(display, getStrokeColor(diff, allOutgoing));
+				Color fillColor = getColor(getFillColor(diff, allOutgoing));
+				Color strokeColor = getColor(getStrokeColor(diff, allOutgoing));
 
 				if (fUseSingleLine) {
 					int w2= 3;
@@ -4672,7 +4670,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 					break;
 				}
 
-				g.setBackground(getColor(display, getFillColor(diff, allOutgoing)));
+				g.setBackground(getColor(getFillColor(diff, allOutgoing)));
 				if (right) {
 					g.fillRectangle(x, y, w2, h);
 				} else {
@@ -4680,7 +4678,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				}
 
 				g.setLineWidth(0 /* LW */);
-				g.setForeground(getColor(display, getStrokeColor(diff, allOutgoing)));
+				g.setForeground(getColor(getStrokeColor(diff, allOutgoing)));
 				if (right) {
 					g.drawRectangle(x-1, y-1, w2, h);
 				} else {
@@ -4712,8 +4710,6 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		Control canvas= (Control) event.widget;
 		GC g= event.gc;
 
-		Display display= canvas.getDisplay();
-
 		int w= canvas.getSize().x;
 		int shift = calculateShift(tp) + (2 - LW);
 		int maxh= event.y+event.height; 	// visibleHeight
@@ -4742,7 +4738,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				break;
 			}
 
-			g.setBackground(getColor(display, getStrokeColor(diff, allOutgoing)));
+			g.setBackground(getColor(getStrokeColor(diff, allOutgoing)));
 			g.fillRectangle(0, y-1, w, LW);
 			g.fillRectangle(0, y+h-1, w, LW);
 		}
@@ -4807,7 +4803,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		return selected ? palette.selected : palette.normal;
 	}
 
-	private Color getColor(Display display, RGB rgb) {
+	private Color getColor(RGB rgb) {
 		if (rgb == null) {
 			return null;
 		}
@@ -4816,7 +4812,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		}
 		Color c= fColors.get(rgb);
 		if (c == null) {
-			c= new Color(display, rgb);
+			c= new Color(rgb);
 			fColors.put(rgb, c);
 		}
 		return c;

--- a/team/examples/org.eclipse.compare.examples.xml/src/org/eclipse/compare/examples/xml/ui/MessageLine.java
+++ b/team/examples/org.eclipse.compare.examples.xml/src/org/eclipse/compare/examples/xml/ui/MessageLine.java
@@ -114,7 +114,7 @@ public class MessageLine extends CLabel {
 			setMessage(fMessageText);
 		} else {
 			if (fErrorColor == null) {
-				fErrorColor= new Color(getDisplay(), fErrorRGB);
+				fErrorColor= new Color(fErrorRGB);
 			}
 			setForeground(fErrorColor);
 			setText(message);

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetPage.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetPage.java
@@ -124,16 +124,16 @@ public class CheatSheetPage extends Page implements IMenuContributor {
 	@Override
 	protected void init(Display display) {
 		super.init(display);
-		computeColors(display);
+		computeColors();
 	}
 
-	private void computeColors(Display display) {
+	private void computeColors() {
 		RGB rgb;
 		RGB white = new RGB(255, 255, 255);
 		RGB black = new RGB(0, 0, 0);
 
 		if (isReverseVideo()) {
-			computeReverseVideoColors(display);
+			computeReverseVideoColors();
 			return;
 		}
 
@@ -159,8 +159,8 @@ public class CheatSheetPage extends Page implements IMenuContributor {
 				// blend with blue
 				rgb = FormColors.blend(rgb, new RGB(100, 100, 255), 90);
 			}
-			introColor = new Color(display, rgb);
-			inactiveColor2 = new Color(display, rgb);
+			introColor = new Color(rgb);
+			inactiveColor2 = new Color(rgb);
 		} else {
 			// colored background
 			rgb = toolkit.getColors().getSystemColor(SWT.COLOR_LIST_SELECTION);
@@ -175,26 +175,26 @@ public class CheatSheetPage extends Page implements IMenuContributor {
 			} else if (FormColors.testTwoPrimaryColors(rgb, 240, 256)) {
 				rgb = FormColors.blend(rgb, black, 30);
 			}
-			introColor = new Color(display, rgb);
-			inactiveColor2 = new Color(display, rgb);
+			introColor = new Color(rgb);
+			inactiveColor2 = new Color(rgb);
 		}
 		rgb = inactiveColor2.getRGB();
 		rgb = FormColors.blend(rgb, backgroundColor.getRGB(), 40);
-		inactiveColor1 = new Color(display, rgb);
-		activeColor = new Color(display, backgroundColor.getRGB());
+		inactiveColor1 = new Color(rgb);
+		activeColor = new Color(backgroundColor.getRGB());
 	}
 
-	private void computeReverseVideoColors(Display display) {
+	private void computeReverseVideoColors() {
 		Color background = toolkit.getColors().getBackground();
 		RGB white = new RGB(255, 255, 255);
 		// Create new colors, they will get disposed
 		RGB rgb = background.getRGB();
-		activeColor = new Color(display, rgb );
+		activeColor = new Color(rgb);
 		rgb = FormColors.blend(rgb, white, 85);
-		inactiveColor1 = new Color(display, rgb);
+		inactiveColor1 = new Color(rgb);
 		rgb = FormColors.blend(rgb, white, 85);
-		inactiveColor2 = new Color(display, rgb );
-		introColor = new Color(display, rgb );
+		inactiveColor2 = new Color(rgb);
+		introColor = new Color(rgb);
 	}
 
 	private boolean isReverseVideo() {

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/IntroLaunchBar.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/IntroLaunchBar.java
@@ -40,7 +40,6 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Layout;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.ToolBar;
@@ -294,7 +293,7 @@ public class IntroLaunchBar {
 
 	public void createControl(Composite parent) {
 		container = new Composite(parent, SWT.NULL);
-		computeColors(parent.getDisplay());
+		computeColors();
 		container.setLayout(new BarLayout());
 		toolBarManager = new ToolBarManager(SWT.FLAT | getOrientation());
 
@@ -327,13 +326,13 @@ public class IntroLaunchBar {
 	}
 
 
-	private void computeColors(Display display) {
+	private void computeColors() {
 		if (element.getBackground() != null) {
 			String value = resolveColor(element.getBackground());
 			if (value!=null) {
 				RGB r = SharedStyleManager.parseRGB(value);
 				if (r != null) {
-					bg = new Color(display, r);
+					bg = new Color(r);
 				}
 			}
 		}


### PR DESCRIPTION
Updated all Color constructors in the repo which used the outdated constructor taking a Device/Display argument, as they are now deprecated in SWT. Removed unused Display/Device imports and parameters where applicable.

See: https://github.com/eclipse-platform/eclipse.platform.swt/issues/3232