### PR TITLE
Drop stale event-type count from IResourceChangeEvent class Javadoc

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IResourceChangeEvent.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IResourceChangeEvent.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 /**
  * Resource change events describe changes to resources.
  * <p>
- * There are currently five different types of resource change events:
+ * The following types of resource change events are reported:
  * <ul>
  *   <li>
  *    Before-the-fact batch reports of arbitrary creations,


### PR DESCRIPTION
The class Javadoc on `IResourceChangeEvent` claims "There are currently five different types of resource change events", but the bullet list immediately below it enumerates six (`PRE_BUILD`, `POST_BUILD`, `POST_CHANGE`, `PRE_CLOSE`, `PRE_DELETE`, `PRE_REFRESH`). The count went stale when `PRE_REFRESH` was added and will keep drifting, so the fix replaces it with a count-free phrasing.