### PR TITLE
Add active launch indicator to launch history menu

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/AbstractLaunchHistoryAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/AbstractLaunchHistoryAction.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -347,8 +348,12 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 
 		// Add favorites
 		int accelerator = 1;
+		ILaunch[] launches = DebugPlugin.getDefault().getLaunchManager().getLaunches();
 		for (ILaunchConfiguration launch : favoriteList) {
 			LaunchAction action= new LaunchAction(launch, getMode());
+			if (checkIfLaunchActive(launch, launches)) {
+				action.setText(action.getText() + "  \u2699"); //$NON-NLS-1$
+			}
 			addToMenu(menu, action, accelerator);
 			accelerator++;
 		}
@@ -361,6 +366,9 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 		// Add history launches next
 		for (ILaunchConfiguration launch : historyList) {
 			LaunchAction action= new LaunchAction(launch, getMode());
+			if (checkIfLaunchActive(launch, launches)) {
+				action.setText(action.getText() + "  \u2699"); //$NON-NLS-1$
+			}
 			addToMenu(menu, action, accelerator);
 			accelerator++;
 		}
@@ -371,6 +379,24 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 			ActionContributionItem item= new ActionContributionItem(action);
 			item.fill(menu, -1);
 		}
+	}
+
+	/**
+	 * Returns whether the given launch configuration has been launched and active
+	 * now.
+	 *
+	 * @param launchConfiguration the launch configuration
+	 * @param launches            the current active launches
+	 * @return {@code true} if a matching launch exists, {@code false} otherwise
+	 */
+	private boolean checkIfLaunchActive(ILaunchConfiguration launchConfiguration, ILaunch[] launches) {
+		for (ILaunch launch : launches) {
+			ILaunchConfiguration activeLaunch = launch.getLaunchConfiguration();
+			if (activeLaunch != null && activeLaunch.equals(launchConfiguration) && !launch.isTerminated()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Adds support to show an active launch indicator in the launch history menu, helping users quickly identify which launch configurations are currently running from launch history. Entries with associated non-terminated launches are marked with a visual indicator "●" ,Once the indicator is shown, users can immediately recognize that the configuration is already running, helping avoid unnecessary or unintended clicks from the launch history menu. 

With Active (Running)
<img width="717" height="338" alt="image" src="https://github.com/user-attachments/assets/1243adb5-bfb7-4473-8ec9-dea18978c12a" />
<img width="333" height="79" alt="image" src="https://github.com/user-attachments/assets/14036e43-5394-46c1-bb46-82221b66fecc" />

<br>
With In-Active (Terminated or not launched)
<img width="657" height="284" alt="image" src="https://github.com/user-attachments/assets/5f35ae4d-b5ed-48e9-b4d4-a1281f2cb7d4" />
