### PR TITLE
[RelEng] Handle absence of eclipse_lg images in release preparation

### DIFF
--- a/prepareNextDevCycle.sh
+++ b/prepareNextDevCycle.sh
@@ -36,7 +36,7 @@ for plugin  in "${brandingPlugins[@]}"; do
 	fi
 done
 rm "org.eclipse.platform/futureSplashScreens/splash_${NEXT_RELEASE_NAME}.png"
-rm org.eclipse.platform/futureSplashScreens/eclipse_lg*.png
+rm -f org.eclipse.platform/futureSplashScreens/eclipse_lg*.png
 popd
 
 git commit --all --message "Splash Screen for ${NEXT_RELEASE_VERSION} (${NEXT_RELEASE_NAME})"


### PR DESCRIPTION
The eclipse_lg*.png images are usually the same for multiple releases and a 'future' version therefore often does not exist.

This was missed in
- https://github.com/eclipse-platform/eclipse.platform/pull/2468