### PR TITLE
Fix Javadoc build error in org.eclipse.team.ui synchronize package.html

### DIFF
--- a/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/ui/synchronize/package.html
+++ b/team/bundles/org.eclipse.team.ui/src/org/eclipse/team/ui/synchronize/package.html
@@ -142,8 +142,7 @@ shown in synchronize viewers.<br>
 <hr style="width: 100%; height: 2px;">
 <h3>Related Documentation</h3>
 <ul>
-  <li>For examples of these APIs in action please see the <a
- href="http://dev.eclipse.org/viewcvs/index.cgi/org.eclipse.team.examples.filesystem/">org.eclipse.team.examples.filesystem</a>
+  <li>For examples of these APIs in action please see the <a href="http://dev.eclipse.org/viewcvs/index.cgi/org.eclipse.team.examples.filesystem/">org.eclipse.team.examples.filesystem</a>
 plug-in example and also refer to the <span style="font-weight: bold;">Platform
 Plug-in Developer Guide &gt; Programmer's Guide &gt; Team Support</span>
 documentation.<br>


### PR DESCRIPTION
The `<a>` tag in `org.eclipse.team.ui/synchronize/package.html` was split across two lines. Java 25's strict HTML5 Javadoc parser treats this as an unknown tag, causing 6 cascading errors and breaking the aggregator build.

Fix: join the `href` attribute onto the opening tag line.