### PR TITLE
Improve console water mark error messages

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2020 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ public class ConsoleMessages extends NLS {
 
 	public static String ConsoleTerminateAction_0;
 	public static String ConsoleTerminateAction_1;
+	public static String ConsoleBufferConfigurationError;
 
 	public static String ProcessConsole_0;
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2025 IBM Corporation and others.
+#  Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ ConsoleRemoveTerminatedAction_1=Remove Launch
 
 ConsoleTerminateAction_0=&Terminate
 ConsoleTerminateAction_1=Terminate
+ConsoleBufferConfigurationError=Console buffer configuration error: High water mark ({0}) must be greater than low water mark ({1}).
 
 ProcessConsole_0=<terminated> {0}
 

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
@@ -91,6 +91,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IPersistableElement;
@@ -527,6 +528,11 @@ public class ProcessConsole extends IOConsole implements IConsole, IDebugEventSe
 				int lowWater = store.getInt(IDebugPreferenceConstants.CONSOLE_LOW_WATER_MARK);
 				if (highWater > lowWater) {
 					setWaterMarks(lowWater, highWater);
+				} else {
+					String msg = NLS.bind(
+							ConsoleMessages.ConsoleBufferConfigurationError,
+							highWater, lowWater);
+					DebugUIPlugin.log(new Status(IStatus.WARNING, IDebugUIConstants.PLUGIN_ID, msg));
 				}
 			} else {
 				setWaterMarks(-1, -1);

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -247,7 +247,8 @@ public class IOConsole extends TextConsole {
 	public void setWaterMarks(int low, int high) {
 		if (low >= 0) {
 			if (low >= high) {
-				throw new IllegalArgumentException("High water mark must be greater than low water mark"); //$NON-NLS-1$
+				throw new IllegalArgumentException(
+						String.format("High water mark (%d) must be greater than low water mark (%d)", high, low)); //$NON-NLS-1$
 			}
 		}
 		partitioner.setWaterMarks(low, high);


### PR DESCRIPTION
This change improves logging when invalid console water mark values are encountered. Previously, users would see an IllegalArgumentException with the message, High water mark must be greater than low water mark without any indication of the actual values that caused the failure. This change updates to include the configured high and low water mark values in the exception message thrown by `IOConsole.setWaterMarks`. Also adds a warning with additional context in logs in `ProcessConsole.propertyChange` when an invalid console buffer configuration is detected.


contributes to: https://github.com/eclipse-platform/eclipse.platform/issues/1262