### PR TITLE
Remove Ctrl C accelerator in Copy Variable/Expression

### DIFF
--- a/debug/org.eclipse.debug.ui/plugin.xml
+++ b/debug/org.eclipse.debug.ui/plugin.xml
@@ -1583,7 +1583,6 @@
          <action
                label="%CopyVariableToClipboardAction.label"
                icon="$nl$/icons/full/elcl16/copy_edit_co.svg"
-               definitionId="org.eclipse.ui.edit.copy"
                helpContextId="copy_variables_to_clipboard_action_context"
                class="org.eclipse.debug.internal.ui.actions.expressions.CopyVariableToClipboardActionDelegate"
                menubarPath="variableGroup"
@@ -1641,7 +1640,6 @@
          <action
                label="%CopyExpressionToClipboardAction.label"
                icon="$nl$/icons/full/elcl16/copy_edit_co.svg"
-               definitionId="org.eclipse.ui.edit.copy"
                helpContextId="copy_variables_to_clipboard_action_context"
                class="org.eclipse.debug.internal.ui.actions.expressions.CopyExpressionToClipboardActionDelegate"
                menubarPath="expressionGroup"

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyExpressionToClipboardActionDelegate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyExpressionToClipboardActionDelegate.java
@@ -47,4 +47,9 @@ public class CopyExpressionToClipboardActionDelegate extends VirtualCopyToClipbo
 		}
 		return true;
 	}
+
+	@Override
+	protected String getActionId() {
+		return "org.eclipse.debug.ui.debugview.popupMenu.copyExpressionToClipboard"; //$NON-NLS-1$
+	}
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyVariableToClipboardActionDelegate.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/CopyVariableToClipboardActionDelegate.java
@@ -54,4 +54,9 @@ public class CopyVariableToClipboardActionDelegate extends VirtualCopyToClipboar
 		}
 		return true;
 	}
+
+	@Override
+	protected String getActionId() {
+		return "org.eclipse.debug.ui.debugview.popupMenu.copyVariableToClipboard"; //$NON-NLS-1$
+	}
 }


### PR DESCRIPTION
Removes cmd+c accelerator in Copy Variable & Copy Expression Context of
Expressions View and Variables View

<img width="323" height="371" alt="Screenshot 2026-05-23 at 9 21 13 PM" src="https://github.com/user-attachments/assets/f1a4690b-adb9-4f19-87d7-152cacb5f8bc" />


Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2670