### PR TITLE
Remove obsolete hover image descriptors

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/DisconnectCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/DisconnectCommandAction.java
@@ -57,11 +57,6 @@ public class DisconnectCommandAction extends DebugCommandAction{
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_LCL_DISCONNECT);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_LCL_DISCONNECT);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/DropToFrameCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/DropToFrameCommandAction.java
@@ -52,11 +52,6 @@ public class DropToFrameCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_DROP_TO_FRAME);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_DROP_TO_FRAME);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/RestartCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/RestartCommandAction.java
@@ -48,11 +48,6 @@ public class RestartCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_RESTART);
-	}
-
-	@Override
 	public String getId() {
 		return "org.eclipse.debug.ui.actions.Restart"; //$NON-NLS-1$
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/ResumeCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/ResumeCommandAction.java
@@ -57,11 +57,6 @@ public class ResumeCommandAction extends DebugCommandAction{
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_RESUME);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_RESUME);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepIntoCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepIntoCommandAction.java
@@ -57,11 +57,6 @@ public class StepIntoCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_STEP_INTO);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_STEP_INTO);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepOverCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepOverCommandAction.java
@@ -48,11 +48,6 @@ public class StepOverCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_STEP_OVER);
-	}
-
-	@Override
 	public String getId() {
 		return "org.eclipse.debug.ui.debugview.toolbar.stepOver"; //$NON-NLS-1$
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepReturnCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/StepReturnCommandAction.java
@@ -43,11 +43,6 @@ public class StepReturnCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_STEP_RETURN);
-	}
-
-	@Override
 	public String getId() {
 		return "org.eclipse.debug.ui.debugview.toolbar.stepReturn"; //$NON-NLS-1$
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/SuspendCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/SuspendCommandAction.java
@@ -57,11 +57,6 @@ public class SuspendCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_SUSPEND);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_SUSPEND);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAllAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAllAction.java
@@ -90,12 +90,6 @@ public class TerminateAllAction extends DebugCommandAction implements ILaunchesL
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages
-				.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_ALL);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages
 				.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_ALL);

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRelaunchAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRelaunchAction.java
@@ -135,11 +135,6 @@ public class TerminateAndRelaunchAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_RELAUNCH);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_RELAUNCH);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRemoveAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateAndRemoveAction.java
@@ -79,11 +79,6 @@ public class TerminateAndRemoveAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_REMOVE);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE_AND_REMOVE);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/TerminateCommandAction.java
@@ -57,11 +57,6 @@ public class TerminateCommandAction extends DebugCommandAction {
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE);
-	}
-
-	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TERMINATE);
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/ToggleStepFiltersAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/commands/actions/ToggleStepFiltersAction.java
@@ -50,11 +50,6 @@ public class ToggleStepFiltersAction extends DebugCommandAction implements IPref
 	}
 
 	@Override
-	public ImageDescriptor getHoverImageDescriptor() {
-		return DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_TOGGLE_STEP_FILTERS);
-	}
-
-	@Override
 	public String getId() {
 		return "org.eclipse.debug.ui.actions.ToggleStepFilters"; //$NON-NLS-1$
 	}

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/DebugCommandAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/DebugCommandAction.java
@@ -301,7 +301,9 @@ public abstract class DebugCommandAction extends Action implements IDebugContext
 	public abstract ImageDescriptor getDisabledImageDescriptor();
 
 	@Override
-	public abstract ImageDescriptor getHoverImageDescriptor();
+	public ImageDescriptor getHoverImageDescriptor() {
+		return super.getHoverImageDescriptor();
+	}
 
 	@Override
 	public abstract ImageDescriptor getImageDescriptor();


### PR DESCRIPTION
For several actions, hover image descriptors that are equal to the ordinary image descriptors are set without any need. This change removes those obsolete descriptors.