### PR TITLE
Remove unwanted single quote from links

### DIFF
--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -163,7 +163,7 @@ ComparePreferencePage.previewRight= 1\nincoming addition\nincoming addition\n2\n
 ComparePreferencePage.baseline= \nline 1\nline 2\nremoved line 2a\nremoved line 2b\nline 3\nline 4\nline 5\nline 6\nline to modify 7\nline 8\nremoved words in line 9\n
 ComparePreferencePage.workingCopy= line 1\nline 2\nline 3\nadded words in line 4\nline 5\nadded line 5a\nadded line 6b\nline 6\nmodified line 7\nline 8\nline 9
 
-ComparePreferencePage.colorAndFontLink=See <a>''{0}''</a> preferences for text compare colors and fonts.
+ComparePreferencePage.colorAndFontLink=See <a>{0}</a> preferences for text compare colors and fonts.
 
 textCompareAppearance.label=Text Compare
 

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/Messages.properties
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/Messages.properties
@@ -139,7 +139,7 @@ SearchResultsPart_showCategoriesAction_tooltip=Group by Categories
 SearchResultsPart_showDescriptionAction_tooltip=Show Descriptions
 
 # Preference pages
-HelpPreferencePage_message=See <a>''{0}''</a> for configuring the external browser used to display help topics.
+HelpPreferencePage_message=See <a>{0}</a> for configuring the external browser used to display help topics.
 HelpPreferencePage_openModeGroup=Open Modes
 HelpPreferencePage_contextHelpGroup=Context help
 HelpPreferencePage_infopop= In an infopop


### PR DESCRIPTION
This PR removes unwanted single quotes from the label links shown in Preference pages and make links in preference page consistent

Before:
<img width="1766" height="854" alt="before_compare" src="https://github.com/user-attachments/assets/fd8eb9ad-54e2-4374-812f-d090e1a2aa95" />
<img width="1864" height="530" alt="before_help" src="https://github.com/user-attachments/assets/949f2556-a5b9-46e2-b532-0a7980acf858" />

After:
<img width="1516" height="858" alt="help_tag" src="https://github.com/user-attachments/assets/66b07a0a-329e-479a-931c-e044367d4b5a" />
<img width="1506" height="886" alt="txt_compare_after" src="https://github.com/user-attachments/assets/a98ef148-f712-49dc-99c5-2fd583ec206d" />

