### PR TITLE
Show disabled icon for Disabled category in Breakpoint Enablement Grouping

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointEnablement.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointEnablement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,8 +23,10 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.IBreakpointsListener;
 import org.eclipse.debug.core.model.IBreakpoint;
+import org.eclipse.debug.internal.ui.DebugPluginImages;
 import org.eclipse.debug.ui.AbstractBreakpointOrganizerDelegate;
 import org.eclipse.debug.ui.BreakpointTypeCategory;
+import org.eclipse.debug.ui.IDebugUIConstants;
 
 /**
  * Breakpoint organizers for breakpoint types based on breakpoint enablement
@@ -33,7 +35,8 @@ import org.eclipse.debug.ui.BreakpointTypeCategory;
 public class BreakpointEnablement extends AbstractBreakpointOrganizerDelegate implements IBreakpointsListener {
 
 	private final BreakpointTypeCategory ENABLED = new BreakpointTypeCategory("Enabled", 0); //$NON-NLS-1$
-	private final BreakpointTypeCategory DISABLED = new BreakpointTypeCategory("Disabled", 1); //$NON-NLS-1$
+	private final BreakpointTypeCategory DISABLED = new BreakpointTypeCategory("Disabled", 1, //$NON-NLS-1$
+			DebugPluginImages.getImageDescriptor(IDebugUIConstants.IMG_OBJS_BREAKPOINT_GROUP_DISABLED));
 
 	private final Map<IBreakpoint, Boolean> breakpointCache;
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/BreakpointTypeCategory.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/BreakpointTypeCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -68,6 +68,22 @@ public class BreakpointTypeCategory extends PlatformObject implements IBreakpoin
 		fName = name;
 		fSortable = true;
 		fSortPriority = sortPriority;
+	}
+
+	/**
+	 * Constructs a type category for the given type name with the given sort
+	 * priority and image.
+	 *
+	 * @param name         breakpoint type name
+	 * @param sortPriority used to calculate the sort order of this category
+	 * @param descriptor   image descriptor
+	 * @since 3.22
+	 */
+	public BreakpointTypeCategory(String name, int sortPriority, ImageDescriptor descriptor) {
+		this(name, sortPriority);
+		if (descriptor != null) {
+			fImageDescriptor = descriptor;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Before 
<img width="235" height="152" alt="Screenshot 2026-06-05 at 6 31 53 PM" src="https://github.com/user-attachments/assets/c74b4e54-e768-4134-bd23-50cafb99f333" />

After
<img width="323" height="205" alt="Screenshot 2026-06-05 at 6 31 47 PM" src="https://github.com/user-attachments/assets/ba8cf100-0e2b-4c7d-a694-867421338152" />
