### PR TITLE
Finish removal of deprecated runtime contentTypes extension point

### DIFF
--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeBuilder.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeBuilder.java
@@ -227,9 +227,7 @@ public class ContentTypeBuilder {
 	private final static IConfigurationElement[] emptyConfArray = new IConfigurationElement[0];
 
 	/**
-	 * Gets configuration elements for both "backward compatible" extension point
-	 * 		org.eclipse.core.runtime.contentTypes
-	 * and "new" extension point controlled by this plugin:
+	 * Gets configuration elements for the extension point controlled by this plugin:
 	 * 		org.eclipse.core.contenttype.contentTypes
 	 */
 	protected IConfigurationElement[] getConfigurationElements() {
@@ -237,24 +235,11 @@ public class ContentTypeBuilder {
 		if (registry == null) {
 			return emptyConfArray;
 		}
-		IConfigurationElement[] oldConfigElements = emptyConfArray;
-		IConfigurationElement[] newConfigElements = emptyConfArray;
-		// "old" extension point
-		IExtensionPoint oldPoint = registry.getExtensionPoint(IContentConstants.RUNTIME_NAME, PT_CONTENTTYPES);
-		if (oldPoint != null) {
-			oldConfigElements = oldPoint.getConfigurationElements();
+		IExtensionPoint contentTypesPoint = registry.getExtensionPoint(IContentConstants.CONTENT_NAME, PT_CONTENTTYPES);
+		if (contentTypesPoint == null) {
+			return emptyConfArray;
 		}
-		// "new" extension point
-		IExtensionPoint newPoint = registry.getExtensionPoint(IContentConstants.CONTENT_NAME, PT_CONTENTTYPES);
-		if (newPoint != null) {
-			newConfigElements = newPoint.getConfigurationElements();
-		}
-
-		IConfigurationElement[] allContentTypeCEs = new IConfigurationElement[oldConfigElements.length + newConfigElements.length];
-		System.arraycopy(oldConfigElements, 0, allContentTypeCEs, 0, oldConfigElements.length);
-		System.arraycopy(newConfigElements, 0, allContentTypeCEs, oldConfigElements.length, newConfigElements.length);
-
-		return allContentTypeCEs;
+		return contentTypesPoint.getConfigurationElements();
 	}
 
 	private void missingMandatoryAttribute(String messageKey, String argument) throws CoreException {

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeManager.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeManager.java
@@ -53,16 +53,13 @@ public class ContentTypeManager extends ContentTypeMatcher implements IContentTy
 		@Override
 		public void registryChanged(IRegistryChangeEvent event) {
 			// no changes related to the content type registry
-			if (event.getExtensionDeltas(IContentConstants.RUNTIME_NAME, ContentTypeBuilder.PT_CONTENTTYPES).length == 0
-					&& event.getExtensionDeltas(IContentConstants.CONTENT_NAME,
-							ContentTypeBuilder.PT_CONTENTTYPES).length == 0) {
+			if (event.getExtensionDeltas(IContentConstants.CONTENT_NAME, ContentTypeBuilder.PT_CONTENTTYPES).length == 0) {
 				return;
 			}
 			getInstance().invalidate();
 		}
 	}
 
-	private static IRegistryChangeListener runtimeExtensionListener = new ContentTypeRegistryChangeListener();
 	private static IRegistryChangeListener contentExtensionListener = new ContentTypeRegistryChangeListener();
 
 	private static volatile ContentTypeManager instance;
@@ -103,9 +100,6 @@ public class ContentTypeManager extends ContentTypeMatcher implements IContentTy
 		if (registry == null) {
 			return;
 		}
-		// Different instances of listener required. See documentation of
-		// IExtensionRegistry.addRegistryChangeListener(IRegistryChangeListener, String).
-		registry.addRegistryChangeListener(runtimeExtensionListener, IContentConstants.RUNTIME_NAME);
 		registry.addRegistryChangeListener(contentExtensionListener, IContentConstants.CONTENT_NAME);
 	}
 
@@ -123,7 +117,6 @@ public class ContentTypeManager extends ContentTypeMatcher implements IContentTy
 			return;
 		}
 		getInstance().invalidate();
-		registry.removeRegistryChangeListener(runtimeExtensionListener);
 		registry.removeRegistryChangeListener(contentExtensionListener);
 	}
 

--- a/runtime/bundles/org.eclipse.core.runtime/plugin.properties
+++ b/runtime/bundles/org.eclipse.core.runtime/plugin.properties
@@ -14,5 +14,4 @@
 pluginName = Core Runtime
 providerName = Eclipse.org
 shutdownHook = Shutdown Hook
-contentTypesName = Content Types
 preferencesName=Preferences

--- a/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
+++ b/runtime/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/perf/ContentTypePerformanceTest.java
@@ -30,6 +30,7 @@ import java.io.Writer;
 import java.net.URL;
 import org.eclipse.core.internal.content.ContentTypeBuilder;
 import org.eclipse.core.internal.content.ContentTypeHandler;
+import org.eclipse.core.internal.content.IContentConstants;
 import org.eclipse.core.internal.content.Util;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
@@ -168,7 +169,7 @@ public class ContentTypePerformanceTest {
 
 	private static Bundle installContentTypes(int numberOfLevels, int nodesPerLevel)
 			throws IOException, BundleException {
-		TestRegistryChangeListener listener = new TestRegistryChangeListener(Platform.PI_RUNTIME, ContentTypeBuilder.PT_CONTENTTYPES, null, null);
+		TestRegistryChangeListener listener = new TestRegistryChangeListener(IContentConstants.CONTENT_NAME, ContentTypeBuilder.PT_CONTENTTYPES, null, null);
 		Bundle installed = null;
 		listener.register();
 		try {
@@ -181,7 +182,7 @@ public class ContentTypePerformanceTest {
 					0x10000)) {
 				writer.write("<plugin>");
 				writer.write(eol);
-				writer.write("<extension point=\"org.eclipse.core.runtime.contentTypes\">");
+				writer.write("<extension point=\"org.eclipse.core.contenttype.contentTypes\">");
 				writer.write(eol);
 				String root = createContentType(writer, 0, null);
 				createContentTypes(writer, root, 1, numberOfLevels, nodesPerLevel);


### PR DESCRIPTION
The `org.eclipse.core.runtime.contentTypes` extension point and its schema were removed earlier, but the runtime still read from that point and registered a registry-change listener for it.
This change drops the dead back-compatibility branch in `ContentTypeBuilder` and the matching listener wiring in `ContentTypeManager`, so the runtime only consumes the long-established `org.eclipse.core.contenttype.contentTypes` point.
It also migrates the content type performance test, which contributed to the old point and would otherwise register nothing, and removes the now-orphaned `contentTypesName` label from the runtime `plugin.properties`.
All edits are in internal classes, a test, and a resource file, so there is no public API change.