### PR TITLE
Replace Plugin.getLog() with static ILog.of(Class)

### DIFF
--- a/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntCorePlugin.java
+++ b/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntCorePlugin.java
@@ -22,6 +22,7 @@ import org.eclipse.ant.internal.core.AntClassLoader;
 import org.eclipse.ant.internal.core.AntCoreUtil;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
@@ -302,6 +303,6 @@ public class AntCorePlugin extends Plugin {
 	 */
 	public static void log(Throwable t) {
 		IStatus status = new Status(IStatus.ERROR, PI_ANTCORE, INTERNAL_ERROR, "Error logged from Ant Core: ", t); //$NON-NLS-1$
-		getPlugin().getLog().log(status);
+		ILog.of(AntCorePlugin.class).log(status);
 	}
 }

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUIPlugin.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUIPlugin.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import org.eclipse.ant.internal.core.IAntCoreConstants;
 import org.eclipse.ant.internal.ui.editor.DecayCodeCompletionDataStructuresThread;
 import org.eclipse.ant.internal.ui.editor.text.AntEditorDocumentProvider;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -124,7 +125,7 @@ public class AntUIPlugin extends AbstractUIPlugin {
 	 *            status
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.of(AntUIPlugin.class).log(status);
 	}
 
 	/**

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/variables/VariablesPlugin.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/variables/VariablesPlugin.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.variables;
 
 import org.eclipse.core.internal.variables.StringVariableManager;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
@@ -96,7 +97,7 @@ public class VariablesPlugin extends Plugin {
 	 * @param status status to log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.of(VariablesPlugin.class).log(status);
 	}
 
 	/**

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/ConsolePlugin.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/ConsolePlugin.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.console;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -83,7 +84,7 @@ public class ConsolePlugin extends AbstractUIPlugin {
 	 * @param status status to log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.of(ConsolePlugin.class).log(status);
 	}
 
 	/**

--- a/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/UnitTestPlugin.java
+++ b/debug/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/UnitTestPlugin.java
@@ -19,6 +19,7 @@ import org.eclipse.unittest.internal.model.UnitTestLaunchListener;
 import org.eclipse.unittest.internal.model.UnitTestModel;
 import org.eclipse.unittest.internal.ui.history.History;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -73,7 +74,7 @@ public class UnitTestPlugin extends AbstractUIPlugin {
 	 * @param status the status to log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.of(UnitTestPlugin.class).log(status);
 	}
 
 	@Override

--- a/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/Activator.java
+++ b/team/bundles/org.eclipse.compare.win32/src/org/eclipse/compare/internal/win32/Activator.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.internal.win32;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
@@ -66,6 +67,6 @@ public class Activator extends Plugin {
 	}
 
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.of(Activator.class).log(status);
 	}
 }


### PR DESCRIPTION
## Summary
- Switch six single-call-site static `log(IStatus)` helpers to `ILog.of(SomeClass.class)` instead of routing through the plugin singleton.
- Removes the last logging-only reason these bundles rely on `getDefault()` / `getPlugin()`, and logging now works even before the activator has stored the singleton.
- No MANIFEST changes required — all affected bundles already require `org.eclipse.core.runtime >= 3.29`, which is when `ILog.of(Class)` was introduced.

Affected bundles:
- `org.eclipse.compare.win32`
- `org.eclipse.unittest.ui`
- `org.eclipse.ui.console`
- `org.eclipse.core.variables`
- `org.eclipse.ant.core`
- `org.eclipse.ant.ui`

Part of an effort to identify activators / `getDefault()` usages that can be simplified or replaced. These six are the lowest-risk starting point — each bundle has exactly one `getDefault().getLog()` call site.

## Test plan
- [ ] CI build succeeds
- [ ] No API baseline warnings for the six bundles
- [ ] Logging still functions (spot-check: trigger a logged error in one of the affected plug-ins)