### PR TITLE
Avoid errors when running headless

### DIFF
--- a/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
@@ -601,17 +601,16 @@ public class DebugUIPlugin extends AbstractUIPlugin implements ILaunchListener, 
 				}
 			};
 			PlatformUI.getWorkbench().getThemeManager().addPropertyChangeListener(fThemeListener);
+			// do the asynchronous exec last - see bug 209920
+			getStandardDisplay().asyncExec(
+					() -> {
+						// initialize the selected resource `
+						SelectedResourceManager.getDefault();
+						// forces launch shortcuts to be initialized so their
+						// key-bindings work
+						getLaunchConfigurationManager().getLaunchShortcuts();
+					});
 		}
-
-		// do the asynchronous exec last - see bug 209920
-		getStandardDisplay().asyncExec(
-				() -> {
-					// initialize the selected resource `
-					SelectedResourceManager.getDefault();
-					// forces launch shortcuts to be initialized so their
-					// key-bindings work
-					getLaunchConfigurationManager().getLaunchShortcuts();
-				});
 
 		DebugUIPluginSaveParticipant saveParticipant = new DebugUIPluginSaveParticipant();
 		ResourcesPlugin.getWorkspace().addSaveParticipant(getUniqueIdentifier(), saveParticipant);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
@@ -227,12 +227,12 @@ public class DebugUIPreferenceInitializer extends AbstractPreferenceInitializer 
 		}
 
 	public static void setThemeBasedPreferences(final IPreferenceStore store, final boolean fireEvent) {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
 		Display display= PlatformUI.getWorkbench().getDisplay();
 		Runnable runnable = () -> {
-			ColorRegistry registry = null;
-			if (PlatformUI.isWorkbenchRunning()) {
-				registry = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry();
-			}
+			ColorRegistry registry = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry();
 			setDefault(store, IDebugPreferenceConstants.CONSOLE_BAKGROUND_COLOR, findRGB(registry, IInternalDebugUIConstants.THEME_CONSOLE_COLOR_BACKGROUND, new RGB(255, 255, 255)), fireEvent);
 			setDefault(store, IDebugPreferenceConstants.CONSOLE_SYS_OUT_COLOR, findRGB(registry, IInternalDebugUIConstants.THEME_CONSOLE_COLOR_STD_OUT, new RGB(0, 0, 0)), fireEvent);
 			setDefault(store, IDebugPreferenceConstants.CONSOLE_SYS_IN_COLOR, findRGB(registry, IInternalDebugUIConstants.THEME_CONSOLE_COLOR_STD_IN, new RGB(0, 200, 125)), fireEvent);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/LaunchingResourceManager.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/contextlaunching/LaunchingResourceManager.java
@@ -554,7 +554,7 @@ public class LaunchingResourceManager implements IPropertyChangeListener, IWindo
 	 * Starts up the manager
 	 */
 	public void startup() {
-		IWorkbench workbench = PlatformUI.getWorkbench();
+		IWorkbench workbench = PlatformUI.isWorkbenchRunning() ? PlatformUI.getWorkbench() : null;
 		if(workbench != null) {
 			workbench.addWindowListener(this);
 			// initialize for already open windows

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointSetOrganizer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointSetOrganizer.java
@@ -54,7 +54,7 @@ import org.osgi.service.prefs.BackingStoreException;
  */
 public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate implements IBreakpointOrganizerDelegateExtension, IPropertyChangeListener, IBreakpointsListener {
 
-	private IWorkingSetManager fWorkingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+	private IWorkingSetManager fWorkingSetManager;
 
 	/**
 	 * A cache for mapping markers to the working set they belong to
@@ -71,7 +71,10 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 	 * working sets and fires property change notification.
 	 */
 	public BreakpointSetOrganizer() {
-		fWorkingSetManager.addPropertyChangeListener(this);
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager != null) {
+			workingSetManager.addPropertyChangeListener(this);
+		}
 		fCache = new BreakpointWorkingSetCache();
 		DebugUIPlugin.getDefault().getPreferenceStore().addPropertyChangeListener(this);
 		DebugPlugin.getDefault().getBreakpointManager().addBreakpointListener(this);
@@ -80,8 +83,12 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 
 	@Override
 	public IAdaptable[] getCategories(IBreakpoint breakpoint) {
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager == null) {
+			return new IAdaptable[0];
+		}
 		List<IAdaptable> result = new ArrayList<>();
-		IWorkingSet[] workingSets = fWorkingSetManager.getWorkingSets();
+		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
 		for (IWorkingSet set : workingSets) {
 			if (IDebugUIConstants.BREAKPOINT_WORKINGSET_ID.equals(set.getId())) {
 				IAdaptable[] elements = set.getElements();
@@ -98,7 +105,10 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 
 	@Override
 	public void dispose() {
-		fWorkingSetManager.removePropertyChangeListener(this);
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager != null) {
+			workingSetManager.removePropertyChangeListener(this);
+		}
 		fWorkingSetManager = null;
 		DebugPlugin.getDefault().getBreakpointManager().removeBreakpointListener(this);
 		DebugUIPlugin.getDefault().getPreferenceStore().removePropertyChangeListener(this);
@@ -220,7 +230,11 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 	@Override
 	public void breakpointsRemoved(IBreakpoint[] breakpoints,
 			IMarkerDelta[] deltas) {
-		IWorkingSet[] workingSets = fWorkingSetManager.getWorkingSets();
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager == null) {
+			return;
+		}
+		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
 		IWorkingSet set = null;
 		for (IWorkingSet workingSet : workingSets) {
 			set = workingSet;
@@ -273,7 +287,7 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 	public static IWorkingSet getDefaultWorkingSet() {
 		IPreferenceStore preferenceStore = DebugUIPlugin.getDefault().getPreferenceStore();
 		String name = preferenceStore.getString(IInternalDebugUIConstants.MEMENTO_BREAKPOINT_WORKING_SET_NAME);
-		if (name != null) {
+		if (name != null && PlatformUI.isWorkbenchRunning()) {
 			return PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSet(name);
 		}
 		return null;
@@ -366,7 +380,11 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 
 	@Override
 	public IAdaptable[] getCategories() {
-		IWorkingSet[] workingSets = fWorkingSetManager.getWorkingSets();
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager == null) {
+			return new IAdaptable[0];
+		}
+		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
 		List<IAdaptable> all = new ArrayList<>();
 		for (IWorkingSet set : workingSets) {
 			if (IDebugUIConstants.BREAKPOINT_WORKINGSET_ID.equals(set
@@ -399,5 +417,16 @@ public class BreakpointSetOrganizer extends AbstractBreakpointOrganizerDelegate 
 			}
 			set.setElements(list.toArray(new IAdaptable[list.size()]));
 		}
+	}
+
+	private IWorkingSetManager getWorkingSetManager() {
+		if (fWorkingSetManager != null) {
+			return fWorkingSetManager;
+		}
+
+		if (PlatformUI.isWorkbenchRunning()) {
+			fWorkingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+		}
+		return fWorkingSetManager;
 	}
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/WorkingSetBreakpointOrganizer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/WorkingSetBreakpointOrganizer.java
@@ -34,14 +34,17 @@ import org.eclipse.ui.PlatformUI;
  */
 public class WorkingSetBreakpointOrganizer extends AbstractBreakpointOrganizerDelegate implements IPropertyChangeListener {
 
-	IWorkingSetManager fWorkingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+	IWorkingSetManager fWorkingSetManager;
 
 	/**
 	 * Constructs a working set breakpoint organizer. Listens for changes in
 	 * working sets and fires property change notification.
 	 */
 	public WorkingSetBreakpointOrganizer() {
-		fWorkingSetManager.addPropertyChangeListener(this);
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager != null) {
+			workingSetManager.addPropertyChangeListener(this);
+		}
 	}
 
 	@Override
@@ -56,7 +59,11 @@ public class WorkingSetBreakpointOrganizer extends AbstractBreakpointOrganizerDe
 				parents.add(res);
 			}
 		}
-		for (IWorkingSet workingSet : fWorkingSetManager.getWorkingSets()) {
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager == null) {
+			return result.toArray(new IAdaptable[result.size()]);
+		}
+		for (IWorkingSet workingSet : workingSetManager.getWorkingSets()) {
 			if (!IDebugUIConstants.BREAKPOINT_WORKINGSET_ID.equals(workingSet.getId())) {
 				for (IAdaptable element : workingSet.getElements()) {
 					IResource resource = element.getAdapter(IResource.class);
@@ -74,7 +81,10 @@ public class WorkingSetBreakpointOrganizer extends AbstractBreakpointOrganizerDe
 
 	@Override
 	public void dispose() {
-		fWorkingSetManager.removePropertyChangeListener(this);
+		IWorkingSetManager workingSetManager = getWorkingSetManager();
+		if (workingSetManager != null) {
+			workingSetManager.removePropertyChangeListener(this);
+		}
 		fWorkingSetManager = null;
 		super.dispose();
 	}
@@ -90,5 +100,16 @@ public class WorkingSetBreakpointOrganizer extends AbstractBreakpointOrganizerDe
 		if (set != null && !IDebugUIConstants.BREAKPOINT_WORKINGSET_ID.equals(set.getId())) {
 			fireCategoryChanged(new WorkingSetCategory(set));
 		}
+	}
+
+	private IWorkingSetManager getWorkingSetManager() {
+		if (fWorkingSetManager != null) {
+			return fWorkingSetManager;
+		}
+
+		if (PlatformUI.isWorkbenchRunning()) {
+			fWorkingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+		}
+		return fWorkingSetManager;
 	}
 }


### PR DESCRIPTION
This change adjusts several classes to handle headless state, i.e. when the workbench is not available. The respective operations now do nothing without a workbench, instead of throwing exceptions.

Fixes: https://github.com/eclipse-platform/eclipse.platform/issues/2673