### PR TITLE
Add Additional Space after <terminated> & <Disconnected> label

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DefaultLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DefaultLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -255,13 +255,13 @@ public class DefaultLabelProvider implements ILabelProvider {
 						int exit = process.getExitValue();
 						terminatedMessage = MessageFormat.format(DebugUIMessages.DefaultLabelProvider_16, Integer.toString(exit));
 					} else {
-						terminatedMessage= DebugUIMessages.DefaultLabelProvider_1;
+						terminatedMessage = DebugUIMessages.DefaultLabelProvider_1;
 					}
-					label.insert(0, terminatedMessage);
+					label.insert(0, terminatedMessage + " "); //$NON-NLS-1$
 				}
 			} else if (element instanceof IDisconnect) {
 				if (((IDisconnect) element).isDisconnected()) {
-					label.insert(0, DebugUIMessages.DefaultLabelProvider__disconnected__1);
+					label.insert(0, DebugUIMessages.DefaultLabelProvider__disconnected__1 + " "); //$NON-NLS-1$
 				}
 			}
 		} catch (DebugException e) {


### PR DESCRIPTION
Current space does not sync with what shown in console 
<img width="279" height="86" alt="Screenshot 2026-06-05 at 5 58 36 PM" src="https://github.com/user-attachments/assets/c12e0a06-5151-48cf-9cda-035036f38523" />

Current (No single space)
<img width="330" height="169" alt="Screenshot 2026-06-05 at 5 58 20 PM" src="https://github.com/user-attachments/assets/fa3010d3-2887-4249-9141-a2a2bb96e05c" />


New (added a single space)
<img width="327" height="47" alt="Screenshot 2026-06-05 at 6 01 07 PM" src="https://github.com/user-attachments/assets/98f632f7-cdb8-49fb-ab18-5cbe4ea6d33d" />

