### PR TITLE
Increment o.e.core.runtime version for PluginVersionIdentifier removal

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/.settings/.api_filters
+++ b/runtime/bundles/org.eclipse.core.runtime/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.core.runtime" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="Removed per API deprecation and removal process." id="926941240">
+            <message_arguments>
+                <message_argument value="3.35.0"/>
+                <message_argument value="3.34.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.core.runtime.PluginVersionIdentifier">
+        <filter comment="Removed per API deprecation and removal process." id="305422471">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.PluginVersionIdentifier"/>
+                <message_argument value="org.eclipse.core.runtime_3.34.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,14 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.34.200.qualifier
+Bundle-Version: 3.35.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.preferences.legacy;x-internal:=true,
  org.eclipse.core.internal.runtime;x-internal:=true,
- org.eclipse.core.runtime;version="3.7.0"
+ org.eclipse.core.runtime;version="3.8.0"
 Require-Bundle: org.eclipse.osgi;bundle-version="[3.23.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.jobs;bundle-version="[3.15.0,4.0.0)";visibility:=reexport,


### PR DESCRIPTION
The bundle `org.eclipse.core.runtime` re-exports
`org.eclipse.equinox.common` and therefore has to handle the API-tools consequences of the removal of `PluginVersionIdentifier` too.

Required due to:
- https://github.com/eclipse-equinox/equinox/pull/1308
