### PR TITLE
Fix cleanup for launchview tests

### DIFF
--- a/debug/org.eclipse.debug.ui.launchview.tests/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.2.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.debug.ui;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.debug.ui.launchview;bundle-version="[1.0.2,2.0.0)"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"

--- a/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/launchview/LaunchViewSmokeTest.java
+++ b/debug/org.eclipse.debug.ui.launchview.tests/src/org/eclipse/debug/ui/launchview/tests/launchview/LaunchViewSmokeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 SSI Schaefer IT Solutions GmbH and others.
+ * Copyright (c) 2021, 2026 SSI Schaefer IT Solutions GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,25 +14,23 @@
 package org.eclipse.debug.ui.launchview.tests.launchview;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
+import org.eclipse.debug.ui.launchview.LaunchConfigurationViewPlugin;
 import org.eclipse.debug.ui.launchview.tests.AbstractLaunchViewTest;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.junit.jupiter.api.Test;
+import org.osgi.annotation.bundle.Referenced;
 
+@Referenced(LaunchConfigurationViewPlugin.class)
 public class LaunchViewSmokeTest extends AbstractLaunchViewTest {
 
 	@Test
-	public void testOpenView() {
+	public void testOpenView() throws PartInitException {
 		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		assertNotNull(page, "The active workbench page should not be null");
-		try {
-			page.showView("org.eclipse.debug.ui.launchView"); //$NON-NLS-1$
-		} catch (PartInitException exception) {
-			fail("Failed to open launch configuration view");
-		}
+		page.showView("org.eclipse.debug.ui.launchView"); //$NON-NLS-1$
 
 	}
 

--- a/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui.launchview;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",

--- a/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
-Export-Package: org.eclipse.debug.ui.launchview;x-internal:=true,
+Export-Package: org.eclipse.debug.ui.launchview;x-friends:="org.eclipse.debug.ui.launchview.tests",
  org.eclipse.debug.ui.launchview.services;x-internal:=true
 Automatic-Module-Name: org.eclipse.debug.ui.launchview
 Service-Component: OSGI-INF/org.eclipse.debug.ui.launchview.internal.impl.DebugCoreProvider.xml,


### PR DESCRIPTION
PDE cleanup removed dependency on org.eclipse.debug.ui.launchview as it is needed for showView(viewId) to work.
Adding @Referenced to LaunchConfigurationViewPlugin in the test to hint the tool. An x-friend in org.eclipse.debug.ui.launchview is needed as all exported packages are internal.
Should fix
https://github.com/eclipse-platform/eclipse.platform/pull/2692 .