### PR TITLE
Fix random failing testBug546710_ConsoleCreationRaceCondition #596

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
@@ -148,6 +148,6 @@ public class ProcessConsoleManagerTests {
 		removeAction.run();
 		TestUtil.waitForJobs(testInfo.getDisplayName(), ProcessConsoleManager.class, 0, 10000);
 		assertNull(processConsoleManager.getConsole(process1), "First console not removed.");
-		assertNull(processConsoleManager.getConsole(process1), "Second console not removed.");
+		assertNull(processConsoleManager.getConsole(process2), "Second console not removed.");
 	}
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsoleManager.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsoleManager.java
@@ -69,6 +69,13 @@ public class ProcessConsoleManager implements ILaunchListener {
 			if (monitor.isCanceled() || getConsoleDocument(process) != null) {
 				return Status.CANCEL_STATUS;
 			}
+			// If a launch is removed the associated console is removed too. It can happen
+			// that the launch is removed even before the console could be created.
+			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=546710#c13
+			ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+			if (!launchManager.isRegistered(launch)) {
+				return Status.CANCEL_STATUS;
+			}
 			IConsoleColorProvider colorProvider = getColorProvider(process.getAttribute(IProcess.ATTR_PROCESS_TYPE));
 			String encoding = launch.getAttribute(DebugPlugin.ATTR_CONSOLE_ENCODING);
 			ProcessConsole pc = new ProcessConsole(process, colorProvider, encoding);
@@ -77,10 +84,8 @@ public class ProcessConsoleManager implements ILaunchListener {
 			// add new console to console manager.
 			ConsolePlugin.getDefault().getConsoleManager().addConsoles(new IConsole[] { pc });
 
-			// If a launch is removed the associated console is removed too. It can happen
-			// that the launch is removed even before the console could be created.
-			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=546710#c13
-			ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+			// Check again: the launch may have been removed while the console was being
+			// created (race between console creation and launch removal).
 			if (!launchManager.isRegistered(launch)) {
 				removeLaunch(launch);
 			}
@@ -139,6 +144,13 @@ public class ProcessConsoleManager implements ILaunchListener {
 
 	protected void removeLaunch(ILaunch launch) {
 		for (IProcess process : launch.getProcesses()) {
+			// Cancel any pending ConsoleCreation jobs for this process to prevent
+			// creating a console for an already-removed launch.
+			for (Job job : Job.getJobManager().find(process)) {
+				if (job instanceof ConsoleCreation) {
+					job.cancel();
+				}
+			}
 			removeProcess(process);
 		}
 		if (fProcesses != null) {


### PR DESCRIPTION
- Cancel all instances of ConsoleCreationJob for a given process when removing a launch.
- Skip the creation of a console for a launch that has been canceled already.
- Adapt assertion in test (it was checking the wrong console)

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/596