### PR TITLE
Use ILog instead of CompareUIPlugin logging helpers

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/EditionSelectionDialog.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/EditionSelectionDialog.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 
 import org.eclipse.compare.internal.CompareContainer;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.CompareUIPlugin;
 import org.eclipse.compare.internal.ResizableDialog;
 import org.eclipse.compare.internal.StructureCreatorDescriptor;
@@ -37,6 +38,7 @@ import org.eclipse.compare.structuremergeviewer.IStructureComparator;
 import org.eclipse.compare.structuremergeviewer.IStructureCreator;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ISelection;
@@ -141,7 +143,7 @@ public class EditionSelectionDialog extends ResizableDialog {
 							fContent= Utilities.readString(sca);
 						} catch (CoreException ex) {
 							// NeedWork
-							CompareUIPlugin.log(ex);
+							ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 						}
 					}
 				}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/ContentMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/ContentMergeViewer.java
@@ -33,7 +33,6 @@ import org.eclipse.compare.internal.CompareEditor;
 import org.eclipse.compare.internal.CompareHandlerService;
 import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.ComparePreferencePage;
-import org.eclipse.compare.internal.CompareUIPlugin;
 import org.eclipse.compare.internal.ICompareUIConstants;
 import org.eclipse.compare.internal.IFlushable2;
 import org.eclipse.compare.internal.ISavingSaveable;
@@ -47,6 +46,7 @@ import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.compare.structuremergeviewer.ICompareInputChangeListener;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.action.Action;
@@ -135,8 +135,8 @@ public abstract class ContentMergeViewer extends ContentViewer
 		public void layout(Composite composite, boolean force) {
 			if (fLeftLabel == null) {
 				if (composite.isDisposed()) {
-					CompareUIPlugin
-							.log(new IllegalArgumentException("Attempted to perform a layout on a disposed composite")); //$NON-NLS-1$
+					ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error,
+							new IllegalArgumentException("Attempted to perform a layout on a disposed composite")); //$NON-NLS-1$
 				}
 				if (Policy.debugContentMergeViewer) {
 					logTrace("found bad label. Layout = " + System.identityHashCode(this) + ". composite = "  //$NON-NLS-1$//$NON-NLS-2$
@@ -150,7 +150,7 @@ public abstract class ContentMergeViewer extends ContentViewer
 
 				// Allow to test whether doing nothing helps
 				if (Boolean.getBoolean("ContentMergeViewer.DEBUG")) { //$NON-NLS-1$
-					CompareUIPlugin.log(npe);
+					ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, npe);
 					return;
 				}
 
@@ -958,7 +958,7 @@ public abstract class ContentMergeViewer extends ContentViewer
 						try {
 							((IPersistentPreferenceStore) preferences).save();
 						} catch (IOException e) {
-							CompareUIPlugin.log(e);
+							ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 						}
 					}
 				}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -95,6 +95,7 @@ import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -628,7 +629,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 						try {
 							fDocumentProvider.resetDocument(fDocumentKey);
 						} catch (CoreException e) {
-							CompareUIPlugin.log(e);
+							ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 						} finally {
 							update(true);
 							updateStructure(fLeg);
@@ -915,7 +916,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 						return newDoc;
 					} catch (CoreException e) {
 						// Connection failed. Log the error and continue without a shared document
-						CompareUIPlugin.log(e);
+						ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 					}
 				}
 			}
