### PR TITLE
Simplify display name in new parameterized tests for console

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleOutputLineTruncateTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleOutputLineTruncateTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.eclipse.ui.internal.console.ConsoleOutputLineTruncate;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,79 +43,79 @@ public class ConsoleOutputLineTruncateTest {
 	 * @param output expected output, repeated {@code repeat} times
 	 * @param nl the newline character sequences
 	 */
-	record Parameters(int limit, int chunks, int repeat, String input, String output, String... nl) {
+	record Parameters(String name, int limit, int chunks, int repeat, String input, String output, String... nl) {
 	}
 
-	private static Parameters test(int limit, String input, String output, String... nl) {
-		return test(limit, 1, 1, input, output, nl);
+	private static Parameters test(String name, int limit, String input, String output, String... nl) {
+		return test(name, limit, 1, 1, input, output, nl);
 	}
 
-	private static Parameters test(int limit, int chunks, int repeat, String input, String output, String... nl) {
-		return new Parameters(limit, chunks, repeat, input, output, nl);
+	private static Parameters test(String name, int limit, int chunks, int repeat, String input, String output, String... nl) {
+		return new Parameters(name, limit, chunks, repeat, input, output, nl);
 	}
 
 	private static final Parameters[] TESTS = {
 			// Unix newlines
-			test(4, "\n========", "\n==== ...\n", "\n"),
-			test(10, "========", "========", "\n"),
-			test(10, 10, 1, "========", "========== ...\n", "\n"),
-			test(4, "========", "==== ...\n", "\n"),
-			test(4, 10, 1, "========", "==== ...\n", "\n"),
-			test(4, "====\n====", "====\n====", "\n"),
-			test(4, 5, 1, "====\n====", "====\n==== ...\n==== ...\n==== ...\n==== ...\n====", "\n"),
-			test(2, 5, 1, "=======\n==", "== ...\n== ...\n== ...\n== ...\n== ...\n==", "\n"),
-			test(2, "====\n====", "== ...\n== ...\n", "\n"),
-			test(2, 5, 1, "====\n====", "== ...\n== ...\n== ...\n== ...\n== ...\n== ...\n", "\n"),
-			test(2, "=========", "== ...\n", "\n"),
-			test(2, "=======\n==", "== ...\n==", "\n"),
-			test(3, "=========", "=== ...\n", "\n"),
-			test(3, 5, 1, "=========", "=== ...\n", "\n"),
-			test(3, "========\n=", "=== ...\n=", "\n"),
-			test(2, "======\n======", "== ...\n== ...\n", "\n"),
-			test(2, 5, 1, "======\n======", "== ...\n== ...\n== ...\n== ...\n== ...\n== ...\n", "\n"),
-			test(3, 3, 1, "========\n=", "=== ...\n=== ...\n=== ...\n="   , "\n"),
-			test(4, 3, 1, "========\n=", "==== ...\n==== ...\n==== ...\n=", "\n"),
+			test("unix_nl_01", 4, "\n========", "\n==== ...\n", "\n"),
+			test("unix_nl_02", 10, "========", "========", "\n"),
+			test("unix_nl_03", 10, 10, 1, "========", "========== ...\n", "\n"),
+			test("unix_nl_04", 4, "========", "==== ...\n", "\n"),
+			test("unix_nl_05", 4, 10, 1, "========", "==== ...\n", "\n"),
+			test("unix_nl_06", 4, "====\n====", "====\n====", "\n"),
+			test("unix_nl_07", 4, 5, 1, "====\n====", "====\n==== ...\n==== ...\n==== ...\n==== ...\n====", "\n"),
+			test("unix_nl_08", 2, 5, 1, "=======\n==", "== ...\n== ...\n== ...\n== ...\n== ...\n==", "\n"),
+			test("unix_nl_09", 2, "====\n====", "== ...\n== ...\n", "\n"),
+			test("unix_nl_10", 2, 5, 1, "====\n====", "== ...\n== ...\n== ...\n== ...\n== ...\n== ...\n", "\n"),
+			test("unix_nl_11", 2, "=========", "== ...\n", "\n"),
+			test("unix_nl_12", 2, "=======\n==", "== ...\n==", "\n"),
+			test("unix_nl_13", 3, "=========", "=== ...\n", "\n"),
+			test("unix_nl_14", 3, 5, 1, "=========", "=== ...\n", "\n"),
+			test("unix_nl_15", 3, "========\n=", "=== ...\n=", "\n"),
+			test("unix_nl_16", 2, "======\n======", "== ...\n== ...\n", "\n"),
+			test("unix_nl_17", 2, 5, 1, "======\n======", "== ...\n== ...\n== ...\n== ...\n== ...\n== ...\n", "\n"),
+			test("unix_nl_18", 3, 3, 1, "========\n=", "=== ...\n=== ...\n=== ...\n=", "\n"),
+			test("unix_nl_19", 4, 3, 1, "========\n=", "==== ...\n==== ...\n==== ...\n=", "\n"),
 
 			// Windows newlines
-			test(4, "\r\n========", "\r\n==== ...\r\n", "\r\n"),
-			test(10, "========", "========", "\r\n"),
-			test(10, 10, 1, "========", "========== ...\r\n", "\r\n"),
-			test(4, "========", "==== ...\r\n", "\r\n"),
-			test(4, 10, 1, "========", "==== ...\r\n", "\r\n"),
-			test(4, "====\r\n====", "====\r\n====", "\r\n"),
-			test(4, 5, 1, "====\r\n====", "====\r\n==== ...\r\n==== ...\r\n==== ...\r\n==== ...\r\n====", "\r\n"),
-			test(2, 5, 1, "=======\r\n==", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n==", "\r\n"),
-			test(2, "====\r\n====", "== ...\r\n== ...\r\n", "\r\n"),
-			test(2, 5, 1, "====\r\n====", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n", "\r\n"),
-			test(2, "=========", "== ...\r\n", "\r\n"),
-			test(2, "=======\r\n==", "== ...\r\n==", "\r\n"),
-			test(3, "=========", "=== ...\r\n", "\r\n"),
-			test(3, 5, 1, "=========", "=== ...\r\n", "\r\n"),
-			test(3, "========\r\n=", "=== ...\r\n=", "\r\n"),
-			test(2, "======\r\n======", "== ...\r\n== ...\r\n", "\r\n"),
-			test(2, 5, 1, "======\r\n======", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n", "\r\n"),
-			test(3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r\n"),
-			test(4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r\n"),
+			test("win_nl_01", 4, "\r\n========", "\r\n==== ...\r\n", "\r\n"),
+			test("win_nl_02", 10, "========", "========", "\r\n"),
+			test("win_nl_03", 10, 10, 1, "========", "========== ...\r\n", "\r\n"),
+			test("win_nl_04", 4, "========", "==== ...\r\n", "\r\n"),
+			test("win_nl_05", 4, 10, 1, "========", "==== ...\r\n", "\r\n"),
+			test("win_nl_06", 4, "====\r\n====", "====\r\n====", "\r\n"),
+			test("win_nl_07", 4, 5, 1, "====\r\n====", "====\r\n==== ...\r\n==== ...\r\n==== ...\r\n==== ...\r\n====", "\r\n"),
+			test("win_nl_08", 2, 5, 1, "=======\r\n==", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n==", "\r\n"),
+			test("win_nl_09", 2, "====\r\n====", "== ...\r\n== ...\r\n", "\r\n"),
+			test("win_nl_10", 2, 5, 1, "====\r\n====", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n", "\r\n"),
+			test("win_nl_11", 2, "=========", "== ...\r\n", "\r\n"),
+			test("win_nl_12", 2, "=======\r\n==", "== ...\r\n==", "\r\n"),
+			test("win_nl_13", 3, "=========", "=== ...\r\n", "\r\n"),
+			test("win_nl_14", 3, 5, 1, "=========", "=== ...\r\n", "\r\n"),
+			test("win_nl_15", 3, "========\r\n=", "=== ...\r\n=", "\r\n"),
+			test("win_nl_16", 2, "======\r\n======", "== ...\r\n== ...\r\n", "\r\n"),
+			test("win_nl_17", 2, 5, 1, "======\r\n======", "== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n== ...\r\n", "\r\n"),
+			test("win_nl_18", 3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r\n"),
+			test("win_nl_19", 4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r\n"),
 
 			// multiple newlines
-			test(3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r\n", "\r", "\n"),
-			test(4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r\n", "\r", "\n"),
-			test(3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r", "\n", "\r\n"),
-			test(4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r", "\n", "\r\n"),
+			test("multi_nl_1", 3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r\n", "\r", "\n"),
+			test("multi_nl_2", 4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r\n", "\r", "\n"),
+			test("multi_nl_3", 3, 3, 1, "========\r\n=", "=== ...\r\n=== ...\r\n=== ...\r\n=", "\r", "\n", "\r\n"),
+			test("multi_nl_4", 4, 3, 1, "========\r\n=", "==== ...\r\n==== ...\r\n==== ...\r\n=", "\r", "\n", "\r\n"),
 
 			// surrogate pairs (emoji 😀 = \uD83D\uDE00, 2 chars) -- truncation must not split a surrogate pair
 			// truncation point falls on the low surrogate: limit=3, "ab😀c" (5 chars) -> back up before emoji
-			test( 3, "ab\uD83D\uDE00c"           , "ab ...\n"     , "\n"),
+			test("surrogate_pairs_1",  3, "ab\uD83D\uDE00c"           , "ab ...\n"     , "\n"),
 			// truncation point falls on the low surrogate: limit=4, "abc😀d" (6 chars)
-			test( 4, "abc\uD83D\uDE00d"          , "abc ...\n"    , "\n"),
+			test("surrogate_pairs_2",  4, "abc\uD83D\uDE00d"          , "abc ...\n"    , "\n"),
 			// truncation with newline in chunk: first line truncated before emoji, second line untouched
-			test( 3, "ab\uD83D\uDE00\n=="         , "ab ...\n=="   , "\n"),
+			test("surrogate_pairs_3",  3, "ab\uD83D\uDE00\n=="         , "ab ...\n=="   , "\n"),
 			// multi-chunk: second chunk (continuation of overlong line) starts with a low surrogate and is deleted entirely
-			test( 2, 2, 1, "ab\uD83D\uDE00"       , "ab ...\n"     , "\n"),
+			test("surrogate_pairs_4",  2, 2, 1, "ab\uD83D\uDE00"       , "ab ...\n"     , "\n"),
 	};
 
 	private static Stream<Arguments> tests() {
-		return Arrays.stream(TESTS).map(Arguments::of);
+		return Arrays.stream(TESTS).map(ConsoleOutputLineTruncateTest::named);
 	}
 
 	@ParameterizedTest
@@ -133,5 +134,9 @@ public class ConsoleOutputLineTruncateTest {
 
 	private static String repeat(String s, int r, String nl) {
 		return (nl + s).repeat(r).substring(nl.length());
+	}
+
+	private static Arguments named(Parameters p) {
+		return Arguments.of(Named.of(p.name, p));
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleOutputLineWrapTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleOutputLineWrapTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.eclipse.ui.internal.console.ConsoleOutputLineWrap;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,92 +43,92 @@ public class ConsoleOutputLineWrapTest {
 	 * @param output expected output, repeated {@code repeat} times
 	 * @param nl the newline character sequences
 	 */
-	record Parameters(int limit, int chunks, int repeat, String input, String output, String... nl) {
+	record Parameters(String name, int limit, int chunks, int repeat, String input, String output, String... nl) {
 	}
 
-	private static Parameters test(int limit, String input, String output, String... nl) {
-		return test(limit, 1, 1, input, output, nl);
+	private static Parameters test(String name, int limit, String input, String output, String... nl) {
+		return test(name, limit, 1, 1, input, output, nl);
 	}
 
-	private static Parameters test(int limit, int chunks, String input, String output, String... nl) {
-		return test(limit, chunks, chunks, input, output, nl);
+	private static Parameters test(String name, int limit, int chunks, String input, String output, String... nl) {
+		return test(name, limit, chunks, chunks, input, output, nl);
 	}
 
-	private static Parameters test(int limit, int chunks, int repeat, String input, String output, String... nl) {
-		return new Parameters(limit, chunks, repeat, input, output, nl);
+	private static Parameters test(String name, int limit, int chunks, int repeat, String input, String output, String... nl) {
+		return new Parameters(name, limit, chunks, repeat, input, output, nl);
 	}
 
 	private static final Parameters[] TESTS = {
 			// Unix newlines
-			test(4, "\n========", "\n====\n====", "\n"),
+			test("unix_nl_01", 4, "\n========", "\n====\n====", "\n"),
 
-			test(10,        "========"      , "========"  , "\n"),
-			test(10, 10, 8, "========"      , "==========", "\n"),
-			test( 4,        "========"      , "====\n====", "\n"),
-			test( 4, 10,    "========"      , "====\n====", "\n"),
-			test( 4,        "====\n===="    , "====\n====", "\n"),
-			test( 4, 10,    "====\n===="    , "====\n====", "\n"),
+			test("unix_nl_02", 10,        "========"      , "========"  , "\n"),
+			test("unix_nl_03", 10, 10, 8, "========"      , "==========", "\n"),
+			test("unix_nl_04",  4,        "========"      , "====\n====", "\n"),
+			test("unix_nl_05",  4, 10,    "========"      , "====\n====", "\n"),
+			test("unix_nl_06",  4,        "====\n===="    , "====\n====", "\n"),
+			test("unix_nl_07",  4, 10,    "====\n===="    , "====\n====", "\n"),
 
-			test( 2, 10,    "=======\n=="   , "==\n==\n==\n=\n==", "\n"),
-			test( 2,        "====\n===="    , "==\n==\n==\n=="   , "\n"),
-			test( 2, 10,    "====\n===="    , "==\n==\n==\n=="   , "\n"),
-			test( 2,        "========="     , "==\n==\n==\n==\n=", "\n"),
-			test( 2,        "=======\n=="   , "==\n==\n==\n=\n==", "\n"),
-			test( 3,        "========="     , "===\n===\n==="    , "\n"),
-			test( 3, 10,    "========="     , "===\n===\n==="    , "\n"),
-			test( 3,        "========\n="   , "===\n===\n==\n="  , "\n"),
+			test("unix_nl_08",  2, 10,    "=======\n=="   , "==\n==\n==\n=\n==", "\n"),
+			test("unix_nl_09",  2,        "====\n===="    , "==\n==\n==\n=="   , "\n"),
+			test("unix_nl_10",  2, 10,    "====\n===="    , "==\n==\n==\n=="   , "\n"),
+			test("unix_nl_11",  2,        "========="     , "==\n==\n==\n==\n=", "\n"),
+			test("unix_nl_12",  2,        "=======\n=="   , "==\n==\n==\n=\n==", "\n"),
+			test("unix_nl_13",  3,        "========="     , "===\n===\n==="    , "\n"),
+			test("unix_nl_14",  3, 10,    "========="     , "===\n===\n==="    , "\n"),
+			test("unix_nl_15",  3,        "========\n="   , "===\n===\n==\n="  , "\n"),
 
-			test( 2,        "======\n======", "==\n==\n==\n==\n==\n==", "\n"),
-			test( 2, 10,    "======\n======", "==\n==\n==\n==\n==\n==", "\n"),
+			test("unix_nl_16",  2,        "======\n======", "==\n==\n==\n==\n==\n==", "\n"),
+			test("unix_nl_17",  2, 10,    "======\n======", "==\n==\n==\n==\n==\n==", "\n"),
 
-			test( 3,  3, 1, "========\n="   , "===\n===\n==\n===\n===\n===\n===\n===\n===\n=", "\n"),
-			test( 4,  3, 1, "========\n="   , "====\n====\n====\n====\n=\n====\n====\n=\n="  , "\n"),
+			test("unix_nl_18",  3,  3, 1, "========\n="   , "===\n===\n==\n===\n===\n===\n===\n===\n===\n=", "\n"),
+			test("unix_nl_19",  4,  3, 1, "========\n="   , "====\n====\n====\n====\n=\n====\n====\n=\n="  , "\n"),
 
 			// Windows newlines
-			test(4, "\r\n========", "\r\n====\r\n====", "\r\n"),
+			test("win_nl_01", 4, "\r\n========", "\r\n====\r\n====", "\r\n"),
 
-			test(10,        "========"        , "========"    , "\r\n"),
-			test(10, 10, 8, "========"        , "=========="  , "\r\n"),
-			test( 4,        "========"        , "====\r\n====", "\r\n"),
-			test( 4, 10,    "========"        , "====\r\n====", "\r\n"),
-			test( 4,        "====\r\n===="    , "====\r\n====", "\r\n"),
-			test( 4, 10,    "====\r\n===="    , "====\r\n====", "\r\n"),
+			test("win_nl_02", 10,        "========"        , "========"    , "\r\n"),
+			test("win_nl_03", 10, 10, 8, "========"        , "=========="  , "\r\n"),
+			test("win_nl_04",  4,        "========"        , "====\r\n====", "\r\n"),
+			test("win_nl_05",  4, 10,    "========"        , "====\r\n====", "\r\n"),
+			test("win_nl_06",  4,        "====\r\n===="    , "====\r\n====", "\r\n"),
+			test("win_nl_07",  4, 10,    "====\r\n===="    , "====\r\n====", "\r\n"),
 
-			test( 2, 10,    "=======\r\n=="   , "==\r\n==\r\n==\r\n=\r\n==", "\r\n"),
-			test( 2,        "====\r\n===="    , "==\r\n==\r\n==\r\n=="     , "\r\n"),
-			test( 2, 10,    "====\r\n===="    , "==\r\n==\r\n==\r\n=="     , "\r\n"),
-			test( 2,        "========="       , "==\r\n==\r\n==\r\n==\r\n=", "\r\n"),
-			test( 2,        "=======\r\n=="   , "==\r\n==\r\n==\r\n=\r\n==", "\r\n"),
-			test( 3,        "========="       , "===\r\n===\r\n==="        , "\r\n"),
-			test( 3, 10,    "========="       , "===\r\n===\r\n==="        , "\r\n"),
-			test( 3,        "========\r\n="   , "===\r\n===\r\n==\r\n="    , "\r\n"),
+			test("win_nl_08",  2, 10,    "=======\r\n=="   , "==\r\n==\r\n==\r\n=\r\n==", "\r\n"),
+			test("win_nl_09",  2,        "====\r\n===="    , "==\r\n==\r\n==\r\n=="     , "\r\n"),
+			test("win_nl_10",  2, 10,    "====\r\n===="    , "==\r\n==\r\n==\r\n=="     , "\r\n"),
+			test("win_nl_11",  2,        "========="       , "==\r\n==\r\n==\r\n==\r\n=", "\r\n"),
+			test("win_nl_12",  2,        "=======\r\n=="   , "==\r\n==\r\n==\r\n=\r\n==", "\r\n"),
+			test("win_nl_13",  3,        "========="       , "===\r\n===\r\n==="        , "\r\n"),
+			test("win_nl_14",  3, 10,    "========="       , "===\r\n===\r\n==="        , "\r\n"),
+			test("win_nl_15",  3,        "========\r\n="   , "===\r\n===\r\n==\r\n="    , "\r\n"),
 
-			test( 2,        "======\r\n======", "==\r\n==\r\n==\r\n==\r\n==\r\n==", "\r\n"),
-			test( 2, 10,    "======\r\n======", "==\r\n==\r\n==\r\n==\r\n==\r\n==", "\r\n"),
+			test("win_nl_16",  2,        "======\r\n======", "==\r\n==\r\n==\r\n==\r\n==\r\n==", "\r\n"),
+			test("win_nl_17",  2, 10,    "======\r\n======", "==\r\n==\r\n==\r\n==\r\n==\r\n==", "\r\n"),
 
-			test( 3,  3, 1, "========\r\n="   , "===\r\n===\r\n==\r\n===\r\n===\r\n===\r\n===\r\n===\r\n===\r\n=", "\r\n"),
-			test( 4,  3, 1, "========\r\n="   , "====\r\n====\r\n====\r\n====\r\n=\r\n====\r\n====\r\n=\r\n="    , "\r\n"),
+			test("win_nl_18",  3,  3, 1, "========\r\n="   , "===\r\n===\r\n==\r\n===\r\n===\r\n===\r\n===\r\n===\r\n===\r\n=", "\r\n"),
+			test("win_nl_19",  4,  3, 1, "========\r\n="   , "====\r\n====\r\n====\r\n====\r\n=\r\n====\r\n====\r\n=\r\n="    , "\r\n"),
 
 			// multiple newlines
-			test( 3,  3, 1, "========\r\n="   , "===\r\n===\r\n==\r\n===\r\n===\r\n===\r\n===\r\n===\r\n===\r\n=", "\r\n", "\r", "\n"),
-			test( 4,  3, 1, "========\r\n="   , "====\r\n====\r\n====\r\n====\r\n=\r\n====\r\n====\r\n=\r\n="    , "\r\n", "\r", "\n"),
+			test("multi_nl_1", 3,  3, 1, "========\r\n="   , "===\r\n===\r\n==\r\n===\r\n===\r\n===\r\n===\r\n===\r\n===\r\n=", "\r\n", "\r", "\n"),
+			test("multi_nl_2",  4,  3, 1, "========\r\n="   , "====\r\n====\r\n====\r\n====\r\n=\r\n====\r\n====\r\n=\r\n="    , "\r\n", "\r", "\n"),
 
-			test( 3,  3, 1, "========\r\n="   , "===\r===\r==\r\n===\r===\r===\r\n===\r===\r===\r\n=", "\r", "\n", "\r\n"),
-			test( 4,  3, 1, "========\r\n="   , "====\r====\r\n====\r====\r=\r\n====\r====\r=\r\n="  , "\r", "\n", "\r\n"),
+			test("multi_nl_3",  3,  3, 1, "========\r\n="   , "===\r===\r==\r\n===\r===\r===\r\n===\r===\r===\r\n=", "\r", "\n", "\r\n"),
+			test("multi_nl_4",  4,  3, 1, "========\r\n="   , "====\r====\r\n====\r====\r=\r\n====\r====\r=\r\n="  , "\r", "\n", "\r\n"),
 
 			// surrogate pairs (emoji 😀 = \uD83D\uDE00, 2 chars) -- wrap must not split a surrogate pair
 			// single wrap: limit=3, "ab😀c" (5 chars) -> wrap before emoji
-			test( 3, "ab\uD83D\uDE00c"      , "ab\n\uD83D\uDE00c"           , "\n"),
+			test("surrogate_pairs_1", 3, "ab\uD83D\uDE00c"      , "ab\n\uD83D\uDE00c"           , "\n"),
 			// single wrap: limit=4, "abc😀d" (6 chars) -> wrap before emoji
-			test( 4, "abc\uD83D\uDE00d"     , "abc\n\uD83D\uDE00d"          , "\n"),
+			test("surrogate_pairs_2", 4, "abc\uD83D\uDE00d"     , "abc\n\uD83D\uDE00d"          , "\n"),
 			// second wrap also falls on a low surrogate: limit=3, "ab😀😀b" (7 chars) -> both wraps before emoji
-			test( 3, "ab\uD83D\uDE00\uD83D\uDE00b", "ab\n\uD83D\uDE00\n\uD83D\uDE00b", "\n"),
+			test("surrogate_pairs_3", 3, "ab\uD83D\uDE00\uD83D\uDE00b", "ab\n\uD83D\uDE00\n\uD83D\uDE00b", "\n"),
 			// wrap between two ASCII chars, then second wrap on low surrogate: limit=3, "abc😀😀" (7 chars)
-			test( 3, "abc\uD83D\uDE00\uD83D\uDE00", "abc\n\uD83D\uDE00\n\uD83D\uDE00", "\n"),
+			test("surrogate_pairs_4", 3, "abc\uD83D\uDE00\uD83D\uDE00", "abc\n\uD83D\uDE00\n\uD83D\uDE00", "\n"),
 	};
 
 	private static Stream<Arguments> tests() {
-		return Arrays.stream(TESTS).map(Arguments::of);
+		return Arrays.stream(TESTS).map(ConsoleOutputLineWrapTest::named);
 	}
 
 	@ParameterizedTest
@@ -146,5 +147,9 @@ public class ConsoleOutputLineWrapTest {
 
 	private static String repeat(String s, int r, String nl) {
 		return (nl + s).repeat(r).substring(nl.length());
+	}
+
+	private static Arguments named(Parameters p) {
+		return Arguments.of(Named.of(p.name, p));
 	}
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
@@ -751,13 +751,13 @@ public class IOConsoleTests {
 		final IOConsoleTestUtil c = getTestUtil("Test trim newline");
 		try (IOConsoleOutputStream out = c.getDefaultOutputStream()) {
 			c.writeFast("first\n");
-			c.writeFast("1😀2😀3\n", out);
+			c.writeFast("1\uD83D\uDE002\uD83D\uDE003\n", out);
 			c.write("last\n");
 			c.verifyContentByLine("first", 0).verifyContentByLine("last", -2);
 			assertTrue(c.getDocument().getNumberOfLines() > 2, "Document not filled.");
 			c.getConsole().setWaterMarks(8, 16);
 			c.waitForScheduledJobs();
-			c.verifyContentByOffset("😀3\nlas", 0);
+			c.verifyContentByOffset("\uD83D\uDE003\nlas", 0);
 			closeConsole(c);
 		}
 	}
@@ -810,12 +810,12 @@ public class IOConsoleTests {
 		try (IOConsoleOutputStream out = c.getDefaultOutputStream()) {
 			c.getConsole().setLimitLineLength(false, 8);
 			c.writeFast("first\n");
-			c.writeFast("01234😀😀😀\n", out);
+			c.writeFast("01234\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\n", out);
 			c.write("last\n");
 			c.verifyContentByLine("first", 0).verifyContentByLine("last", -2);
 			assertTrue(c.getDocument().getNumberOfLines() > 2, "Document not filled.");
 			c.waitForScheduledJobs();
-			c.verifyContent("first\n01234😀 ...\nlast\n");
+			c.verifyContent("first\n01234\uD83D\uDE00 ...\nlast\n");
 			closeConsole(c);
 		}
 	}
@@ -870,12 +870,12 @@ public class IOConsoleTests {
 			String nl = c.getConsole().getDocument().getLegalLineDelimiters()[0];
 			c.getConsole().setLimitLineLength(true, 8);
 			c.writeFast("first\n");
-			c.writeFast("0123456😀😀\n", out);
+			c.writeFast("0123456\uD83D\uDE00\uD83D\uDE00\n", out);
 			c.write("last\n");
 			c.verifyContentByLine("first", 0).verifyContentByLine("last", -2);
 			assertTrue(c.getDocument().getNumberOfLines() > 2, "Document not filled.");
 			c.waitForScheduledJobs();
-			c.verifyContent("first\n0123456" + nl + "😀😀\nlast\n");
+			c.verifyContent("first\n0123456" + nl + "\uD83D\uDE00\uD83D\uDE00\nlast\n");
 			closeConsole(c);
 		}
 	}


### PR DESCRIPTION
This change adjusts display names in new parameterized tests, for console line wrapping. This hopefully avoids confusing GitHub jobs.

In addition, emojis in `IOConsoleTests` are replaced with unicode codepoints.

See: https://github.com/eclipse-platform/eclipse.platform/issues/2650
