### PR TITLE
Replace SubProgressMonitor with SubMonitor in org.eclipse.core.resources

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/utils/Policy.java
@@ -189,6 +189,6 @@ public class Policy {
 		if (monitor instanceof NullProgressMonitor) {
 			return monitor;
 		}
-		return new SubProgressMonitor(monitor, ticks);
+		return SubMonitor.convert(monitor, ticks);
 	}
 }


### PR DESCRIPTION
**Planned for 4.41**

Replaces the deprecated `SubProgressMonitor` in the internal `subMonitorFor` helper in `org.eclipse.core.resources` with `SubMonitor.convert`, which is the modern equivalent. One-line change.