@@ -3737,7 +3738,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		try {
 			fMerger.doDiff();
 		} catch (CoreException e) {
-			CompareUIPlugin.log(e.getStatus());
+			ILog.of(getClass()).log(e.getStatus());
 			String title= Utilities.getString(getResourceBundle(), "tooComplexError.title"); //$NON-NLS-1$
 			String msg= Utilities.getString(getResourceBundle(), "tooComplexError.message"); //$NON-NLS-1$
 			MessageDialog.openError(fComposite.getShell(), title, msg);
@@ -3750,7 +3751,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		try {
 			return fMerger.findDiff(type, pos);
 		} catch (CoreException e) {
-			CompareUIPlugin.log(e.getStatus());
+			ILog.of(getClass()).log(e.getStatus());
 			String title= Utilities.getString(getResourceBundle(), "tooComplexError.title"); //$NON-NLS-1$
 			String msg= Utilities.getString(getResourceBundle(), "tooComplexError.message"); //$NON-NLS-1$
 			MessageDialog.openError(fComposite.getShell(), title, msg);
@@ -5616,7 +5617,7 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 			handleException(ite.getTargetException());
 			return;
 		}
-		CompareUIPlugin.log(throwable);
+		ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, throwable);
 	}
 
 	@Override

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BinaryCompareViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/BinaryCompareViewer.java
@@ -25,6 +25,7 @@ import org.eclipse.compare.IStreamContentAccessor;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -112,7 +113,7 @@ public class BinaryCompareViewer extends AbstractViewer {
 				}
 			} catch (CoreException | IOException ex) {
 				message = Utilities.getString(fBundle, "errorMessage"); //$NON-NLS-1$
-				CompareUIPlugin.log(ex);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 			}
 			if (message != null) {
 				fMessage.setText(message);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareEditor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareEditor.java
@@ -24,6 +24,7 @@ import org.eclipse.compare.IPropertyChangeNotifier;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -589,12 +590,12 @@ public class CompareEditor extends EditorPart
 		} else {
 			for (Saveable saveable : sourceSaveables) {
 				if (!knownSaveables.contains(saveable)) {
-					CompareUIPlugin.logErrorMessage(NLS.bind("Saveable {0} was not added using a saveables lifecycle event.", saveable.getName())); //$NON-NLS-1$
+					ILog.of(getClass()).error(NLS.bind("Saveable {0} was not added using a saveables lifecycle event.", saveable.getName())); //$NON-NLS-1$
 					knownSaveables.add(saveable);
 				}
 			}
 			if (sourceSaveables.length != knownSaveables.size()) {
-				CompareUIPlugin.logErrorMessage("Saveables were removed without an appropriate event"); //$NON-NLS-1$
+				ILog.of(getClass()).error("Saveables were removed without an appropriate event"); //$NON-NLS-1$
 				knownSaveables.clear();
 				recordSaveables(sourceSaveables);
 			}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareFilterDescriptor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareFilterDescriptor.java
@@ -21,6 +21,7 @@ import org.eclipse.compare.ICompareFilter;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -95,7 +96,7 @@ public class CompareFilterDescriptor {
 			return (ICompareFilter) fConfiguration
 					.createExecutableExtension(CLASS_ATTRIBUTE);
 		} catch (CoreException e) {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 		}
 		return null;
 	}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -67,6 +67,7 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -166,7 +167,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String type= element.getAttribute(CONTENT_TYPE_ID_ATTRIBUTE);
 			String id= element.getAttribute(idAttributeName);
 			if (id == null) {
-				logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.targetIdAttributeMissing", idAttributeName)); //$NON-NLS-1$
+				ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.targetIdAttributeMissing", idAttributeName)); //$NON-NLS-1$
 			}
 			if (type != null && id != null && fIdMap != null) {
 				T o= fIdMap.get(id);
@@ -182,10 +183,10 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 						}
 						l.add(o);
 					} else {
-						logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.contentTypeNotFound", type)); //$NON-NLS-1$
+						ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.contentTypeNotFound", type)); //$NON-NLS-1$
 					}
 				} else {
-					logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.targetNotFound", id)); //$NON-NLS-1$
+					ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.targetNotFound", id)); //$NON-NLS-1$
 				}
 			}
 		}
@@ -410,7 +411,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String name= element.getName();
 			if (!CONTENT_TYPE_BINDING.equals(name)) {
 				if (!STRUCTURE_CREATOR.equals(name)) {
-					logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, STRUCTURE_CREATOR)); //$NON-NLS-1$
+					ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, STRUCTURE_CREATOR)); //$NON-NLS-1$
 				}
 				fStructureCreators.register(element, new StructureCreatorDescriptor(element));
 			}
@@ -427,7 +428,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String name= element.getName();
 			if (!CONTENT_TYPE_BINDING.equals(name)) {
 				if (!VIEWER_TAG.equals(name)) {
-					logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
+					ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
 				}
 				fStructureMergeViewers.register(element, new ViewerDescriptor(element));
 			}
