### PR TITLE
Show relative last termination time in Launch History tooltip

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/Launch.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/Launch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,15 +25,19 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.PlatformObject;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IDisconnect;
 import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.core.model.ISourceLocator;
 import org.eclipse.debug.internal.core.DebugCoreMessages;
 import org.eclipse.debug.internal.core.LaunchManager;
+import org.osgi.service.prefs.BackingStoreException;
 
 /**
  * A launch is the result of launching a debug session
@@ -475,7 +479,24 @@ public class Launch extends PlatformObject implements ILaunch, IDisconnect, ILau
 	 * properly created/initialized.
 	 */
 	protected void fireTerminate() {
-		setAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP, Long.toString(System.currentTimeMillis()));
+		String timeStamp = Long.toString(System.currentTimeMillis());
+		setAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP, timeStamp);
+		ILaunchConfiguration launchConfig = getLaunchConfiguration();
+		if (launchConfig != null) {
+			try {
+				if (launchConfig.isLocal()) {
+					ILaunchConfigurationWorkingCopy launchCopy = launchConfig.getWorkingCopy();
+					launchCopy.setAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP, timeStamp);
+					launchCopy.doSave();
+				} else {
+					IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(DebugPlugin.getUniqueIdentifier());
+					prefs.put(launchConfig.getName(), timeStamp);
+					prefs.flush();
+				}
+			} catch (CoreException | BackingStoreException e) {
+				DebugPlugin.log(e);
+			}
+		}
 		if (!fSuppressChange) {
 			((LaunchManager)getLaunchManager()).fireUpdate(this, LaunchManager.TERMINATE);
 			((LaunchManager)getLaunchManager()).fireUpdate(new ILaunch[] {this}, LaunchManager.TERMINATE);

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfiguration.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,8 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -62,6 +64,7 @@ import org.eclipse.debug.core.model.ILaunchConfigurationDelegate;
 import org.eclipse.debug.core.model.ILaunchConfigurationDelegate2;
 import org.eclipse.debug.core.model.IPersistableSourceLocator;
 import org.eclipse.debug.core.sourcelookup.IPersistableSourceLocator2;
+import org.osgi.service.prefs.BackingStoreException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
@@ -304,6 +307,15 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 	@Override
 	public void delete() throws CoreException {
 		if (exists()) {
+			if (!isLocal()) {
+				try {
+					IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(DebugPlugin.getUniqueIdentifier());
+					prefs.remove(getName());
+					prefs.flush();
+				} catch (BackingStoreException e) {
+					DebugPlugin.log(e);
+				}
+			}
 			IFile file = getFile();
 			if (file == null) {
 				IFileStore store = getFileStore();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -2039,4 +2039,105 @@ public class LaunchConfigurationTests implements ILaunchConfigurationListener {
 
 	}
 
+	@Test
+	public void testSharedTerminateTimeStampPersistence() throws Exception {
+		IProject project = getProject();
+		ILaunchConfigurationWorkingCopy workingCopy = newConfiguration(project, "TestSharedTimestamp");
+
+		Set<ILaunch> terminatedLaunches = Collections.synchronizedSet(new HashSet<>());
+
+		ILaunchesListener2 listener = new ILaunchesListener2() {
+			@Override
+			public void launchesRemoved(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesChanged(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesAdded(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesTerminated(ILaunch[] launches) {
+				terminatedLaunches.addAll(Arrays.asList(launches));
+			}
+		};
+
+		DebugPlugin.getDefault().getLaunchManager().addLaunchListener(listener);
+
+		ILaunch launch = workingCopy.launch(ILaunchManager.DEBUG_MODE, null);
+		IProcess process = null;
+
+		try {
+			process = DebugPlugin.newProcess(launch, new MockProcess(0), "test");
+			waitWhile(() -> !terminatedLaunches.contains(launch), () -> "Launch termination event did not occur");
+			IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(DebugPlugin.getUniqueIdentifier());
+			String stamp = prefs.get(workingCopy.getName(), null);
+			assertNotNull(stamp, "Missing persisted terminate timestamp");
+			long timestamp = Long.parseLong(stamp);
+			assertTrue(timestamp <= System.currentTimeMillis());
+		} finally {
+			DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(listener);
+			if (launch != null) {
+				getLaunchManager().removeLaunch(launch);
+			}
+			if (process != null) {
+				process.terminate();
+			}
+		}
+	}
+
+	@Test
+	public void testLocalTerminateTimeStampPersistence() throws Exception {
+		ILaunchConfigurationWorkingCopy workingCopy = newConfiguration(null, "TestLocalTimestamp");
+		Set<ILaunch> terminatedLaunches = Collections.synchronizedSet(new HashSet<>());
+		ILaunchesListener2 listener = new ILaunchesListener2() {
+			@Override
+			public void launchesRemoved(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesChanged(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesAdded(ILaunch[] launches) {
+			}
+
+			@Override
+			public void launchesTerminated(ILaunch[] launches) {
+				terminatedLaunches.addAll(Arrays.asList(launches));
+			}
+		};
+
+		DebugPlugin.getDefault().getLaunchManager().addLaunchListener(listener);
+
+		ILaunch launch = workingCopy.launch(ILaunchManager.DEBUG_MODE, null);
+		IProcess process = null;
+
+		try {
+			process = DebugPlugin.newProcess(launch, new MockProcess(0), "test");
+			waitWhile(() -> !terminatedLaunches.contains(launch), () -> "Launch termination event did not occur");
+			ILaunchConfiguration config = launch.getLaunchConfiguration();
+			assertNotNull(config);
+			assertTrue(config.isLocal());
+			String timeStamp = config.getAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP, (String) null);
+			assertNotNull(timeStamp, "Terminate timestamp was not persisted");
+			long timestamp = Long.parseLong(timeStamp);
+
+			assertTrue(timestamp > 0);
+			assertTrue(timestamp <= System.currentTimeMillis());
+		} finally {
+			DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(listener);
+			if (launch != null) {
+				getLaunchManager().removeLaunch(launch);
+			}
+			if (process != null) {
+				process.terminate();
+			}
+		}
+	}
+
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.java
@@ -263,5 +263,12 @@ public class ActionMessages extends NLS {
 	public static String ExpressionPastePromptButton;
 	public static String ResumeOtherThreadsAction;
 	public static String ResumeOtherThreadsActionToolTip;
+	public static String LaunchActionToolTip_Seconds;
+	public static String LaunchActionToolTip_Minutes;
+	public static String LaunchActionToolTip_OneMinute;
+	public static String LaunchActionToolTip_OneHour;
+	public static String LaunchActionToolTip_Hours;
+	public static String LaunchActionToolTip_OneDay;
+	public static String LaunchActionToolTip_Days;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/ActionMessages.properties
@@ -248,3 +248,14 @@ ExpressionPastePromptButton=Prompt
 ExpressionPasteTitle=Paste Multiline Expression
 ExpressionPasteDialog=You are pasting a multiline expression. Choose whether to paste it as a single combined expression or as separate multiple expressions.
 ExpressionPasteRemember=Remember my preference next time
+
+LaunchActionToolTip_Seconds =Last executed a moment ago
+LaunchActionToolTip_OneMinute =Last executed 1 min ago
+LaunchActionToolTip_Minutes =Last executed {0} mins ago
+LaunchActionToolTip_OneHour =Last executed 1 hour ago
+LaunchActionToolTip_Hours =Last executed {0} hours ago
+LaunchActionToolTip_OneDay =Last executed 1 day ago
+LaunchActionToolTip_Days =Last executed {0} days ago
+
+
+

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/AbstractLaunchHistoryAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/AbstractLaunchHistoryAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,8 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -50,6 +52,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MenuAdapter;
 import org.eclipse.swt.events.MenuEvent;
@@ -353,6 +356,8 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 			LaunchAction action= new LaunchAction(launch, getMode());
 			if (checkIfLaunchActive(launch, launches)) {
 				action.setText(action.getText() + "  \u2699"); //$NON-NLS-1$
+			} else {
+				addRecentLaunchTimeTooltip(launch, action);
 			}
 			addToMenu(menu, action, accelerator);
 			accelerator++;
@@ -368,6 +373,8 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 			LaunchAction action= new LaunchAction(launch, getMode());
 			if (checkIfLaunchActive(launch, launches)) {
 				action.setText(action.getText() + "  \u2699"); //$NON-NLS-1$
+			} else {
+				addRecentLaunchTimeTooltip(launch, action);
 			}
 			addToMenu(menu, action, accelerator);
 			accelerator++;
@@ -627,4 +634,71 @@ public abstract class AbstractLaunchHistoryAction implements IActionDelegate2, I
 	protected String getLaunchGroupIdentifier() {
 		return fLaunchGroup.getIdentifier();
 	}
+
+	/**
+	 * Adds a tooltip showing how long ago the given launch was terminated if
+	 * there's a valid terminate timestamp attribute.
+	 *
+	 * @param launch       launch configuration
+	 * @param launchAction launch action to update
+	 */
+	private void addRecentLaunchTimeTooltip(ILaunchConfiguration launch, LaunchAction launchAction) {
+		try {
+			String timeStamp;
+			if (launch.isLocal()) {
+				timeStamp = launch.getAttribute(DebugPlugin.ATTR_TERMINATE_TIMESTAMP, ""); //$NON-NLS-1$
+			} else {
+				IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(DebugPlugin.getUniqueIdentifier());
+				timeStamp = prefs.get(launch.getName(), ""); //$NON-NLS-1$
+			}
+
+			if (!timeStamp.isEmpty()) {
+				long timestamp = Long.parseLong(timeStamp);
+				launchAction.setToolTipText(getRelativeTime(timestamp));
+			}
+		} catch (CoreException | NumberFormatException e) {
+			DebugUIPlugin.log(e);
+		}
+	}
+
+	/**
+	 * Returns a human-readable relative time string for the given timestamp.
+	 *
+	 * @param timestamp timestamp in milliseconds since the epoch
+	 * @return relative time string
+	 */
+	private String getRelativeTime(long timestamp) {
+		long diffMillis = Math.max(0L, System.currentTimeMillis() - timestamp);
+		long seconds = diffMillis / 1000;
+
+		if (seconds < 60) {
+			return ActionMessages.LaunchActionToolTip_Seconds;
+		}
+
+		long minutes = seconds / 60;
+
+		if (minutes == 1) {
+			return ActionMessages.LaunchActionToolTip_OneMinute;
+		}
+		if (minutes < 60) {
+			return NLS.bind(ActionMessages.LaunchActionToolTip_Minutes, minutes);
+		}
+
+		long hours = minutes / 60;
+
+		if (hours == 1) {
+			return ActionMessages.LaunchActionToolTip_OneHour;
+		}
+		if (hours < 24) {
+			return NLS.bind(ActionMessages.LaunchActionToolTip_Hours, hours);
+		}
+
+		long days = hours / 24;
+
+		if (days == 1) {
+			return ActionMessages.LaunchActionToolTip_OneDay;
+		}
+		return NLS.bind(ActionMessages.LaunchActionToolTip_Days, days);
+	}
+
 }


### PR DESCRIPTION
This change enhances the launch history menu by displaying a relative termination time in the tooltip for previously launched configurations. Instead of showing only the launch configuration name, the tooltip now indicates how recently the launch was terminated using user-friendly text such as "a moment ago", "5 mins ago", or "1 hour ago", based on the stored termination timestamp. This provides quick contextual information about recent launches, making it easier to identify and relaunch configurations that were used recently. The additional context is particularly useful when launch favorites are pinned to the top of the menu, as their fixed ordering does not reflect recent usage and can make it harder to determine which configuration was run most recently.

<img width="346" height="323" alt="Screenshot 2026-06-08 at 2 39 06 PM" src="https://github.com/user-attachments/assets/9e02d6bd-e817-4410-9b05-684008f58fb8" />
<img width="323" height="320" alt="Screenshot 2026-06-08 at 2 43 43 PM" src="https://github.com/user-attachments/assets/cdba38a0-d4a1-4dad-9493-234045222126" />
<img width="318" height="303" alt="Screenshot 2026-06-08 at 2 43 38 PM" src="https://github.com/user-attachments/assets/badd289c-9da0-4a25-b5c9-370c783b9ad7" />
<img width="322" height="347" alt="Screenshot 2026-06-08 at 2 39 36 PM" src="https://github.com/user-attachments/assets/ee1fa136-1749-43a1-abf5-c12c5afe3c00" />
<img width="374" height="109" alt="image" src="https://github.com/user-attachments/assets/0a8630fc-db8f-4916-93ab-dfd1e52a5381" />

