### PR TITLE
Remove remaining pseudo dependency of E4-Injector to jakarta annotations

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
@@ -15,9 +15,7 @@ Export-Package: org.eclipse.e4.core.di;version="1.7.0",
  org.eclipse.e4.core.internal.di.osgi;x-internal:=true,
  org.eclipse.e4.core.internal.di.shared;x-friends:="org.eclipse.e4.core.contexts,org.eclipse.e4.core.di.extensions.supplier"
 Require-Bundle: org.eclipse.e4.core.di.annotations;bundle-version="[1.4.0,2.0.0)";visibility:=reexport
-Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
- jakarta.inject;version="[2,3)",
- org.eclipse.osgi.framework.log;version="1.1.0",
+Import-Package: org.eclipse.osgi.framework.log;version="1.1.0",
  org.osgi.framework;version="[1.8.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.1,2.0.0)"
 Automatic-Module-Name: org.eclipse.e4.core.di

--- a/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.e4.core.di/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.core.di
-Bundle-Version: 1.9.800.qualifier
+Bundle-Version: 1.9.900.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/IInjector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,10 +14,6 @@
  *******************************************************************************/
 package org.eclipse.e4.core.di;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import jakarta.inject.Scope;
-import jakarta.inject.Singleton;
 import java.lang.annotation.Annotation;
 import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
 
@@ -37,7 +33,8 @@ import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
  * The injection of values is generally done as a number of calls. User objects
  * that want to finalize the injected data (for instance, to perform
  * calculations based on multiple injected values) can place such calculations
- * in a method with the {@link PostConstruct} annotation.
+ * in a method with a {@code PostConstruct} annotation, e.g.
+ * {@code jakarta.annotation.PostConstruct}
  * </p>
  * <p>
  * When injecting values, all fields are injected prior to injection of methods.
@@ -51,7 +48,8 @@ import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
  * </p>
  * <p>
  * When supplier is disposed, the injector will attempt to notify all injected
