### PR TITLE
Add back org.eclipse.ui.genericeditor dependency

### DIFF
--- a/team/bundles/org.eclipse.team.genericeditor.diff.extension/META-INF/MANIFEST.MF
+++ b/team/bundles/org.eclipse.team.genericeditor.diff.extension/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.filebuffers,
  org.eclipse.jface.text;bundle-version="[3.11.100,4.0.0)",
- org.eclipse.ui;bundle-version="[3.208.0,4.0.0)"
+ org.eclipse.ui;bundle-version="[3.208.0,4.0.0)",
+ org.eclipse.ui.genericeditor;bundle-version="1.4.100"
 Export-Package: org.eclipse.team.internal.genericeditor.diff.extension.partitioner;x-internal:=true,
  org.eclipse.team.internal.genericeditor.diff.extension.presentation;x-internal:=true,
  org.eclipse.team.internal.genericeditor.diff.extension.rules;x-internal:=true


### PR DESCRIPTION
This should prevent errors on startup from `EditorRegistryReader.readEditorContentTypeBinding(IConfigurationElement)`

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2759