### PR TITLE
Switch to `Platform.getDebugBoolean(String)` where appropriate

### DIFF
--- a/docs/FAQ/FAQ_How_do_I_use_the_platform_debug_tracing_facility.md
+++ b/docs/FAQ/FAQ_How_do_I_use_the_platform_debug_tracing_facility.md
@@ -34,7 +34,7 @@ If you do not need dynamic trace enablement or if you are concerned about code c
 
 
 ```java
-       private static final boolean DEBUG_TWO = "true".equalsIgnoreCase(Platform.getDebugOption(
+       private static final boolean DEBUG_TWO = Platform.getDebugBoolean(
              "org.eclipse.faq.examples/debug/option2"));
        ...
        if (DEBUG_TWO)

--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/Expressions.java
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/Expressions.java
@@ -56,7 +56,7 @@ public class Expressions {
 	private static WeakHashMap<ClassLoader, Set<String>> fgNotFoundClasses;
 
 	/* debugging flag to enable tracing */
-	public static final boolean TRACING= "true".equalsIgnoreCase(Platform.getDebugOption("org.eclipse.core.expressions/tracePropertyResolving")); //$NON-NLS-1$ //$NON-NLS-2$
+	public static final boolean TRACING= Platform.getDebugBoolean("org.eclipse.core.expressions/tracePropertyResolving"); //$NON-NLS-1$
 
 
 	private Expressions() {

--- a/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/TypeExtensionManager.java
+++ b/runtime/bundles/org.eclipse.core.expressions/src/org/eclipse/core/internal/expressions/TypeExtensionManager.java
@@ -40,7 +40,7 @@ public class TypeExtensionManager implements IRegistryChangeListener {
 	 *
 	 * @since 3.5
 	 */
-	private static boolean DEBUG= "true".equalsIgnoreCase(Platform.getDebugOption("org.eclipse.core.expressions/debug/TypeExtensionManager")); //$NON-NLS-1$//$NON-NLS-2$
+	private static boolean DEBUG = Platform.getDebugBoolean("org.eclipse.core.expressions/debug/TypeExtensionManager"); //$NON-NLS-1$
 
 	private static final String TYPE= "type"; //$NON-NLS-1$
 

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/Logger.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/connector/Logger.java
@@ -59,10 +59,10 @@ public final class Logger {
 
 	static {
 		// Any of the known debugging options turns on the creation of the log file
-		boolean createLogFile = TerminalPlugin.isOptionEnabled(TRACE_DEBUG_LOG)
-				|| TerminalPlugin.isOptionEnabled(TRACE_DEBUG_LOG_CHAR)
-				|| TerminalPlugin.isOptionEnabled(TRACE_DEBUG_LOG_VT100BACKEND)
-				|| TerminalPlugin.isOptionEnabled(TRACE_DEBUG_LOG_HOVER);
+		boolean createLogFile = Platform.getDebugBoolean(TRACE_DEBUG_LOG)
+				|| Platform.getDebugBoolean(TRACE_DEBUG_LOG_CHAR)
+				|| Platform.getDebugBoolean(TRACE_DEBUG_LOG_VT100BACKEND)
+				|| Platform.getDebugBoolean(TRACE_DEBUG_LOG_HOVER);
 
 		// Log only if tracing is enabled
 		if (createLogFile && TerminalPlugin.getDefault() != null) {

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalPlugin.java
@@ -20,7 +20,6 @@
  *******************************************************************************/
 package org.eclipse.terminal.internal.control.impl;
 
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -52,15 +51,6 @@ public class TerminalPlugin extends AbstractUIPlugin {
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
 		super.stop(context);
-	}
-
-	public static boolean isOptionEnabled(String strOption) {
-		String strEnabled = Platform.getDebugOption(strOption);
-		if (strEnabled == null) {
-			return false;
-		}
-
-		return Boolean.parseBoolean(strEnabled);
 	}
 
 }

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/emulator/VT100Emulator.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/emulator/VT100Emulator.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Arrays;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.graphics.RGB;
@@ -49,7 +50,6 @@ import org.eclipse.terminal.connector.ITerminalConnector;
 import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.control.TerminalTitleRequestor;
 import org.eclipse.terminal.internal.control.impl.ITerminalControlForText;
-import org.eclipse.terminal.internal.control.impl.TerminalPlugin;
 import org.eclipse.terminal.model.ITerminalTextData;
 import org.eclipse.terminal.model.TerminalStyle;
 
@@ -168,7 +168,7 @@ public class VT100Emulator implements ControlListener {
 			ansiParameters[i] = new StringBuffer();
 		}
 		setInputStreamReader(reader);
-		if (TerminalPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_VT100BACKEND)) {
+		if (Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_VT100BACKEND)) {
 			text = new VT100BackendTraceDecorator(new VT100EmulatorBackend(data), System.out);
 		} else {
 			text = new VT100EmulatorBackend(data);

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/emulator/VT100TerminalControl.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/emulator/VT100TerminalControl.java
@@ -58,6 +58,7 @@ import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.bindings.Binding;
@@ -828,7 +829,7 @@ public class VT100TerminalControl implements ITerminalControlForText, ITerminalC
 	}
 
 	protected boolean isLogCharEnabled() {
-		return TerminalPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_CHAR);
+		return Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_CHAR);
 	}
 
 	@Override

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/AbstractTextCanvasModel.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/AbstractTextCanvasModel.java
@@ -18,15 +18,15 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.terminal.connector.Logger;
-import org.eclipse.terminal.internal.control.impl.TerminalPlugin;
 import org.eclipse.terminal.model.ITerminalTextDataReadOnly;
 import org.eclipse.terminal.model.ITerminalTextDataSnapshot;
 import org.eclipse.terminal.model.TextRange;
 
 abstract public class AbstractTextCanvasModel implements ITextCanvasModel {
-	private static final boolean DEBUG_HOVER = TerminalPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_HOVER);
+	private static final boolean DEBUG_HOVER = Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_HOVER);
 	protected List<ITextCanvasModelListener> fListeners = new ArrayList<>();
 	private int fCursorLine;
 	private int fCursorColumn;

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextLineRenderer.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/textcanvas/TextLineRenderer.java
@@ -19,13 +19,13 @@ package org.eclipse.terminal.internal.textcanvas;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Drawable;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.terminal.connector.Logger;
-import org.eclipse.terminal.internal.control.impl.TerminalPlugin;
 import org.eclipse.terminal.model.ITerminalTextDataReadOnly;
 import org.eclipse.terminal.model.LineSegment;
 import org.eclipse.terminal.model.TerminalColor;
@@ -35,7 +35,7 @@ import org.eclipse.terminal.model.TerminalStyle;
  *
  */
 public class TextLineRenderer implements ILinelRenderer {
-	private static final boolean DEBUG_HOVER = TerminalPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_HOVER);
+	private static final boolean DEBUG_HOVER = Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_HOVER);
 	private final ITextCanvasModel fModel;
 	private final StyleMap fStyleMap;
 

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/model/TerminalStyle.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/model/TerminalStyle.java
@@ -15,9 +15,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.terminal.connector.Logger;
-import org.eclipse.terminal.internal.control.impl.TerminalPlugin;
 
 /**
  * @author scharf
@@ -43,7 +43,7 @@ public class TerminalStyle {
 				protected boolean removeEldestEntry(Map.Entry<TerminalStyle, TerminalStyle> eldest) {
 					int size = size();
 					boolean removeEldest = size >= 1000;
-					if (TerminalPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_VT100BACKEND)) {
+					if (Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_VT100BACKEND)) {
 						if (removeEldest) {
 							Logger.log("Removing eldest Style from style cache, size = " + size); //$NON-NLS-1$
 						} else {

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TraceHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TraceHandler.java
@@ -86,7 +86,7 @@ public class TraceHandler {
 		 * @return <code>true</code> if the slot is defined and enabled, <code>false</code> otherwise.
 		 */
 		protected boolean isSlotEnabled(String slotId) {
-			return fIdentifier != null ? Boolean.parseBoolean(Platform.getDebugOption(fIdentifier + "/" + slotId)) //$NON-NLS-1$
+			return fIdentifier != null ? Platform.getDebugBoolean(fIdentifier + "/" + slotId) //$NON-NLS-1$
 					: false;
 		}
 

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/UIPlugin.java
@@ -17,7 +17,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
@@ -263,15 +262,6 @@ public class UIPlugin extends AbstractUIPlugin {
 	 */
 	public static ImageDescriptor getImageDescriptor(String key) {
 		return getDefault().getImageRegistry().getDescriptor(key);
-	}
-
-	public static boolean isOptionEnabled(String strOption) {
-		String strEnabled = Platform.getDebugOption(strOption);
-		if (strEnabled == null) {
-			return false;
-		}
-
-		return Boolean.parseBoolean(strEnabled);
 	}
 
 	public static ITerminalService getTerminalService() {

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/tabs/OpenFileMouseHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/tabs/OpenFileMouseHandler.java
@@ -36,7 +36,6 @@ import org.eclipse.terminal.connector.Logger;
 import org.eclipse.terminal.control.ITerminalMouseListener;
 import org.eclipse.terminal.control.ITerminalViewControl;
 import org.eclipse.terminal.model.ITerminalTextDataReadOnly;
-import org.eclipse.terminal.view.ui.internal.UIPlugin;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
@@ -54,7 +53,7 @@ import org.osgi.framework.Bundle;
  * @noreference This class is not intended to be referenced by clients.
  */
 public class OpenFileMouseHandler implements ITerminalMouseListener {
-	private static final boolean DEBUG_HOVER = UIPlugin.isOptionEnabled(Logger.TRACE_DEBUG_LOG_HOVER);
+	private static final boolean DEBUG_HOVER = Platform.getDebugBoolean(Logger.TRACE_DEBUG_LOG_HOVER);
 	private static final List<String> NEEDED_BUNDLES = //
 			List.of("org.eclipse.core.resources", //$NON-NLS-1$
 					"org.eclipse.ui.ide", //$NON-NLS-1$

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/HelpUIPlugin.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/HelpUIPlugin.java
@@ -68,7 +68,7 @@ public class HelpUIPlugin extends AbstractUIPlugin {
 		// Setup debugging options
 		DEBUG = isDebugging();
 		if (DEBUG) {
-			DEBUG_INFOPOP = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/infopop")); //$NON-NLS-1$ //$NON-NLS-2$
+			DEBUG_INFOPOP = Platform.getDebugBoolean(PLUGIN_ID + "/debug/infopop"); //$NON-NLS-1$
 		}
 
 		if (BaseHelpSystem.getMode() == BaseHelpSystem.MODE_WORKBENCH) {

--- a/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/HelpWebappPlugin.java
+++ b/ua/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/HelpWebappPlugin.java
@@ -44,7 +44,7 @@ public class HelpWebappPlugin extends Plugin {
 		// Setup debugging options
 		DEBUG = isDebugging();
 		if (DEBUG) {
-			DEBUG_WORKINGSETS = "true".equalsIgnoreCase(Platform.getDebugOption("org.eclipse.help.webapp/debug/workingsets")); //$NON-NLS-1$ //$NON-NLS-2$
+			DEBUG_WORKINGSETS = Platform.getDebugBoolean("org.eclipse.help.webapp/debug/workingsets"); //$NON-NLS-1$
 		}
 	}
 

--- a/ua/org.eclipse.help/src/org/eclipse/help/internal/HelpPlugin.java
+++ b/ua/org.eclipse.help/src/org/eclipse/help/internal/HelpPlugin.java
@@ -147,11 +147,11 @@ public class HelpPlugin extends Plugin {
 		// Setup debugging options
 		DEBUG = isDebugging();
 		if (DEBUG) {
-			DEBUG_CONTEXT = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/context")); //$NON-NLS-1$ //$NON-NLS-2$
-			DEBUG_SEARCH = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/search")); //$NON-NLS-1$ //$NON-NLS-2$
-			DEBUG_TOC = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/toc")); //$NON-NLS-1$ //$NON-NLS-2$
-			DEBUG_INDEX = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/index")); //$NON-NLS-1$ //$NON-NLS-2$
-			DEBUG_CRITERIA = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/criteria")); //$NON-NLS-1$ //$NON-NLS-2$
+			DEBUG_CONTEXT = Platform.getDebugBoolean(PLUGIN_ID + "/debug/context"); //$NON-NLS-1$
+			DEBUG_SEARCH = Platform.getDebugBoolean(PLUGIN_ID + "/debug/search"); //$NON-NLS-1$
+			DEBUG_TOC = Platform.getDebugBoolean(PLUGIN_ID + "/debug/toc"); //$NON-NLS-1$
+			DEBUG_INDEX = Platform.getDebugBoolean(PLUGIN_ID + "/debug/index"); //$NON-NLS-1$
+			DEBUG_CRITERIA = Platform.getDebugBoolean(PLUGIN_ID + "/debug/criteria"); //$NON-NLS-1$
 		}
 	}
 

--- a/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetStopWatch.java
+++ b/ua/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetStopWatch.java
@@ -108,10 +108,7 @@ public class CheatSheetStopWatch {
 
 	public static boolean isTracing() {
 		if (CheatSheetPlugin.getPlugin().isDebugging()) {
-			String traceTimes = Platform.getDebugOption("org.eclipse.ui.cheatsheets/trace/creation/times"); //$NON-NLS-1$
-			if (traceTimes != null && traceTimes.equalsIgnoreCase("true")) { //$NON-NLS-1$
-				return true;
-			}
+			return Platform.getDebugBoolean("org.eclipse.ui.cheatsheets/trace/creation/times"); //$NON-NLS-1$
 		}
 		return false;
 	}

--- a/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/Log.java
+++ b/ua/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/Log.java
@@ -55,15 +55,10 @@ public class Log implements IUniversalIntroConstants {
 		// the plugin is not in debug mode, no point setting debug options.
 		if (UniversalIntroPlugin.getDefault().isDebugging()) {
 			logWarning = true;
-			logInfo = getDebugOption("/trace/logInfo"); //$NON-NLS-1$
-			logPerformance = getDebugOption("/trace/logPerformance"); //$NON-NLS-1$
+			logInfo = Platform.getDebugBoolean(PLUGIN_ID + "/trace/logInfo"); //$NON-NLS-1$
+			logPerformance = Platform.getDebugBoolean(PLUGIN_ID + "/trace/logPerformance"); //$NON-NLS-1$
 		}
 
-	}
-
-	private static boolean getDebugOption(String option) {
-		return "true".equalsIgnoreCase(//$NON-NLS-1$
-			Platform.getDebugOption(PLUGIN_ID + option));
 	}
 
 	/**

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/IntroPlugin.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/IntroPlugin.java
@@ -32,10 +32,8 @@ public class IntroPlugin extends AbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.ui.intro"; //$NON-NLS-1$
 
 	// Debug control variables
-	public static boolean LOG_WARN =
-		"true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID+"/debug/warn")); //$NON-NLS-1$ //$NON-NLS-2$
-	public static boolean LOG_INFO =
-		"true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID+"/debug/info")); //$NON-NLS-1$ //$NON-NLS-2$
+	public static boolean LOG_WARN = Platform.getDebugBoolean(PLUGIN_ID + "/debug/warn"); //$NON-NLS-1$
+	public static boolean LOG_INFO = Platform.getDebugBoolean(PLUGIN_ID + "/debug/info"); //$NON-NLS-1$
 
 	// The static shared instance.
 	private static IntroPlugin inst;
@@ -176,10 +174,10 @@ public class IntroPlugin extends AbstractUIPlugin {
 		// Setup debugging options
 		DEBUG = isDebugging();
 		if (DEBUG) {
-			DEBUG_NO_BROWSER = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/flags/noBrowser")); //$NON-NLS-1$ //$NON-NLS-2$
+			DEBUG_NO_BROWSER = Platform.getDebugBoolean(PLUGIN_ID + "/flags/noBrowser"); //$NON-NLS-1$
 		}
 		if (DEBUG) {
-			DEBUG_TOOLBAR = "true".equalsIgnoreCase(Platform.getDebugOption(PLUGIN_ID + "/debug/toolbar")); //$NON-NLS-1$ //$NON-NLS-2$
+			DEBUG_TOOLBAR = Platform.getDebugBoolean(PLUGIN_ID + "/debug/toolbar"); //$NON-NLS-1$
 		}
 
 	}

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/BrowserIntroPartImplementation.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/presentations/BrowserIntroPartImplementation.java
@@ -388,9 +388,7 @@ public class BrowserIntroPartImplementation extends
 
 		// print the HTML if we are in debug mode and have tracing turned on
 		if (IntroPlugin.getDefault().isDebugging()) {
-			String printHtml = Platform
-				.getDebugOption("org.eclipse.ui.intro/trace/printHTML"); //$NON-NLS-1$
-			if (printHtml != null && printHtml.equalsIgnoreCase("true")) { //$NON-NLS-1$
+			if (Platform.getDebugBoolean("org.eclipse.ui.intro/trace/printHTML")) { //$NON-NLS-1$
 				System.out.println(content);
 			}
 			if (IntroPlugin.DEBUG_TOOLBAR) {

--- a/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/util/Log.java
+++ b/ua/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/util/Log.java
@@ -55,15 +55,10 @@ public class Log implements IIntroConstants {
 		// the plugin is not in debug mode, no point setting debug options.
 		if (IntroPlugin.getDefault().isDebugging()) {
 			logWarning = true;
-			logInfo = getDebugOption("/trace/logInfo"); //$NON-NLS-1$
-			logPerformance = getDebugOption("/trace/logPerformance"); //$NON-NLS-1$
+			logInfo = Platform.getDebugBoolean(PLUGIN_ID + "/trace/logInfo"); //$NON-NLS-1$
+			logPerformance = Platform.getDebugBoolean(PLUGIN_ID + "/trace/logPerformance"); //$NON-NLS-1$
 		}
 
-	}
-
-	private static boolean getDebugOption(String option) {
-		return "true".equalsIgnoreCase(//$NON-NLS-1$
-			Platform.getDebugOption(PLUGIN_ID + option));
 	}
 
 	/**


### PR DESCRIPTION
With 3b76d20c6f6da97f8ba449d6303e8a47b4543331, a convenience method `getDebugBoolean(String)` was added, which returns `true` if the given tracing option is enabled. Using this method avoids a lot of the boilerplate code that comes with using `getDebugOption(String)` and which usually looks something like:

`"true".equals(Platform.getDebugOption("..."))`