### PR TITLE
Remove stale JNI comment in ProxyProviderLinux

### DIFF
--- a/team/bundles/org.eclipse.core.net/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.core.net/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.eclipse.core.net;singleton:=true
-Bundle-Version: 1.5.800.qualifier
+Bundle-Version: 1.5.900.qualifier
 Bundle-Activator: org.eclipse.core.internal.net.Activator
 Bundle-Vendor: %PLUGIN_PROVIDER
 Bundle-Localization: plugin

--- a/team/bundles/org.eclipse.core.net/src/org/eclipse/core/net/internal/proxy/linux/ProxyProviderLinux.java
+++ b/team/bundles/org.eclipse.core.net/src/org/eclipse/core/net/internal/proxy/linux/ProxyProviderLinux.java
@@ -55,7 +55,6 @@ public class ProxyProviderLinux extends AbstractProxyProvider {
 	private static boolean isGnomeLibLoaded = false;
 
 	static {
-		// Load the GSettings JNI library if org.eclipse.core.net.enableGnome is specified
 		String value = System.getProperty(ENABLE_GNOME);
 		if ("".equals(value) || "true".equals(value)) { //$NON-NLS-1$ //$NON-NLS-2$
 			initializeSettings();


### PR DESCRIPTION
The static initializer of `ProxyProviderLinux` carries a comment claiming it loads a GSettings JNI library, but the bundle has used JNA (`com.sun.jna.Native.load`) since the 2021 fragment merge. The comment predates the JNA rewrite and is misleading. This removes it; no behavior change.