### PR TITLE
Collapse inline Status allocations to ILog.of(Class) log sites

### DIFF
--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDADebugTarget.java
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDADebugTarget.java
@@ -31,6 +31,7 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IMarkerDelta;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -121,8 +122,7 @@ public class PDADebugTarget extends PDADebugElement implements IDebugTarget, IBr
 							event = PDAEvent.parseEvent(message);
 						}
 						catch (IllegalArgumentException e) {
-							DebugCorePlugin.getDefault().getLog().log(
-								new Status (IStatus.ERROR, "org.eclipse.debug.examples.core", "Error parsing PDA event", e)); //$NON-NLS-1$ //$NON-NLS-2$
+							ILog.of(PDADebugTarget.class).error("Error parsing PDA event", e); //$NON-NLS-1$
 							continue;
 						}
 						for (Object listener : fEventListeners.toArray()) {

--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -29,6 +29,7 @@ import org.eclipse.cdt.utils.pty.PTY;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
@@ -41,7 +42,6 @@ import org.eclipse.terminal.connector.ISettingsStore;
 import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.InMemorySettingsStore;
 import org.eclipse.terminal.connector.TerminalConnectorExtension;
-import org.eclipse.terminal.connector.local.activator.UIPlugin;
 import org.eclipse.terminal.connector.local.controls.LocalWizardConfigurationPanel;
 import org.eclipse.terminal.connector.process.ProcessSettings;
 import org.eclipse.terminal.view.core.ILineSeparatorConstants;
@@ -147,7 +147,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 					}
 				} catch (CoreException ex) {
 					if (Platform.inDebugMode()) {
-						UIPlugin.getDefault().getLog().log(ex.getStatus());
+						ILog.of(LocalLauncherDelegate.class).log(ex.getStatus());
 					}
 				}
 			}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/actions/AbstractAction.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/actions/AbstractAction.java
@@ -16,15 +16,13 @@ import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.expressions.EvaluationContext;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.terminal.control.ITerminalViewControl;
 import org.eclipse.terminal.view.ui.internal.Messages;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderManager;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderToolbarHandler;
 import org.eclipse.ui.ISources;
@@ -118,11 +116,10 @@ public abstract class AbstractAction extends AbstractTerminalAction {
 
 					handlerSvc.executeCommandInContext(pCmd, null, context);
 				} catch (Exception e) {
-					IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
+					ILog.of(AbstractAction.class).error(
 							NLS.bind(Messages.AbstractAction_error_commandExecutionFailed, getCommandId(),
 									e.getLocalizedMessage()),
 							e);
-					UIPlugin.getDefault().getLog().log(status);
 				}
 			}
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/actions/NewTerminalViewAction.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/actions/NewTerminalViewAction.java
@@ -15,9 +15,8 @@ package org.eclipse.terminal.view.ui.internal.actions;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.terminal.view.ui.ITerminalsView;
 import org.eclipse.terminal.view.ui.internal.ImageConsts;
@@ -64,9 +63,7 @@ public class NewTerminalViewAction extends AbstractTerminalAction {
 			} catch (Exception e) {
 				// If the platform is in debug mode, we print the exception to the log view
 				if (Platform.inDebugMode()) {
-					IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
-							Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
-					UIPlugin.getDefault().getLog().log(status);
+					ILog.of(NewTerminalViewAction.class).error(Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
 				}
 			}
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/handler/AbstractTriggerCommandHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/handler/AbstractTriggerCommandHandler.java
@@ -17,12 +17,10 @@ import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.expressions.EvaluationContext;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.terminal.view.ui.internal.Messages;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.ui.ISources;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
@@ -59,9 +57,7 @@ public abstract class AbstractTriggerCommandHandler extends AbstractHandler {
 			} catch (Exception e) {
 				// If the platform is in debug mode, we print the exception to the log view
 				if (Platform.inDebugMode()) {
-					IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
-							Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
-					UIPlugin.getDefault().getLog().log(status);
+					ILog.of(AbstractTriggerCommandHandler.class).error(Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
 				}
 			}
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/preferences/PreferencePage.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/preferences/PreferencePage.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
@@ -313,7 +314,7 @@ public class PreferencePage extends org.eclipse.jface.preference.PreferencePage 
 						dialog.setFilterPath(resolved);
 					} catch (CoreException ex) {
 						if (Platform.inDebugMode()) {
-							UIPlugin.getDefault().getLog().log(ex.getStatus());
+							ILog.of(PreferencePage.class).log(ex.getStatus());
 						}
 					}
 				}
@@ -676,7 +677,7 @@ public class PreferencePage extends org.eclipse.jface.preference.PreferencePage 
 						p.toFile().canRead() && p.toFile().isDirectory() ? text.trim() : ""); //$NON-NLS-1$
 			} catch (CoreException e) {
 				if (Platform.inDebugMode()) {
-					UIPlugin.getDefault().getLog().log(e.getStatus());
+					ILog.of(PreferencePage.class).log(e.getStatus());
 				}
 			}
 		}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsView.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsView.java
