### PR TITLE
Run terminal tests with the UI test harness

### DIFF
--- a/terminal/tests/org.eclipse.terminal.test/test.xml
+++ b/terminal/tests/org.eclipse.terminal.test/test.xml
@@ -32,7 +32,7 @@
 	<target name="suite">
 		<property name="sniff-folder" value="${eclipse-home}/terminal_sniff_folder" />
 		<delete dir="${sniff-folder}" quiet="true" />
-		<ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
+		<ant target="ui-test" antfile="${library-file}" dir="${eclipse-home}">
 			<property name="data-dir" value="${sniff-folder}"/>
 			<property name="plugin-name" value="${plugin-name}"/>
 			<property name="classname" value="org.eclipse.terminal.test.AutomatedIntegrationSuite"/>


### PR DESCRIPTION
Since #2681 the terminal test suite contains TerminalsViewReorderTest, which loads the TerminalsView class and thereby lazily activates org.eclipse.terminal.view.ui. That activation fails in the headless core-test harness used by the SDK I-builds because UIPlugin.start() registers a workbench listener, causing the 5 failures reported in #2762. The Tycho build stayed green because it auto-detects the UI harness for this bundle and already runs the whole suite with a workbench.

This switches the test.xml suite target from core-test to ui-test so the SDK builds get the same environment, matching the other UI test bundles in this repository.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2762