### PR TITLE
Fix "Show Command Line" button clipping at larger font sizes

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -276,6 +276,7 @@ public class LaunchConfigurationTabGroupViewer {
 		fShowCommandLineButton = SWTFactory.createPushButton(buttonComp,
 				LaunchConfigurationsMessages.LaunchConfigurationDialog_ShowCommandLine, null,
 				GridData.HORIZONTAL_ALIGN_BEGINNING);
+		fShowCommandLineButton.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
 		fShowCommandLineButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent evt) {


### PR DESCRIPTION
Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/462

Before:
<img width="564" height="158" alt="image" src="https://github.com/user-attachments/assets/6a6660db-efc3-4135-b0c5-e983915b5917" />


After: 
<img width="735" height="224" alt="image" src="https://github.com/user-attachments/assets/1bae39ca-3a07-4f52-91a8-ac5b3913d5a6" />
