### PR TITLE
Modernized help UI prototype: Fix DOM-based XSS vulnerability

### DIFF
--- a/ua/org.eclipse.help.webapp/m/index.js
+++ b/ua/org.eclipse.help.webapp/m/index.js
@@ -378,9 +378,9 @@
                             var scopeName = decodeHtml(match[1]);
                             if (scopeName.substring(0, 1) == '\u200B') continue;
                             var li = createElement(ol, 'li');
-                            createButton(li, scopeName, 0, function(scopeName, scopeIndex) {
+                            createButton(li, 0, 0, function(scopeName, scopeIndex) {
                                 return function() { showScopesPage('operation=edit&workingSet=' + encodeURIComponent(scopeName), scopeIndex); };
-                            }(scopeName, scopeIndex), 'ba');
+                            }(scopeName, scopeIndex), 'ba', scopeName);
                             scopeIndex++;
                         }
                         createButton(scopesPage, '<%js:scopes_new_button_label%>', '<%js:scopes_new_button_description%>', function() { showScopesPage('operation=add'); });


### PR DESCRIPTION
When the [modernized help UI is activated](https://github.com/eclipse-platform/eclipse.platform/blob/master/ua/org.eclipse.help.webapp/m/README.md#activation), this vulnerability can be reproduced by creating a search scope with the following name: `scope1<video src=0 onloadstart=alert('XSS')>`
This will cause an alert box to pop up, proving that the JavaScript code within the scope name will be executed.

**Caused by:**
The search scope configuration page is created dynamically via JavaScript: A button element is inserted into the DOM for each scope. However, the scope name is incorrectly set to the button as `innerHTML` rather than `textContent` or a child text node.

**Type of vulnerability:**
DOM-based or type-0 cross-site scripting (XSS)
See: https://owasp.org/www-community/attacks/DOM_Based_XSS

**Attack vector:**
The attacker tricks the user into entering a scope name, containing the malicious JavaScript code.