### PR TITLE
Show unified diff for compare inputs that carry an ancestor

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -738,10 +738,8 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			if (!(res instanceof ICompareInput compareInput)) {
 				return null;
 			}
-			ITypedElement ancestor = compareInput.getAncestor();
-			if (ancestor != null) {
-				return null;
-			}
+			// A common ancestor (3-way input) is ignored; the unified diff renders a
+			// plain left-vs-right overlay.
 			ITypedElement left = compareInput.getLeft();
 			if (left == null) {
 				return null;


### PR DESCRIPTION
The experimental unified diff overlay was only offered for strict 2-way compare inputs, because `canShowInUnifiedDiff` bailed out whenever the input carried a common ancestor.
That excluded EGit history compares such as "Compare With Previous Version", which attach a git merge-base ancestor even for a conceptually 2-way diff.
Since the overlay is computed purely from the left and right sides, the ancestor can safely be ignored.
With this change those compares render inline diff markers when the experimental unified diff preference is enabled.