### PR TITLE
Fixes BreakpointLabelAction being enabled when selecting a BreakpointContainer

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -1502,6 +1502,9 @@
                menubarPath="breakpointGroup"
                enablesFor="1"
                id="org.eclipse.debug.ui.breakpointsView.breakpointLabel">
+           <selection
+                 class="org.eclipse.debug.core.model.IBreakpoint">
+           </selection>
         </action>
         <action
                label="%DisableAllBreakpointsAction.label"


### PR DESCRIPTION
Currently, the BreakpointLabelAction is enabled when selecting a single BreakpointContainer (e.g. by grouping the breakpoints view by enablement state and selecting the "Enabled" group entry). 

<img width="1435" height="322" alt="image" src="https://github.com/user-attachments/assets/634d02d3-2bbd-49f0-92d5-a2234c095234" />

For such selections, the action has no effect because org.eclipse.debug.internal.ui.actions.breakpoints.BreakpointLabelAction.run(IAction) returns instantly if something other than a single org.eclipse.debug.core.model.Breakpoint is selected (which is the correct behavior here, since breakpoint containers are not renamable in general).

<img width="634" height="240" alt="image" src="https://github.com/user-attachments/assets/d4c174ae-ca58-465b-b611-e9a1c235cd2d" />

This PR disables the action if something other than a single breakpoint is currently selected.

Note: Making the action invisible would be more correct here, but this would require a restructure of the breakpoint view context menu since the action extension point does not allow making actions invisible.

### How to test / reproduce
1. Set (at least) 1 active breakpoint and open the breakpoint view
2. Group breakpoints by enablement
3. Select the "Enabled" entry -> Context menu shows "Label" action, clicking the action has no effect