### PR TITLE
Remove requirement of inlined o.e.jdt.launching.macosx fragment

### DIFF
--- a/ant/org.eclipse.ant.tests.ui/META-INF/p2.inf
+++ b/ant/org.eclipse.ant.tests.ui/META-INF/p2.inf
@@ -1,3 +1,0 @@
-requires.0.namespace = org.eclipse.equinox.p2.iu
-requires.0.name = org.eclipse.jdt.launching.macosx
-requires.0.filter = (osgi.os=macosx)


### PR DESCRIPTION
Part of
- https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/855