### PR TITLE
Improve Compare With Clipboard Editor title

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ClipboardCompare.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.graphics.Image;
@@ -178,6 +179,7 @@ public class ClipboardCompare extends BaseCompareAction implements IObjectAction
 
 			}
 		};
+		compareInput.setTitle(NLS.bind(CompareMessages.CompareWithClipboardTitle, fileName));
 		CompareUI.openCompareEditor(compareInput);
 	}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -132,6 +132,7 @@ public final class CompareMessages extends NLS {
 	public static String CompareStructureViewerSwitchingPane_discoveredLabel;
 
 	public static String ReaderCreator_fileIsNotAccessible;
+	public static String CompareWithClipboardTitle;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2019 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -146,3 +146,5 @@ CompareStructureViewerSwitchingPane_switchButtonTooltip=Switch Structure Compare
 CompareStructureViewerSwitchingPane_discoveredLabel={0} Structure Compare
 
 ReaderCreator_fileIsNotAccessible=Cannot create a reader because the file is inaccessible.
+
+CompareWithClipboardTitle=Compare {0} and Clipboard


### PR DESCRIPTION
This PR improves compare with clipboard's editor title similar to other editor compare titles.

Before 
<img width="154" height="42" alt="image" src="https://github.com/user-attachments/assets/a57fb285-7d5c-4b43-b8a3-0de9008dc561" />

After 
<img width="374" height="43" alt="Screenshot 2026-04-27 at 7 40 53 AM" src="https://github.com/user-attachments/assets/9b04ad58-b4b5-4173-889e-7f540d784791" />
