### PR TITLE
Remove unwanted single quote from links

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/DebugPreferencesMessages.properties
@@ -37,7 +37,7 @@ ConsoleDefaultElapsedTimeFormat=H:MM:SS
 ConsoleElapsedTimeToolTip=Supports formats like: 'H:MM:SS.mmm', 'MMm SSs', 'H:MM:SS' \nYou can also use positional parameters \n%1$ = (H)hours\n%2$ = (M)minutes\n%3$ = (S)seconds\n%4$ = (mmm)milliseconds
 ConsoleDisableElapsedTime=None
 ConsolePreferencePage_ConsoleIconUpdate=Update Console icon based on currently active page
-ConsoleFontSettingsLink=To configure font style settings, see <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">'Font Styles'</a> preferences
+ConsoleFontSettingsLink=To configure font style settings, see <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">Font Styles</a> preferences
 
 DebugPreferencePage_1=General Settings for Running and Debugging.
 DebugPreferencePage_2=Re&use editor when displaying source code


### PR DESCRIPTION
This commit removes unwanted single quotes from label links in the Run/Debug console Preference pages and makes links across Preference pages consistent.
Before:
<img width="2112" height="900" alt="image" src="https://github.com/user-attachments/assets/cf05af45-4805-4205-8b2d-ad97dd1f8f87" />

After:
<img width="2168" height="1530" alt="image" src="https://github.com/user-attachments/assets/d7899a6d-12a7-4bf8-9be4-6a3f926b67c8" />