@@ -444,7 +445,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String name= element.getName();
 			if (!CONTENT_TYPE_BINDING.equals(name)) {
 				if (!VIEWER_TAG.equals(name)) {
-					logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
+					ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
 				}
 				fContentMergeViewers.register(element, new ViewerDescriptor(element));
 			}
@@ -462,7 +463,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String name = element.getName();
 			if (!CONTENT_TYPE_BINDING.equals(name)) {
 				if (!FILTER_TAG.equals(name)) {
-					logErrorMessage(Utilities.getFormattedString(
+					ILog.of(getClass()).error(Utilities.getFormattedString(
 							"CompareUIPlugin.unexpectedTag", name, FILTER_TAG)); //$NON-NLS-1$
 				}
 				fCompareFilters.register(element, new CompareFilterDescriptor(element));
@@ -481,7 +482,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String name= element.getName();
 			if (!CONTENT_TYPE_BINDING.equals(name)) {
 				if (!VIEWER_TAG.equals(name)) {
-					logErrorMessage(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
+					ILog.of(getClass()).error(Utilities.getFormattedString("CompareUIPlugin.unexpectedTag", name, VIEWER_TAG)); //$NON-NLS-1$
 				}
 				fContentViewers.register(element, new ViewerDescriptor(element));
 			}
@@ -659,7 +660,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 					}
 				}
 			} catch (PartInitException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			}
 		}
 		return false;
@@ -693,7 +694,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			String result = toString(right.getContents());
 			return result;
 		} catch (CoreException | IOException e) {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 		}
 		// UnifiedDiff.Builder requires a non-null source. Return an empty string so
 		// the unified diff path can still attempt to open and the fallback to the
@@ -785,7 +786,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			return new LeftEditorInputAndRightStreamContentAccessor(leftEditorInput, left, leftSa, rightEditorInput,
 					right, rightSa, documentMergerInput);
 		} catch (InvocationTargetException | InterruptedException e) {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 		}
 		return null;
 	}
@@ -1789,21 +1790,6 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			}
 		}
 		return result.toArray(new IEditorPart[result.size()]);
-	}
-
-	public static void logErrorMessage(String message) {
-		if (message == null) {
-			message= ""; //$NON-NLS-1$
-		}
-		log(new Status(IStatus.ERROR, getPluginId(), INTERNAL_ERROR, message, null));
-	}
-
-	public static void log(Throwable e) {
-		log(new Status(IStatus.ERROR, getPluginId(), INTERNAL_ERROR, CompareMessages.ComparePlugin_internal_error, e));
-	}
-
-	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
 	}
 
 	String findContentTypeNameOrType(ICompareInput input, ViewerDescriptor vd, CompareConfiguration cc) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareWithOtherResourceDialog.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareWithOtherResourceDialog.java
