### PR TITLE
Update stale references to removed runtime contentTypes point

### DIFF
--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/XMLContentDescriber.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/XMLContentDescriber.java
@@ -36,7 +36,7 @@ package org.eclipse.core.internal.content;
  *                Clients should use it to provide their own XML-based
  *                describers that can be referenced by the "describer"
  *                configuration element in extensions to the
- *                <code>org.eclipse.core.runtime.contentTypes</code> extension
+ *                <code>org.eclipse.core.contenttype.contentTypes</code> extension
  *                point.
  *
  * @see org.eclipse.core.runtime.content.IContentDescriber

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/BinarySignatureDescriber.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/BinarySignatureDescriber.java
@@ -47,7 +47,7 @@ import org.eclipse.osgi.util.NLS;
  * <p>
  * This class is not intended to be subclassed or instantiated by clients,
  * only to be referenced by the "describer" configuration element in
- * extensions to the <code>org.eclipse.core.runtime.contentTypes</code>
+ * extensions to the <code>org.eclipse.core.contenttype.contentTypes</code>
  * extension point.
  * </p>
  *

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLContentDescriber.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLContentDescriber.java
@@ -41,7 +41,7 @@ import org.eclipse.core.runtime.QualifiedName;
  *                Clients should use it to provide their own XML-based
  *                describers that can be referenced by the "describer"
  *                configuration element in extensions to the
- *                <code>org.eclipse.core.runtime.contentTypes</code> extension
+ *                <code>org.eclipse.core.contenttype.contentTypes</code> extension
  *                point.
  * @see org.eclipse.core.runtime.content.IContentDescriber
  * @see org.eclipse.core.runtime.content.XMLRootElementContentDescriber2

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLRootElementContentDescriber.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLRootElementContentDescriber.java
@@ -33,7 +33,7 @@ import org.xml.sax.InputSource;
  * <p>
  * This class is not intended to be subclassed or instantiated by clients,
  * only to be referenced by the "describer" configuration element in
- * extensions to the <code>org.eclipse.core.runtime.contentTypes</code>
+ * extensions to the <code>org.eclipse.core.contenttype.contentTypes</code>
  * extension point.
  * </p>
  *

--- a/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLRootElementContentDescriber2.java
+++ b/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/runtime/content/XMLRootElementContentDescriber2.java
@@ -61,7 +61,7 @@ import org.xml.sax.SAXException;
  * <p>
  * This class is not intended to be subclassed or instantiated by clients,
  * only to be referenced by the "describer" configuration element in
- * extensions to the <code>org.eclipse.core.runtime.contentTypes</code>
+ * extensions to the <code>org.eclipse.core.contenttype.contentTypes</code>
  * extension point.
  * </p>
  *

--- a/ua/org.eclipse.ua.tests/data/help/dynamic/toc.xml
+++ b/ua/org.eclipse.ua.tests/data/help/dynamic/toc.xml
@@ -437,7 +437,6 @@
        <topic label="org.eclipse.core.resources.teamHook" href="reference/extension-points/org_eclipse_core_resources_teamHook.html"/>
        <topic label="org.eclipse.core.runtime.adapters" href="reference/extension-points/org_eclipse_core_runtime_adapters.html"/>
        <topic label="org.eclipse.core.runtime.applications" href="reference/extension-points/org_eclipse_core_runtime_applications.html"/>
-       <topic label="org.eclipse.core.runtime.contentTypes" href="reference/extension-points/org_eclipse_core_runtime_contentTypes.html"/>
        <topic label="org.eclipse.core.runtime.preferences" href="reference/extension-points/org_eclipse_core_runtime_preferences.html"/>
        <topic label="org.eclipse.core.runtime.products" href="reference/extension-points/org_eclipse_core_runtime_products.html"/>
        <topic label="org.eclipse.core.variables.dynamicVariables" href="reference/extension-points/org_eclipse_core_variables_dynamicVariables.html"/>

--- a/ua/org.eclipse.ua.tests/data/help/dynamic/toc_expected.txt
+++ b/ua/org.eclipse.ua.tests/data/help/dynamic/toc_expected.txt
@@ -424,7 +424,6 @@
        <topic href="reference/extension-points/org_eclipse_core_resources_teamHook.html" label="org.eclipse.core.resources.teamHook"/>
        <topic href="reference/extension-points/org_eclipse_core_runtime_adapters.html" label="org.eclipse.core.runtime.adapters"/>
        <topic href="reference/extension-points/org_eclipse_core_runtime_applications.html" label="org.eclipse.core.runtime.applications"/>
-       <topic href="reference/extension-points/org_eclipse_core_runtime_contentTypes.html" label="org.eclipse.core.runtime.contentTypes"/>
        <topic href="reference/extension-points/org_eclipse_core_runtime_preferences.html" label="org.eclipse.core.runtime.preferences"/>
        <topic href="reference/extension-points/org_eclipse_core_runtime_products.html" label="org.eclipse.core.runtime.products"/>
        <topic href="reference/extension-points/org_eclipse_core_variables_dynamicVariables.html" label="org.eclipse.core.variables.dynamicVariables"/>

--- a/ua/org.eclipse.ua.tests/data/help/performance/org.eclipse.platform.doc.isv/topics_Reference.xml
+++ b/ua/org.eclipse.ua.tests/data/help/performance/org.eclipse.platform.doc.isv/topics_Reference.xml
@@ -213,7 +213,6 @@
        <topic label="org.eclipse.core.resources.teamHook" href="reference/extension-points/org_eclipse_core_resources_teamHook.html"/>
        <topic label="org.eclipse.core.runtime.adapters" href="reference/extension-points/org_eclipse_core_runtime_adapters.html"/>
        <topic label="org.eclipse.core.runtime.applications" href="reference/extension-points/org_eclipse_core_runtime_applications.html"/>
-       <topic label="org.eclipse.core.runtime.contentTypes" href="reference/extension-points/org_eclipse_core_runtime_contentTypes.html"/>
        <topic label="org.eclipse.core.runtime.preferences" href="reference/extension-points/org_eclipse_core_runtime_preferences.html"/>
        <topic label="org.eclipse.core.runtime.products" href="reference/extension-points/org_eclipse_core_runtime_products.html"/>
        <topic label="org.eclipse.core.variables.dynamicVariables" href="reference/extension-points/org_eclipse_core_variables_dynamicVariables.html"/>


### PR DESCRIPTION
Follow-up to the removal of the `org.eclipse.core.runtime.contentTypes` extension point.
The content describer Javadocs (`BinarySignatureDescriber`, `XMLRootElementContentDescriber`, `XMLRootElementContentDescriber2`, and both `XMLContentDescriber` classes) still told clients to reference the deleted point, so they now point at the replacement `org.eclipse.core.contenttype.contentTypes`.
The unused help test fixtures (`toc.xml`, its matching `toc_expected.txt`, and `topics_Reference.xml`) listed a reference topic for the deleted point, which is dropped.
This is a documentation and test-data only change with no code or behavior impact.