@@ -24,10 +24,9 @@ import org.eclipse.core.expressions.EvaluationContext;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -56,7 +55,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.terminal.view.ui.ITerminalsView;
 import org.eclipse.terminal.view.ui.internal.Messages;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderManager;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderMenuHandler;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderToolbarHandler;
@@ -734,9 +732,7 @@ public class TerminalsView extends ViewPart implements ITerminalsView, IShowInTa
 						} catch (Exception e) {
 							// If the platform is in debug mode, we print the exception to the log view
 							if (Platform.inDebugMode()) {
-								IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
-										Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
-								UIPlugin.getDefault().getLog().log(status);
+								ILog.of(TerminalsView.class).error(Messages.AbstractTriggerCommandHandler_error_executionFailed, e);
 							}
 						}
 					}

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/InputStreamMonitor.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/InputStreamMonitor.java
@@ -19,13 +19,11 @@ import java.util.List;
 import java.util.Queue;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.view.core.ILineSeparatorConstants;
 import org.eclipse.terminal.view.ui.internal.Messages;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.ui.services.IDisposable;
 
 /**
@@ -265,10 +263,8 @@ public class InputStreamMonitor extends OutputStream implements IDisposable {
 				} catch (IOException e) {
 					// IOException received. If this is happening when already disposed -> ignore
 					if (!disposed && !disposalComing) {
-						IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
-								NLS.bind(Messages.InputStreamMonitor_error_writingToStream, e.getLocalizedMessage()),
-								e);
-						UIPlugin.getDefault().getLog().log(status);
+						ILog.of(InputStreamMonitor.class).error(
+								NLS.bind(Messages.InputStreamMonitor_error_writingToStream, e.getLocalizedMessage()), e);
 					}
 				} catch (InterruptedException e) {
 					break;

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/OutputStreamMonitor.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/streams/OutputStreamMonitor.java
@@ -18,9 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ListenerList;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.terminal.connector.ITerminalControl;
 import org.eclipse.terminal.view.core.ILineSeparatorConstants;
@@ -220,18 +219,16 @@ public class OutputStreamMonitor implements IDisposable {
 			} catch (IOException e) {
 				// IOException received. If this is happening when already disposed -> ignore
 				if (!disposed && !disposalComing) {
-					IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
+					ILog.of(OutputStreamMonitor.class).error(
 							NLS.bind(Messages.OutputStreamMonitor_error_readingFromStream, e.getLocalizedMessage()), e);
-					UIPlugin.getDefault().getLog().log(status);
 				}
 				break;
 			} catch (NullPointerException e) {
 				// killing the stream monitor while reading can cause an NPE
 				// when reading from the stream
 				if (!disposed && thread != null && !disposalComing) {
-					IStatus status = new Status(IStatus.ERROR, UIPlugin.getUniqueIdentifier(),
+					ILog.of(OutputStreamMonitor.class).error(
 							NLS.bind(Messages.OutputStreamMonitor_error_readingFromStream, e.getLocalizedMessage()), e);
-					UIPlugin.getDefault().getLog().log(status);
 				}
 				break;
 			}


### PR DESCRIPTION
## Summary

Replaces `Plugin.getDefault().getLog().log(new Status(...))` with `ILog.of(MyClass.class).error(...)` / `.log(status)` in non-activator classes, dropping the activator round-trip and the `Status` allocation where applicable. Follow-up to the counterpart cleanup in [eclipse-platform/eclipse.platform.ui](https://github.com/eclipse-platform/eclipse.platform.ui).

Scope of this PR is intentionally narrow: only sites where the class and the previously-used activator live in the **same bundle**, so log attribution is unchanged. Remaining sites (activator static `log()` helpers, utility `Log` classes, cross-bundle attribution, etc.) are deferred to follow-up PRs so each category can be reviewed on its own merits.

Files touched (9):
- `debug/org.eclipse.debug.examples.core` — `PDADebugTarget`
- `terminal/org.eclipse.terminal.connector.local` — `LocalLauncherDelegate`
- `terminal/org.eclipse.terminal.view.ui` — `PreferencePage`, `TerminalsView`, `AbstractAction`, `NewTerminalViewAction`, `AbstractTriggerCommandHandler`, `InputStreamMonitor`, `OutputStreamMonitor`

Context: vogellacompany/tasks#1837

## Test plan

- [ ] `mvn clean verify -Pbuild-individual-bundles` on each affected bundle
- [ ] PDE API Tools: no new baseline errors (no API signatures change)
- [ ] Spot-check at runtime: trigger one of the catch branches and confirm the log entry still lands in `.log` with the expected bundle id