@@ -28,6 +28,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
@@ -649,7 +650,7 @@ public class CompareWithOtherResourceDialog extends TitleAreaDialog {
 					((IFolder)r).createLink(path, IResource.REPLACE, null);
 				}
 			} catch (CoreException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 				MessageDialog.openError(getShell(),
 								CompareMessages.CompareWithOtherResourceDialog_externalFile_errorTitle,
 								CompareMessages.CompareWithOtherResourceDialog_externalFile_errorMessage);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ExceptionHandler.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ExceptionHandler.java
@@ -17,6 +17,7 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -39,7 +40,7 @@ public class ExceptionHandler {
 	 * logged as an error with the error code <code>JavaStatusConstants.INTERNAL_ERROR</code>.
 	 */
 	public static void log(Throwable t, String message) {
-		CompareUIPlugin.log(new Status(IStatus.ERROR, CompareUIPlugin.getPluginId(),
+		ILog.of(ExceptionHandler.class).log(new Status(IStatus.ERROR, CompareUIPlugin.getPluginId(),
 			CompareUIPlugin.INTERNAL_ERROR, message, t));
 	}
 
@@ -94,7 +95,7 @@ public class ExceptionHandler {
 	//---- Hooks for subclasses to control exception handling ------------------------------------
 
 	protected void perform(CoreException e, Shell shell, String title, String message) {
-		CompareUIPlugin.log(e);
+		ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 		IStatus status= e.getStatus();
 		if (status != null) {
 			ErrorDialog.openError(shell, title, message, status);
@@ -108,7 +109,7 @@ public class ExceptionHandler {
 		if (target instanceof CoreException) {
 			perform((CoreException)target, shell, title, message);
 		} else {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			if (e.getMessage() != null && e.getMessage().length() > 0) {
 				displayMessageDialog(e, e.getMessage(), shell, title, message);
 			} else {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/SimpleTextViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/SimpleTextViewer.java
@@ -17,6 +17,7 @@ import org.eclipse.compare.IStreamContentAccessor;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.swt.SWT;
@@ -63,7 +64,7 @@ public class SimpleTextViewer extends AbstractViewer {
 				return Utilities.readString((IStreamContentAccessor) input);
 			} catch (CoreException ex) {
 				// NeedWork
-				CompareUIPlugin.log(ex);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 			}
 		}
 		return ""; //$NON-NLS-1$

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/StructureCreatorDescriptor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/StructureCreatorDescriptor.java
@@ -16,6 +16,7 @@ package org.eclipse.compare.internal;
 import org.eclipse.compare.structuremergeviewer.IStructureCreator;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 
 /**
  * A factory proxy for creating a StructureCreator.
@@ -41,7 +42,7 @@ public class StructureCreatorDescriptor {
 		try {
 			return (IStructureCreator)fElement.createExecutableExtension(CLASS_ATTRIBUTE);
 		} catch (CoreException ex) {
-			CompareUIPlugin.log(ex.getStatus());
+			ILog.of(getClass()).log(ex.getStatus());
 			//ExceptionHandler.handle(ex, SearchMessages.getString("Search.Error.createSorter.title"), SearchMessages.getString("Search.Error.createSorter.message")); //$NON-NLS-2$ //$NON-NLS-1$
 			return null;
 		} catch (ClassCastException ex) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/Utilities.java
@@ -56,6 +56,7 @@ import org.eclipse.core.resources.mapping.ResourceTraversal;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -214,7 +215,7 @@ public class Utilities {
 							}
 						}
 					} catch (CoreException ex) {
-						CompareUIPlugin.log(ex);
+						ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, ex);
 					}
 				} else if (o instanceof IAdaptable a) {
 					Object adapter= a.getAdapter(IResource.class);
@@ -337,7 +338,7 @@ public class Utilities {
 			try {
 				return MessageFormat.format(bundle.getString(key), arg);
 			} catch (MissingResourceException x) {
-				CompareUIPlugin.log(x);
+				ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, x);
 			}
 		}
 		return "!" + key + "!";	//$NON-NLS-2$ //$NON-NLS-1$
@@ -371,7 +372,7 @@ public class Utilities {
 					return Integer.parseInt(s);
 				}
 			} catch (NumberFormatException x) {
-				CompareUIPlugin.log(x);
+				ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, x);
 			} catch (MissingResourceException x) {
 				// Silently ignore Exception
 			}
@@ -631,7 +632,7 @@ public class Utilities {
 			try {
 				return ((IEncodedStorage)resource).getCharset();
 			} catch (CoreException ex) {
-				CompareUIPlugin.log(ex);
+				ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, ex);
 			}
 		}
 		return ResourcesPlugin.getEncoding();

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ViewerDescriptor.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ViewerDescriptor.java
@@ -18,6 +18,7 @@ import org.eclipse.compare.IViewerCreator;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.widgets.Composite;
 
@@ -49,7 +50,7 @@ public class ViewerDescriptor implements IViewerDescriptor {
 			try {
 				fViewerCreator= (IViewerCreator) fConfiguration.createExecutableExtension(CLASS_ATTRIBUTE);
 			} catch (CoreException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			}
 		}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/LineReader.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/LineReader.java
@@ -24,11 +24,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 
 public class LineReader {
 	/**
@@ -54,7 +55,7 @@ public class LineReader {
 				}
 			} catch (CoreException ex) {
 				// TODO
-				CompareUIPlugin.log(ex);
+				ILog.of(LineReader.class).error(CompareMessages.ComparePlugin_internal_error, ex);
 			} catch (IOException closeException) {
 				// silently ignored
 			}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchFileTypedElement.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PatchFileTypedElement.java
@@ -21,13 +21,14 @@ import java.util.List;
 import org.eclipse.compare.CompareUI;
 import org.eclipse.compare.IEncodedStreamContentAccessor;
 import org.eclipse.compare.ITypedElement;
-import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.core.patch.DiffProject;
 import org.eclipse.compare.internal.core.patch.FileDiffResult;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.graphics.Image;
 
@@ -110,7 +111,7 @@ public class PatchFileTypedElement implements ITypedElement,
 			try {
 				bytes = contents.getBytes(charSet);
 			} catch (UnsupportedEncodingException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			}
 		}
 		if (bytes == null) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PreviewPatchPage2.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/PreviewPatchPage2.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.regex.Pattern;
 
 import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.ComparePreferencePage;
 import org.eclipse.compare.internal.CompareUIPlugin;
 import org.eclipse.compare.internal.ICompareUIConstants;
@@ -27,6 +28,7 @@ import org.eclipse.compare.internal.core.patch.Hunk;
 import org.eclipse.compare.patch.IHunk;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.action.Action;
@@ -359,7 +361,7 @@ public class PreviewPatchPage2 extends WizardPage {
 					try {
 						fInput.saveChanges(null);
 					} catch (CoreException e) {
-						CompareUIPlugin.log(e);
+						ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 					}
 					result[0] = fInput.confirmRebuild(promptToConfirm);
 				}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/UnmatchedHunkTypedElement.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/UnmatchedHunkTypedElement.java
@@ -22,13 +22,14 @@ import org.eclipse.compare.IContentChangeListener;
 import org.eclipse.compare.IContentChangeNotifier;
 import org.eclipse.compare.IEditableContent;
 import org.eclipse.compare.ITypedElement;
-import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.ContentChangeNotifier;
 import org.eclipse.compare.internal.core.patch.FilePatch2;
 import org.eclipse.compare.internal.core.patch.HunkResult;
 import org.eclipse.compare.patch.PatchConfiguration;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 
 public class UnmatchedHunkTypedElement extends HunkTypedElement implements IContentChangeNotifier, IEditableContent {
 
@@ -97,7 +98,7 @@ public class UnmatchedHunkTypedElement extends HunkTypedElement implements ICont
 			try {
 				bytes = content.getBytes(getCharset());
 			} catch (UnsupportedEncodingException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			}
 		}
 		if (bytes == null) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Utilities.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Utilities.java
@@ -30,6 +30,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
@@ -40,7 +41,7 @@ public class Utilities {
 			try {
 				return ((IEncodedStorage) resource).getCharset();
 			} catch (CoreException ex) {
-				CompareUIPlugin.log(ex);
+				ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, ex);
 			}
 		}
 		return ResourcesPlugin.getEncoding();
@@ -86,7 +87,7 @@ public class Utilities {
 			try {
 				in = new InputStreamReader(contents, charset);
 			} catch (UnsupportedEncodingException e) {
-				CompareUIPlugin.log(e);
+				ILog.of(Utilities.class).error(CompareMessages.ComparePlugin_internal_error, e);
 				try {
 					contents.close();
 				} catch (IOException e1) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DocumentRangeNode.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/DocumentRangeNode.java
@@ -26,10 +26,11 @@ import org.eclipse.compare.ISharedDocumentAdapter;
 import org.eclipse.compare.IStreamContentAccessor;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.contentmergeviewer.IDocumentRange;
-import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.Utilities;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -120,7 +121,7 @@ public class DocumentRangeNode
 		try {
 			fBaseDocument.addPosition(RANGE_CATEGORY, fRange);
 		} catch (BadPositionCategoryException | BadLocationException ex) {
-			CompareUIPlugin.log(ex);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 		}
 	}
 
@@ -332,7 +333,7 @@ public class DocumentRangeNode
 			try {
 				fBaseDocument.replace(p.getOffset(), p.getLength(), s);
 			} catch (BadLocationException ex) {
-				CompareUIPlugin.log(ex);
+				ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 			}
 		}
 	}
@@ -382,7 +383,7 @@ public class DocumentRangeNode
 						srcContents= Utilities.readString((IStreamContentAccessor)other);
 					} catch(CoreException ex) {
 						// NeedWork
-						CompareUIPlugin.log(ex);
+						ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, ex);
 					}
 				}
 			}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/StructureCreator.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/StructureCreator.java
@@ -27,11 +27,12 @@ import org.eclipse.compare.IStreamContentAccessor;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.SharedDocumentAdapter;
 import org.eclipse.compare.contentmergeviewer.IDocumentRange;
-import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.internal.Utilities;
 import org.eclipse.compare.internal.patch.LineReader;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jface.text.Document;
@@ -62,7 +63,7 @@ public abstract class StructureCreator implements IStructureCreator2 {
 					contents= Utilities.readString(sca);
 				} catch (CoreException e) {
 					// return null indicates the error.
-					CompareUIPlugin.log(e);
+					ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 					return null;
 				}
 			}
@@ -79,7 +80,7 @@ public abstract class StructureCreator implements IStructureCreator2 {
 		try {
 			return createStructureComparator(input, doc, null, null);
 		} catch (CoreException e) {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 			return null;
 		}
 	}
@@ -118,7 +119,7 @@ public abstract class StructureCreator implements IStructureCreator2 {
 					} catch (CoreException e) {
 						// Connection to the document provider failed.
 						// Log and fall through to use simple structure
-						CompareUIPlugin.log(e);
+						ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 					}
 				}
 			}
@@ -266,7 +267,7 @@ public abstract class StructureCreator implements IStructureCreator2 {
 			sda.flushDocument(provider, key, document, false);
 			return true;
 		} catch (CoreException e) {
-			CompareUIPlugin.log(e);
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 		}
 		return false;
 	}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/StructureDiffViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/structuremergeviewer/StructureDiffViewer.java
@@ -25,9 +25,9 @@ import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.contentmergeviewer.IDocumentRange;
 import org.eclipse.compare.internal.ChangeCompareFilterPropertyAction;
 import org.eclipse.compare.internal.CompareMessages;
-import org.eclipse.compare.internal.CompareUIPlugin;
 import org.eclipse.compare.internal.Utilities;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -163,7 +163,7 @@ public class StructureDiffViewer extends DiffTreeViewer {
 				try {
 					return sc2.createStructure(input, monitor);
 				} catch (CoreException e) {
-					CompareUIPlugin.log(e);
+					ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e);
 				}
 			}
 			return fStructureCreator.getStructure(input);
@@ -327,7 +327,7 @@ public class StructureDiffViewer extends DiffTreeViewer {
 				try {
 					inputChangedTask.run(new NullProgressMonitor());
 				} catch (InvocationTargetException e1) {
-					CompareUIPlugin.log(e1.getTargetException());
+					ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e1.getTargetException());
 				} catch (InterruptedException e2) {
 					// Ignore
 				}
@@ -554,7 +554,7 @@ public class StructureDiffViewer extends DiffTreeViewer {
 			}
 		} catch (InvocationTargetException e) {
 			// Shouldn't happen since the run doesn't throw
-			CompareUIPlugin.log(e.getTargetException());
+			ILog.of(getClass()).error(CompareMessages.ComparePlugin_internal_error, e.getTargetException());
 			handleFailedRefresh(e.getTargetException().getMessage());
 		} catch (InterruptedException e) {
 			// Canceled by user


### PR DESCRIPTION
This replaces the static `CompareUIPlugin.log`/`logErrorMessage` helpers with `org.eclipse.core.runtime.ILog` at every call site in `org.eclipse.compare` and removes the three helpers.
Severity and messages are preserved, so there is no behavior change; it just moves logging off the `CompareUIPlugin` activator and drops one more use of the `getDefault()` singleton.
All call sites in the bundle were migrated and the bundle compiles cleanly.