### PR TITLE
Fix progress overshoot >100% in Synchronize refresh jobs

### DIFF
--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/RefreshModelParticipantJob.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/RefreshModelParticipantJob.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.team.core.diff.IDiff;
 import org.eclipse.team.core.diff.IDiffChangeEvent;
@@ -77,11 +78,12 @@ public class RefreshModelParticipantJob extends RefreshParticipantJob {
 		ISynchronizationContext context = ((ModelSynchronizeParticipant)getParticipant()).getContext();
 		try {
 			context.getDiffTree().addDiffChangeListener((ChangeDescription)changeListener);
+			SubMonitor sub = SubMonitor.convert(monitor, 100);
 			// TODO: finer grained refresh
-			context.refresh(mappings, monitor);
+			context.refresh(mappings, sub.split(80));
 			// Wait for any asynchronous updating to complete
 			try {
-				Job.getJobManager().join(context, monitor);
+				Job.getJobManager().join(context, sub.split(20));
 			} catch (InterruptedException e) {
 				// Ignore
 			}

--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/RefreshSubscriberParticipantJob.java
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/internal/ui/synchronize/RefreshSubscriberParticipantJob.java
@@ -16,6 +16,7 @@ package org.eclipse.team.internal.ui.synchronize;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.team.core.TeamException;
 import org.eclipse.team.core.subscribers.Subscriber;
 import org.eclipse.team.core.synchronize.SyncInfo;
@@ -119,11 +120,16 @@ public class RefreshSubscriberParticipantJob extends RefreshParticipantJob {
 		if (subscriber != null) {
 			try {
 				subscriber.addListener((RefreshChangeListener)changeListener);
-				subscriber.refresh(resources, IResource.DEPTH_INFINITE, monitor);
-				getCollector().waitForCollector(monitor);
+				SubMonitor sub = SubMonitor.convert(monitor, 100);
+				subscriber.refresh(resources, IResource.DEPTH_INFINITE, sub.split(80));
+				waitForCollector(sub.split(20));
 			} finally {
 				subscriber.removeListener((RefreshChangeListener)changeListener);
 			}
 		}
+	}
+
+	protected void waitForCollector(IProgressMonitor monitor) {
+		getCollector().waitForCollector(monitor);
 	}
 }

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/internal/ui/synchronize/RefreshSubscriberParticipantJobProgressTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/internal/ui/synchronize/RefreshSubscriberParticipantJobProgressTests.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Foxy BOA and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Foxy BOA - initial implementation, issue #2645
+ *******************************************************************************/
+package org.eclipse.team.internal.ui.synchronize;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.team.core.TeamException;
+import org.eclipse.team.core.subscribers.Subscriber;
+import org.eclipse.team.tests.core.mapping.ScopeTestSubscriber;
+import org.eclipse.team.ui.synchronize.ISynchronizePageConfiguration;
+import org.eclipse.team.ui.synchronize.SubscriberParticipant;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for issue #2645: {@link RefreshSubscriberParticipantJob#doRefresh
+ * RefreshSubscriberParticipantJob.doRefresh} must split its progress monitor between
+ * {@code subscriber.refresh} and {@code waitForCollector} instead of handing the same
+ * monitor to both.
+ */
+public class RefreshSubscriberParticipantJobProgressTests {
+
+	private static class CountingMonitor extends NullProgressMonitor {
+		volatile double total;
+
+		@Override
+		public void worked(int work) {
+			total += work;
+		}
+
+		@Override
+		public void internalWorked(double work) {
+			total += work;
+		}
+	}
+
+	private static class ConsumingSubscriber extends ScopeTestSubscriber {
+		@Override
+		public void refresh(IResource[] resources, int depth, IProgressMonitor monitor) {
+			SubMonitor sm = SubMonitor.convert(monitor, 100);
+			sm.worked(100);
+			sm.done();
+		}
+	}
+
+	private static class TestableJob extends RefreshSubscriberParticipantJob {
+		private final Subscriber subscriberOverride;
+
+		TestableJob(SubscriberParticipant participant, IResource[] resources, Subscriber subscriber) {
+			super(participant, "test-job", "test-task", resources, null);
+			this.subscriberOverride = subscriber;
+		}
+
+		@Override
+		protected Subscriber getSubscriber() {
+			return subscriberOverride;
+		}
+
+		@Override
+		protected void waitForCollector(IProgressMonitor monitor) {
+			SubMonitor sm = SubMonitor.convert(monitor, 100);
+			sm.worked(100);
+			sm.done();
+		}
+
+		void invokeDoRefresh(RefreshChangeListener changeDescription, IProgressMonitor monitor) throws TeamException {
+			doRefresh(changeDescription, monitor);
+		}
+	}
+
+	@Test
+	public void doRefreshDoesNotOverConsumeParentMonitor() throws Exception {
+		ConsumingSubscriber subscriber = new ConsumingSubscriber();
+		SubscriberParticipant participant = new SubscriberParticipant() {
+			@Override
+			public Subscriber getSubscriber() {
+				return subscriber;
+			}
+
+			@Override
+			protected void initializeConfiguration(ISynchronizePageConfiguration configuration) {
+				// not needed for this test
+			}
+		};
+
+		TestableJob job = new TestableJob(participant, new IResource[0], subscriber);
+		RefreshChangeListener changeDescription = new RefreshChangeListener(new IResource[0], null);
+
+		CountingMonitor parent = new CountingMonitor();
+		parent.beginTask("test", 100);
+		job.invokeDoRefresh(changeDescription, parent);
+		parent.done();
+
+		// Without the fix, both consumers receive the same monitor and parent.total ~= 2000.
+		// With the fix, doRefresh splits the parent 80/20 and parent.total ~= 1000.
+		assertTrue(parent.total <= 1500,
+				"Parent monitor over-consumed: total=" + parent.total + " (expected <= 1500)");
+	}
+}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.team.tests.core;
 
