### PR TITLE
Create Launch Group from selected launch configurations in Launch Config View

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/groups/GroupMemberChangeListener.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/groups/GroupMemberChangeListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2016, 2017 SSI Schaefer IT Solutions GmbH and others.
+ *  Copyright (c) 2016, 2026 SSI Schaefer IT Solutions GmbH and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,7 @@ import org.eclipse.debug.core.ILaunchManager;
  */
 public class GroupMemberChangeListener implements ILaunchConfigurationListener {
 
-	private static final String GROUP_TYPE_ID = "org.eclipse.debug.core.groups.GroupLaunchConfigurationType"; //$NON-NLS-1$
+	public static final String GROUP_TYPE_ID = "org.eclipse.debug.core.groups.GroupLaunchConfigurationType"; //$NON-NLS-1$
 
 	@Override
 	public void launchConfigurationAdded(ILaunchConfiguration configuration) {

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -89,7 +89,7 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 	private UnlinkPrototypeAction fUnlinkPrototypeAction;
 	private ResetWithPrototypeValuesAction fResetWithPrototypeValuesAction;
 	private ImportLaunchConfigurationAction fImportAction;
-
+	private QuickGroupLaunch quickGroupLaunchAction;
 	/**
 	 * Action for providing filtering to the Launch Configuration Dialog
 	 * @since 3.2
@@ -233,6 +233,10 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 
 		fResetWithPrototypeValuesAction = new ResetWithPrototypeValuesAction(getViewer(), getLaunchGroup().getMode());
 		setAction(ResetWithPrototypeValuesAction.ID_RESET_WITH_PROTOTYPE_VALUES_ACTION, fResetWithPrototypeValuesAction);
+
+		quickGroupLaunchAction = new QuickGroupLaunch(getViewer(), getLaunchGroup().getMode());
+		setAction(QuickGroupLaunch.ID_QUICK_GROUP_LAUNCH_ACTION, quickGroupLaunchAction);
+
 	}
 
 	/**
@@ -253,6 +257,7 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		menu.add(fExportAction);
 		menu.add(fDuplicateAction);
 		menu.add(fDeleteAction);
+		menu.add(quickGroupLaunchAction);
 		menu.add(new Separator());
 		menu.add(fLinkPrototypeAction);
 		menu.add(fUnlinkPrototypeAction);
@@ -290,6 +295,7 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		fLinkPrototypeAction.dispose();
 		fUnlinkPrototypeAction.dispose();
 		fResetWithPrototypeValuesAction.dispose();
+		quickGroupLaunchAction.dispose();
 		getLaunchManager().removeLaunchConfigurationListener(this);
 	}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2025 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -863,6 +863,16 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 		return (AbstractLaunchConfigurationAction)fLaunchConfigurationView.getAction(CreateLaunchConfigurationAction.ID_CREATE_ACTION);
 	}
 
+	/**
+	 * Gets the quick group launch menu action
+	 *
+	 * @return the quick group launch menu action
+	 *
+	 */
+	protected AbstractLaunchConfigurationAction getQuickGroupLaunchAction() {
+		return (AbstractLaunchConfigurationAction) fLaunchConfigurationView
+				.getAction(QuickGroupLaunch.ID_QUICK_GROUP_LAUNCH_ACTION);
+	}
 	/**
 	 * Gets the new prototype menu action
 	 *

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2025 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -314,5 +314,9 @@ public class LaunchConfigurationsMessages extends NLS {
 	public static String LaunchConfigurationImportDialog;
 
 	public static String LaunchConfigurationTabGroupViewer_19;
+
+	public static String QuickGroupLaunchActionLabel;
+
+	public static String QuickGroupLaunchActionToolTip;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2025 IBM Corporation and others.
+#  Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -198,6 +198,8 @@ LinkPrototypeAction_Link_prototype_1=&Link Prototype...
 UnlinkPrototypeAction_Unlink_prototype_1=&Unlink Prototype
 ResetWithPrototypeValuesAction_Reset_with_prototype_values_1=&Reset with Prototype Values
 ImportLaunchConfigurationAction=Import
+QuickGroupLaunchActionLabel=Quick Group Launch
+QuickGroupLaunchActionToolTip=Create a new launch group with the selected launches
 
 EnvironmentTab_Variable_1=Variable
 EnvironmentTab_Value_2=Value

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/QuickGroupLaunch.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/QuickGroupLaunch.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.internal.ui.launchConfigurations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.internal.core.groups.GroupLaunchConfigurationDelegate;
+import org.eclipse.debug.internal.core.groups.GroupLaunchElement;
+import org.eclipse.debug.internal.core.groups.GroupLaunchElement.GroupElementPostLaunchAction;
+import org.eclipse.debug.internal.core.groups.GroupMemberChangeListener;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * Quickly create a group launch configuration with launch configuration
+ * selections
+ *
+ */
+public class QuickGroupLaunch extends AbstractLaunchConfigurationAction {
+
+	/**
+	 * Action identifier for IDebugView#getAction(String)
+	 */
+	public static final String ID_QUICK_GROUP_LAUNCH_ACTION = DebugUIPlugin.getUniqueIdentifier()
+			+ ".ID_QUICK_GROUP_LAUNCH_ACTION"; //$NON-NLS-1$
+
+	/**
+	 * Constructs an action to apply a prototype to a launch configuration
+	 *
+	 * @param viewer the viewer
+	 * @param mode the mode the action applies to
+	 */
+	public QuickGroupLaunch(Viewer viewer, String mode) {
+		super(LaunchConfigurationsMessages.QuickGroupLaunchActionLabel, viewer, mode);
+	}
+
+	/**
+	 * @see AbstractLaunchConfigurationAction#performAction()
+	 */
+	@Override
+	protected void performAction() {
+		String mode = getMode();
+		ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+
+		try {
+			ILaunchConfigurationType groupType = manager
+					.getLaunchConfigurationType(GroupMemberChangeListener.GROUP_TYPE_ID);
+
+			ILaunchConfigurationWorkingCopy wc = groupType.newInstance(
+					null,
+					manager.generateLaunchConfigurationName(
+							LaunchConfigurationsMessages.CreateLaunchConfigurationAction_New_configuration_2));
+
+			List<GroupLaunchElement> input = new ArrayList<>();
+
+			IStructuredSelection selection = getStructuredSelection();
+
+			for (Object selected : selection) {
+				if (selected instanceof ILaunchConfiguration launchConfig) {
+					GroupLaunchElement element = new GroupLaunchElement();
+					element.index = input.size();
+					element.enabled = true;
+					element.name = launchConfig.getName();
+					element.data = launchConfig;
+					element.mode = mode;
+					element.action = GroupElementPostLaunchAction.NONE;
+					element.adoptIfRunning = false;
+					element.actionParam = GroupElementPostLaunchAction.NONE;
+
+					input.add(element);
+				}
+			}
+
+			GroupLaunchConfigurationDelegate.storeLaunchElements(wc, input);
+
+			ILaunchConfiguration config = wc.doSave();
+
+			String launchGroupId = ILaunchManager.DEBUG_MODE.equals(mode) ? IDebugUIConstants.ID_DEBUG_LAUNCH_GROUP
+					: IDebugUIConstants.ID_RUN_LAUNCH_GROUP;
+
+			DebugUITools.openLaunchConfigurationDialogOnGroup(Display.getDefault().getActiveShell(),
+					new StructuredSelection(config), launchGroupId);
+
+		} catch (CoreException e) {
+			DebugPlugin.log(e);
+		}
+	}
+
+	/**
+	 * @see org.eclipse.ui.actions.SelectionListenerAction#updateSelection(org.eclipse.jface.viewers.IStructuredSelection)
+	 */
+	@Override
+	protected boolean updateSelection(IStructuredSelection selection) {
+		return selection.size() > 1;
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+		return DebugUITools.getImageDescriptor(IInternalDebugUIConstants.IMG_OBJS_LAUNCH_GROUP);
+	}
+
+	@Override
+	public String getToolTipText() {
+		return LaunchConfigurationsMessages.QuickGroupLaunchActionToolTip;
+	}
+}


### PR DESCRIPTION
This PR adds a new context menu action in the Launch Configurations dialog that allows users to quickly create a Launch Group from the currently selected launch configurations. 
<img width="260" height="244" alt="Screenshot 2026-06-07 at 12 30 34 PM" src="https://github.com/user-attachments/assets/8933c874-c69e-40a9-89ec-5199c1223c0d" />


Previously, creating a Launch Group required first creating a new Launch Group configuration and then manually adding the desired launch configurations as group members, which could be repetitive and time-consuming. With this enhancement, the selected launch configurations are automatically added to the newly created Launch Group, streamlining the workflow while still allowing users to further customize the group configuration if needed.


https://github.com/user-attachments/assets/f819dc67-3e8c-4d3c-a20d-a126ca9e018f

