### PR TITLE
Restore supplier-disposal link in ClassRequestor without jakarta

### DIFF
--- a/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
+++ b/runtime/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/ClassRequestor.java
@@ -13,8 +13,10 @@
  *******************************************************************************/
 package org.eclipse.e4.core.internal.di;
 
+import java.lang.reflect.Field;
 import org.eclipse.e4.core.di.IInjector;
 import org.eclipse.e4.core.di.InjectionException;
+import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.suppliers.IObjectDescriptor;
 import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
 
@@ -26,7 +28,23 @@ import org.eclipse.e4.core.di.suppliers.PrimaryObjectSupplier;
  */
 public class ClassRequestor extends Requestor<Class<?>> {
 
-	private static IObjectDescriptor[] pseudoVariableDescriptor = {};
+	private interface InjectionLink {
+		// Marker type for the pseudo dependency. It is intentionally never available
+		// from any supplier, so the (optional) dependency never resolves to a value.
+	}
+
+	@Optional
+	private static final InjectionLink PSEUDO_VARIABLE = null;
+	static {
+		try {
+			Field field = ClassRequestor.class.getDeclaredField("PSEUDO_VARIABLE"); //$NON-NLS-1$
+			pseudoVariableDescriptor = new IObjectDescriptor[] {
+					new ObjectDescriptor(field.getGenericType(), field.getAnnotations()) };
+		} catch (NoSuchFieldException e) {
+			throw new IllegalStateException(e); // the field is declared right above, this cannot happen
+		}
+	}
+	private static final IObjectDescriptor[] pseudoVariableDescriptor;
 
 	public ClassRequestor(Class<?> clazz, IInjector injector, PrimaryObjectSupplier primarySupplier, PrimaryObjectSupplier tempSupplier, Object requestingObject, boolean track) {
 		super(clazz, injector, primarySupplier, tempSupplier, requestingObject, track);


### PR DESCRIPTION
PR #2649 decoupled the E4 injector from jakarta annotations by replacing the ClassRequestor pseudo-dependency descriptor with an empty array. That pseudo-link is what notifies an injected object when its supplier is disposed. With an empty descriptor the link is no longer established, so @PreDestroy of objects that only use constructor/@PostConstruct injection (no @Inject links) is no longer guaranteed to run before the supplying context is disposed.

This broke disposal ordering and surfaced as a failure of PartRenderingEngineTests.testBut336225 ("The shell should not have been disposed first"), reported in eclipse-platform/eclipse.platform#2700.

Restore a non-empty, optional descriptor without re-introducing jakarta: use a private marker interface InjectionLink that is never available from any supplier together with e4's own @Optional annotation. This keeps the injector free of specific jakarta annotation classes (the goal of #2649) while re-establishing the supplier-disposal link.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2700