+import org.eclipse.team.internal.ui.synchronize.RefreshSubscriberParticipantJobProgressTests;
 import org.eclipse.team.tests.core.regression.AllTeamRegressionTests;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -20,6 +21,7 @@ import org.junit.platform.suite.api.Suite;
 @Suite
 @SelectClasses({ //
 		AllTeamRegressionTests.class, //
+		RefreshSubscriberParticipantJobProgressTests.class, //
 		RepositoryProviderTests.class, //
 		StorageMergerTests.class, //
 		StreamTests.class, //


### PR DESCRIPTION
## Summary

Fixes #2645.

`RefreshSubscriberParticipantJob.doRefresh` (and the sibling `RefreshModelParticipantJob.doRefresh`) were handing the same `IProgressMonitor` instance to two sequential consumers — for the Subscriber job: `subscriber.refresh(...)` then `SubscriberSyncInfoCollector.waitForCollector(...)`; for the Model job: `context.refresh(...)` then `Job.getJobManager().join(...)`. Each consumer treated the monitor as exclusively its own and reported its full budget against the parent, which is how the JobManager group ends up displaying 115–160 % for Synchronize jobs (originally observed with the Subversive subscriber, but reproducible with any team provider).

Both methods now wrap the incoming monitor with `SubMonitor.convert(monitor, 100)` and split 80/20 between the two consumers, mirroring the existing 80/20 split already in use in `RefreshParticipantJob.initialize` (`setProgressGroup(group, 80)` + `handleProgressGroupSet(group, 20)`).

## Changes

- `RefreshSubscriberParticipantJob.doRefresh`: split monitor 80/20.
- `RefreshSubscriberParticipantJob`: new `protected void waitForCollector(IProgressMonitor)` seam delegating to `getCollector().waitForCollector(...)`. Production code shape is unchanged for clients (the seam is internal-only, x-friends).
- `RefreshModelParticipantJob.doRefresh`: same split applied to the sibling code path (same antipattern).
- New regression test `RefreshSubscriberParticipantJobProgressTests` in `org.eclipse.team.tests.core`, wired into `AllTeamTests`. It overrides the new seam in a `TestableJob` to imitate a greedy collector.

## Test plan

- The new test reports `parent.total = 2000` against the unfixed code and `parent.total ≈ 1000` with the fix; threshold is `≤ 1500`.
- All other tests in `AllTeamTests` still pass.
- Verified locally with `mvn -pl team/bundles/org.eclipse.team.core,team/bundles/org.eclipse.team.ui,team/tests/org.eclipse.team.tests.core,team/tests/org.eclipse.compare.tests,runtime/tests/org.eclipse.core.tests.harness,resources/tests/org.eclipse.core.tests.resources,resources/tests/org.eclipse.core.tests.filesystem.feature clean install -Dtest=AllTeamTests -DfailIfNoTests=false` → BUILD SUCCESS, 22 tests, 0 failures.

## Notes for review

- The 80/20 split is intentional, not arbitrary: it matches the existing budget split in `RefreshParticipantJob.initialize`. Empirically `subscriber.refresh` does the bulk of the wall time and `waitForCollector` the tail.
- Reported and diagnosed originally via the Subversive client, but the antipattern (and the fix) are entirely in `o.e.team.ui` — no SCM-provider-specific code involved.