- * objects by calling methods with the {@link PreDestroy} annotation.
+ * objects by calling methods with a {@code PreDestroy} annotation, e.g.
+ * {@code jakarta.annotation.PreDestroy}.
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
@@ -151,13 +149,16 @@ public interface IInjector {
 
 	/**
 	 * Obtain an instance of the specified class and inject it with the data from the supplier.
+	 * <p>
+	 * For examples, see also {@code jakarta.inject.Scope} or
+	 * {@code jakarta.inject.Singleton}.
+	 * </p>
+	 *
 	 * @param <T> the type of the object to be created
 	 * @param clazz the class to be instantiated
 	 * @param objectSupplier primary object supplier for the injection
 	 * @return an instance of the specified class
 	 * @throws InjectionException if an exception occurred while performing this operation
-	 * @see Scope
-	 * @see Singleton
 	 */
 	<T> T make(Class<T> clazz, PrimaryObjectSupplier objectSupplier) throws InjectionException;
 
@@ -168,14 +169,17 @@ public interface IInjector {
 	 * the static supplier are injected. Injected values from the static supplier are not tracked and no links
 	 * between the static supplier and the object are established.
 	 * </p>
+	 * <p>
+	 * For examples, see also {@code jakarta.inject.Scope} or
+	 * {@code jakarta.inject.Singleton}.
+	 * </p>
+	 *
 	 * @param <T> the type of the object to be created
 	 * @param clazz the class to be instantiated
 	 * @param objectSupplier primary object supplier for the injection
 	 * @param staticSupplier additional object supplier for the injection, changes in injected values are not tracked
 	 * @return an instance of the specified class
 	 * @throws InjectionException if an exception occurred while performing this operation
-	 * @see Scope
-	 * @see Singleton
 	 */
 	<T> T make(Class<T> clazz, PrimaryObjectSupplier objectSupplier, PrimaryObjectSupplier staticSupplier) throws InjectionException;
 

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/ExtendedObjectSupplier.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/ExtendedObjectSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2010 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,8 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.e4.core.di.suppliers;
-
-import org.osgi.framework.BundleContext;
 
 /**
  * The base class for an "object supplier" - something that knows how to
@@ -39,7 +37,7 @@ abstract public class ExtendedObjectSupplier {
 	 * The OSGi service name for an object provider service. This name can be used to obtain
 	 * instances of the service.
 	 *
-	 * @see BundleContext#getServiceReference(String)
+	 * @see org.osgi.framework.BundleContext#getServiceReference(String)
 	 */
 	public static final String SERVICE_NAME = ExtendedObjectSupplier.class.getName();
 
@@ -47,7 +45,7 @@ abstract public class ExtendedObjectSupplier {
 	 * An OSGi service property used to indicate the context key this function should be registered
 	 * in.
 	 *
-	 * @see BundleContext#getServiceReference(String)
+	 * @see org.osgi.framework.BundleContext#getServiceReference(String)
 	 */
 	public static final String SERVICE_CONTEXT_KEY = "dependency.injection.annotation"; //$NON-NLS-1$
 

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/IObjectDescriptor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/di/suppliers/IObjectDescriptor.java
@@ -22,8 +22,10 @@ import java.lang.reflect.Type;
  * From the view point of the injector, objects are described by a type with a
  * set of optional qualifiers.
  * </p>
+ * <p>
+ * For example, see also {@code jakarta.inject.Qualifier}.
+ * </p>
  *
- * @see jakarta.inject.Qualifier
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 1.7

--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,8 @@
  *******************************************************************************/
 package org.eclipse.e4.core.internal.di;
 
-import jakarta.inject.Named;
-import java.lang.reflect.Field;
 import org.eclipse.e4.core.di.IInjector;
 import org.eclipse.e4.core.di.InjectionException;
-import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.suppliers.IObjectDescriptor;
 import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
 
@@ -29,11 +26,7 @@ import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
  */
 public class ClassRequestor extends Requestor<Class<?>> {
 
-	@Optional
-	@Named("e4.internal.injectionLink")
-	final static public String pseudoVariable = null;
-
-	private static IObjectDescriptor[] pseudoVariableDescriptor;
+	private static IObjectDescriptor[] pseudoVariableDescriptor = {};
 
 	public ClassRequestor(Class<?> clazz, IInjector injector, PrimaryObjectSupplier primarySupplier, PrimaryObjectSupplier tempSupplier, Object requestingObject, boolean track) {
 		super(clazz, injector, primarySupplier, tempSupplier, requestingObject, track);
@@ -47,18 +40,6 @@ public class ClassRequestor extends Requestor<Class<?>> {
 
 	@Override
 	public IObjectDescriptor[] calcDependentObjects() {
-		if (pseudoVariableDescriptor == null) {
-			Field field = null;
-			try {
-				field = ClassRequestor.class.getField("pseudoVariable"); //$NON-NLS-1$
-			} catch (SecurityException | NoSuchFieldException e) {
-				e.printStackTrace(); // tested - not going to happen
-				return null;
-			}
-			pseudoVariableDescriptor = new IObjectDescriptor[] {
-					new ObjectDescriptor(field.getGenericType(), field.getAnnotations()) };
-		}
-
 		return pseudoVariableDescriptor;
 	}
 
@@ -69,7 +50,7 @@ public class ClassRequestor extends Requestor<Class<?>> {
 			tmp.append(location.getSimpleName());
 		}
 		tmp.append('.');
-		tmp.append(pseudoVariable);
+		tmp.append("pseudoVariable"); //$NON-NLS-1$
 		return tmp.toString();
 	}
 }


### PR DESCRIPTION
This ensures that the E4-Injector does not work with any specific annotation class.

The pseudo dependency was introduced when resolving [Bug 301462](https://bugs.eclipse.org/bugs/show_bug.cgi?id=301462), but just returning an empty array as dependencies of the ClassRequestor also passes the then added `DisposeClassLinkTest`.
I stepped through the code a bit when using the `ClassRequestor` and the `pseudoVariable` doesn't seem to have an effect.
Or does anyone know a reason to keep it?

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform/pull/1566