### PR TITLE
Migrate test fixtures to non-deprecated contentTypes extension point

### DIFF
--- a/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle01/plugin.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle01/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
-	<extension point="org.eclipse.core.runtime.contentTypes">
+	<extension point="org.eclipse.core.contenttype.contentTypes">
 		<content-type id="missing" name="Missing"/>
 	</extension>	
 </plugin>

--- a/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle02/plugin.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle02/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
-	<extension point="org.eclipse.core.runtime.contentTypes">
+	<extension point="org.eclipse.core.contenttype.contentTypes">
 		<content-type id="missing-target" name="Missing alias target"
 		file-extensions="missing-target"/>		
 	</extension>	

--- a/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle03/plugin.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle03/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
-      <extension point="org.eclipse.core.runtime.contentTypes">
+      <extension point="org.eclipse.core.contenttype.contentTypes">
       <!-- this content type has an invalid describer, it should never be picked on content-based content type lookup -->
       <content-type
             name="Invalid Describer"

--- a/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle04/plugin.xml
+++ b/resources/tests/org.eclipse.core.tests.resources/Plugin_Testing/content/bundle04/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
-	<extension point="org.eclipse.core.runtime.contentTypes">
+	<extension point="org.eclipse.core.contenttype.contentTypes">
 		<content-type id="empty_extension1" name="Empty Extension 1" file-extensions=""/>	
 		<content-type id="empty_extension2" name="Empty Extension 2" file-extensions="foo,"/>
 		<content-type id="empty_extension3" name="Empty Extension 3" file-extensions=",foo"/>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/IContentTypeManagerTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/content/IContentTypeManagerTest.java
@@ -204,7 +204,7 @@ public class IContentTypeManagerTest {
 		assertThat(selected).containsExactly(alias, derived);
 
 		// test late addition of content type
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME,
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME,
 				ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		BundleTestingHelper.runWithBundles(() -> {
 			IContentType alias1 = contentTypeManager.getContentType(PI_RESOURCES_TESTS + ".alias");
@@ -761,7 +761,7 @@ public class IContentTypeManagerTest {
 		assertEquals(text[0], text[1]);
 		assertEquals(text[0], text[1]);
 		// make arbitrary dynamic changes to the contentTypes extension point
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME,
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME,
 				ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		BundleTestingHelper.runWithBundles(() -> {
 			IContentType missing = manager.getContentType("org.eclipse.bundle01.missing");
@@ -1031,7 +1031,7 @@ public class IContentTypeManagerTest {
 		assertThat(finder.findContentTypesFor("invalid.missing.identifier")).isEmpty();
 		assertThat(finder.findContentTypesFor("invalid.missing.name")).isEmpty();
 		assertNull(contentTypeManager.getContentType(PI_RESOURCES_TESTS + '.' + "invalid-missing-name"));
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME,
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME,
 				ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		BundleTestingHelper.runWithBundles(() -> {
 			// ensure the invalid content types are not available
@@ -1173,7 +1173,7 @@ public class IContentTypeManagerTest {
 		IContentType[] selected = manager.findContentTypesFor("file_with_no_extension");
 		assertThat(selected).isEmpty();
 
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME,
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME,
 				ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		BundleTestingHelper.runWithBundles(() -> {
 			final String namespace = "org.eclipse.bundle04";
@@ -1240,7 +1240,7 @@ public class IContentTypeManagerTest {
 		assertThat(contentTypeManager.findContentTypesFor("foo.orphan2")).isEmpty();
 
 		// test late addition of content type - orphan2 should become visible
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME,
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME,
 				ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 
 		BundleTestingHelper.runWithBundles(() -> {


### PR DESCRIPTION
The `org.eclipse.core.runtime.contentTypes` extension point was deprecated in 2018 and is being removed in #1644. This swaps the four test fixture `plugin.xml` files in `org.eclipse.core.tests.resources` over to the canonical successor `org.eclipse.core.contenttype.contentTypes`. The child element schema is identical, so this is a mechanical id swap with no behavioral change.

The fixtures are intentionally kept — they provide negative-case coverage (missing names, invalid describers, empty file-extensions, missing alias targets) for the content-type registry tests.