### PR TITLE
Remove unwanted single quote from links

### DIFF
--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreferencesMessages.properties
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2010 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -155,7 +155,7 @@ AntEditorPreferencePage_2=&Mark occurrences of the selected element in the curre
 AntEditorPreferencePage_4=&Keep marks when selection changes
 
 # DO NOT TRANSLATE "org.eclipse.ui.preferencePages.GeneralTextEditor" and "org.eclipse.ui.preferencePages.ColorsAndFonts"
-AntEditorPreferencePage_0=See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">'Text Editors'</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">'Colors and Fonts'</a> to configure the font.
+AntEditorPreferencePage_0=See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">Text Editors</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">Colors and Fonts</a> to configure the font.
 
 ClasspathModel_2=Ant Home Entries
 ClasspathModel_3=Global Entries


### PR DESCRIPTION
This commit removes unwanted single quotes from label links in the Ant editor’s Preference pages and makes links across Preference pages consistent.
Before:
<img width="1938" height="1386" alt="image" src="https://github.com/user-attachments/assets/5863bc73-1e98-409f-83fe-ac8fd142c866" />
After:
<img width="1684" height="1094" alt="image" src="https://github.com/user-attachments/assets/fd98c617-3bb5-497f-b8c0-bc12e92df099" />
